### PR TITLE
feat: add MINISTACK_WORKER_INIT_SCRIPT hook for Lambda workers

### DIFF
--- a/ministack/core/lambda_runtime.py
+++ b/ministack/core/lambda_runtime.py
@@ -183,6 +183,12 @@ rl.on("line", async (line) => {
       const { code_dir, module: modPath, handler: handlerName, env } = msg;
       Object.assign(process.env, env || {});
       patchAwsSdk();
+      // Load optional worker init script (e.g. ES compat patches, custom SDK config)
+      const workerInit = process.env.MINISTACK_WORKER_INIT_SCRIPT;
+      if (workerInit) {
+        try { require(path.resolve(workerInit)); }
+        catch (e) { console.error("MINISTACK_WORKER_INIT_SCRIPT error:", e.message); }
+      }
       try {
         const fullPath = path.resolve(code_dir, modPath);
         const mod = require(fullPath);


### PR DESCRIPTION
## Summary

- Adds a `MINISTACK_WORKER_INIT_SCRIPT` environment variable that Lambda functions can use to load a custom Node.js init script before the handler module is imported
- The script is `require()`'d after AWS SDK patching (`patchAwsSdk()`) but before `require(handlerModule)`, so it can patch `http`/`https` modules or configure the environment
- Use case: Elasticsearch 7.x compatibility patches, custom SDK configuration, or any per-worker initialization that should run before handler code

## Implementation

A 5-line addition to the Node.js worker script in `lambda_runtime.py`:

```javascript
const workerInit = process.env.MINISTACK_WORKER_INIT_SCRIPT;
if (workerInit) {
  try { require(path.resolve(workerInit)); }
  catch (e) { console.error("MINISTACK_WORKER_INIT_SCRIPT error:", e.message); }
}
```

Errors in the init script are logged to stderr but don't prevent the worker from starting.

## Test plan

- [x] Deploy Lambda with `MINISTACK_WORKER_INIT_SCRIPT` pointing to a `.js` file — file is loaded before handler
- [x] Deploy Lambda without the env var — no change in behavior
- [x] Init script with an error — error logged, worker still starts and handles invocations