### PR TITLE
docs: add Community Integrations section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -787,6 +787,14 @@ See [`Testcontainers/java-testcontainers`](Testcontainers/java-testcontainers), 
 
 ---
 
+## Community Integrations
+
+| Project | Description |
+|---------|-------------|
+| [**StackPort**](https://github.com/DaviReisVieira/stackport) | Visual dashboard to browse and inspect AWS resources in MiniStack. Available on [PyPI](https://pypi.org/project/stackport/) and [Docker Hub](https://hub.docker.com/r/davireis/stackport). |
+
+---
+
 ## Contributing
 
 PRs welcome. The codebase is intentionally simple — each service is a single self-contained Python file in `ministack/services/`. Adding a new service means:


### PR DESCRIPTION
## Summary

- Adds a **Community Integrations** section to the README, just before the Contributing section
- Lists [StackPort](https://github.com/DaviReisVieira/stackport) — a visual dashboard for browsing and inspecting AWS resources in MiniStack

As discussed in #116, StackPort is a standalone UI that connects to MiniStack on port 4566 and provides a dashboard to browse all 35+ emulated services. Available on [PyPI](https://pypi.org/project/stackport/) and [Docker Hub](https://hub.docker.com/r/davireis/stackport).

The table format makes it easy to add more community projects in the future.