### PR TITLE
feat: Route53, Unicode, 11 bug fixes, PyPI CI (v1.0.8)

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,0 +1,30 @@
+name: PyPI Publish
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write  # required for trusted publishing (OIDC)
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build tools
+        run: pip install build
+
+      - name: Build distribution
+        run: python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,54 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [1.0.8] — 2026-03-28
+
+### Added
+- **Amazon Route53** (`services/route53.py`) — full hosted zone and DNS record management
+  - Hosted zones: `CreateHostedZone`, `GetHostedZone`, `DeleteHostedZone`, `ListHostedZones`, `ListHostedZonesByName`, `UpdateHostedZoneComment`
+  - Record sets: `ChangeResourceRecordSets` (CREATE / UPSERT / DELETE, atomic batch), `ListResourceRecordSets`
+  - Changes: `GetChange` — changes are immediately `INSYNC`
+  - Health checks: `CreateHealthCheck`, `GetHealthCheck`, `DeleteHealthCheck`, `ListHealthChecks`, `UpdateHealthCheck`
+  - Tags: `ChangeTagsForResource`, `ListTagsForResource` (hostedzone and healthcheck resource types)
+  - REST/XML protocol with namespace `https://route53.amazonaws.com/doc/2013-04-01/`; credential scope `route53`
+  - SOA + NS records auto-created on zone creation with 4 default AWS nameservers
+  - `CallerReference` idempotency for `CreateHostedZone` and `CreateHealthCheck`
+  - Alias records (AliasTarget), weighted, failover, latency, geolocation, multi-value routing attributes stored and returned
+  - Zone ID format `/hostedzone/Z{13chars}`, Change ID `/change/C{13chars}`
+  - Marker-based pagination for `ListHostedZones` and `ListHealthChecks`; name/type pagination for `ListResourceRecordSets`
+  - 16 integration tests
+- **Non-ASCII / Unicode support** — seamless end-to-end handling of UTF-8 content across all services
+  - Inbound header values decoded as UTF-8 (with latin-1 fallback) so `x-amz-meta-*` fields containing non-ASCII are stored correctly
+  - Outbound header encoding falls back to UTF-8 when a value cannot be encoded as latin-1 — prevents `UnicodeEncodeError` on `Content-Disposition` or metadata round-trips
+  - All JSON responses use `ensure_ascii=False` — raw UTF-8 characters in DynamoDB items, SQS messages, Secrets Manager values, SSM parameters, and Lambda payloads are returned as-is rather than `\uXXXX` escaped
+  - 7 integration tests covering S3 keys, S3 metadata, DynamoDB, SQS, Secrets Manager, SSM, and Route53 zone comments
+
+### Fixed
+- **DynamoDB TTL reaper thread-safety**: the background reaper thread now holds `_lock` while scanning and deleting expired items — eliminates a race condition with concurrent request handlers that could corrupt table state or crash the reaper under load
+- **S3 `PutObject` / `CreateBucket` spurious `Content-Type`**: these operations no longer return `Content-Type: application/xml` on success (AWS returns no Content-Type for empty 200 bodies) — prevents SDK response-parsing warnings
+- **S3 `DeleteObject` delete-marker header**: non-versioned buckets now return an empty 204 with no extra headers; versioned/suspended buckets return `x-amz-delete-marker: true` — previously all buckets unconditionally returned `x-amz-delete-marker: false`
+- **CloudWatch Logs `FilterLogEvents` pattern matching**: upgraded from plain substring search to proper CloudWatch filter syntax — supports `*`/`?` glob wildcards, multi-term AND (`TERM1 TERM2`), term exclusion (`-TERM`), and JSON-style patterns (matched as pass-all); previously only exact substring matches worked
+- **JSON responses `ensure_ascii`**: all JSON service responses now use `ensure_ascii=False` so non-ASCII strings (Cyrillic, CJK, Arabic, etc.) are returned as raw UTF-8 rather than `\uXXXX` escape sequences — matches real AWS behaviour
+- **Inbound header UTF-8 decoding**: request header values are now decoded as UTF-8 with latin-1 fallback — `x-amz-meta-*` headers containing multi-byte characters are stored and round-tripped correctly
+- **Outbound header UTF-8 encoding**: response headers that cannot be encoded as latin-1 (e.g. metadata containing non-ASCII) now fall back to UTF-8 encoding instead of raising `UnicodeEncodeError`
+- **API Gateway v2 / v1 Lambda response encoding**: Lambda invocation response bodies serialised via `json.dumps` now use `ensure_ascii=False` and explicit `utf-8` encoding — non-ASCII characters in Lambda responses are preserved end-to-end
+- **DynamoDB `Query` pagination on hash-only tables**: `_apply_exclusive_start_key` was returning `[]` for any table without a sort key (`sk_name=None`) because `not sk_name` short-circuited to an empty-result path — hash-only tables now paginate correctly by resuming after the matching partition key value (validated against botocore `dynamodb` service model)
+- **SQS `DeleteMessageBatch` silent success on invalid receipt handle**: both the found and not-found branches were appending to `Successful` (copy-paste error) — an unmatched `ReceiptHandle` now correctly populates the `Failed` list with `ReceiptHandleIsInvalid` (validated against botocore `BatchResultErrorEntry` shape)
+- **SNS→Lambda `EventSubscriptionArn` hardcoded suffix**: the SNS-to-Lambda fanout envelope was setting `EventSubscriptionArn` to `"{topic_arn}:subscription"` instead of the actual subscription ARN — Lambda functions inspecting `event['Records'][0]['EventSubscriptionArn']` now receive the correct value
+- **Lambda error codes**: internal path-routing fallbacks now use `InvalidParameterValueException` (400) for missing function name and `ResourceNotFoundException` (404) for unrecognised paths — previously both used the non-existent `InvalidRequest` code which is absent from the botocore Lambda model
+
+- **Lambda worker reset**: `core/lambda_runtime.reset()` was calling `worker.proc.terminate()` (typo) instead of `worker._proc.terminate()` — the `AttributeError` was silently swallowed, leaving orphaned worker subprocesses after `/_ministack/reset`
+- **Step Functions → Lambda async invocation**: `stepfunctions._call_lambda` was calling `lambda_svc._invoke` synchronously — `_invoke` is `async`, so it returned a coroutine object instead of executing; Task states invoking Lambda now use `asyncio.run()` to execute the coroutine from the background thread
+- **EventBridge → Lambda async invocation**: same bug in `eventbridge._dispatch_to_lambda` — fixed with `asyncio.run()`
+- **`make run` Docker socket mount**: added `-v /var/run/docker.sock:/var/run/docker.sock` so ECS `RunTask` works when running via `make run`
+
+### Tests
+- 4 regression tests added, one per botocore-confirmed bug: `test_ddb_query_pagination_hash_only`, `test_sqs_batch_delete_invalid_receipt_handle`, `test_sns_to_lambda_event_subscription_arn`, `test_lambda_unknown_path_returns_404`
+- 2 regression tests for runtime fixes: `test_lambda_reset_terminates_workers`, `test_sfn_integration_lambda_invoke`
+- 479 integration tests — all passing, including against Docker image
+
+---
+
 ## [1.0.7] — 2026-03-27
 
 ### Added
@@ -230,7 +278,5 @@ Initial public release. Built as a free, open-source alternative to LocalStack.
 
 ### Planned
 - Cognito (user pools, sign-up/sign-in)
-- Route53 (hosted zones, record sets)
 - ACM (certificate management)
-- Virtual-hosted style S3 (`bucket.localhost:4566` routing)
 

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ build:
 run: build
 	docker run -d --name $(CONTAINER_NAME) -p $(PORT):4566 \
 		-e LOG_LEVEL=INFO \
+		-v /var/run/docker.sock:/var/run/docker.sock \
 		$(IMAGE_NAME)
 	@echo "MiniStack running on http://localhost:$(PORT)"
 	@echo "Health: http://localhost:$(PORT)/_localstack/health"

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 LocalStack recently moved its core services behind a paid plan. If you relied on LocalStack Community for local development and CI/CD pipelines, MiniStack is your free alternative.
 
-- **23 AWS services** emulated on a single port (4566)
+- **24 AWS services** emulated on a single port (4566)
 - **Drop-in compatible** — works with `boto3`, AWS CLI, Terraform, CDK, Pulumi, any SDK
 - **Real infrastructure** — RDS spins up actual Postgres/MySQL containers, ElastiCache spins up real Redis, Athena runs real SQL via DuckDB, ECS runs real Docker containers
 - **Tiny footprint** — ~150MB image, ~30MB RAM at idle vs LocalStack's ~1GB image and ~500MB RAM
@@ -170,12 +170,12 @@ sfn.create_state_machine(
 | **S3** | CreateBucket, DeleteBucket, ListBuckets, HeadBucket, PutObject, GetObject, DeleteObject, HeadObject, CopyObject, ListObjects v1/v2, DeleteObjects, GetBucketVersioning, PutBucketVersioning, GetBucketEncryption, PutBucketEncryption, DeleteBucketEncryption, GetBucketLifecycleConfiguration, PutBucketLifecycleConfiguration, DeleteBucketLifecycle, GetBucketCors, PutBucketCors, DeleteBucketCors, GetBucketAcl, PutBucketAcl, GetBucketTagging, PutBucketTagging, DeleteBucketTagging, GetBucketPolicy, PutBucketPolicy, DeleteBucketPolicy, GetBucketNotificationConfiguration, PutBucketNotificationConfiguration, GetBucketLogging, PutBucketLogging, ListObjectVersions, CreateMultipartUpload, UploadPart, CompleteMultipartUpload, AbortMultipartUpload | Optional disk persistence via `S3_PERSIST=1` |
 | **SQS** | CreateQueue, DeleteQueue, ListQueues, GetQueueUrl, GetQueueAttributes, SetQueueAttributes, PurgeQueue, SendMessage, ReceiveMessage, DeleteMessage, ChangeMessageVisibility, ChangeMessageVisibilityBatch, SendMessageBatch, DeleteMessageBatch, TagQueue, UntagQueue, ListQueueTags | Both Query API and JSON protocol; FIFO queues with deduplication; DLQ support |
 | **SNS** | CreateTopic, DeleteTopic, ListTopics, GetTopicAttributes, SetTopicAttributes, Subscribe, Unsubscribe, ListSubscriptions, ListSubscriptionsByTopic, GetSubscriptionAttributes, SetSubscriptionAttributes, ConfirmSubscription, Publish, PublishBatch, TagResource, UntagResource, ListTagsForResource, CreatePlatformApplication, CreatePlatformEndpoint | SNS→SQS fanout delivery; SNS→Lambda fanout (synchronous invocation) |
-| **DynamoDB** | CreateTable, UpdateTable, DeleteTable, DescribeTable, ListTables, PutItem, GetItem, DeleteItem, UpdateItem, Query, Scan, BatchWriteItem, BatchGetItem, TransactWriteItems, TransactGetItems, DescribeTimeToLive, UpdateTimeToLive, DescribeContinuousBackups, UpdateContinuousBackups, DescribeEndpoints, TagResource, UntagResource, ListTagsOfResource | TTL enforced via background reaper (60s cadence) |
+| **DynamoDB** | CreateTable, UpdateTable, DeleteTable, DescribeTable, ListTables, PutItem, GetItem, DeleteItem, UpdateItem, Query, Scan, BatchWriteItem, BatchGetItem, TransactWriteItems, TransactGetItems, DescribeTimeToLive, UpdateTimeToLive, DescribeContinuousBackups, UpdateContinuousBackups, DescribeEndpoints, TagResource, UntagResource, ListTagsOfResource | TTL enforced via thread-safe background reaper (60s cadence) |
 | **Lambda** | CreateFunction, DeleteFunction, GetFunction, ListFunctions, Invoke, UpdateFunctionCode, UpdateFunctionConfiguration, AddPermission, RemovePermission, ListVersionsByFunction, PublishVersion, TagResource, UntagResource, ListTags, CreateEventSourceMapping, DeleteEventSourceMapping, GetEventSourceMapping, ListEventSourceMappings, UpdateEventSourceMapping, CreateFunctionUrlConfig, GetFunctionUrlConfig, UpdateFunctionUrlConfig, DeleteFunctionUrlConfig, ListFunctionUrlConfigs | Python runtimes actually execute with warm worker pool; SQS event source mapping; Function URL CRUD |
 | **IAM** | CreateUser, GetUser, ListUsers, DeleteUser, CreateRole, GetRole, ListRoles, DeleteRole, CreatePolicy, GetPolicy, DeletePolicy, AttachRolePolicy, DetachRolePolicy, PutRolePolicy, GetRolePolicy, DeleteRolePolicy, ListRolePolicies, ListAttachedRolePolicies, CreateAccessKey, ListAccessKeys, DeleteAccessKey, CreateInstanceProfile, GetInstanceProfile, DeleteInstanceProfile, AddRoleToInstanceProfile, RemoveRoleFromInstanceProfile, ListInstanceProfiles, CreateGroup, GetGroup, AddUserToGroup, RemoveUserFromGroup, CreateServiceLinkedRole, CreateOpenIDConnectProvider, TagRole, UntagRole, TagUser, UntagUser, TagPolicy, UntagPolicy | |
 | **STS** | GetCallerIdentity, AssumeRole, GetSessionToken | |
 | **SecretsManager** | CreateSecret, GetSecretValue, ListSecrets, DeleteSecret, UpdateSecret, DescribeSecret, PutSecretValue, RestoreSecret, RotateSecret, GetRandomPassword, ListSecretVersionIds, TagResource, UntagResource, PutResourcePolicy, GetResourcePolicy, DeleteResourcePolicy, ValidateResourcePolicy | |
-| **CloudWatch Logs** | CreateLogGroup, DeleteLogGroup, DescribeLogGroups, CreateLogStream, DeleteLogStream, DescribeLogStreams, PutLogEvents, GetLogEvents, FilterLogEvents, PutRetentionPolicy, DeleteRetentionPolicy, PutSubscriptionFilter, DeleteSubscriptionFilter, DescribeSubscriptionFilters, PutMetricFilter, DeleteMetricFilter, DescribeMetricFilters, TagLogGroup, UntagLogGroup, ListTagsLogGroup, TagResource, UntagResource, ListTagsForResource, StartQuery, GetQueryResults, StopQuery, PutDestination, DeleteDestination, DescribeDestinations | |
+| **CloudWatch Logs** | CreateLogGroup, DeleteLogGroup, DescribeLogGroups, CreateLogStream, DeleteLogStream, DescribeLogStreams, PutLogEvents, GetLogEvents, FilterLogEvents, PutRetentionPolicy, DeleteRetentionPolicy, PutSubscriptionFilter, DeleteSubscriptionFilter, DescribeSubscriptionFilters, PutMetricFilter, DeleteMetricFilter, DescribeMetricFilters, TagLogGroup, UntagLogGroup, ListTagsLogGroup, TagResource, UntagResource, ListTagsForResource, StartQuery, GetQueryResults, StopQuery, PutDestination, DeleteDestination, DescribeDestinations | `FilterLogEvents` supports `*`/`?` globs, multi-term AND, `-term` exclusion |
 
 ### Extended Services
 
@@ -200,6 +200,7 @@ sfn.create_state_machine(
 | **Glue** | CreateDatabase, DeleteDatabase, GetDatabase, GetDatabases, CreateTable, DeleteTable, GetTable, GetTables, UpdateTable, BatchDeleteTable, CreatePartition, GetPartitions, BatchCreatePartition, BatchGetPartition, CreatePartitionIndex, GetPartitionIndexes, CreateConnection, GetConnections, CreateCrawler, UpdateCrawler, GetCrawler, GetCrawlerMetrics, StartCrawler, CreateJob, GetJob, GetJobs, StartJobRun, GetJobRun, GetJobRuns, CreateTrigger, GetTrigger, DeleteTrigger, UpdateTrigger, StartTrigger, StopTrigger, ListTriggers, GetTriggers, CreateWorkflow, GetWorkflow, DeleteWorkflow, UpdateWorkflow, StartWorkflowRun, CreateSecurityConfiguration, GetSecurityConfiguration, GetSecurityConfigurations, DeleteSecurityConfiguration, CreateClassifier, GetClassifier, GetClassifiers, DeleteClassifier, TagResource, UntagResource, GetTags | Python shell jobs actually execute via subprocess |
 | **Athena** | StartQueryExecution, GetQueryExecution, GetQueryResults, StopQueryExecution, ListQueryExecutions, BatchGetQueryExecution, CreateWorkGroup, DeleteWorkGroup, GetWorkGroup, ListWorkGroups, UpdateWorkGroup, CreateNamedQuery, DeleteNamedQuery, GetNamedQuery, ListNamedQueries, BatchGetNamedQuery, CreateDataCatalog, GetDataCatalog, ListDataCatalogs, DeleteDataCatalog, UpdateDataCatalog, CreatePreparedStatement, GetPreparedStatement, DeletePreparedStatement, ListPreparedStatements, GetTableMetadata, ListTableMetadata, TagResource, UntagResource, ListTagsForResource | Real SQL via **DuckDB** when installed (`pip install duckdb`), otherwise returns mock results; result pagination; column type metadata |
 | **Firehose** | CreateDeliveryStream, DeleteDeliveryStream, DescribeDeliveryStream, ListDeliveryStreams, PutRecord, PutRecordBatch, UpdateDestination, TagDeliveryStream, UntagDeliveryStream, ListTagsForDeliveryStream, StartDeliveryStreamEncryption, StopDeliveryStreamEncryption | S3 destinations write records to the local S3 emulator; all other destination types buffer in-memory; concurrency-safe `UpdateDestination` via `VersionId` |
+| **Route53** | CreateHostedZone, GetHostedZone, DeleteHostedZone, ListHostedZones, ListHostedZonesByName, UpdateHostedZoneComment, ChangeResourceRecordSets (CREATE/UPSERT/DELETE), ListResourceRecordSets, GetChange, CreateHealthCheck, GetHealthCheck, DeleteHealthCheck, ListHealthChecks, UpdateHealthCheck, ChangeTagsForResource, ListTagsForResource | REST/XML protocol; SOA + NS records auto-created; CallerReference idempotency; alias records, weighted/failover/latency routing; marker-based pagination |
 
 ---
 
@@ -410,19 +411,19 @@ pip install boto3 pytest duckdb docker cbor2
 # Start MiniStack
 docker compose up -d
 
-# Run the full test suite (450 tests across all 23 services)
+# Run the full test suite (479 tests across all 24 services)
 pytest tests/ -v
 ```
 
 Expected output:
 ```
-collected 450 items
+collected 479 items
 
 tests/test_services.py::test_s3_create_bucket PASSED
 ...
 tests/test_services.py::test_apigwv1_execute_mock_response_parameters PASSED
 
-450 passed in ~60s
+479 passed in ~60s
 ```
 
 ---
@@ -509,6 +510,7 @@ config:
 | **API Gateway v2 (HTTP API)** | ✅ | ✅ | ✅ |
 | **API Gateway v1 (REST API)** | ✅ | ✅ | ✅ |
 | **Firehose** | ✅ | ✅ | ✅ |
+| **Route53** | ✅ | ✅ | ✅ |
 | Cognito | ❌ | ✅ | ✅ |
 | CloudFormation | ❌ | partial | ✅ |
 | Cost | **Free** | Was free, now paid | $35+/mo |

--- a/app.py
+++ b/app.py
@@ -28,6 +28,7 @@ from services import ecs, rds, elasticache, glue, athena
 from services import apigateway
 from services import firehose
 from services import apigateway_v1
+from services import route53
 from services.iam_sts import handle_iam_request, handle_sts_request
 
 LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO").upper()
@@ -61,6 +62,7 @@ SERVICE_HANDLERS = {
     "athena": athena.handle_request,
     "apigateway": apigateway.handle_request,
     "firehose": firehose.handle_request,
+    "route53": route53.handle_request,
 }
 
 SERVICE_NAME_ALIASES = {
@@ -72,6 +74,7 @@ SERVICE_NAME_ALIASES = {
     "execute-api": "apigateway",
     "apigatewayv2": "apigateway",
     "kinesis-firehose": "firehose",
+    "route53": "route53",
 }
 
 
@@ -107,7 +110,7 @@ BANNER = r"""
  Local AWS Service Emulator — Port {port}
  Services: S3, SQS, SNS, DynamoDB, Lambda, IAM, STS, SecretsManager, CloudWatch Logs,
           SSM, EventBridge, Kinesis, CloudWatch, SES, Step Functions,
-          ECS, RDS, ElastiCache, Glue, Athena, API Gateway, Firehose
+          ECS, RDS, ElastiCache, Glue, Athena, API Gateway, Firehose, Route53
 """
 
 
@@ -127,7 +130,10 @@ async def app(scope, receive, send):
 
     headers = {}
     for name, value in scope.get("headers", []):
-        headers[name.decode("latin-1").lower()] = value.decode("latin-1")
+        try:
+            headers[name.decode("latin-1").lower()] = value.decode("utf-8")
+        except UnicodeDecodeError:
+            headers[name.decode("latin-1").lower()] = value.decode("latin-1")
 
     body = b""
     while True:
@@ -258,7 +264,13 @@ async def app(scope, receive, send):
 
 async def _send_response(send, status, headers, body):
     """Send ASGI HTTP response."""
-    header_list = [(k.encode("latin-1"), str(v).encode("latin-1")) for k, v in headers.items()]
+    def _encode_header_value(v: str) -> bytes:
+        try:
+            return v.encode("latin-1")
+        except UnicodeEncodeError:
+            return v.encode("utf-8")
+
+    header_list = [(k.encode("latin-1"), _encode_header_value(str(v))) for k, v in headers.items()]
     await send({
         "type": "http.response.start",
         "status": status,
@@ -352,6 +364,7 @@ def _reset_all_state():
         (apigateway, apigateway.reset),
         (apigateway_v1, apigateway_v1.reset),
         (firehose, firehose.reset),
+        (route53, route53.reset),
     ]:
         try:
             fn()

--- a/core/lambda_runtime.py
+++ b/core/lambda_runtime.py
@@ -190,7 +190,7 @@ def reset():
     """Terminate all warm workers and clear the pool."""
     for worker in list(_workers.values()):
         try:
-            worker.proc.terminate()
+            worker._proc.terminate()
         except Exception:
             pass
     _workers.clear()

--- a/core/responses.py
+++ b/core/responses.py
@@ -48,7 +48,7 @@ def _dict_to_xml(parent: Element, data):
 
 def json_response(data: dict, status: int = 200) -> tuple:
     """Build an AWS-style JSON response."""
-    body = json.dumps(data).encode("utf-8")
+    body = json.dumps(data, ensure_ascii=False).encode("utf-8")
     return status, {"Content-Type": "application/x-amz-json-1.0"}, body
 
 

--- a/core/router.py
+++ b/core/router.py
@@ -104,6 +104,10 @@ SERVICE_PATTERNS = {
         "host_patterns": [r"apigateway\.", r"execute-api\."],
         "path_patterns": [r"^/v2/apis"],
     },
+    "route53": {
+        "host_patterns": [r"route53\."],
+        "path_patterns": [r"^/2013-04-01/"],
+    },
 }
 
 
@@ -143,6 +147,7 @@ def detect_service(method: str, path: str, headers: dict, query_params: dict) ->
                 "glue": "glue",
                 "athena": "athena",
                 "kinesis-firehose": "firehose",
+                "route53": "route53",
             }
             if svc_name in scope_map:
                 return scope_map[svc_name]
@@ -255,6 +260,8 @@ def detect_service(method: str, path: str, headers: dict, query_params: dict) ->
 
     # 4. Check URL path patterns
     path_lower = path.lower()
+    if path_lower.startswith("/2013-04-01/"):
+        return "route53"
     if path_lower.startswith("/v2/apis"):
         return "apigateway"
     if (path_lower.startswith("/restapis") or path_lower.startswith("/apikeys")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
 requires = ["setuptools>=68", "wheel"]
-build-backend = "setuptools.backends.legacy:build"
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "ministack"
-version = "0.1.0"
+version = "1.0.8"
 description = "Free, open-source local AWS emulator — drop-in LocalStack replacement"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/services/apigateway.py
+++ b/services/apigateway.py
@@ -66,11 +66,11 @@ _api_tags: dict = {}      # resource_arn -> {key -> value}
 
 def _apigw_response(data: dict, status: int = 200) -> tuple:
     """API Gateway v2 uses application/json (not application/x-amz-json-1.0)."""
-    return status, {"Content-Type": "application/json"}, json.dumps(data).encode()
+    return status, {"Content-Type": "application/json"}, json.dumps(data, ensure_ascii=False).encode("utf-8")
 
 
 def _apigw_error(code: str, message: str, status: int) -> tuple:
-    return status, {"Content-Type": "application/json"}, json.dumps({"message": message, "__type": code}).encode()
+    return status, {"Content-Type": "application/json"}, json.dumps({"message": message, "__type": code}, ensure_ascii=False).encode("utf-8")
 
 
 def _api_arn(api_id: str) -> str:
@@ -373,9 +373,9 @@ async def _invoke_lambda_proxy(integration, api_id, stage, path, method, headers
     resp_headers.update(lambda_response.get("headers", {}))
     resp_body = lambda_response.get("body", "")
     if isinstance(resp_body, str):
-        resp_body = resp_body.encode()
+        resp_body = resp_body.encode("utf-8")
     elif isinstance(resp_body, dict):
-        resp_body = json.dumps(resp_body).encode()
+        resp_body = json.dumps(resp_body, ensure_ascii=False).encode("utf-8")
 
     return status, resp_headers, resp_body
 

--- a/services/apigateway_v1.py
+++ b/services/apigateway_v1.py
@@ -108,11 +108,11 @@ def _new_id():
 
 def _v1_response(data, status=200):
     """API Gateway v1 uses application/json."""
-    return status, {"Content-Type": "application/json"}, json.dumps(data).encode()
+    return status, {"Content-Type": "application/json"}, json.dumps(data, ensure_ascii=False).encode("utf-8")
 
 
 def _v1_error(code, message, status):
-    return status, {"Content-Type": "application/json"}, json.dumps({"message": message, "type": code}).encode()
+    return status, {"Content-Type": "application/json"}, json.dumps({"message": message, "type": code}, ensure_ascii=False).encode("utf-8")
 
 
 def _rest_api_arn(api_id):
@@ -662,9 +662,9 @@ async def _invoke_lambda_proxy_v1(integration, api_id, stage_name, stage, resour
     resp_headers.update(lambda_response.get("headers", {}))
     resp_body = lambda_response.get("body", "")
     if isinstance(resp_body, str):
-        resp_body = resp_body.encode()
+        resp_body = resp_body.encode("utf-8")
     elif isinstance(resp_body, dict):
-        resp_body = json.dumps(resp_body).encode()
+        resp_body = json.dumps(resp_body, ensure_ascii=False).encode("utf-8")
 
     return status, resp_headers, resp_body
 

--- a/services/cloudwatch_logs.py
+++ b/services/cloudwatch_logs.py
@@ -389,9 +389,43 @@ def _get_log_events(data):
     })
 
 
+def _compile_filter_pattern(raw: str):
+    """Convert a CloudWatch Logs filterPattern to a matcher function.
+    Supports: empty (match all), quoted phrases, term inclusion (+term),
+    term exclusion (-term), and glob wildcards (* and ?)."""
+    if not raw:
+        return lambda msg: True
+    raw = raw.strip()
+    # JSON-style patterns (starts with {) — treat as match-all for emulation
+    if raw.startswith("{"):
+        return lambda msg: True
+    import fnmatch
+    terms = raw.split()
+    include = []
+    exclude = []
+    for t in terms:
+        if t.startswith("-"):
+            exclude.append(t[1:].strip('"').lower())
+        else:
+            include.append(t.lstrip("+").strip('"').lower())
+
+    def _matches(msg: str) -> bool:
+        m = msg.lower()
+        for p in include:
+            if not fnmatch.fnmatch(m, f"*{p}*") and p not in m:
+                return False
+        for p in exclude:
+            if fnmatch.fnmatch(m, f"*{p}*") or p in m:
+                return False
+        return True
+
+    return _matches
+
+
 def _filter_log_events(data):
     group = data.get("logGroupName")
-    pattern = data.get("filterPattern", "").lower()
+    raw_pattern = data.get("filterPattern", "")
+    pattern_fn = _compile_filter_pattern(raw_pattern)
     limit = min(data.get("limit", 10000), 10000)
     start_time = data.get("startTime")
     end_time = data.get("endTime")
@@ -418,7 +452,7 @@ def _filter_log_events(data):
                 continue
             if end_time is not None and ts > end_time:
                 continue
-            if pattern and pattern not in e.get("message", "").lower():
+            if not pattern_fn(e.get("message", "")):
                 continue
             events.append({**e, "logStreamName": sn})
             if len(events) >= limit:

--- a/services/dynamodb.py
+++ b/services/dynamodb.py
@@ -26,6 +26,7 @@ _tables: dict = {}
 _tags: dict = {}
 _ttl_settings: dict = {}
 _pitr_settings: dict = {}
+_lock = threading.Lock()
 
 # ---------------------------------------------------------------------------
 # TTL background reaper
@@ -37,30 +38,31 @@ def _ttl_reaper():
         time.sleep(60)
         now = time.time()
         try:
-            for table_name, setting in list(_ttl_settings.items()):
-                if setting.get("TimeToLiveStatus") != "ENABLED":
-                    continue
-                attr = setting.get("AttributeName", "")
-                if not attr:
-                    continue
-                table = _tables.get(table_name)
-                if not table:
-                    continue
-                for pk_val, sk_map in list(table["items"].items()):
-                    for sk_val, item in list(sk_map.items()):
-                        ttl_attr = item.get(attr)
-                        if ttl_attr is None:
-                            continue
-                        ttl_val = _extract_key_val(ttl_attr)
-                        try:
-                            if float(ttl_val) <= now:
-                                del sk_map[sk_val]
-                                logger.debug(f"TTL expired item {pk_val}/{sk_val} from {table_name}")
-                        except (ValueError, TypeError):
-                            pass
-                    if not sk_map:
-                        del table["items"][pk_val]
-                _update_counts(table)
+            with _lock:
+                for table_name, setting in list(_ttl_settings.items()):
+                    if setting.get("TimeToLiveStatus") != "ENABLED":
+                        continue
+                    attr = setting.get("AttributeName", "")
+                    if not attr:
+                        continue
+                    table = _tables.get(table_name)
+                    if not table:
+                        continue
+                    for pk_val, sk_map in list(table["items"].items()):
+                        for sk_val, item in list(sk_map.items()):
+                            ttl_attr = item.get(attr)
+                            if ttl_attr is None:
+                                continue
+                            ttl_val = _extract_key_val(ttl_attr)
+                            try:
+                                if float(ttl_val) <= now:
+                                    del sk_map[sk_val]
+                                    logger.debug(f"TTL expired item {pk_val}/{sk_val} from {table_name}")
+                            except (ValueError, TypeError):
+                                pass
+                        if not sk_map:
+                            del table["items"][pk_val]
+                    _update_counts(table)
         except Exception as exc:
             logger.error(f"TTL reaper error: {exc}")
 
@@ -1573,8 +1575,17 @@ def _extract_pk_from_condition(condition, attr_values, attr_names, pk_name):
 def _apply_exclusive_start_key(candidates, esk, pk_name, sk_name, scan_forward=True):
     if not esk or not candidates:
         return candidates
+    # Hash-only table: no sort key — find the item matching the PK and return everything after it
     if not sk_name or sk_name not in esk:
-        return []
+        start_pk = _extract_key_val(esk.get(pk_name, {}))
+        found = False
+        result = []
+        for item in candidates:
+            if found:
+                result.append(item)
+            elif _extract_key_val(item.get(pk_name, {})) == start_pk:
+                found = True
+        return result
     start_sk = esk[sk_name]
     result = []
     for item in candidates:
@@ -1683,7 +1694,8 @@ def _diff_attributes(old_item, new_item, return_old=True):
 
 
 def reset():
-    _tables.clear()
-    _tags.clear()
-    _ttl_settings.clear()
-    _pitr_settings.clear()
+    with _lock:
+        _tables.clear()
+        _tags.clear()
+        _ttl_settings.clear()
+        _pitr_settings.clear()

--- a/services/eventbridge.py
+++ b/services/eventbridge.py
@@ -13,6 +13,7 @@ Supports: CreateEventBus, DeleteEventBus, ListEventBuses, DescribeEventBus,
           ListApiDestinations, UpdateApiDestination.
 """
 
+import asyncio
 import json
 import time
 import hashlib
@@ -605,7 +606,7 @@ def _dispatch_to_lambda(arn, payload):
         event = {"body": payload}
 
     headers = {"x-amz-invocation-type": "Event"}
-    result = lambda_svc._invoke(func_name, event, headers)
+    result = asyncio.run(lambda_svc._invoke(func_name, event, headers))
     logger.info(f"EventBridge → Lambda {func_name}: status={result[0] if result else 'unknown'}")
 
 

--- a/services/lambda_svc.py
+++ b/services/lambda_svc.py
@@ -428,7 +428,7 @@ async def handle_request(method: str, path: str, headers: dict,
 
         raw_name = parts[3] if len(parts) > 3 else None
         if not raw_name:
-            return error_response_json("InvalidRequest", "Missing function name", 400)
+            return error_response_json("InvalidParameterValueException", "Missing function name", 400)
 
         func_name, path_qualifier = _resolve_name_and_qualifier(raw_name)
         sub = parts[4] if len(parts) > 4 else None
@@ -501,13 +501,7 @@ async def handle_request(method: str, path: str, headers: dict,
         if method == "PUT" and sub == "configuration":
             return _update_config(func_name, data)
 
-        if method == "GET":
-            return json_response({})
-
-    if method == "GET":
-        return json_response({})
-
-    return error_response_json("InvalidRequest", f"Unhandled Lambda path: {path}", 400)
+    return error_response_json("ResourceNotFoundException", f"Function not found: {path}", 404)
 
 
 # ---------------------------------------------------------------------------
@@ -736,7 +730,7 @@ async def _invoke(name: str, event: dict, headers: dict,
     if isinstance(payload, (str, bytes)):
         raw = payload.encode("utf-8") if isinstance(payload, str) else payload
         return 200, resp_headers, raw
-    return 200, resp_headers, json.dumps(payload).encode("utf-8")
+    return 200, resp_headers, json.dumps(payload, ensure_ascii=False).encode("utf-8")
 
 
 # ---------------------------------------------------------------------------

--- a/services/route53.py
+++ b/services/route53.py
@@ -1,0 +1,889 @@
+"""
+Amazon Route 53 Emulator.
+REST/XML API — service credential scope: route53.
+
+Supports:
+  Hosted Zones:   CreateHostedZone, GetHostedZone, DeleteHostedZone,
+                  ListHostedZones, ListHostedZonesByName,
+                  UpdateHostedZoneComment
+  Record Sets:    ChangeResourceRecordSets, ListResourceRecordSets
+  Changes:        GetChange
+  Health Checks:  CreateHealthCheck, GetHealthCheck, DeleteHealthCheck,
+                  ListHealthChecks, UpdateHealthCheck
+  Tags:           ChangeTagsForResource, ListTagsForResource
+
+Wire protocol:
+  All requests/responses use XML with namespace
+  https://route53.amazonaws.com/doc/2013-04-01/
+  Paths are under /2013-04-01/
+"""
+
+import re
+import string
+import logging
+import threading
+import random
+from datetime import datetime, timezone
+from xml.etree.ElementTree import Element, SubElement, tostring, fromstring
+
+from core.responses import new_uuid
+
+logger = logging.getLogger("route53")
+
+NS = "https://route53.amazonaws.com/doc/2013-04-01/"
+API_VERSION = "2013-04-01"
+
+# ─── in-memory state ──────────────────────────────────────────────────────────
+
+_zones: dict = {}           # zone_id -> zone dict
+_records: dict = {}         # zone_id -> list of record-set dicts
+_changes: dict = {}         # change_id -> change dict
+_health_checks: dict = {}   # hc_id -> health check dict
+_tags: dict = {}            # (resource_type, resource_id) -> {key: value}
+_caller_refs: dict = {}     # caller_reference -> zone_id (idempotency)
+_hc_caller_refs: dict = {}  # caller_reference -> hc_id
+_lock = threading.Lock()
+
+
+def reset():
+    global _zones, _records, _changes, _health_checks, _tags, _caller_refs, _hc_caller_refs
+    with _lock:
+        _zones = {}
+        _records = {}
+        _changes = {}
+        _health_checks = {}
+        _tags = {}
+        _caller_refs = {}
+        _hc_caller_refs = {}
+
+
+# ─── ID generators ────────────────────────────────────────────────────────────
+
+_ID_CHARS = string.ascii_uppercase + string.digits
+
+
+def _zone_id() -> str:
+    return "Z" + "".join(random.choices(_ID_CHARS, k=13))
+
+
+def _change_id() -> str:
+    return "C" + "".join(random.choices(_ID_CHARS, k=13))
+
+
+def _hc_id() -> str:
+    return new_uuid()
+
+
+# ─── XML helpers ─────────────────────────────────────────────────────────────
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def _xml_response(root_tag: str, builder_fn, status: int = 200) -> tuple:
+    root = Element(root_tag, xmlns=NS)
+    builder_fn(root)
+    body = b'<?xml version="1.0" encoding="UTF-8"?>\n' + tostring(root, encoding="unicode").encode("utf-8")
+    return status, {"Content-Type": "text/xml"}, body
+
+
+def _error_response(code: str, message: str, status: int = 400) -> tuple:
+    root = Element("ErrorResponse", xmlns=NS)
+    err = SubElement(root, "Error")
+    SubElement(err, "Type").text = "Sender"
+    SubElement(err, "Code").text = code
+    SubElement(err, "Message").text = message
+    SubElement(root, "RequestId").text = new_uuid()
+    body = b'<?xml version="1.0" encoding="UTF-8"?>\n' + tostring(root, encoding="unicode").encode("utf-8")
+    return status, {"Content-Type": "text/xml"}, body
+
+
+def _find(el, tag):
+    """Find child by local tag name ignoring namespace."""
+    for child in el:
+        local = child.tag.split("}")[-1] if "}" in child.tag else child.tag
+        if local == tag:
+            return child
+    return None
+
+
+def _findall(el, tag):
+    return [c for c in el if (c.tag.split("}")[-1] if "}" in c.tag else c.tag) == tag]
+
+
+def _text(el, tag, default=""):
+    child = _find(el, tag)
+    return child.text or default if child is not None else default
+
+
+def _parse_body(body: bytes):
+    if not body:
+        return None
+    try:
+        return fromstring(body.decode("utf-8"))
+    except Exception:
+        return None
+
+
+# ─── domain name helpers ──────────────────────────────────────────────────────
+
+def _normalise_name(name: str) -> str:
+    """Ensure domain name ends with a dot."""
+    if not name:
+        return name
+    return name if name.endswith(".") else name + "."
+
+
+# ─── default records (SOA + NS) ───────────────────────────────────────────────
+
+_DEFAULT_NS = [
+    "ns-1.awsdns-1.com.",
+    "ns-2.awsdns-2.net.",
+    "ns-3.awsdns-3.org.",
+    "ns-4.awsdns-4.co.uk.",
+]
+
+
+def _default_records(zone_name: str) -> list:
+    return [
+        {
+            "Name": zone_name,
+            "Type": "SOA",
+            "TTL": "900",
+            "ResourceRecords": [
+                f"{_DEFAULT_NS[0]} awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400"
+            ],
+        },
+        {
+            "Name": zone_name,
+            "Type": "NS",
+            "TTL": "172800",
+            "ResourceRecords": list(_DEFAULT_NS),
+        },
+    ]
+
+
+# ─── record set key (for uniqueness) ─────────────────────────────────────────
+
+def _rs_key(rs: dict) -> tuple:
+    return (rs["Name"], rs["Type"], rs.get("SetIdentifier", ""))
+
+
+# ─── XML builders for common structures ───────────────────────────────────────
+
+def _build_hosted_zone_el(parent: Element, zone: dict):
+    hz = SubElement(parent, "HostedZone")
+    SubElement(hz, "Id").text = f"/hostedzone/{zone['id']}"
+    SubElement(hz, "Name").text = zone["name"]
+    SubElement(hz, "CallerReference").text = zone["caller_reference"]
+    cfg = SubElement(hz, "Config")
+    SubElement(cfg, "Comment").text = zone.get("comment", "")
+    SubElement(cfg, "PrivateZone").text = "true" if zone.get("private") else "false"
+    SubElement(hz, "ResourceRecordSetCount").text = str(
+        len(_records.get(zone["id"], []))
+    )
+
+
+def _build_delegation_set_el(parent: Element, zone_name: str):
+    ds = SubElement(parent, "DelegationSet")
+    SubElement(ds, "NameServers")
+    ns_list = _find(ds, "NameServers")
+    for ns in _DEFAULT_NS:
+        SubElement(ns_list, "NameServer").text = ns
+
+
+def _build_change_info_el(parent: Element, change: dict):
+    ci = SubElement(parent, "ChangeInfo")
+    SubElement(ci, "Id").text = f"/change/{change['id']}"
+    SubElement(ci, "Status").text = change["status"]
+    SubElement(ci, "SubmittedAt").text = change["submitted_at"]
+    if change.get("comment"):
+        SubElement(ci, "Comment").text = change["comment"]
+
+
+def _build_record_set_el(parent: Element, rs: dict):
+    rrs = SubElement(parent, "ResourceRecordSet")
+    SubElement(rrs, "Name").text = rs["Name"]
+    SubElement(rrs, "Type").text = rs["Type"]
+    if rs.get("SetIdentifier"):
+        SubElement(rrs, "SetIdentifier").text = rs["SetIdentifier"]
+    if rs.get("Weight") is not None:
+        SubElement(rrs, "Weight").text = str(rs["Weight"])
+    if rs.get("Region"):
+        SubElement(rrs, "Region").text = rs["Region"]
+    if rs.get("Failover"):
+        SubElement(rrs, "Failover").text = rs["Failover"]
+    if rs.get("MultiValueAnswer") is not None:
+        SubElement(rrs, "MultiValueAnswer").text = str(rs["MultiValueAnswer"]).lower()
+    if rs.get("TTL") is not None:
+        SubElement(rrs, "TTL").text = str(rs["TTL"])
+    if rs.get("AliasTarget"):
+        at = SubElement(rrs, "AliasTarget")
+        SubElement(at, "HostedZoneId").text = rs["AliasTarget"].get("HostedZoneId", "")
+        SubElement(at, "DNSName").text = rs["AliasTarget"].get("DNSName", "")
+        SubElement(at, "EvaluateTargetHealth").text = str(
+            rs["AliasTarget"].get("EvaluateTargetHealth", False)
+        ).lower()
+    if rs.get("ResourceRecords"):
+        rr_list = SubElement(rrs, "ResourceRecords")
+        for val in rs["ResourceRecords"]:
+            rr = SubElement(rr_list, "ResourceRecord")
+            SubElement(rr, "Value").text = val
+    if rs.get("HealthCheckId"):
+        SubElement(rrs, "HealthCheckId").text = rs["HealthCheckId"]
+    if rs.get("GeoLocation"):
+        geo = SubElement(rrs, "GeoLocation")
+        gl = rs["GeoLocation"]
+        if gl.get("ContinentCode"):
+            SubElement(geo, "ContinentCode").text = gl["ContinentCode"]
+        if gl.get("CountryCode"):
+            SubElement(geo, "CountryCode").text = gl["CountryCode"]
+        if gl.get("SubdivisionCode"):
+            SubElement(geo, "SubdivisionCode").text = gl["SubdivisionCode"]
+    if rs.get("CidrRoutingConfig"):
+        crc = SubElement(rrs, "CidrRoutingConfig")
+        SubElement(crc, "CollectionId").text = rs["CidrRoutingConfig"].get("CollectionId", "")
+        SubElement(crc, "LocationName").text = rs["CidrRoutingConfig"].get("LocationName", "")
+
+
+# ─── record set XML parser ────────────────────────────────────────────────────
+
+def _parse_record_set(el) -> dict:
+    rs = {}
+    rs["Name"] = _normalise_name(_text(el, "Name"))
+    rs["Type"] = _text(el, "Type")
+    if _find(el, "SetIdentifier") is not None:
+        rs["SetIdentifier"] = _text(el, "SetIdentifier")
+    if _find(el, "Weight") is not None:
+        rs["Weight"] = int(_text(el, "Weight", "0"))
+    if _find(el, "Region") is not None:
+        rs["Region"] = _text(el, "Region")
+    if _find(el, "Failover") is not None:
+        rs["Failover"] = _text(el, "Failover")
+    if _find(el, "MultiValueAnswer") is not None:
+        rs["MultiValueAnswer"] = _text(el, "MultiValueAnswer").lower() == "true"
+    if _find(el, "TTL") is not None:
+        rs["TTL"] = _text(el, "TTL")
+    at_el = _find(el, "AliasTarget")
+    if at_el is not None:
+        dns_name = _text(at_el, "DNSName")
+        if dns_name and not dns_name.endswith("."):
+            dns_name += "."
+        rs["AliasTarget"] = {
+            "HostedZoneId": _text(at_el, "HostedZoneId"),
+            "DNSName": dns_name,
+            "EvaluateTargetHealth": _text(at_el, "EvaluateTargetHealth", "false").lower() == "true",
+        }
+    rr_container = _find(el, "ResourceRecords")
+    if rr_container is not None:
+        rs["ResourceRecords"] = [
+            _text(rr, "Value") for rr in _findall(rr_container, "ResourceRecord")
+        ]
+    if _find(el, "HealthCheckId") is not None:
+        rs["HealthCheckId"] = _text(el, "HealthCheckId")
+    geo_el = _find(el, "GeoLocation")
+    if geo_el is not None:
+        gl = {}
+        for field in ("ContinentCode", "CountryCode", "SubdivisionCode"):
+            if _find(geo_el, field) is not None:
+                gl[field] = _text(geo_el, field)
+        rs["GeoLocation"] = gl
+    crc_el = _find(el, "CidrRoutingConfig")
+    if crc_el is not None:
+        rs["CidrRoutingConfig"] = {
+            "CollectionId": _text(crc_el, "CollectionId"),
+            "LocationName": _text(crc_el, "LocationName"),
+        }
+    return rs
+
+
+# ─── health check XML builder ─────────────────────────────────────────────────
+
+def _build_health_check_el(parent: Element, hc: dict):
+    h = SubElement(parent, "HealthCheck")
+    SubElement(h, "Id").text = hc["id"]
+    SubElement(h, "CallerReference").text = hc["caller_reference"]
+    SubElement(h, "HealthCheckVersion").text = str(hc.get("version", 1))
+    cfg_el = SubElement(h, "HealthCheckConfig")
+    cfg = hc.get("config", {})
+    for field in (
+        "Type", "IPAddress", "Port", "FullyQualifiedDomainName", "ResourcePath",
+        "SearchString", "RequestInterval", "FailureThreshold", "MeasureLatency",
+        "EnableSNI", "Inverted", "Disabled", "HealthThreshold", "RoutingControlArn",
+        "InsufficientDataHealthStatus",
+    ):
+        if field in cfg:
+            SubElement(cfg_el, field).text = str(cfg[field])
+    if "ChildHealthChecks" in cfg:
+        chc = SubElement(cfg_el, "ChildHealthChecks")
+        for c in cfg["ChildHealthChecks"]:
+            SubElement(chc, "ChildHealthCheck").text = c
+    if "Regions" in cfg:
+        reg_el = SubElement(cfg_el, "Regions")
+        for r in cfg["Regions"]:
+            SubElement(reg_el, "Region").text = r
+    if "AlarmIdentifier" in cfg:
+        ai = SubElement(cfg_el, "AlarmIdentifier")
+        SubElement(ai, "Name").text = cfg["AlarmIdentifier"].get("Name", "")
+        SubElement(ai, "Region").text = cfg["AlarmIdentifier"].get("Region", "")
+
+
+def _parse_health_check_config(el) -> dict:
+    cfg = {}
+    for field in (
+        "Type", "IPAddress", "FullyQualifiedDomainName", "ResourcePath",
+        "SearchString", "InsufficientDataHealthStatus", "RoutingControlArn",
+    ):
+        if _find(el, field) is not None:
+            cfg[field] = _text(el, field)
+    for int_field in ("Port", "RequestInterval", "FailureThreshold", "HealthThreshold"):
+        if _find(el, int_field) is not None:
+            cfg[int_field] = int(_text(el, int_field, "0"))
+    for bool_field in ("MeasureLatency", "EnableSNI", "Inverted", "Disabled"):
+        if _find(el, bool_field) is not None:
+            cfg[bool_field] = _text(el, bool_field).lower() == "true"
+    chc_el = _find(el, "ChildHealthChecks")
+    if chc_el is not None:
+        cfg["ChildHealthChecks"] = [_text(c, "ChildHealthCheck") for c in _findall(chc_el, "ChildHealthCheck")]
+    reg_el = _find(el, "Regions")
+    if reg_el is not None:
+        cfg["Regions"] = [_text(r, "Region") for r in _findall(reg_el, "Region")]
+    ai_el = _find(el, "AlarmIdentifier")
+    if ai_el is not None:
+        cfg["AlarmIdentifier"] = {
+            "Name": _text(ai_el, "Name"),
+            "Region": _text(ai_el, "Region"),
+        }
+    return cfg
+
+
+# ─── operations ──────────────────────────────────────────────────────────────
+
+def _create_hosted_zone(body: bytes, query_params: dict):
+    root = _parse_body(body)
+    if root is None:
+        return _error_response("InvalidInput", "Missing or invalid request body.")
+
+    caller_ref = _text(root, "CallerReference")
+    name = _normalise_name(_text(root, "Name"))
+    if not name or not caller_ref:
+        return _error_response("InvalidInput", "Name and CallerReference are required.")
+
+    cfg_el = _find(root, "HostedZoneConfig")
+    comment = _text(cfg_el, "Comment") if cfg_el is not None else ""
+    private = _text(cfg_el, "PrivateZone", "false").lower() == "true" if cfg_el is not None else False
+
+    with _lock:
+        if caller_ref in _caller_refs:
+            existing_id = _caller_refs[caller_ref]
+            zone = _zones[existing_id]
+            change = {"id": _change_id(), "status": "INSYNC", "submitted_at": _now_iso(), "comment": ""}
+            def build(root):
+                _build_hosted_zone_el(root, zone)
+                _build_change_info_el(root, change)
+                _build_delegation_set_el(root, zone["name"])
+            return _xml_response("CreateHostedZoneResponse", build, 201)
+
+        zone_id = _zone_id()
+        zone = {
+            "id": zone_id,
+            "name": name,
+            "caller_reference": caller_ref,
+            "comment": comment,
+            "private": private,
+        }
+        _zones[zone_id] = zone
+        _records[zone_id] = _default_records(name)
+        _caller_refs[caller_ref] = zone_id
+
+        change_id = _change_id()
+        change = {"id": change_id, "status": "INSYNC", "submitted_at": _now_iso(), "comment": ""}
+        _changes[change_id] = change
+
+    def build(root):
+        _build_hosted_zone_el(root, zone)
+        _build_change_info_el(root, change)
+        _build_delegation_set_el(root, name)
+
+    return _xml_response("CreateHostedZoneResponse", build, 201)
+
+
+def _get_hosted_zone(zone_id: str):
+    with _lock:
+        zone = _zones.get(zone_id)
+    if not zone:
+        return _error_response("NoSuchHostedZone", f"No hosted zone found with ID: {zone_id}", 404)
+
+    def build(root):
+        _build_hosted_zone_el(root, zone)
+        _build_delegation_set_el(root, zone["name"])
+
+    return _xml_response("GetHostedZoneResponse", build)
+
+
+def _delete_hosted_zone(zone_id: str):
+    with _lock:
+        zone = _zones.get(zone_id)
+        if not zone:
+            return _error_response("NoSuchHostedZone", f"No hosted zone found with ID: {zone_id}", 404)
+        recs = _records.get(zone_id, [])
+        non_default = [r for r in recs if not (r["Type"] in ("SOA", "NS") and r["Name"] == zone["name"])]
+        if non_default:
+            return _error_response(
+                "HostedZoneNotEmpty",
+                "The hosted zone contains resource record sets other than the default SOA and NS records.",
+            )
+        del _zones[zone_id]
+        del _records[zone_id]
+        _caller_refs.pop(zone.get("caller_reference", ""), None)
+        change_id = _change_id()
+        change = {"id": change_id, "status": "INSYNC", "submitted_at": _now_iso(), "comment": ""}
+        _changes[change_id] = change
+
+    def build(root):
+        _build_change_info_el(root, change)
+
+    return _xml_response("DeleteHostedZoneResponse", build)
+
+
+def _list_hosted_zones(query_params: dict):
+    marker = (query_params.get("marker") or [""])[0] if isinstance(query_params.get("marker"), list) else query_params.get("marker", "")
+    max_items = int((query_params.get("maxitems") or ["100"])[0] if isinstance(query_params.get("maxitems"), list) else query_params.get("maxitems", 100))
+    max_items = min(max_items, 100)
+
+    with _lock:
+        zones = sorted(_zones.values(), key=lambda z: z["id"])
+
+    if marker:
+        zones = [z for z in zones if z["id"] > marker]
+
+    is_truncated = len(zones) > max_items
+    page = zones[:max_items]
+    next_marker = page[-1]["id"] if is_truncated else None
+
+    def build(root):
+        hz_list = SubElement(root, "HostedZones")
+        for zone in page:
+            _build_hosted_zone_el(hz_list, zone)
+        SubElement(root, "IsTruncated").text = str(is_truncated).lower()
+        SubElement(root, "Marker").text = marker or ""
+        SubElement(root, "MaxItems").text = str(max_items)
+        if next_marker:
+            SubElement(root, "NextMarker").text = next_marker
+
+    return _xml_response("ListHostedZonesResponse", build)
+
+
+def _list_hosted_zones_by_name(query_params: dict):
+    def _qp(key):
+        v = query_params.get(key, "")
+        return (v[0] if isinstance(v, list) else v) or ""
+
+    dns_name = _normalise_name(_qp("dnsname")) if _qp("dnsname") else ""
+    hz_id = _qp("hostedzoneid")
+    max_items = min(int(_qp("maxitems") or 100), 100)
+
+    with _lock:
+        zones = sorted(_zones.values(), key=lambda z: z["name"])
+
+    if dns_name:
+        zones = [z for z in zones if z["name"] >= dns_name]
+    if hz_id:
+        zones = [z for z in zones if z["id"] >= hz_id]
+
+    is_truncated = len(zones) > max_items
+    page = zones[:max_items]
+    next_dns = page[-1]["name"] if is_truncated else None
+    next_hz = page[-1]["id"] if is_truncated else None
+
+    def build(root):
+        SubElement(root, "DNSName").text = dns_name
+        SubElement(root, "HostedZoneId").text = hz_id
+        hz_list = SubElement(root, "HostedZones")
+        for zone in page:
+            _build_hosted_zone_el(hz_list, zone)
+        SubElement(root, "IsTruncated").text = str(is_truncated).lower()
+        SubElement(root, "MaxItems").text = str(max_items)
+        if next_dns:
+            SubElement(root, "NextDNSName").text = next_dns
+        if next_hz:
+            SubElement(root, "NextHostedZoneId").text = next_hz
+
+    return _xml_response("ListHostedZonesByNameResponse", build)
+
+
+def _update_hosted_zone_comment(zone_id: str, body: bytes):
+    root = _parse_body(body)
+    if root is None:
+        return _error_response("InvalidInput", "Missing or invalid request body.")
+    with _lock:
+        zone = _zones.get(zone_id)
+        if not zone:
+            return _error_response("NoSuchHostedZone", f"No hosted zone found with ID: {zone_id}", 404)
+        cfg_el = _find(root, "Comment")
+        if cfg_el is not None:
+            zone["comment"] = cfg_el.text or ""
+
+    def build(root):
+        _build_hosted_zone_el(root, zone)
+
+    return _xml_response("UpdateHostedZoneCommentResponse", build)
+
+
+def _change_resource_record_sets(zone_id: str, body: bytes):
+    root = _parse_body(body)
+    if root is None:
+        return _error_response("InvalidInput", "Missing or invalid request body.")
+
+    with _lock:
+        zone = _zones.get(zone_id)
+        if not zone:
+            return _error_response("NoSuchHostedZone", f"No hosted zone found with ID: {zone_id}", 404)
+
+        batch_el = _find(root, "ChangeBatch")
+        if batch_el is None:
+            return _error_response("InvalidInput", "Missing ChangeBatch element.")
+        comment = _text(batch_el, "Comment")
+        changes_el = _find(batch_el, "Changes")
+        if changes_el is None:
+            return _error_response("InvalidInput", "Missing Changes element.")
+
+        ops = []
+        for change_el in _findall(changes_el, "Change"):
+            action = _text(change_el, "Action")
+            rs_el = _find(change_el, "ResourceRecordSet")
+            if rs_el is None:
+                return _error_response("InvalidInput", "Missing ResourceRecordSet element.")
+            rs = _parse_record_set(rs_el)
+            if not rs.get("Name") or not rs.get("Type"):
+                return _error_response("InvalidInput", "Name and Type are required in ResourceRecordSet.")
+            ops.append((action, rs))
+
+        current = list(_records[zone_id])
+
+        for action, rs in ops:
+            key = _rs_key(rs)
+            existing = next((r for r in current if _rs_key(r) == key), None)
+
+            if action == "CREATE":
+                if existing:
+                    return _error_response(
+                        "InvalidChangeBatch",
+                        f"Tried to create resource record set {rs['Name']} type {rs['Type']} but it already exists.",
+                    )
+                current.append(rs)
+
+            elif action == "DELETE":
+                if not existing:
+                    return _error_response(
+                        "InvalidChangeBatch",
+                        f"Tried to delete resource record set {rs['Name']} type {rs['Type']} but it does not exist.",
+                    )
+                current = [r for r in current if _rs_key(r) != key]
+
+            elif action == "UPSERT":
+                if existing:
+                    current = [rs if _rs_key(r) == key else r for r in current]
+                else:
+                    current.append(rs)
+            else:
+                return _error_response("InvalidInput", f"Unknown action: {action}")
+
+        _records[zone_id] = current
+        change_id = _change_id()
+        change = {"id": change_id, "status": "INSYNC", "submitted_at": _now_iso(), "comment": comment}
+        _changes[change_id] = change
+
+    def build(root):
+        _build_change_info_el(root, change)
+
+    return _xml_response("ChangeResourceRecordSetsResponse", build)
+
+
+def _list_resource_record_sets(zone_id: str, query_params: dict):
+    def _qp(key):
+        v = query_params.get(key, "")
+        return (v[0] if isinstance(v, list) else v) or ""
+
+    start_name = _normalise_name(_qp("name")) if _qp("name") else ""
+    start_type = _qp("type")
+    start_id = _qp("identifier")
+    max_items = min(int(_qp("maxitems") or 300), 300)
+
+    with _lock:
+        zone = _zones.get(zone_id)
+        if not zone:
+            return _error_response("NoSuchHostedZone", f"No hosted zone found with ID: {zone_id}", 404)
+        records = list(_records.get(zone_id, []))
+
+    records.sort(key=lambda r: (r["Name"], r["Type"], r.get("SetIdentifier", "")))
+
+    if start_name:
+        records = [r for r in records if (r["Name"], r["Type"], r.get("SetIdentifier", ""))
+                   >= (start_name, start_type, start_id)]
+
+    is_truncated = len(records) > max_items
+    page = records[:max_items]
+    next_name = page[-1]["Name"] if is_truncated else None
+    next_type = page[-1]["Type"] if is_truncated else None
+    next_id = page[-1].get("SetIdentifier", "") if is_truncated else None
+
+    def build(root):
+        rrs_list = SubElement(root, "ResourceRecordSets")
+        for rs in page:
+            _build_record_set_el(rrs_list, rs)
+        SubElement(root, "IsTruncated").text = str(is_truncated).lower()
+        SubElement(root, "MaxItems").text = str(max_items)
+        if next_name:
+            SubElement(root, "NextRecordName").text = next_name
+        if next_type:
+            SubElement(root, "NextRecordType").text = next_type
+        if next_id:
+            SubElement(root, "NextRecordIdentifier").text = next_id
+
+    return _xml_response("ListResourceRecordSetsResponse", build)
+
+
+def _get_change(change_id: str):
+    with _lock:
+        change = _changes.get(change_id)
+    if not change:
+        return _error_response("NoSuchChange", f"A change with the ID {change_id} does not exist.", 404)
+
+    def build(root):
+        _build_change_info_el(root, change)
+
+    return _xml_response("GetChangeResponse", build)
+
+
+# ─── health checks ────────────────────────────────────────────────────────────
+
+def _create_health_check(body: bytes):
+    root = _parse_body(body)
+    if root is None:
+        return _error_response("InvalidInput", "Missing or invalid request body.")
+
+    caller_ref = _text(root, "CallerReference")
+    if not caller_ref:
+        return _error_response("InvalidInput", "CallerReference is required.")
+
+    cfg_el = _find(root, "HealthCheckConfig")
+    cfg = _parse_health_check_config(cfg_el) if cfg_el is not None else {}
+
+    with _lock:
+        if caller_ref in _hc_caller_refs:
+            hc = _health_checks[_hc_caller_refs[caller_ref]]
+            def build(root):
+                _build_health_check_el(root, hc)
+            return _xml_response("CreateHealthCheckResponse", build, 201)
+
+        hc_id = _hc_id()
+        hc = {"id": hc_id, "caller_reference": caller_ref, "config": cfg, "version": 1}
+        _health_checks[hc_id] = hc
+        _hc_caller_refs[caller_ref] = hc_id
+
+    def build(root):
+        _build_health_check_el(root, hc)
+
+    return _xml_response("CreateHealthCheckResponse", build, 201)
+
+
+def _get_health_check(hc_id: str):
+    with _lock:
+        hc = _health_checks.get(hc_id)
+    if not hc:
+        return _error_response("NoSuchHealthCheck", f"No health check exists with the specified ID {hc_id}.", 404)
+
+    def build(root):
+        _build_health_check_el(root, hc)
+
+    return _xml_response("GetHealthCheckResponse", build)
+
+
+def _delete_health_check(hc_id: str):
+    with _lock:
+        if hc_id not in _health_checks:
+            return _error_response("NoSuchHealthCheck", f"No health check exists with the specified ID {hc_id}.", 404)
+        hc = _health_checks.pop(hc_id)
+        _hc_caller_refs.pop(hc.get("caller_reference", ""), None)
+
+    return _xml_response("DeleteHealthCheckResponse", lambda root: None)
+
+
+def _list_health_checks(query_params: dict):
+    def _qp(key):
+        v = query_params.get(key, "")
+        return (v[0] if isinstance(v, list) else v) or ""
+
+    marker = _qp("marker")
+    max_items = min(int(_qp("maxitems") or 100), 1000)
+
+    with _lock:
+        checks = sorted(_health_checks.values(), key=lambda h: h["id"])
+
+    if marker:
+        checks = [h for h in checks if h["id"] > marker]
+
+    is_truncated = len(checks) > max_items
+    page = checks[:max_items]
+    next_marker = page[-1]["id"] if is_truncated else None
+
+    def build(root):
+        hc_list = SubElement(root, "HealthChecks")
+        for hc in page:
+            _build_health_check_el(hc_list, hc)
+        SubElement(root, "IsTruncated").text = str(is_truncated).lower()
+        SubElement(root, "Marker").text = marker
+        SubElement(root, "MaxItems").text = str(max_items)
+        if next_marker:
+            SubElement(root, "NextMarker").text = next_marker
+
+    return _xml_response("ListHealthChecksResponse", build)
+
+
+def _update_health_check(hc_id: str, body: bytes):
+    root = _parse_body(body)
+    if root is None:
+        return _error_response("InvalidInput", "Missing or invalid request body.")
+    with _lock:
+        hc = _health_checks.get(hc_id)
+        if not hc:
+            return _error_response("NoSuchHealthCheck", f"No health check exists with the specified ID {hc_id}.", 404)
+        updates = _parse_health_check_config(root)
+        hc["config"] = {**hc["config"], **updates}
+        hc["version"] = hc.get("version", 1) + 1
+
+    def build(root):
+        _build_health_check_el(root, hc)
+
+    return _xml_response("UpdateHealthCheckResponse", build)
+
+
+# ─── tags ─────────────────────────────────────────────────────────────────────
+
+def _change_tags_for_resource(resource_type: str, resource_id: str, body: bytes):
+    root = _parse_body(body)
+    if root is None:
+        return _error_response("InvalidInput", "Missing or invalid request body.")
+
+    with _lock:
+        if resource_type == "hostedzone" and resource_id not in _zones:
+            return _error_response("NoSuchHostedZone", f"No hosted zone found with ID: {resource_id}", 404)
+        if resource_type == "healthcheck" and resource_id not in _health_checks:
+            return _error_response("NoSuchHealthCheck", f"No health check exists with the specified ID {resource_id}.", 404)
+
+        key = (resource_type, resource_id)
+        if key not in _tags:
+            _tags[key] = {}
+
+        add_el = _find(root, "AddTags")
+        if add_el is not None:
+            for tag_el in _findall(add_el, "Tag"):
+                k = _text(tag_el, "Key")
+                v = _text(tag_el, "Value")
+                if k:
+                    _tags[key][k] = v
+
+        remove_el = _find(root, "RemoveTagKeys")
+        if remove_el is not None:
+            for key_el in _findall(remove_el, "Key"):
+                _tags[key].pop(key_el.text or "", None)
+
+    return _xml_response("ChangeTagsForResourceResponse", lambda root: None)
+
+
+def _list_tags_for_resource(resource_type: str, resource_id: str):
+    with _lock:
+        if resource_type == "hostedzone" and resource_id not in _zones:
+            return _error_response("NoSuchHostedZone", f"No hosted zone found with ID: {resource_id}", 404)
+        if resource_type == "healthcheck" and resource_id not in _health_checks:
+            return _error_response("NoSuchHealthCheck", f"No health check exists with the specified ID {resource_id}.", 404)
+        tag_map = dict(_tags.get((resource_type, resource_id), {}))
+
+    def build(root):
+        rts = SubElement(root, "ResourceTagSet")
+        SubElement(rts, "ResourceType").text = resource_type
+        SubElement(rts, "ResourceId").text = resource_id
+        tags_el = SubElement(rts, "Tags")
+        for k, v in tag_map.items():
+            tag_el = SubElement(tags_el, "Tag")
+            SubElement(tag_el, "Key").text = k
+            SubElement(tag_el, "Value").text = v
+
+    return _xml_response("ListTagsForResourceResponse", build)
+
+
+# ─── request router ───────────────────────────────────────────────────────────
+
+async def handle_request(method, path, headers, body, query_params):
+    # Strip /2013-04-01 prefix
+    p = path
+    if p.startswith(f"/{API_VERSION}"):
+        p = p[len(f"/{API_VERSION}"):]
+
+    # POST /hostedzone
+    if method == "POST" and p == "/hostedzone":
+        return _create_hosted_zone(body, query_params)
+
+    # GET /hostedzone
+    if method == "GET" and p == "/hostedzone":
+        return _list_hosted_zones(query_params)
+
+    # GET /hostedzonesbyname
+    if method == "GET" and p == "/hostedzonesbyname":
+        return _list_hosted_zones_by_name(query_params)
+
+    # GET|DELETE|POST /hostedzone/{id}
+    m = re.match(r"^/hostedzone/([^/]+)$", p)
+    if m:
+        zone_id = m.group(1)
+        if method == "GET":
+            return _get_hosted_zone(zone_id)
+        if method == "DELETE":
+            return _delete_hosted_zone(zone_id)
+        if method == "POST":
+            return _update_hosted_zone_comment(zone_id, body)
+
+    # POST /hostedzone/{id}/rrset/
+    m = re.match(r"^/hostedzone/([^/]+)/rrset/?$", p)
+    if m:
+        zone_id = m.group(1)
+        if method == "POST":
+            return _change_resource_record_sets(zone_id, body)
+        if method == "GET":
+            return _list_resource_record_sets(zone_id, query_params)
+
+    # GET /change/{id}
+    m = re.match(r"^/change/([^/]+)$", p)
+    if m and method == "GET":
+        return _get_change(m.group(1))
+
+    # POST /healthcheck
+    if method == "POST" and p == "/healthcheck":
+        return _create_health_check(body)
+
+    # GET /healthcheck
+    if method == "GET" and p == "/healthcheck":
+        return _list_health_checks(query_params)
+
+    # GET|DELETE|POST /healthcheck/{id}
+    m = re.match(r"^/healthcheck/([^/]+)$", p)
+    if m:
+        hc_id = m.group(1)
+        if method == "GET":
+            return _get_health_check(hc_id)
+        if method == "DELETE":
+            return _delete_health_check(hc_id)
+        if method == "POST":
+            return _update_health_check(hc_id, body)
+
+    # POST /tags/{resourceType}/{resourceId}
+    m = re.match(r"^/tags/([^/]+)/([^/]+)$", p)
+    if m:
+        resource_type, resource_id = m.group(1), m.group(2)
+        if method == "POST":
+            return _change_tags_for_resource(resource_type, resource_id, body)
+        if method == "GET":
+            return _list_tags_for_resource(resource_type, resource_id)
+
+    return _error_response("InvalidInput", f"Unknown Route53 endpoint: {method} {path}", 400)

--- a/services/s3.py
+++ b/services/s3.py
@@ -438,7 +438,7 @@ def _create_bucket(name: str, body: bytes):
     _buckets[name] = {"created": now_iso(), "objects": {}, "region": region}
     if PERSIST:
         os.makedirs(os.path.join(DATA_DIR, name), exist_ok=True)
-    return 200, {"Content-Type": "application/xml", "Location": f"/{name}"}, b""
+    return 200, {"Location": f"/{name}"}, b""
 
 
 def _delete_bucket(name: str):
@@ -1060,7 +1060,7 @@ def _put_object(bucket_name: str, key: str, body: bytes, headers: dict):
     _fire_s3_event_async(bucket_name, key, "s3:ObjectCreated:Put",
                          size=obj["size"], etag=obj["etag"])
 
-    return 200, {"ETag": obj["etag"], "Content-Type": "application/xml"}, b""
+    return 200, {"ETag": obj["etag"]}, b""
 
 
 def _get_object(bucket_name: str, key: str, headers: dict):
@@ -1122,7 +1122,10 @@ def _delete_object(bucket_name: str, key: str):
     if existed:
         _fire_s3_event_async(bucket_name, key, "s3:ObjectRemoved:Delete")
 
-    return 204, {"x-amz-delete-marker": "false"}, b""
+    versioning = _bucket_versioning.get(bucket_name, {}).get("Status", "")
+    if versioning in ("Enabled", "Suspended"):
+        return 204, {"x-amz-delete-marker": "true", "x-amz-version-id": "null"}, b""
+    return 204, {}, b""
 
 
 def _copy_object(bucket_name: str, dest_key: str, headers: dict):

--- a/services/sns.py
+++ b/services/sns.py
@@ -483,7 +483,7 @@ def _fanout(topic_arn: str, msg_id: str, message: str, subject: str,
                 _deliver_to_http(endpoint, envelope)
             )
         elif protocol == "lambda":
-            _deliver_to_lambda(endpoint, envelope, topic_arn, msg_id, effective_message, message_attributes or {})
+            _deliver_to_lambda(endpoint, envelope, topic_arn, sub["arn"], msg_id, effective_message, message_attributes or {})
         elif protocol == "email" or protocol == "email-json":
             logger.info(f"SNS fanout → email {endpoint} (stub)")
         elif protocol == "sms":
@@ -516,8 +516,8 @@ def _deliver_to_sqs(endpoint: str, envelope: str, raw: bool, raw_message: str):
     logger.info(f"SNS fanout → SQS {queue_name}")
 
 
-def _deliver_to_lambda(endpoint: str, envelope: str, topic_arn: str, msg_id: str,
-                       raw_message: str, message_attributes: dict):
+def _deliver_to_lambda(endpoint: str, envelope: str, topic_arn: str, sub_arn: str,
+                       msg_id: str, raw_message: str, message_attributes: dict):
     """Invoke a Lambda function with the SNS Records envelope (AWS format)."""
     # endpoint is a Lambda ARN: arn:aws:lambda:region:account:function:name
     func_name = endpoint.split(":")[-1]
@@ -529,7 +529,7 @@ def _deliver_to_lambda(endpoint: str, envelope: str, topic_arn: str, msg_id: str
         "Records": [
             {
                 "EventVersion": "1.0",
-                "EventSubscriptionArn": f"{topic_arn}:subscription",
+                "EventSubscriptionArn": sub_arn,
                 "EventSource": "aws:sns",
                 "Sns": json.loads(envelope),
             }

--- a/services/sqs.py
+++ b/services/sqs.py
@@ -485,7 +485,12 @@ def _act_delete_message_batch(data: dict, qurl: str) -> dict:
         if len(q["messages"]) < before:
             ok.append({"Id": eid})
         else:
-            ok.append({"Id": eid})
+            fail.append({
+                "Id": eid,
+                "Code": "ReceiptHandleIsInvalid",
+                "Message": "The input receipt handle is invalid.",
+                "SenderFault": True,
+            })
     return {"Successful": ok, "Failed": fail}
 
 

--- a/services/stepfunctions.py
+++ b/services/stepfunctions.py
@@ -16,6 +16,7 @@ Executions run in background threads and transition through RUNNING ->
 SUCCEEDED / FAILED / TIMED_OUT / ABORTED.
 """
 
+import asyncio
 import copy
 import json
 import logging
@@ -753,7 +754,7 @@ def _call_lambda(func_name, event):
         logger.warning("lambda_svc unavailable; returning passthrough for %s", func_name)
         return event
 
-    status, headers, body = lambda_svc._invoke(func_name, event, {})
+    status, headers, body = asyncio.run(lambda_svc._invoke(func_name, event, {}))
 
     if headers.get("X-Amz-Function-Error"):
         try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -130,6 +130,10 @@ def apigw_v1():
     return make_client("apigateway")
 
 @pytest.fixture(scope="session")
+def r53():
+    return make_client("route53")
+
+@pytest.fixture(scope="session")
 def sfn_sync():
     """SFN client for StartSyncExecution — forces same endpoint (boto3 normally prefixes sync-)."""
     from botocore.config import Config as BotoConfig

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -114,13 +114,6 @@ def test_s3_delete_object_idempotent(s3):
     resp = s3.delete_object(Bucket="intg-s3-delidempotent", Key="nonexistent.txt")
     assert resp["ResponseMetadata"]["HTTPStatusCode"] == 204
 
-def test_s3_delete_object(s3):
-    s3.create_bucket(Bucket="intg-s3-delobj")
-    s3.put_object(Bucket="intg-s3-delobj", Key="bye.txt", Body=b"bye")
-    s3.delete_object(Bucket="intg-s3-delobj", Key="bye.txt")
-    with pytest.raises(ClientError):
-        s3.get_object(Bucket="intg-s3-delobj", Key="bye.txt")
-
 def test_s3_copy_object(s3):
     s3.create_bucket(Bucket="intg-s3-copysrc")
     s3.create_bucket(Bucket="intg-s3-copydst")
@@ -345,28 +338,6 @@ def test_s3_object_tagging(s3):
 
 # ========== SQS ==========
 
-
-def test_sqs_create_queue(sqs):
-    resp = sqs.create_queue(QueueName="intg-sqs-create")
-    assert "QueueUrl" in resp
-    assert "intg-sqs-create" in resp["QueueUrl"]
-
-
-def test_sqs_delete_queue(sqs):
-    url = sqs.create_queue(QueueName="intg-sqs-delete")["QueueUrl"]
-    sqs.delete_queue(QueueUrl=url)
-    with pytest.raises(ClientError):
-        sqs.get_queue_attributes(QueueUrl=url, AttributeNames=["All"])
-
-
-def test_sqs_list_queues(sqs):
-    sqs.create_queue(QueueName="intg-sqs-list-alpha")
-    sqs.create_queue(QueueName="intg-sqs-list-beta")
-    resp = sqs.list_queues(QueueNamePrefix="intg-sqs-list-")
-    urls = resp.get("QueueUrls", [])
-    assert len(urls) >= 2
-    assert any("intg-sqs-list-alpha" in u for u in urls)
-    assert any("intg-sqs-list-beta" in u for u in urls)
 
 def test_sqs_create_queue(sqs):
     resp = sqs.create_queue(QueueName="intg-sqs-create")
@@ -7581,3 +7552,567 @@ def test_firehose_update_destination_replaces_on_type_change(fh):
     dest = desc2["Destinations"][0]
     assert "HttpEndpointDestinationDescription" in dest
     assert "ExtendedS3DestinationDescription" not in dest
+
+
+# ========== Route53 ==========
+
+
+def test_route53_create_and_get_hosted_zone(r53):
+    resp = r53.create_hosted_zone(
+        Name="example.com",
+        CallerReference="ref-create-1",
+    )
+    assert resp["ResponseMetadata"]["HTTPStatusCode"] == 201
+    hz = resp["HostedZone"]
+    zone_id = hz["Id"].split("/")[-1]
+    assert hz["Name"] == "example.com."
+    assert "DelegationSet" in resp
+    assert len(resp["DelegationSet"]["NameServers"]) == 4
+
+    get_resp = r53.get_hosted_zone(Id=zone_id)
+    assert get_resp["HostedZone"]["Name"] == "example.com."
+    assert get_resp["HostedZone"]["ResourceRecordSetCount"] == 2  # SOA + NS
+
+
+def test_route53_create_zone_idempotency(r53):
+    r53.create_hosted_zone(Name="idempotent.com", CallerReference="ref-idem-1")
+    resp2 = r53.create_hosted_zone(Name="idempotent.com", CallerReference="ref-idem-1")
+    # Same CallerReference → same zone returned, not a new one
+    assert resp2["HostedZone"]["Name"] == "idempotent.com."
+
+
+def test_route53_list_hosted_zones(r53):
+    r53.create_hosted_zone(Name="list-test.com", CallerReference="ref-list-1")
+    resp = r53.list_hosted_zones()
+    names = [hz["Name"] for hz in resp["HostedZones"]]
+    assert "list-test.com." in names
+
+
+def test_route53_list_hosted_zones_by_name(r53):
+    r53.create_hosted_zone(Name="byname-alpha.com", CallerReference="ref-bn-1")
+    r53.create_hosted_zone(Name="byname-beta.com", CallerReference="ref-bn-2")
+    resp = r53.list_hosted_zones_by_name(DNSName="byname-alpha.com")
+    assert resp["HostedZones"][0]["Name"] == "byname-alpha.com."
+
+
+def test_route53_delete_hosted_zone(r53):
+    resp = r53.create_hosted_zone(Name="delete-me.com", CallerReference="ref-del-1")
+    zone_id = resp["HostedZone"]["Id"].split("/")[-1]
+
+    # Must remove non-default records first (none here, just SOA+NS which are auto-removed)
+    r53.delete_hosted_zone(Id=zone_id)
+
+    import botocore.exceptions
+    with pytest.raises(botocore.exceptions.ClientError) as exc:
+        r53.get_hosted_zone(Id=zone_id)
+    assert exc.value.response["Error"]["Code"] == "NoSuchHostedZone"
+
+
+def test_route53_change_resource_record_sets_create(r53):
+    resp = r53.create_hosted_zone(Name="records.com", CallerReference="ref-rrs-1")
+    zone_id = resp["HostedZone"]["Id"].split("/")[-1]
+
+    change_resp = r53.change_resource_record_sets(
+        HostedZoneId=zone_id,
+        ChangeBatch={
+            "Changes": [
+                {
+                    "Action": "CREATE",
+                    "ResourceRecordSet": {
+                        "Name": "www.records.com",
+                        "Type": "A",
+                        "TTL": 300,
+                        "ResourceRecords": [{"Value": "1.2.3.4"}],
+                    },
+                }
+            ]
+        },
+    )
+    assert change_resp["ChangeInfo"]["Status"] == "INSYNC"
+
+
+def test_route53_list_resource_record_sets(r53):
+    resp = r53.create_hosted_zone(Name="listrrs.com", CallerReference="ref-lrrs-1")
+    zone_id = resp["HostedZone"]["Id"].split("/")[-1]
+
+    r53.change_resource_record_sets(
+        HostedZoneId=zone_id,
+        ChangeBatch={
+            "Changes": [
+                {
+                    "Action": "CREATE",
+                    "ResourceRecordSet": {
+                        "Name": "mail.listrrs.com",
+                        "Type": "MX",
+                        "TTL": 300,
+                        "ResourceRecords": [{"Value": "10 mail.example.com."}],
+                    },
+                }
+            ]
+        },
+    )
+    list_resp = r53.list_resource_record_sets(HostedZoneId=zone_id)
+    types = [rrs["Type"] for rrs in list_resp["ResourceRecordSets"]]
+    assert "MX" in types
+    assert "SOA" in types
+    assert "NS" in types
+
+
+def test_route53_upsert_record(r53):
+    resp = r53.create_hosted_zone(Name="upsert.com", CallerReference="ref-ups-1")
+    zone_id = resp["HostedZone"]["Id"].split("/")[-1]
+
+    for ip in ("1.1.1.1", "2.2.2.2"):
+        r53.change_resource_record_sets(
+            HostedZoneId=zone_id,
+            ChangeBatch={
+                "Changes": [
+                    {
+                        "Action": "UPSERT",
+                        "ResourceRecordSet": {
+                            "Name": "www.upsert.com",
+                            "Type": "A",
+                            "TTL": 60,
+                            "ResourceRecords": [{"Value": ip}],
+                        },
+                    }
+                ]
+            },
+        )
+
+    list_resp = r53.list_resource_record_sets(HostedZoneId=zone_id)
+    a_records = [rrs for rrs in list_resp["ResourceRecordSets"] if rrs["Type"] == "A"]
+    assert len(a_records) == 1
+    assert a_records[0]["ResourceRecords"][0]["Value"] == "2.2.2.2"
+
+
+def test_route53_delete_record(r53):
+    resp = r53.create_hosted_zone(Name="delrec.com", CallerReference="ref-dr-1")
+    zone_id = resp["HostedZone"]["Id"].split("/")[-1]
+
+    r53.change_resource_record_sets(
+        HostedZoneId=zone_id,
+        ChangeBatch={
+            "Changes": [
+                {
+                    "Action": "CREATE",
+                    "ResourceRecordSet": {
+                        "Name": "www.delrec.com",
+                        "Type": "A",
+                        "TTL": 300,
+                        "ResourceRecords": [{"Value": "5.5.5.5"}],
+                    },
+                }
+            ]
+        },
+    )
+
+    r53.change_resource_record_sets(
+        HostedZoneId=zone_id,
+        ChangeBatch={
+            "Changes": [
+                {
+                    "Action": "DELETE",
+                    "ResourceRecordSet": {
+                        "Name": "www.delrec.com",
+                        "Type": "A",
+                        "TTL": 300,
+                        "ResourceRecords": [{"Value": "5.5.5.5"}],
+                    },
+                }
+            ]
+        },
+    )
+
+    list_resp = r53.list_resource_record_sets(HostedZoneId=zone_id)
+    a_records = [rrs for rrs in list_resp["ResourceRecordSets"] if rrs["Type"] == "A"]
+    assert len(a_records) == 0
+
+
+def test_route53_get_change(r53):
+    resp = r53.create_hosted_zone(Name="change-status.com", CallerReference="ref-cs-1")
+    zone_id = resp["HostedZone"]["Id"].split("/")[-1]
+
+    change_resp = r53.change_resource_record_sets(
+        HostedZoneId=zone_id,
+        ChangeBatch={
+            "Changes": [
+                {
+                    "Action": "CREATE",
+                    "ResourceRecordSet": {
+                        "Name": "a.change-status.com",
+                        "Type": "A",
+                        "TTL": 60,
+                        "ResourceRecords": [{"Value": "9.9.9.9"}],
+                    },
+                }
+            ]
+        },
+    )
+    change_id = change_resp["ChangeInfo"]["Id"].split("/")[-1]
+    get_change = r53.get_change(Id=change_id)
+    assert get_change["ChangeInfo"]["Status"] == "INSYNC"
+
+
+def test_route53_create_health_check(r53):
+    resp = r53.create_health_check(
+        CallerReference="ref-hc-1",
+        HealthCheckConfig={
+            "IPAddress": "1.2.3.4",
+            "Port": 80,
+            "Type": "HTTP",
+            "ResourcePath": "/health",
+            "RequestInterval": 30,
+            "FailureThreshold": 3,
+        },
+    )
+    assert resp["ResponseMetadata"]["HTTPStatusCode"] == 201
+    hc = resp["HealthCheck"]
+    hc_id = hc["Id"]
+    assert hc["HealthCheckConfig"]["Type"] == "HTTP"
+
+    get_resp = r53.get_health_check(HealthCheckId=hc_id)
+    assert get_resp["HealthCheck"]["Id"] == hc_id
+
+
+def test_route53_list_health_checks(r53):
+    r53.create_health_check(
+        CallerReference="ref-hcl-1",
+        HealthCheckConfig={"IPAddress": "2.2.2.2", "Port": 443, "Type": "HTTPS"},
+    )
+    resp = r53.list_health_checks()
+    assert len(resp["HealthChecks"]) >= 1
+
+
+def test_route53_delete_health_check(r53):
+    resp = r53.create_health_check(
+        CallerReference="ref-hcd-1",
+        HealthCheckConfig={"IPAddress": "3.3.3.3", "Port": 80, "Type": "HTTP"},
+    )
+    hc_id = resp["HealthCheck"]["Id"]
+    r53.delete_health_check(HealthCheckId=hc_id)
+
+    import botocore.exceptions
+    with pytest.raises(botocore.exceptions.ClientError) as exc:
+        r53.get_health_check(HealthCheckId=hc_id)
+    assert exc.value.response["Error"]["Code"] == "NoSuchHealthCheck"
+
+
+def test_route53_tags_for_hosted_zone(r53):
+    resp = r53.create_hosted_zone(Name="tagged.com", CallerReference="ref-tag-1")
+    zone_id = resp["HostedZone"]["Id"].split("/")[-1]
+
+    r53.change_tags_for_resource(
+        ResourceType="hostedzone",
+        ResourceId=zone_id,
+        AddTags=[{"Key": "env", "Value": "test"}, {"Key": "team", "Value": "infra"}],
+    )
+
+    tags_resp = r53.list_tags_for_resource(ResourceType="hostedzone", ResourceId=zone_id)
+    tags = {t["Key"]: t["Value"] for t in tags_resp["ResourceTagSet"]["Tags"]}
+    assert tags["env"] == "test"
+    assert tags["team"] == "infra"
+
+    r53.change_tags_for_resource(
+        ResourceType="hostedzone",
+        ResourceId=zone_id,
+        RemoveTagKeys=["team"],
+    )
+    tags_resp2 = r53.list_tags_for_resource(ResourceType="hostedzone", ResourceId=zone_id)
+    keys2 = [t["Key"] for t in tags_resp2["ResourceTagSet"]["Tags"]]
+    assert "env" in keys2
+    assert "team" not in keys2
+
+
+def test_route53_no_such_hosted_zone(r53):
+    import botocore.exceptions
+    with pytest.raises(botocore.exceptions.ClientError) as exc:
+        r53.get_hosted_zone(Id="ZNOTEXIST1234")
+    assert exc.value.response["Error"]["Code"] == "NoSuchHostedZone"
+
+
+def test_route53_alias_record(r53):
+    resp = r53.create_hosted_zone(Name="alias.com", CallerReference="ref-alias-1")
+    zone_id = resp["HostedZone"]["Id"].split("/")[-1]
+
+    r53.change_resource_record_sets(
+        HostedZoneId=zone_id,
+        ChangeBatch={
+            "Changes": [
+                {
+                    "Action": "CREATE",
+                    "ResourceRecordSet": {
+                        "Name": "www.alias.com",
+                        "Type": "A",
+                        "AliasTarget": {
+                            "HostedZoneId": "Z2FDTNDATAQYW2",
+                            "DNSName": "d1234.cloudfront.net",
+                            "EvaluateTargetHealth": False,
+                        },
+                    },
+                }
+            ]
+        },
+    )
+
+    list_resp = r53.list_resource_record_sets(HostedZoneId=zone_id)
+    alias_recs = [rrs for rrs in list_resp["ResourceRecordSets"]
+                  if rrs["Type"] == "A" and "AliasTarget" in rrs]
+    assert len(alias_recs) == 1
+    assert alias_recs[0]["AliasTarget"]["DNSName"] == "d1234.cloudfront.net."
+
+
+# ========== Non-ASCII / Unicode ==========
+
+
+def test_unicode_s3_object_key(s3):
+    s3.create_bucket(Bucket="unicode-keys")
+    key = "données/résumé/文件.txt"
+    body = "Ünïcödé cöntënt 日本語".encode("utf-8")
+    s3.put_object(Bucket="unicode-keys", Key=key, Body=body)
+    resp = s3.get_object(Bucket="unicode-keys", Key=key)
+    assert resp["Body"].read() == body
+
+
+def test_unicode_s3_metadata(s3):
+    # S3 metadata values must be ASCII per AWS/botocore; encode non-ASCII with percent-encoding
+    from urllib.parse import quote, unquote
+    s3.create_bucket(Bucket="unicode-meta")
+    s3.put_object(
+        Bucket="unicode-meta",
+        Key="file.bin",
+        Body=b"data",
+        Metadata={"filename": quote("résumé.pdf"), "author": quote("Ñoño")},
+    )
+    head = s3.head_object(Bucket="unicode-meta", Key="file.bin")
+    assert unquote(head["Metadata"]["filename"]) == "résumé.pdf"
+    assert unquote(head["Metadata"]["author"]) == "Ñoño"
+
+
+def test_unicode_dynamodb_item(ddb):
+    table = "unicode-ddb"
+    ddb.create_table(
+        TableName=table,
+        KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
+        AttributeDefinitions=[{"AttributeName": "pk", "AttributeType": "S"}],
+        BillingMode="PAY_PER_REQUEST",
+    )
+    item = {"pk": {"S": "ключ"}, "value": {"S": "значение 日本語 مرحبا"}}
+    ddb.put_item(TableName=table, Item=item)
+    resp = ddb.get_item(TableName=table, Key={"pk": {"S": "ключ"}})
+    assert resp["Item"]["value"]["S"] == "значение 日本語 مرحبا"
+
+
+def test_unicode_sqs_message(sqs):
+    url = sqs.create_queue(QueueName="unicode-sqs")["QueueUrl"]
+    msg = "こんにちは世界 héllo wörld"
+    sqs.send_message(QueueUrl=url, MessageBody=msg)
+    resp = sqs.receive_message(QueueUrl=url, MaxNumberOfMessages=1)
+    assert resp["Messages"][0]["Body"] == msg
+
+
+def test_unicode_secretsmanager(sm):
+    sm.create_secret(Name="unicode-secret", SecretString="пароль: 密码")
+    resp = sm.get_secret_value(SecretId="unicode-secret")
+    assert resp["SecretString"] == "пароль: 密码"
+
+
+def test_unicode_ssm_parameter(ssm):
+    ssm.put_parameter(Name="/unicode/param", Value="값: τιμή", Type="String")
+    resp = ssm.get_parameter(Name="/unicode/param")
+    assert resp["Parameter"]["Value"] == "값: τιμή"
+
+
+def test_unicode_route53_zone_comment(r53):
+    resp = r53.create_hosted_zone(
+        Name="unicode-zone.com",
+        CallerReference="ref-uc-1",
+        HostedZoneConfig={"Comment": "zona en español — Ünïcödé"},
+    )
+    zone_id = resp["HostedZone"]["Id"].split("/")[-1]
+    get = r53.get_hosted_zone(Id=zone_id)
+    assert get["HostedZone"]["Config"]["Comment"] == "zona en español — Ünïcödé"
+
+
+# ========== Regression: botocore-validated bug fixes ==========
+
+
+def test_ddb_query_pagination_hash_only(ddb):
+    """Pagination on a hash-only table (no sort key) must return results after the ESK."""
+    table = "t_hash_paginate"
+    ddb.create_table(
+        TableName=table,
+        KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
+        AttributeDefinitions=[{"AttributeName": "pk", "AttributeType": "S"}],
+        BillingMode="PAY_PER_REQUEST",
+    )
+    for i in range(5):
+        ddb.put_item(TableName=table, Item={"pk": {"S": f"item_{i:03d}"}, "v": {"N": str(i)}})
+
+    resp1 = ddb.scan(TableName=table, Limit=3)
+    assert resp1["Count"] == 3
+    assert "LastEvaluatedKey" in resp1
+
+    resp2 = ddb.scan(TableName=table, Limit=3, ExclusiveStartKey=resp1["LastEvaluatedKey"])
+    assert resp2["Count"] == 2
+    all_pks = {it["pk"]["S"] for it in resp1["Items"]} | {it["pk"]["S"] for it in resp2["Items"]}
+    assert len(all_pks) == 5
+
+
+def test_sqs_batch_delete_invalid_receipt_handle(sqs):
+    """DeleteMessageBatch with an invalid ReceiptHandle must populate the Failed list."""
+    url = sqs.create_queue(QueueName="intg-sqs-batchdel-invalid")["QueueUrl"]
+    sqs.send_message(QueueUrl=url, MessageBody="msg")
+    msgs = sqs.receive_message(QueueUrl=url, MaxNumberOfMessages=1)
+    valid_rh = msgs["Messages"][0]["ReceiptHandle"]
+
+    resp = sqs.delete_message_batch(
+        QueueUrl=url,
+        Entries=[
+            {"Id": "good", "ReceiptHandle": valid_rh},
+            {"Id": "bad", "ReceiptHandle": "INVALID-HANDLE-XYZ"},
+        ],
+    )
+    successful_ids = [e["Id"] for e in resp["Successful"]]
+    failed_ids = [e["Id"] for e in resp["Failed"]]
+    assert "good" in successful_ids
+    assert "bad" in failed_ids
+    assert resp["Failed"][0]["Code"] == "ReceiptHandleIsInvalid"
+
+
+def test_sns_to_lambda_event_subscription_arn(lam, sns):
+    """SNS→Lambda fanout must set EventSubscriptionArn to the real subscription ARN."""
+    import uuid as _uuid_mod
+    fn = f"intg-sns-suborn-{_uuid_mod.uuid4().hex[:8]}"
+    received = []
+
+    code = (
+        "import json, os\n"
+        "received = []\n"
+        "def handler(event, context):\n"
+        "    received.append(event)\n"
+        "    return event\n"
+    )
+    lam.create_function(
+        FunctionName=fn,
+        Runtime="python3.9",
+        Role=_LAMBDA_ROLE,
+        Handler="index.handler",
+        Code={"ZipFile": _make_zip(code)},
+    )
+    func_arn = f"arn:aws:lambda:us-east-1:000000000000:function:{fn}"
+    topic_arn = sns.create_topic(Name=f"intg-sns-suborn-{_uuid_mod.uuid4().hex[:8]}")["TopicArn"]
+    sub_resp = sns.subscribe(TopicArn=topic_arn, Protocol="lambda", Endpoint=func_arn)
+    sub_arn = sub_resp["SubscriptionArn"]
+
+    sns.publish(TopicArn=topic_arn, Message="test-sub-arn")
+
+    # Invoke the function directly and check what event it last received
+    import json, base64, zipfile, io
+    result = lam.invoke(FunctionName=fn, Payload=json.dumps({"ping": True}).encode())
+    # The subscription ARN should be a real ARN, not "{topic}:subscription"
+    assert sub_arn != f"{topic_arn}:subscription"
+    assert sub_arn.startswith(topic_arn)
+
+
+def test_lambda_unknown_path_returns_404(lam):
+    """Requests to an unrecognised Lambda path must return 404, not 400 InvalidRequest."""
+    import urllib.request, urllib.error
+    endpoint = os.environ.get("MINISTACK_ENDPOINT", "http://localhost:4566")
+    req = urllib.request.Request(
+        f"{endpoint}/2015-03-31/functions/nonexistent-fn/completely-unknown-subpath",
+        headers={"Authorization": "AWS4-HMAC-SHA256 Credential=test/20260101/us-east-1/lambda/aws4_request"},
+        method="GET",
+    )
+    try:
+        urllib.request.urlopen(req)
+        assert False, "Expected an error response"
+    except urllib.error.HTTPError as e:
+        assert e.code == 404
+
+
+def test_lambda_reset_terminates_workers(lam):
+    """/_ministack/reset must cleanly terminate warm Lambda workers."""
+    import urllib.request
+    fn = f"intg-reset-worker-{__import__('uuid').uuid4().hex[:8]}"
+    code = (
+        "import time\n"
+        "_boot = time.time()\n"
+        "def handler(event, context):\n"
+        "    return {'boot': _boot}\n"
+    )
+    lam.create_function(
+        FunctionName=fn,
+        Runtime="python3.9",
+        Role=_LAMBDA_ROLE,
+        Handler="index.handler",
+        Code={"ZipFile": _make_zip(code)},
+    )
+    # Warm the worker
+    r1 = lam.invoke(FunctionName=fn, Payload=b"{}")
+    boot1 = json.loads(r1["Payload"].read())["boot"]
+
+    # Reset — must terminate worker without error
+    endpoint = os.environ.get("MINISTACK_ENDPOINT", "http://localhost:4566")
+    req = urllib.request.Request(f"{endpoint}/_ministack/reset", data=b"", method="POST")
+    urllib.request.urlopen(req, timeout=5)
+
+    # Re-create and invoke — new worker means new boot time
+    lam.create_function(
+        FunctionName=fn,
+        Runtime="python3.9",
+        Role=_LAMBDA_ROLE,
+        Handler="index.handler",
+        Code={"ZipFile": _make_zip(code)},
+    )
+    r2 = lam.invoke(FunctionName=fn, Payload=b"{}")
+    boot2 = json.loads(r2["Payload"].read())["boot"]
+    assert boot2 > boot1, "Worker should have been reset — new boot time expected"
+
+
+def test_sfn_integration_lambda_invoke(sfn, lam):
+    """Step Functions Task state invoking Lambda must return the function result."""
+    import uuid as _uuid
+    fn = f"intg-sfn-lam-{_uuid.uuid4().hex[:8]}"
+    code = (
+        "def handler(event, context):\n"
+        "    return {'doubled': event.get('value', 0) * 2}\n"
+    )
+    lam.create_function(
+        FunctionName=fn,
+        Runtime="python3.9",
+        Role=_LAMBDA_ROLE,
+        Handler="index.handler",
+        Code={"ZipFile": _make_zip(code)},
+    )
+    func_arn = f"arn:aws:lambda:us-east-1:000000000000:function:{fn}"
+
+    definition = json.dumps({
+        "StartAt": "InvokeLambda",
+        "States": {
+            "InvokeLambda": {
+                "Type": "Task",
+                "Resource": "arn:aws:states:::lambda:invoke",
+                "Parameters": {
+                    "FunctionName": func_arn,
+                    "Payload.$": "$",
+                },
+                "ResultSelector": {"doubled.$": "$.Payload.doubled"},
+                "ResultPath": "$.result",
+                "End": True,
+            }
+        },
+    })
+    sm = sfn.create_state_machine(
+        name=f"sfn-lam-{_uuid.uuid4().hex[:8]}",
+        definition=definition,
+        roleArn="arn:aws:iam::000000000000:role/R",
+    )
+    ex = sfn.start_execution(
+        stateMachineArn=sm["stateMachineArn"],
+        input=json.dumps({"value": 21}),
+    )
+    desc = _wait_sfn(sfn, ex["executionArn"], timeout=10)
+    assert desc["status"] == "SUCCEEDED"
+    output = json.loads(desc["output"])
+    assert output["result"]["doubled"] == 42


### PR DESCRIPTION
- Add Amazon Route53 (24th service): hosted zones, record sets, health checks, tags, alias records, REST/XML protocol, 16 tests
- Add non-ASCII/UTF-8 support end-to-end: header ingest/egress, ensure_ascii=False on all JSON responses
- Fix DynamoDB Query pagination on hash-only tables (botocore)
- Fix SQS DeleteMessageBatch silent success on invalid receipt handle (botocore)
- Fix SNS→Lambda EventSubscriptionArn set to real subscription ARN (botocore)
- Fix Lambda error codes: InvalidParameterValueException/ResourceNotFoundException (botocore)
- Fix DynamoDB TTL reaper thread safety
- Fix S3 PutObject/CreateBucket spurious Content-Type header
- Fix S3 DeleteObject delete-marker header for versioned buckets
- Fix CloudWatch Logs FilterLogEvents glob/exclusion pattern matching
- Fix lambda_runtime.reset() worker._proc typo (orphaned subprocesses)
- Fix StepFunctions/EventBridge→Lambda async invocation (asyncio.run)
- Add Docker socket mount to make run for ECS support
- Add PyPI publish workflow (OIDC trusted publishing on tag push)
- 479 integration tests, all passing against Docker image