### PR TITLE
fix: ECS DescribeTasks transitions task to STOPPED after container exits

### DIFF
--- a/services/ecs.py
+++ b/services/ecs.py
@@ -473,10 +473,51 @@ def _describe_tasks(data):
                     task = t
                     break
         if task:
+            _maybe_mark_stopped(task)
             result.append({k: v for k, v in task.items() if not k.startswith("_")})
         else:
             failures.append({"arn": ref, "reason": "MISSING"})
     return json_response({"tasks": result, "failures": failures})
+
+
+def _maybe_mark_stopped(task):
+    """Check Docker containers and transition task to STOPPED if all have exited."""
+    if task.get("lastStatus") != "RUNNING" or not task.get("_docker_ids"):
+        return
+
+    docker_client = _get_docker()
+    if not docker_client:
+        return
+
+    all_stopped = True
+    exit_code = 0
+    for docker_id in task["_docker_ids"]:
+        try:
+            container = docker_client.containers.get(docker_id)
+            if container.status != "exited":
+                all_stopped = False
+                break
+            result = container.wait()
+            exit_code = max(exit_code, result.get("StatusCode", 0))
+        except Exception:
+            # Container removed or unreachable — treat as stopped
+            pass
+
+    if not all_stopped:
+        return
+
+    task["lastStatus"] = "STOPPED"
+    task["desiredStatus"] = "STOPPED"
+    task["stoppedAt"] = time.time()
+    task["stoppedReason"] = "Essential container exited"
+    task["stopCode"] = "EssentialContainerExited"
+    for c in task.get("containers", []):
+        c["lastStatus"] = "STOPPED"
+        c["exitCode"] = exit_code
+
+    cluster_name = _resolve_cluster_name(task.get("clusterArn", "").split("/")[-1] if "/" in task.get("clusterArn", "") else "")
+    if cluster_name in _clusters:
+        _clusters[cluster_name]["runningTasksCount"] = max(0, _clusters[cluster_name]["runningTasksCount"] - 1)
 
 
 def _list_tasks(data):

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -532,6 +532,38 @@ def test_ecs_list_task_defs(ecs):
     assert len(resp["taskDefinitionArns"]) >= 1
 
 
+def test_ecs_run_task_stops_after_exit(ecs):
+    """DescribeTasks transitions to STOPPED after Docker container exits."""
+    ecs.create_cluster(clusterName="task-lifecycle")
+    ecs.register_task_definition(
+        family="short-lived",
+        containerDefinitions=[{
+            "name": "worker",
+            "image": "alpine:latest",
+            "command": ["sh", "-c", "echo done"],
+            "essential": True,
+        }],
+    )
+    resp = ecs.run_task(cluster="task-lifecycle", taskDefinition="short-lived")
+    task_arn = resp["tasks"][0]["taskArn"]
+    assert resp["tasks"][0]["lastStatus"] == "RUNNING"
+
+    # Poll until STOPPED (container exits almost immediately)
+    stopped = False
+    for _ in range(10):
+        time.sleep(1)
+        desc = ecs.describe_tasks(cluster="task-lifecycle", tasks=[task_arn])
+        task = desc["tasks"][0]
+        if task["lastStatus"] == "STOPPED":
+            stopped = True
+            assert task["desiredStatus"] == "STOPPED"
+            assert task["stopCode"] == "EssentialContainerExited"
+            assert task["containers"][0]["lastStatus"] == "STOPPED"
+            assert task["containers"][0]["exitCode"] == 0
+            break
+    assert stopped, "Task should transition to STOPPED after container exits"
+
+
 def test_ecs_service(ecs):
     ecs.create_service(
         cluster="test-cluster",


### PR DESCRIPTION
## Summary

- `DescribeTasks` now checks Docker container status before returning — if all containers have exited, the task transitions to `STOPPED` with appropriate `exitCode`, `stopCode`, and `stoppedReason`
- Adds `_maybe_mark_stopped` helper following existing patterns (`_stop_task`, `_get_docker()` graceful degradation)
- Adds integration test `test_ecs_run_task_stops_after_exit` that verifies the full lifecycle

## Test plan

- [x] Built local image and tested manually (`alpine:latest` with `echo done` exits → `DescribeTasks` returns `STOPPED`)
- [x] Integration test passes: `pytest tests/test_services.py::test_ecs_run_task_stops_after_exit -v`
- [x] Full test suite passes: `pytest tests/ -v` (57/57 passed)