### PR TITLE
feat: add state persistence to Step Functions service

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,7 +511,7 @@ Install DuckDB for full Athena SQL compatibility: `pip install ministack[full]`.
 
 When `PERSIST_STATE=1`, MiniStack saves service state to `STATE_DIR` on shutdown and reloads it on startup. Writes are atomic (write-to-tmp then rename) to prevent corruption on crash.
 
-Services currently supporting persistence: **API Gateway v1**, **API Gateway v2**
+Services currently supporting persistence: **API Gateway v1**, **API Gateway v2**, **AppSync**, **CloudWatch**, **CloudWatch Logs**, **Cognito**, **DynamoDB**, **EC2**, **ECR**, **ECS**, **ElastiCache**, **EventBridge**, **IAM/STS**, **Kinesis**, **KMS**, **Lambda**, **RDS**, **Route 53**, **S3**, **Secrets Manager**, **SNS**, **SQS**, **SSM**, **Step Functions**
 
 ```bash
 docker run -p 4566:4566 \

--- a/ministack/app.py
+++ b/ministack/app.py
@@ -590,6 +590,7 @@ async def _handle_lifespan(scope, receive, send):
                     "ecs": ecs.get_state,
                     "elasticache": elasticache.get_state,
                     "appsync": appsync.get_state,
+                    "stepfunctions": stepfunctions.get_state,
                 })
             await send({"type": "lifespan.shutdown.complete"})
             return

--- a/ministack/services/stepfunctions.py
+++ b/ministack/services/stepfunctions.py
@@ -19,10 +19,10 @@ SUCCEEDED / FAILED / TIMED_OUT / ABORTED.
 """
 
 import asyncio
-import os
 import copy
 import json
 import logging
+import os
 import re
 import threading
 import time
@@ -30,6 +30,7 @@ from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import wait as futures_wait
 from datetime import datetime, timezone
 
+from ministack.core.persistence import PERSIST_STATE, load_state
 from ministack.core.responses import (
     error_response_json,
     json_response,
@@ -96,6 +97,38 @@ _task_tokens: dict = {}
 _tags: dict = {}
 _activities: dict = {}
 _activity_tasks: dict = {}
+
+# ── Persistence ────────────────────────────────────────────
+
+def get_state():
+    return {
+        "state_machines": copy.deepcopy(_state_machines),
+        "executions": copy.deepcopy(_executions),
+        "tags": copy.deepcopy(_tags),
+        "activities": copy.deepcopy(_activities),
+    }
+
+
+def restore_state(data):
+    if not data:
+        return
+    _state_machines.update(data.get("state_machines", {}))
+    _executions.update(data.get("executions", {}))
+    _tags.update(data.get("tags", {}))
+    _activities.update(data.get("activities", {}))
+    # Executions that were RUNNING when the process died cannot resume —
+    # mark them FAILED, following the ECS precedent (tasks → STOPPED).
+    for exc in _executions.values():
+        if exc.get("status") == "RUNNING":
+            exc["status"] = "FAILED"
+            exc["stopDate"] = now_iso()
+            exc["error"] = "States.ServiceRestart"
+            exc["cause"] = "Execution was running when service restarted"
+
+
+_restored = load_state("stepfunctions")
+if _restored:
+    restore_state(_restored)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -19290,3 +19290,64 @@ def test_firehose_s3_destination_writes(s3, fh):
     obj = s3.get_object(Bucket=bucket, Key=key)
     body = obj["Body"].read()
     assert b"hello from firehose" in body
+
+
+# ========== Persistence roundtrip — Step Functions ==========
+
+
+def test_persist_stepfunctions_roundtrip():
+    from ministack.services import stepfunctions as _sfn
+    sm_arn = "arn:aws:states:us-east-1:000000000000:stateMachine:persist-sm"
+    _sfn._state_machines[sm_arn] = {
+        "stateMachineArn": sm_arn,
+        "name": "persist-sm",
+        "definition": '{"StartAt":"Pass","States":{"Pass":{"Type":"Pass","End":true}}}',
+        "roleArn": "arn:aws:iam::000000000000:role/sfn",
+        "type": "STANDARD",
+        "status": "ACTIVE",
+    }
+    state = _sfn.get_state()
+    assert "state_machines" in state
+    assert sm_arn in state["state_machines"]
+    _sfn._state_machines.pop(sm_arn)
+    _sfn.restore_state(state)
+    assert sm_arn in _sfn._state_machines
+    assert _sfn._state_machines[sm_arn]["name"] == "persist-sm"
+    _sfn._state_machines.pop(sm_arn)
+
+
+def test_persist_stepfunctions_running_marked_failed():
+    from ministack.services import stepfunctions as _sfn
+    run_arn = "arn:aws:states:us-east-1:000000000000:execution:persist-sm:run-1"
+    done_arn = "arn:aws:states:us-east-1:000000000000:execution:persist-sm:done-1"
+    _sfn._executions[run_arn] = {
+        "executionArn": run_arn,
+        "stateMachineArn": "arn:aws:states:us-east-1:000000000000:stateMachine:persist-sm",
+        "status": "RUNNING",
+        "startDate": "2026-01-01T00:00:00.000Z",
+    }
+    _sfn._executions[done_arn] = {
+        "executionArn": done_arn,
+        "stateMachineArn": "arn:aws:states:us-east-1:000000000000:stateMachine:persist-sm",
+        "status": "SUCCEEDED",
+        "startDate": "2026-01-01T00:00:00.000Z",
+        "stopDate": "2026-01-01T00:01:00.000Z",
+        "output": '{"result": "ok"}',
+    }
+    state = _sfn.get_state()
+    _sfn._executions.pop(run_arn)
+    _sfn._executions.pop(done_arn)
+    _sfn.restore_state(state)
+    # RUNNING execution should be marked FAILED
+    restored_run = _sfn._executions[run_arn]
+    assert restored_run["status"] == "FAILED"
+    assert restored_run["error"] == "States.ServiceRestart"
+    assert restored_run["cause"] == "Execution was running when service restarted"
+    assert "stopDate" in restored_run
+    assert restored_run["startDate"] == "2026-01-01T00:00:00.000Z"
+    # SUCCEEDED execution should pass through unchanged
+    restored_done = _sfn._executions[done_arn]
+    assert restored_done["status"] == "SUCCEEDED"
+    assert restored_done["output"] == '{"result": "ok"}'
+    _sfn._executions.pop(run_arn)
+    _sfn._executions.pop(done_arn)


### PR DESCRIPTION
# What

- Add `PERSIST_STATE=1` support for Step Functions (`get_state()` / `restore_state()`)
- Persist state machines, executions, tags, and activities across container restarts
- RUNNING executions are restored as FAILED with `States.ServiceRestart` error (matching ECS precedent)
- Transient state (`_task_tokens`, `_activity_tasks`) intentionally excluded — meaningless after restart
- Register stepfunctions in `save_all()` shutdown hook
- Update README persistence list from 2 → 24 services (was stale)
