### PR TITLE
fix: improve error handling, fix action routing conflicts and harden persistence

### DIFF
--- a/ministack/app.py
+++ b/ministack/app.py
@@ -319,8 +319,8 @@ async def app(scope, receive, send):
                     existing = s3._bucket_tags.get(bucket_name, {})
                     existing.update(new_tags)
                     s3._bucket_tags[bucket_name] = existing
-                except Exception:
-                    pass
+                except Exception as e:
+                    logger.warning("S3 Control TagResource parse error: %s", e)
                 await _send_response(send, 204, {
                     "x-amzn-requestid": request_id,
                 }, b"")
@@ -397,7 +397,7 @@ async def app(scope, receive, send):
                     api_id, stage, execute_path, method, headers, body, query_params
                 )
         except Exception as e:
-            logger.exception(f"Error in execute-api dispatch: {e}")
+            logger.exception("Error in execute-api dispatch: %s", e)
             status, resp_headers, resp_body = 500, {"Content-Type": "application/json"}, json.dumps({"message": str(e)}).encode()
         resp_headers.update({
             "Access-Control-Allow-Origin": "*",
@@ -429,7 +429,7 @@ async def app(scope, receive, send):
                 _alb_lb, method, path, headers, body, query_params, _alb_port
             )
         except Exception as e:
-            logger.exception(f"Error in ALB data-plane dispatch: {e}")
+            logger.exception("Error in ALB data-plane dispatch: %s", e)
             status, resp_headers, resp_body = (
                 500, {"Content-Type": "application/json"},
                 json.dumps({"message": str(e)}).encode(),
@@ -457,9 +457,10 @@ async def app(scope, receive, send):
                     method, vhost_path, headers, body, query_params
                 )
             except Exception as e:
-                logger.exception(f"Error handling virtual-hosted S3 request: {e}")
+                logger.exception("Error handling virtual-hosted S3 request: %s", e)
+                from xml.sax.saxutils import escape as _xml_esc
                 status, resp_headers, resp_body = 500, {"Content-Type": "application/xml"}, (
-                    f"<Error><Code>InternalError</Code><Message>{e}</Message></Error>".encode()
+                    f"<Error><Code>InternalError</Code><Message>{_xml_esc(str(e))}</Message></Error>".encode()
                 )
             resp_headers.update({
                 "Access-Control-Allow-Origin": "*",
@@ -481,7 +482,7 @@ async def app(scope, receive, send):
     service = detect_service(method, path, headers, routing_params)
     region = extract_region(headers)
 
-    logger.debug(f"{method} {path} -> service={service} region={region}")
+    logger.debug("%s %s -> service=%s region=%s", method, path, service, region)
 
     handler = SERVICE_HANDLERS.get(service)
     if not handler:
@@ -492,7 +493,7 @@ async def app(scope, receive, send):
     try:
         status, resp_headers, resp_body = await handler(method, path, headers, body, query_params)
     except Exception as e:
-        logger.exception(f"Error handling {service} request: {e}")
+        logger.exception("Error handling %s request: %s", service, e)
         await _send_response(send, 500, {"Content-Type": "application/json"},
             json.dumps({"__type": "InternalError", "message": str(e)}).encode())
         return

--- a/ministack/core/persistence.py
+++ b/ministack/core/persistence.py
@@ -22,12 +22,20 @@ def save_state(service: str, data: dict) -> None:
         os.makedirs(STATE_DIR, exist_ok=True)
         path = os.path.join(STATE_DIR, f"{service}.json")
         tmp = path + ".tmp"
-        with open(tmp, "w") as f:
-            json.dump(data, f)
-        os.replace(tmp, path)
-        logger.info(f"Persistence: saved {service} state to {path}")
+        try:
+            with open(tmp, "w") as f:
+                json.dump(data, f)
+            os.replace(tmp, path)
+        except BaseException:
+            # Clean up temp file on any failure to avoid stale partial writes
+            try:
+                os.remove(tmp)
+            except OSError:
+                pass
+            raise
+        logger.info("Persistence: saved %s state to %s", service, path)
     except Exception as e:
-        logger.error(f"Persistence: failed to save {service}: {e}")
+        logger.error("Persistence: failed to save %s: %s", service, e)
 
 
 def load_state(service: str) -> dict | None:
@@ -39,10 +47,10 @@ def load_state(service: str) -> dict | None:
     try:
         with open(path) as f:
             data = json.load(f)
-        logger.info(f"Persistence: loaded {service} state from {path}")
+        logger.info("Persistence: loaded %s state from %s", service, path)
         return data
-    except Exception as e:
-        logger.error(f"Persistence: failed to load {service}: {e}")
+    except (json.JSONDecodeError, OSError) as e:
+        logger.error("Persistence: failed to load %s: %s", service, e)
         return None
 
 
@@ -52,4 +60,4 @@ def save_all(services: dict) -> None:
         try:
             save_state(name, get_state())
         except Exception as e:
-            logger.error(f"Persistence: error getting state for {name}: {e}")
+            logger.error("Persistence: error getting state for %s: %s", name, e)

--- a/ministack/core/router.py
+++ b/ministack/core/router.py
@@ -398,7 +398,9 @@ def detect_service(method: str, path: str, headers: dict, query_params: dict) ->
             "UpdateTerminationProtection": "cloudformation",
             "SetStackPolicy": "cloudformation", "GetStackPolicy": "cloudformation",
             # EBS Snapshots
-            "CreateSnapshot": "ec2", "DeleteSnapshot": "ec2", "DescribeSnapshots": "ec2",
+            # Note: CreateSnapshot, DeleteSnapshot, DescribeSnapshots are intentionally
+            # omitted here because they conflict with ElastiCache actions of the same
+            # name. These are routed via credential scope or host header instead.
             "CopySnapshot": "ec2", "ModifySnapshotAttribute": "ec2",
             "DescribeSnapshotAttribute": "ec2",
         }

--- a/ministack/services/rds.py
+++ b/ministack/services/rds.py
@@ -450,7 +450,6 @@ def _reboot_db_instance(p):
     instance = _instances.get(db_id)
     if not instance:
         return _error("DBInstanceNotFound", f"DBInstance {db_id} not found.", 404)
-    instance["DBInstanceStatus"] = "rebooting"
     instance["DBInstanceStatus"] = "available"
     return _single_instance_response("RebootDBInstanceResponse", "RebootDBInstanceResult", instance)
 
@@ -2053,3 +2052,4 @@ def reset():
     _db_cluster_snapshots.clear()
     _option_groups.clear()
     _tags.clear()
+    _port_counter[0] = BASE_PORT


### PR DESCRIPTION
A few fixes which might be worth adding.

- Fix Action-based routing conflict: CreateSnapshot/DeleteSnapshot/DescribeSnapshots were mapped to both ec2 and elasticache in the router action map. The last mapping wins (ec2), which means ElastiCache snapshot operations routed to ec2 incorrectly. Removed the conflicting EBS snapshot entries; these are correctly routed via credential scope or host header instead.

- Fix RDS reboot status: _reboot_db_instance set status to 'rebooting' then immediately overwrote it with 'available' on the next line (dead code). Removed the redundant assignment.

- Fix RDS reset: port counter was not reset on state reset, causing port numbers to keep incrementing across reset cycles. Now resets to BASE_PORT.

- Fix persistence temp file leak: if json.dump() failed mid-write, the .tmp file was left on disk. Added cleanup in a try/finally block.

- Fix persistence load: narrowed bare 'except Exception' to catch only json.JSONDecodeError and OSError, avoiding masking of unexpected errors.

- Fix XML injection in S3 virtual-host error: exception message was interpolated directly into XML without escaping. Now uses xml.sax escape().

- Fix silent S3 Control TagResource failures: bare 'except Exception: pass' swallowed all errors. Now logs a warning.

- Fix logging: replaced f-string interpolation in logger calls with lazy % formatting throughout app.py and persistence.py to avoid unnecessary string formatting when log level is disabled.