### PR TITLE
feat: MINISTACK_REGION env var across all 25 services (v1.1.16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [1.1.16] — 2026-04-01
+
+### Added
+- **`MINISTACK_REGION` environment variable** — all 25 services now read region from `MINISTACK_REGION` (defaulting to `us-east-1`); previously all services hardcoded the region in ARNs and response metadata. Lambda also checks `AWS_DEFAULT_REGION` as a secondary fallback. Contributed by @xingzihai and @santiagodoldan
+
+### Tests
+- 815 tests total, all passing
+
+---
+
 ## [1.1.15] — 2026-04-01
 
 ### Added

--- a/ministack/services/acm.py
+++ b/ministack/services/acm.py
@@ -8,6 +8,7 @@ Supports: RequestCertificate, DescribeCertificate, ListCertificates,
 """
 
 import json
+import os
 import logging
 import time
 
@@ -16,7 +17,7 @@ from ministack.core.responses import error_response_json, json_response, new_uui
 logger = logging.getLogger("acm")
 
 ACCOUNT_ID = "000000000000"
-REGION = "us-east-1"
+REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 
 _certificates: dict = {}  # arn -> certificate dict
 

--- a/ministack/services/apigateway.py
+++ b/ministack/services/apigateway.py
@@ -56,7 +56,7 @@ _PORT = os.environ.get("GATEWAY_PORT", "4566")
 logger = logging.getLogger("apigateway")
 
 ACCOUNT_ID = "000000000000"
-REGION = "us-east-1"
+REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 
 # ---- Module-level state ----
 _apis: dict = {}          # api_id -> api object

--- a/ministack/services/apigateway_v1.py
+++ b/ministack/services/apigateway_v1.py
@@ -70,6 +70,7 @@ Data plane:
 import datetime
 import json
 import logging
+import os
 import re
 import time
 import urllib.error
@@ -87,7 +88,7 @@ def _now_unix():
 logger = logging.getLogger("apigateway_v1")
 
 ACCOUNT_ID = "000000000000"
-REGION = "us-east-1"
+REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 
 # ---- Module-level state ----
 _rest_apis: dict = {}           # rest_api_id -> RestApi

--- a/ministack/services/athena.py
+++ b/ministack/services/athena.py
@@ -25,7 +25,7 @@ from ministack.core.responses import error_response_json, json_response, new_uui
 logger = logging.getLogger("athena")
 
 ACCOUNT_ID = "000000000000"
-REGION = "us-east-1"
+REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 S3_DATA_DIR = os.environ.get("S3_DATA_DIR", "/tmp/ministack-data/s3")
 ATHENA_ENGINE = os.environ.get("ATHENA_ENGINE", "auto")  # "auto" | "duckdb" | "mock"
 

--- a/ministack/services/cloudformation/__init__.py
+++ b/ministack/services/cloudformation/__init__.py
@@ -10,12 +10,13 @@ Uses Query API (Action=...) with form-encoded body.
 """
 
 import logging
+import os
 from urllib.parse import parse_qs
 
 logger = logging.getLogger("cloudformation")
 
 ACCOUNT_ID = "000000000000"
-REGION = "us-east-1"
+REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 
 # In-memory state (shared across all submodules)
 _stacks: dict = {}          # stack_name -> stack dict

--- a/ministack/services/cloudformation/engine.py
+++ b/ministack/services/cloudformation/engine.py
@@ -4,6 +4,7 @@ condition evaluation, intrinsic function resolution, and topological sorting.
 """
 
 import base64
+import os
 import heapq
 import json
 import re
@@ -17,7 +18,7 @@ from ministack.core.responses import new_uuid
 _NO_VALUE = object()
 
 ACCOUNT_ID = "000000000000"
-REGION = "us-east-1"
+REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 # Note: ACCOUNT_ID/REGION duplicated here to keep engine.py free of __init__ imports (avoids circular deps)
 
 

--- a/ministack/services/cloudformation/provisioners.py
+++ b/ministack/services/cloudformation/provisioners.py
@@ -3,6 +3,7 @@ CloudFormation provisioners — resource create/delete handlers for each AWS res
 """
 
 import io
+import os
 import json
 import logging
 import random
@@ -27,7 +28,7 @@ import ministack.services.iam_sts as _iam_sts
 logger = logging.getLogger("cloudformation")
 
 ACCOUNT_ID = "000000000000"
-REGION = "us-east-1"
+REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 
 
 def _physical_name(stack_name: str, logical_id: str, *,

--- a/ministack/services/cloudwatch.py
+++ b/ministack/services/cloudwatch.py
@@ -11,6 +11,7 @@ Operations: PutMetricData, GetMetricStatistics, GetMetricData, ListMetrics,
 """
 
 import json
+import os
 import logging
 import re
 import time
@@ -23,7 +24,7 @@ from ministack.core.responses import new_uuid
 logger = logging.getLogger("cloudwatch")
 
 ACCOUNT_ID = "000000000000"
-REGION = "us-east-1"
+REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 TWO_WEEKS_SECONDS = 14 * 24 * 3600
 
 _metrics: dict = defaultdict(list)

--- a/ministack/services/cloudwatch_logs.py
+++ b/ministack/services/cloudwatch_logs.py
@@ -15,6 +15,7 @@ Supports: CreateLogGroup, DeleteLogGroup, DescribeLogGroups,
 """
 
 import base64
+import os
 import fnmatch
 import json
 import logging
@@ -25,7 +26,7 @@ from ministack.core.responses import error_response_json, json_response, new_uui
 logger = logging.getLogger("logs")
 
 ACCOUNT_ID = "000000000000"
-REGION = "us-east-1"
+REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 
 _log_groups: dict = {}
 # group_name -> {

--- a/ministack/services/cognito.py
+++ b/ministack/services/cognito.py
@@ -43,6 +43,7 @@ Wire protocol:
 """
 
 import base64
+import os
 import json
 import logging
 import re
@@ -57,7 +58,7 @@ from ministack.core.responses import error_response_json, json_response, new_uui
 logger = logging.getLogger("cognito")
 
 ACCOUNT_ID = "000000000000"
-REGION = "us-east-1"
+REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 
 # ---------------------------------------------------------------------------
 # In-memory state — User Pools (cognito-idp)

--- a/ministack/services/dynamodb.py
+++ b/ministack/services/dynamodb.py
@@ -10,6 +10,7 @@ Uses X-Amz-Target header for action routing (JSON API).
 """
 
 import copy
+import os
 import json
 import logging
 import re
@@ -74,7 +75,7 @@ def _ttl_reaper():
 
 threading.Thread(target=_ttl_reaper, daemon=True, name="dynamodb-ttl-reaper").start()
 
-REGION = "us-east-1"
+REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 ACCOUNT_ID = "000000000000"
 
 

--- a/ministack/services/elasticache.py
+++ b/ministack/services/elasticache.py
@@ -30,7 +30,7 @@ from ministack.core.responses import new_uuid
 logger = logging.getLogger("elasticache")
 
 ACCOUNT_ID = "000000000000"
-REGION = "us-east-1"
+REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 REDIS_DEFAULT_HOST = os.environ.get("REDIS_HOST", "redis")
 REDIS_DEFAULT_PORT = int(os.environ.get("REDIS_PORT", "6379"))
 BASE_PORT = int(os.environ.get("ELASTICACHE_BASE_PORT", "16379"))

--- a/ministack/services/eventbridge.py
+++ b/ministack/services/eventbridge.py
@@ -14,6 +14,7 @@ Supports: CreateEventBus, DeleteEventBus, ListEventBuses, DescribeEventBus,
 """
 
 import asyncio
+import os
 import hashlib
 import json
 import logging
@@ -26,7 +27,7 @@ from ministack.core.responses import error_response_json, json_response, new_uui
 logger = logging.getLogger("events")
 
 ACCOUNT_ID = "000000000000"
-REGION = "us-east-1"
+REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 
 
 def _now_iso() -> str:

--- a/ministack/services/firehose.py
+++ b/ministack/services/firehose.py
@@ -15,6 +15,7 @@ in-memory (accessible for testing via PutRecord/PutRecordBatch round-trip).
 """
 
 import asyncio
+import os
 import base64
 import json
 import logging
@@ -31,7 +32,7 @@ from ministack.core.responses import (
 logger = logging.getLogger("firehose")
 
 ACCOUNT_ID = "000000000000"
-REGION = "us-east-1"
+REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 
 # ─── in-memory state ──────────────────────────────────────────────────────────
 

--- a/ministack/services/glue.py
+++ b/ministack/services/glue.py
@@ -22,7 +22,7 @@ from ministack.core.responses import error_response_json, json_response, new_uui
 logger = logging.getLogger("glue")
 
 ACCOUNT_ID = "000000000000"
-REGION = "us-east-1"
+REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 CRAWLER_RUN_SECONDS = int(os.environ.get("GLUE_CRAWLER_RUN_SECONDS", "5"))
 S3_DATA_DIR = os.environ.get("S3_DATA_DIR", "/tmp/ministack-data/s3")
 

--- a/ministack/services/iam_sts.py
+++ b/ministack/services/iam_sts.py
@@ -29,6 +29,7 @@ STS actions:
 """
 
 import json
+import os
 import logging
 import time
 from urllib.parse import parse_qs
@@ -39,7 +40,7 @@ from ministack.core.responses import new_uuid
 logger = logging.getLogger("iam")
 
 ACCOUNT_ID = "000000000000"
-REGION = "us-east-1"
+REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 
 # ---------------------------------------------------------------------------
 # Module-level state

--- a/ministack/services/kinesis.py
+++ b/ministack/services/kinesis.py
@@ -13,6 +13,7 @@ Supports: CreateStream, DeleteStream, DescribeStream, DescribeStreamSummary,
 """
 
 import base64
+import os
 import hashlib
 import json
 import logging
@@ -24,7 +25,7 @@ from ministack.core.responses import error_response_json, json_response, new_uui
 logger = logging.getLogger("kinesis")
 
 ACCOUNT_ID = "000000000000"
-REGION = "us-east-1"
+REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 MAX_HASH_KEY = (2**128) - 1
 ITERATOR_EXPIRY_SECONDS = 300
 

--- a/ministack/services/lambda_svc.py
+++ b/ministack/services/lambda_svc.py
@@ -46,7 +46,7 @@ from ministack.core.responses import error_response_json, json_response, new_uui
 logger = logging.getLogger("lambda")
 
 ACCOUNT_ID = "000000000000"
-REGION = os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
+REGION = os.environ.get("MINISTACK_REGION", os.environ.get("AWS_DEFAULT_REGION", "us-east-1"))
 LAMBDA_EXECUTOR = os.environ.get("LAMBDA_EXECUTOR", "local").lower()
 LAMBDA_DOCKER_VOLUME_MOUNT = os.environ.get("LAMBDA_REMOTE_DOCKER_VOLUME_MOUNT", "")
 

--- a/ministack/services/secretsmanager.py
+++ b/ministack/services/secretsmanager.py
@@ -10,6 +10,7 @@ Supports: CreateSecret, GetSecretValue, ListSecrets, DeleteSecret,
 """
 
 import base64
+import os
 import json
 import logging
 import secrets as stdlib_secrets
@@ -21,7 +22,7 @@ from ministack.core.responses import error_response_json, json_response, new_uui
 logger = logging.getLogger("secretsmanager")
 
 ACCOUNT_ID = "000000000000"
-REGION = "us-east-1"
+REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 
 _secrets: dict = {}
 _resource_policies: dict = {}

--- a/ministack/services/ses.py
+++ b/ministack/services/ses.py
@@ -23,6 +23,7 @@ Send statistics aggregated into 15-minute buckets per AWS spec.
 """
 
 import base64
+import os
 import hashlib
 import json
 import logging
@@ -38,7 +39,7 @@ from ministack.core.responses import new_uuid
 logger = logging.getLogger("ses")
 
 ACCOUNT_ID = "000000000000"
-REGION = "us-east-1"
+REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 
 _identities: dict = {}
 _sent_emails: list = []

--- a/ministack/services/ses_v2.py
+++ b/ministack/services/ses_v2.py
@@ -10,6 +10,7 @@ Supports: SendEmail, CreateEmailIdentity, GetEmailIdentity, DeleteEmailIdentity,
 
 import json
 import logging
+import os
 import re
 
 from ministack.core.responses import json_response, new_uuid, now_iso
@@ -17,7 +18,7 @@ from ministack.core.responses import json_response, new_uuid, now_iso
 logger = logging.getLogger("ses-v2")
 
 ACCOUNT_ID = "000000000000"
-REGION = "us-east-1"
+REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 
 _identities: dict = {}        # identity -> dict
 _config_sets: dict = {}       # name -> dict

--- a/ministack/services/ssm.py
+++ b/ministack/services/ssm.py
@@ -8,6 +8,7 @@ Supports: PutParameter, GetParameter, GetParameters, GetParametersByPath,
 """
 
 import base64
+import os
 import json
 import logging
 import time
@@ -18,7 +19,7 @@ from ministack.core.responses import error_response_json, json_response, new_uui
 logger = logging.getLogger("ssm")
 
 ACCOUNT_ID = "000000000000"
-REGION = "us-east-1"
+REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 DEFAULT_PAGE_SIZE = 10
 
 _parameters: dict = {}

--- a/ministack/services/stepfunctions.py
+++ b/ministack/services/stepfunctions.py
@@ -19,6 +19,7 @@ SUCCEEDED / FAILED / TIMED_OUT / ABORTED.
 """
 
 import asyncio
+import os
 import copy
 import json
 import logging
@@ -39,7 +40,7 @@ from ministack.core.responses import (
 logger = logging.getLogger("states")
 
 ACCOUNT_ID = "000000000000"
-REGION = "us-east-1"
+REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 
 _state_machines: dict = {}
 _executions: dict = {}

--- a/ministack/services/waf.py
+++ b/ministack/services/waf.py
@@ -10,6 +10,7 @@ Supports: CreateWebACL, GetWebACL, UpdateWebACL, DeleteWebACL, ListWebACLs,
 """
 
 import json
+import os
 import logging
 
 from ministack.core.responses import error_response_json, json_response, new_uuid, now_iso
@@ -17,7 +18,7 @@ from ministack.core.responses import error_response_json, json_response, new_uui
 logger = logging.getLogger("wafv2")
 
 ACCOUNT_ID = "000000000000"
-REGION = "us-east-1"
+REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 
 _web_acls: dict = {}       # id -> webacl
 _ip_sets: dict = {}        # id -> ipset

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ministack"
-version = "1.1.15"
+version = "1.1.16"
 description = "Free, open-source local AWS emulator — drop-in LocalStack replacement"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
- remove hardcoded us-east-1 