### PR TITLE
fix: S3 VersionId in all responses, S3→EventBridge notifications, REA…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [1.1.21] — 2026-04-02
+
+### Added
+- **S3 → EventBridge notifications** — buckets with `EventBridgeConfiguration` enabled now publish events to the default EventBridge bus on object create/delete/copy; EventBridge rules with `InputTransformer` route and reshape events to downstream targets (SQS, Lambda, etc.)
+
+### Fixed
+- **S3 `PutObject` missing `VersionId` in response** — versioned buckets now return `VersionId` in the `PutObject`, `GetObject`, `HeadObject`, and `CopyObject` responses; each put generates a unique version ID. Reported by @McDoit
+
+### Tests
+- 841 tests total, all passing
+
+---
+
 ## [1.1.20] — 2026-04-02
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -259,10 +259,10 @@ subnet = ec2.create_subnet(
 
 Unsupported resource types fail with `CREATE_FAILED` (or `ROLLBACK_COMPLETE` if rollback is enabled), so templates with unsupported types won't silently succeed.
 
-### Infrastructure Services (with real Docker execution)
+### Infrastructure Services
 
-| Service | Operations | Real Execution |
-|---------|-----------|----------------|
+| Service | Operations | Notes |
+|---------|-----------|-------|
 | **ECS** | CreateCluster, UpdateCluster, DeleteCluster, DescribeClusters, ListClusters, RegisterTaskDefinition, DeregisterTaskDefinition, DescribeTaskDefinition, ListTaskDefinitions, CreateService, DeleteService, DescribeServices, UpdateService, ListServices, RunTask, StopTask, DescribeTasks, ListTasks, CreateCapacityProvider, DeleteCapacityProvider, DescribeCapacityProviders, PutClusterCapacityProviders, TagResource, UntagResource, ListTagsForResource | `RunTask` starts real Docker containers via Docker socket |
 | **RDS** | CreateDBInstance, DeleteDBInstance, DescribeDBInstances, StartDBInstance, StopDBInstance, RebootDBInstance, ModifyDBInstance, CreateDBCluster, DeleteDBCluster, DescribeDBClusters, StartDBCluster, StopDBCluster, CreateDBSubnetGroup, DescribeDBSubnetGroups, ModifyDBSubnetGroup, DeleteDBSubnetGroup, CreateDBParameterGroup, DescribeDBParameterGroups, ModifyDBParameterGroup, DeleteDBParameterGroup, DescribeDBParameters, CreateDBClusterParameterGroup, DescribeDBEngineVersions, DescribeOrderableDBInstanceOptions, CreateDBSnapshot, DeleteDBSnapshot, DescribeDBSnapshots, CreateDBClusterSnapshot, DeleteDBClusterSnapshot, DescribeDBClusterSnapshots, CreateDBInstanceReadReplica, RestoreDBInstanceFromDBSnapshot, CreateOptionGroup, DescribeOptionGroups, AddTagsToResource, RemoveTagsFromResource, ListTagsForResource | `CreateDBInstance` spins up real Postgres/MySQL Docker container, returns actual `host:port` endpoint |
 | **ElastiCache** | CreateCacheCluster, DeleteCacheCluster, DescribeCacheClusters, ModifyCacheCluster, RebootCacheCluster, CreateReplicationGroup, DeleteReplicationGroup, DescribeReplicationGroups, ModifyReplicationGroup, IncreaseReplicaCount, DecreaseReplicaCount, CreateCacheSubnetGroup, DescribeCacheSubnetGroups, ModifyCacheSubnetGroup, DeleteCacheSubnetGroup, CreateCacheParameterGroup, DescribeCacheParameterGroups, ModifyCacheParameterGroup, ResetCacheParameterGroup, DeleteCacheParameterGroup, DescribeCacheParameters, DescribeCacheEngineVersions, CreateUser, DescribeUsers, DeleteUser, ModifyUser, CreateUserGroup, DescribeUserGroups, DeleteUserGroup, ModifyUserGroup, CreateSnapshot, DeleteSnapshot, DescribeSnapshots, DescribeEvents | `CreateCacheCluster` spins up real Redis/Memcached Docker container |
@@ -536,20 +536,20 @@ pip install boto3 pytest duckdb docker cbor2
 # Start MiniStack
 docker compose up -d
 
-# Run the full test suite (838 tests across all 34 services)
+# Run the full test suite (841 tests across all 34 services)
 pytest tests/ -v
 ```
 
 Expected output:
 
 ```
-collected 838 items
+collected 841 items
 
 tests/test_services.py::test_s3_create_bucket PASSED
 ...
 tests/test_services.py::test_app_asgi_callable PASSED
 
-838 passed in ~100s
+841 passed in ~100s
 ```
 
 ---

--- a/ministack/services/s3.py
+++ b/ministack/services/s3.py
@@ -275,6 +275,8 @@ def _object_response_headers(obj: dict, bucket_name: str = "", key: str = "") ->
     for k, val in obj.get("preserved_headers", {}).items():
         h[k] = val
     h.update(obj.get("metadata", {}))
+    if obj.get("version_id"):
+        h["x-amz-version-id"] = obj["version_id"]
     if bucket_name and key:
         retention = _object_retention.get((bucket_name, key))
         if retention:
@@ -1105,7 +1107,9 @@ def _fire_s3_event(
     """Build and deliver an S3 event notification. Best-effort — errors are logged."""
     try:
         configs = _parse_notification_config(bucket_name)
-        if not configs:
+        raw_xml = _bucket_notifications.get(bucket_name, b"")
+        has_eventbridge = b"EventBridgeConfiguration" in raw_xml
+        if not configs and not has_eventbridge:
             return
 
         short_event = event_name.replace("s3:", "", 1)
@@ -1170,6 +1174,34 @@ def _fire_s3_event(
                 logger.exception(
                     "S3 notification delivery failed for config %s", cfg.get("id")
                 )
+
+        # S3 → EventBridge delivery (if EventBridgeConfiguration is enabled)
+        try:
+            if has_eventbridge:
+                from ministack.services import eventbridge as _eb
+                eb_event = {
+                    "EventId": request_id,
+                    "Source": "aws.s3",
+                    "DetailType": event_name.replace("s3:", "Object ").replace(":", " ").replace("*", ""),
+                    "Detail": json.dumps({
+                        "version": "0",
+                        "bucket": {"name": bucket_name},
+                        "object": {"key": key, "size": size, "etag": clean_etag, "sequencer": "0"},
+                        "request-id": request_id,
+                        "requester": "000000000000",
+                        "source-ip-address": "127.0.0.1",
+                        "reason": "PutObject",
+                    }),
+                    "EventBusName": "default",
+                    "Time": event_time,
+                    "Resources": [f"arn:aws:s3:::{bucket_name}"],
+                    "Account": "000000000000",
+                    "Region": os.environ.get("MINISTACK_REGION", "us-east-1"),
+                }
+                _eb._dispatch_event(eb_event)
+                logger.debug("S3→EventBridge: %s for %s/%s", event_name, bucket_name, key)
+        except Exception:
+            logger.exception("S3→EventBridge delivery failed for %s/%s", bucket_name, key)
 
     except Exception:
         logger.exception(
@@ -1282,7 +1314,12 @@ def _put_object(bucket_name: str, key: str, body: bytes, headers: dict):
         bucket_name, key, "s3:ObjectCreated:Put", size=obj["size"], etag=obj["etag"]
     )
 
-    return 200, {"ETag": obj["etag"]}, b""
+    resp_headers = {"ETag": obj["etag"]}
+    if _bucket_versioning.get(bucket_name) in ("Enabled", "Suspended"):
+        version_id = new_uuid()
+        obj["version_id"] = version_id
+        resp_headers["x-amz-version-id"] = version_id
+    return 200, resp_headers, b""
 
 
 def _apply_object_lock_from_headers(bucket_name: str, key: str, headers: dict):
@@ -1555,10 +1592,16 @@ def _copy_object(bucket_name: str, dest_key: str, headers: dict):
         etag=new_etag,
     )
 
+    resp_headers = {"Content-Type": "application/xml"}
+    if _bucket_versioning.get(bucket_name) in ("Enabled", "Suspended"):
+        version_id = new_uuid()
+        dest_obj["version_id"] = version_id
+        resp_headers["x-amz-version-id"] = version_id
+
     root = Element("CopyObjectResult", xmlns=S3_NS)
     SubElement(root, "LastModified").text = last_modified
     SubElement(root, "ETag").text = new_etag
-    return 200, {"Content-Type": "application/xml"}, _xml_body(root)
+    return 200, resp_headers, _xml_body(root)
 
 
 # ---------------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ministack"
-version = "1.1.20"
+version = "1.1.21"
 description = "Free, open-source local AWS emulator — drop-in LocalStack replacement"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -5161,6 +5161,43 @@ def test_s3_event_notification_delete(s3, sqs):
     assert "ObjectRemoved" in body["Records"][0]["eventName"]
 
 
+def test_s3_eventbridge_notification(s3, sqs, eb):
+    """S3 EventBridgeConfiguration sends events to EventBridge, routed to SQS via rule."""
+    s3.create_bucket(Bucket="s3-eb-bkt")
+    queue_url = sqs.create_queue(QueueName="s3-eb-target-q")["QueueUrl"]
+    queue_arn = sqs.get_queue_attributes(
+        QueueUrl=queue_url, AttributeNames=["QueueArn"],
+    )["Attributes"]["QueueArn"]
+
+    # Enable EventBridge on bucket
+    s3.put_bucket_notification_configuration(
+        Bucket="s3-eb-bkt",
+        NotificationConfiguration={"EventBridgeConfiguration": {}},
+    )
+
+    # Create EventBridge rule matching S3 events → SQS target
+    eb.put_rule(
+        Name="s3-to-sqs-rule",
+        EventPattern=json.dumps({"source": ["aws.s3"]}),
+        State="ENABLED",
+    )
+    eb.put_targets(
+        Rule="s3-to-sqs-rule",
+        Targets=[{"Id": "sqs-target", "Arn": queue_arn}],
+    )
+
+    # Upload object — should trigger S3 → EventBridge → SQS
+    s3.put_object(Bucket="s3-eb-bkt", Key="hello.txt", Body=b"world")
+    time.sleep(0.5)
+
+    msgs = sqs.receive_message(QueueUrl=queue_url, MaxNumberOfMessages=10, WaitTimeSeconds=2)
+    assert "Messages" in msgs and len(msgs["Messages"]) > 0
+    body = json.loads(msgs["Messages"][0]["Body"])
+    assert body["source"] == "aws.s3"
+    assert body["detail"]["bucket"]["name"] == "s3-eb-bkt"
+    assert body["detail"]["object"]["key"] == "hello.txt"
+
+
 # ========== S3 ListObjectVersions / Website / Logging ==========
 
 
@@ -7049,6 +7086,27 @@ def test_s3_bucket_versioning(s3):
     )
     resp = s3.get_bucket_versioning(Bucket="intg-s3-versioning")
     assert resp["Status"] == "Enabled"
+
+
+def test_s3_put_object_returns_version_id(s3):
+    s3.create_bucket(Bucket="intg-s3-ver-put")
+    s3.put_bucket_versioning(
+        Bucket="intg-s3-ver-put",
+        VersioningConfiguration={"Status": "Enabled"},
+    )
+    resp = s3.put_object(Bucket="intg-s3-ver-put", Key="hello.txt", Body=b"v1")
+    assert "VersionId" in resp
+    assert len(resp["VersionId"]) > 0
+
+    # Second put should get a different version
+    resp2 = s3.put_object(Bucket="intg-s3-ver-put", Key="hello.txt", Body=b"v2")
+    assert resp2["VersionId"] != resp["VersionId"]
+
+
+def test_s3_put_object_no_version_id_without_versioning(s3):
+    s3.create_bucket(Bucket="intg-s3-nover-put")
+    resp = s3.put_object(Bucket="intg-s3-nover-put", Key="hello.txt", Body=b"data")
+    assert "VersionId" not in resp
 
 
 def test_s3_bucket_encryption(s3):


### PR DESCRIPTION
### Fixed
- **S3 `PutObject` missing `VersionId` in response** — versioned buckets now return `VersionId` in the `PutObject`, `GetObject`, `HeadObject`, and `CopyObject` responses; each put generates a unique version ID. Reported by @McDoit