### PR TITLE
fix: add <Type> element to XML error responses for botocore compatibility

### DIFF
--- a/ministack/core/responses.py
+++ b/ministack/core/responses.py
@@ -56,6 +56,8 @@ def error_response_xml(code: str, message: str, status: int, namespace: str = "h
     """AWS-style XML error response."""
     root = Element("ErrorResponse", xmlns=namespace)
     error = SubElement(root, "Error")
+    t = SubElement(error, "Type")
+    t.text = "Sender" if status < 500 else "Receiver"
     c = SubElement(error, "Code")
     c.text = code
     m = SubElement(error, "Message")

--- a/ministack/services/sqs.py
+++ b/ministack/services/sqs.py
@@ -801,10 +801,11 @@ def _xml_resp(status: int, root: str, inner: str) -> tuple:
 
 
 def _xml_err_resp(code: str, msg: str, status: int = 400) -> tuple:
+    sender_type = "Sender" if status < 500 else "Receiver"
     body = (
         f'<?xml version="1.0" encoding="UTF-8"?>'
         f'<ErrorResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/">'
-        f'<Error><Code>{_esc(code)}</Code><Message>{_esc(msg)}</Message></Error>'
+        f'<Error><Type>{sender_type}</Type><Code>{_esc(code)}</Code><Message>{_esc(msg)}</Message></Error>'
         f'<RequestId>{new_uuid()}</RequestId>'
         f'</ErrorResponse>'
     ).encode("utf-8")


### PR DESCRIPTION
## Problem

botocore's Query protocol parser requires a `<Type>` element (`Sender` or `Receiver`) inside `<Error>` to map errors to typed exception classes. For example, SQS's `client.exceptions.QueueDoesNotExist` is only populated when the XML error response includes `<Type>Sender</Type>`.

Currently, MiniStack's XML error responses omit `<Type>`:

```xml
<Error>
  <Code>AWS.SimpleQueueService.NonExistentQueue</Code>
  <Message>The specified queue does not exist.</Message>
</Error>
```

This causes botocore to fall back to generic `ClientError`, even though the error `Code` is correct. Clients catching typed exceptions (e.g. `except client.exceptions.QueueDoesNotExist`) never match, and the error propagates unhandled.

## Fix

Add `<Type>Sender</Type>` (4xx) or `<Type>Receiver</Type>` (5xx) to both:

- `ministack/services/sqs.py` → `_xml_err_resp()`
- `ministack/core/responses.py` → `error_response_xml()` (shared by S3, SNS, IAM, STS, CloudWatch)

After:

```xml
<Error>
  <Type>Sender</Type>
  <Code>AWS.SimpleQueueService.NonExistentQueue</Code>
  <Message>The specified queue does not exist.</Message>
</Error>
```

This matches [real AWS error response format](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/CommonErrors.html) and allows botocore to correctly populate typed exception classes.

## Testing

- Existing test `test_sqs_nonexistent_queue` continues to pass (validates via `response["Error"]["Code"]`)
- With this fix, `client.exceptions.QueueDoesNotExist` is now also usable for SQS queue-not-found errors