### PR TITLE
fix: version bump + changelog for S3 aws-chunked decoding fix (v1.1.28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [1.1.28] — 2026-04-03
+
+### Fixed
+- **S3 aws-chunked decoding** — chunked body decoder now also triggers on `Content-Encoding: aws-chunked` and `x-amz-decoded-content-length` header, not only `STREAMING-*`; fixes AWS SDK Java v2 and Spring Boot S3Template storing raw chunk metadata in object bodies. Strips `aws-chunked` from Content-Encoding before passing to S3 handler. Contributed by @moabukar
+
+---
+
 ## [1.1.27] — 2026-04-03
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ministack"
-version = "1.1.27"
+version = "1.1.28"
 description = "Free, open-source local AWS emulator — drop-in LocalStack replacement"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
- Bump version + release due chunked body decoder now also triggers on `Content-Encoding: aws-chunked` and `x-amz-decoded-content-length` header. Contributed by @moabukar 