### PR TITLE
fix: SecretsManager KmsKeyId, Lambda env vars at process spawn (NODE_…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [1.1.20] — 2026-04-02
+
+### Fixed
+- **SecretsManager `KmsKeyId`** — `CreateSecret` and `UpdateSecret` now store `KmsKeyId`; `DescribeSecret` returns it. Previously always null.
+- **Lambda env vars applied at process spawn** — Lambda environment variables are now passed to the worker subprocess at startup (`env=` on `Popen`) instead of after via `Object.assign`. `NODE_OPTIONS=--require ./init.js` and similar process-level env vars now work correctly, matching real AWS Lambda behaviour. Contributed by @jv2222
+
+### Tests
+- 838 tests total, all passing
+
+---
+
 ## [1.1.19] — 2026-04-02
 
 - Version bump from v1.1.18 — no code changes, re-tag for PyPI publish

--- a/README.md
+++ b/README.md
@@ -536,20 +536,20 @@ pip install boto3 pytest duckdb docker cbor2
 # Start MiniStack
 docker compose up -d
 
-# Run the full test suite (834 tests across all 34 services)
+# Run the full test suite (838 tests across all 34 services)
 pytest tests/ -v
 ```
 
 Expected output:
 
 ```
-collected 834 items
+collected 838 items
 
 tests/test_services.py::test_s3_create_bucket PASSED
 ...
 tests/test_services.py::test_app_asgi_callable PASSED
 
-834 passed in ~100s
+838 passed in ~100s
 ```
 
 ---

--- a/ministack/core/lambda_runtime.py
+++ b/ministack/core/lambda_runtime.py
@@ -313,6 +313,7 @@ class Worker:
         handler = self.config.get("Handler", "index.handler")
         module_name, handler_name = handler.rsplit(".", 1)
         env_vars = self.config.get("Environment", {}).get("Variables", {})
+        spawn_env = {**os.environ, **env_vars}
 
         self._proc = subprocess.Popen(
             [binary, worker_path],
@@ -321,6 +322,7 @@ class Worker:
             stderr=subprocess.PIPE,
             text=True,
             bufsize=1,
+            env=spawn_env,
         )
 
         init = {

--- a/ministack/services/secretsmanager.py
+++ b/ministack/services/secretsmanager.py
@@ -172,6 +172,7 @@ def _create_secret(data):
         "RotationEnabled": False,
         "RotationLambdaARN": data.get("RotationLambdaARN"),
         "RotationRules": data.get("RotationRules"),
+        "KmsKeyId": data.get("KmsKeyId"),
         "ReplicationStatus": [],
         "Versions": {
             vid: {
@@ -361,6 +362,8 @@ def _update_secret(data):
 
     if "Description" in data:
         secret["Description"] = data["Description"]
+    if "KmsKeyId" in data:
+        secret["KmsKeyId"] = data["KmsKeyId"]
 
     has_new_value = "SecretString" in data or "SecretBinary" in data
     if not has_new_value:
@@ -402,6 +405,8 @@ def _describe_secret(data):
     }
     if secret.get("DeletedDate"):
         result["DeletedDate"] = secret["DeletedDate"]
+    if secret.get("KmsKeyId"):
+        result["KmsKeyId"] = secret["KmsKeyId"]
     if secret.get("RotationLambdaARN"):
         result["RotationLambdaARN"] = secret["RotationLambdaARN"]
     if secret.get("RotationRules"):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ministack"
-version = "1.1.19"
+version = "1.1.20"
 description = "Free, open-source local AWS emulator — drop-in LocalStack replacement"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -6285,6 +6285,47 @@ def test_lambda_nodejs_callback_handler(lam):
     assert payload["val"] == 7
 
 
+def test_lambda_nodejs_env_vars_at_spawn(lam):
+    """Lambda env vars are available at process startup (NODE_OPTIONS, etc.)."""
+    code = (
+        "exports.handler = async (event) => ({"
+        " myVar: process.env.MY_CUSTOM_VAR,"
+        " region: process.env.AWS_REGION"
+        "});"
+    )
+    lam.create_function(
+        FunctionName="lam-node-env-spawn",
+        Runtime="nodejs20.x",
+        Role=_LAMBDA_ROLE,
+        Handler="index.handler",
+        Code={"ZipFile": _make_zip_js(code, "index.js")},
+        Environment={"Variables": {"MY_CUSTOM_VAR": "from-spawn"}},
+    )
+    resp = lam.invoke(FunctionName="lam-node-env-spawn", Payload=b"{}")
+    payload = json.loads(resp["Payload"].read())
+    assert payload["myVar"] == "from-spawn"
+
+
+def test_lambda_python_env_vars_at_spawn(lam):
+    """Python Lambda env vars are available at process startup."""
+    code = (
+        "import os\n"
+        "def handler(event, context):\n"
+        "    return {'myVar': os.environ.get('MY_PY_VAR', 'missing')}\n"
+    )
+    lam.create_function(
+        FunctionName="lam-py-env-spawn",
+        Runtime="python3.11",
+        Role=_LAMBDA_ROLE,
+        Handler="index.handler",
+        Code={"ZipFile": _make_zip(code)},
+        Environment={"Variables": {"MY_PY_VAR": "from-spawn-py"}},
+    )
+    resp = lam.invoke(FunctionName="lam-py-env-spawn", Payload=b"{}")
+    payload = json.loads(resp["Payload"].read())
+    assert payload["myVar"] == "from-spawn-py"
+
+
 # ========== Lambda — DynamoDB Streams ESM ==========
 
 def test_lambda_dynamodb_stream_esm(lam, ddb):
@@ -11538,6 +11579,18 @@ def test_sm_get_random_password(sm):
     pwd = resp["RandomPassword"]
     assert len(pwd) == 24
     assert not any(c.isdigit() for c in pwd)
+
+
+def test_sm_kms_key_id_on_create_and_describe(sm):
+    sm.create_secret(Name="kms-test-secret", SecretString="val", KmsKeyId="alias/my-key")
+    resp = sm.describe_secret(SecretId="kms-test-secret")
+    assert resp["KmsKeyId"] == "alias/my-key"
+
+
+def test_sm_kms_key_id_on_update(sm):
+    sm.update_secret(SecretId="kms-test-secret", KmsKeyId="alias/other-key")
+    resp = sm.describe_secret(SecretId="kms-test-secret")
+    assert resp["KmsKeyId"] == "alias/other-key"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
- **SecretsManager `KmsKeyId`** — `CreateSecret` and `UpdateSecret` now store `KmsKeyId`; `DescribeSecret` returns it. Previously always null.
- **Lambda env vars applied at process spawn** — Lambda environment variables are now passed to the worker subprocess at startup (`env=` on `Popen`) instead of after via `Object.assign`. `NODE_OPTIONS=--require ./init.js` and similar process-level env vars now work correctly, matching real AWS Lambda behaviour. Contributed by @jv2222
