### PR TITLE
fix: align Route53 record-set ordering and pagination cursors

### DIFF
--- a/ministack/services/route53.py
+++ b/ministack/services/route53.py
@@ -134,6 +134,12 @@ def _normalise_name(name: str) -> str:
     return name if name.endswith(".") else name + "."
 
 
+def _name_sort_key(name: str) -> tuple[str, ...]:
+    """Route53 sorts names by labels reversed (e.g. com.example.www.)."""
+    labels = _normalise_name(name).rstrip(".").split(".")
+    return tuple(reversed(labels))
+
+
 # ─── default records (SOA + NS) ───────────────────────────────────────────────
 
 _DEFAULT_NS = [
@@ -616,17 +622,36 @@ def _list_resource_record_sets(zone_id: str, query_params: dict):
             return _error_response("NoSuchHostedZone", f"No hosted zone found with ID: {zone_id}", 404)
         records = list(_records.get(zone_id, []))
 
-    records.sort(key=lambda r: (r["Name"], r["Type"], r.get("SetIdentifier", "")))
+    records.sort(
+        key=lambda r: (
+            _name_sort_key(r["Name"]),
+            r["Type"],
+            r.get("SetIdentifier", ""),
+        )
+    )
 
     if start_name:
-        records = [r for r in records if (r["Name"], r["Type"], r.get("SetIdentifier", ""))
-                   >= (start_name, start_type, start_id)]
+        start_key = (
+            _name_sort_key(start_name),
+            start_type,
+            start_id,
+        )
+        records = [
+            r
+            for r in records
+            if (
+                _name_sort_key(r["Name"]),
+                r["Type"],
+                r.get("SetIdentifier", ""),
+            )
+            >= start_key
+        ]
 
     is_truncated = len(records) > max_items
     page = records[:max_items]
-    next_name = page[-1]["Name"] if is_truncated else None
-    next_type = page[-1]["Type"] if is_truncated else None
-    next_id = page[-1].get("SetIdentifier", "") if is_truncated else None
+    next_name = records[max_items]["Name"] if is_truncated else None
+    next_type = records[max_items]["Type"] if is_truncated else None
+    next_id = records[max_items].get("SetIdentifier", "") if is_truncated else None
 
     def build(root):
         rrs_list = SubElement(root, "ResourceRecordSets")

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -9203,6 +9203,169 @@ def test_route53_list_resource_record_sets(r53):
     assert "NS" in types
 
 
+def test_route53_list_resource_record_sets_start_name_uses_reversed_label_order(r53):
+    parent = r53.create_hosted_zone(
+        Name="parent-zone.com", CallerReference="ref-parent-zone"
+    )
+    parent_zone_id = parent["HostedZone"]["Id"].split("/")[-1]
+
+    child = r53.create_hosted_zone(
+        Name="child.parent-zone.com",
+        CallerReference="ref-child-zone",
+    )
+    child_zone_id = child["HostedZone"]["Id"].split("/")[-1]
+
+    child_ns = [
+        rrs
+        for rrs in r53.list_resource_record_sets(HostedZoneId=child_zone_id)["ResourceRecordSets"]
+        if rrs["Name"] == "child.parent-zone.com."
+        and rrs["Type"] == "NS"
+    ][0]
+
+    r53.change_resource_record_sets(
+        HostedZoneId=parent_zone_id,
+        ChangeBatch={
+            "Changes": [
+                {
+                    "Action": "CREATE",
+                    "ResourceRecordSet": {
+                        "Name": "child.parent-zone.com",
+                        "Type": "NS",
+                        "TTL": child_ns["TTL"],
+                        "ResourceRecords": child_ns["ResourceRecords"],
+                    },
+                }
+            ]
+        },
+    )
+
+    list_resp = r53.list_resource_record_sets(
+        HostedZoneId=parent_zone_id,
+        StartRecordName="child.parent-zone.com.",
+        StartRecordType="NS",
+    )
+    returned = list_resp["ResourceRecordSets"]
+
+    assert returned[0]["Name"] == "child.parent-zone.com."
+    assert returned[0]["Type"] == "NS"
+    assert all(
+        not (rrs["Name"] == "parent-zone.com." and rrs["Type"] == "NS")
+        for rrs in returned
+    )
+
+
+def test_route53_list_resource_record_sets_truncated_next_record_uses_next_page_start(r53):
+    resp = r53.create_hosted_zone(
+        Name="pagination-zone.com", CallerReference="ref-next-record"
+    )
+    zone_id = resp["HostedZone"]["Id"].split("/")[-1]
+
+    r53.change_resource_record_sets(
+        HostedZoneId=zone_id,
+        ChangeBatch={
+            "Changes": [
+                {
+                    "Action": "CREATE",
+                    "ResourceRecordSet": {
+                        "Name": "token.pagination-zone.com",
+                        "Type": "TXT",
+                        "TTL": 60,
+                        "ResourceRecords": [{"Value": '"target.pagination-zone.com"'}],
+                    },
+                },
+                {
+                    "Action": "CREATE",
+                    "ResourceRecordSet": {
+                        "Name": "zz-next.pagination-zone.com",
+                        "Type": "NS",
+                        "TTL": 120,
+                        "ResourceRecords": [
+                            {"Value": "ns-1.example.com."},
+                            {"Value": "ns-2.example.com."},
+                            {"Value": "ns-3.example.com."},
+                            {"Value": "ns-4.example.com."},
+                        ],
+                    },
+                }
+            ]
+        },
+    )
+
+    list_resp = r53.list_resource_record_sets(
+        HostedZoneId=zone_id,
+        StartRecordName="token.pagination-zone.com.",
+        StartRecordType="TXT",
+        MaxItems="1",
+    )
+
+    assert list_resp["ResourceRecordSets"][0]["Name"] == "token.pagination-zone.com."
+    assert list_resp["ResourceRecordSets"][0]["Type"] == "TXT"
+    assert list_resp["IsTruncated"] is True
+    assert list_resp["NextRecordName"] == "zz-next.pagination-zone.com."
+    assert list_resp["NextRecordType"] == "NS"
+
+
+def test_route53_list_resource_record_sets_pagination_advances_with_next_record_cursor(r53):
+    resp = r53.create_hosted_zone(
+        Name="cursor-zone.com", CallerReference="ref-cursor-pagination"
+    )
+    zone_id = resp["HostedZone"]["Id"].split("/")[-1]
+
+    r53.change_resource_record_sets(
+        HostedZoneId=zone_id,
+        ChangeBatch={
+            "Changes": [
+                {
+                    "Action": "CREATE",
+                    "ResourceRecordSet": {
+                        "Name": "token.cursor-zone.com",
+                        "Type": "TXT",
+                        "TTL": 60,
+                        "ResourceRecords": [{"Value": '"target.cursor-zone.com"'}],
+                    },
+                },
+                {
+                    "Action": "CREATE",
+                    "ResourceRecordSet": {
+                        "Name": "zz-next.cursor-zone.com",
+                        "Type": "NS",
+                        "TTL": 120,
+                        "ResourceRecords": [
+                            {"Value": "ns-1.example.com."},
+                            {"Value": "ns-2.example.com."},
+                            {"Value": "ns-3.example.com."},
+                            {"Value": "ns-4.example.com."},
+                        ],
+                    },
+                },
+            ]
+        },
+    )
+
+    first_page = r53.list_resource_record_sets(
+        HostedZoneId=zone_id,
+        StartRecordName="token.cursor-zone.com.",
+        StartRecordType="TXT",
+        MaxItems="1",
+    )
+
+    assert first_page["ResourceRecordSets"][0]["Name"] == "token.cursor-zone.com."
+    assert first_page["ResourceRecordSets"][0]["Type"] == "TXT"
+    assert first_page["IsTruncated"] is True
+
+    second_page = r53.list_resource_record_sets(
+        HostedZoneId=zone_id,
+        StartRecordName=first_page["NextRecordName"],
+        StartRecordType=first_page["NextRecordType"],
+        MaxItems="1",
+    )
+
+    assert second_page["ResourceRecordSets"][0]["Name"] == "zz-next.cursor-zone.com."
+    assert second_page["ResourceRecordSets"][0]["Type"] == "NS"
+    assert second_page["ResourceRecordSets"][0]["Name"] != first_page["ResourceRecordSets"][0]["Name"]
+    assert second_page["IsTruncated"] is False
+
+
 def test_route53_upsert_record(r53):
     resp = r53.create_hosted_zone(Name="upsert.com", CallerReference="ref-ups-1")
     zone_id = resp["HostedZone"]["Id"].split("/")[-1]


### PR DESCRIPTION
While running my own Terraform modules against Ministack, I encountered an error that Terraform would run in an endless loop when creating `aws_route53_record` resources.

This PR fixes two Route53 `ListResourceRecordSets` behavior mismatches with AWS that were blocking Terraform flows:
- **Correct DNS name ordering for start cursors**
  - Route53 sorts by reversed labels (for example, `com.example.www.`), not plain string order.
  - Updated listing sort/filter logic to use reversed-label ordering for `StartRecordName` + `StartRecordType`.
  - This prevents parent-zone records from being incorrectly returned ahead of an exact child-name start point.
- **Correct pagination cursor semantics**
  - When `IsTruncated=true`, `NextRecordName` / `NextRecordType` must point to the **first record of the next page**, not the last record of the current page.
  - Fixed cursor generation so `MaxItems=1` no longer returns self-referential `NextRecord*` values.
## Test coverage added/updated
- `test_route53_list_resource_record_sets_start_name_uses_reversed_label_order`
- `test_route53_list_resource_record_sets_truncated_next_record_uses_next_page_start`
- `test_route53_list_resource_record_sets_pagination_advances_with_next_record_cursor`
These tests verify ordering, correct next-page cursor generation, and end-to-end forward pagination progress.

Disclaimer: Yes, I used opencode to create this PR. I tested it locally with Terraform.