### PR TITLE
feat: support configurable region via MINISTACK_REGION env variable

### DIFF
--- a/ministack/services/sns.py
+++ b/ministack/services/sns.py
@@ -28,7 +28,7 @@ from ministack.services import sqs as _sqs
 logger = logging.getLogger("sns")
 
 ACCOUNT_ID = "000000000000"
-REGION = "us-east-1"
+REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 
 _topics: dict = {}
 _sub_arn_to_topic: dict = {}

--- a/ministack/services/sqs.py
+++ b/ministack/services/sqs.py
@@ -41,7 +41,7 @@ _queues: dict = {}
 _queue_name_to_url: dict = {}
 
 ACCOUNT_ID = "000000000000"
-REGION = "us-east-1"
+REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 DEFAULT_HOST = os.environ.get("MINISTACK_HOST", "localhost")
 DEFAULT_PORT = os.environ.get("GATEWAY_PORT", "4566")
 _DEDUP_WINDOW_S = 300  # 5 minutes


### PR DESCRIPTION
## Summary

This PR adds support for configuring the AWS region via the `MINISTACK_REGION` environment variable.

## Changes

- Changed hardcoded `REGION = "us-east-1"` to `REGION = os.environ.get("MINISTACK_REGION", "us-east-1")` in:
  - `ministack/services/sns.py` (line 31)
  - `ministack/services/sqs.py` (line 44)

## Motivation

Currently, the REGION constant is hardcoded to `us-east-1` in both sns.py and sqs.py. This causes NotFoundException errors when the client-side configured AWS region differs from the hardcoded region, as ARNs are generated with `us-east-1` regardless of the actual region.

This change allows users to configure the region via the `MINISTACK_REGION` environment variable, with a fallback to `us-east-1` for backwards compatibility.

## Testing

Users can now set:
```bash
export MINISTACK_REGION=us-east-2
```
And all ARNs will be generated with the configured region.

Fixes #59