### PR TITLE
feat: implement IAM ListEntitiesForPolicy API

### DIFF
--- a/ministack/services/iam_sts.py
+++ b/ministack/services/iam_sts.py
@@ -433,6 +433,52 @@ def _delete_policy(p):
     return _xml(200, "DeletePolicyResponse", "", ns="iam")
 
 
+# -------------------- List entities for policy --------------------
+
+def _list_entities_for_policy(p):
+    arn = _p(p, "PolicyArn")
+    if arn not in _policies:
+        return _error(404, "NoSuchEntity", f"Policy {arn} not found.", ns="iam")
+    entity_filter = _p(p, "EntityFilter") or ""
+    path_prefix = _p(p, "PathPrefix") or "/"
+
+    groups_xml = ""
+    if entity_filter in ("", "Group"):
+        for g in _groups.values():
+            if not g.get("Path", "/").startswith(path_prefix):
+                continue
+            if arn in g.get("AttachedPolicies", []):
+                groups_xml += (f"<member><GroupName>{g['GroupName']}</GroupName>"
+                               f"<GroupId>{g['GroupId']}</GroupId></member>")
+
+    roles_xml = ""
+    if entity_filter in ("", "Role"):
+        for r in _roles.values():
+            if not r.get("Path", "/").startswith(path_prefix):
+                continue
+            if arn in r.get("AttachedPolicies", []):
+                roles_xml += (f"<member><RoleName>{r['RoleName']}</RoleName>"
+                              f"<RoleId>{r['RoleId']}</RoleId></member>")
+
+    users_xml = ""
+    if entity_filter in ("", "User"):
+        for u in _users.values():
+            if not u.get("Path", "/").startswith(path_prefix):
+                continue
+            if arn in u.get("AttachedPolicies", []):
+                users_xml += (f"<member><UserName>{u['UserName']}</UserName>"
+                              f"<UserId>{u['UserId']}</UserId></member>")
+
+    return _xml(200, "ListEntitiesForPolicyResponse",
+                f"<ListEntitiesForPolicyResult>"
+                f"<PolicyGroups>{groups_xml}</PolicyGroups>"
+                f"<PolicyRoles>{roles_xml}</PolicyRoles>"
+                f"<PolicyUsers>{users_xml}</PolicyUsers>"
+                f"<IsTruncated>false</IsTruncated>"
+                f"</ListEntitiesForPolicyResult>",
+                ns="iam")
+
+
 # -------------------- Attached role policies --------------------
 
 def _attach_role_policy(p):
@@ -1559,6 +1605,7 @@ _IAM_HANDLERS = {
     "DeletePolicyVersion": _delete_policy_version,
     "ListPolicies": _list_policies,
     "DeletePolicy": _delete_policy,
+    "ListEntitiesForPolicy": _list_entities_for_policy,
     "AttachRolePolicy": _attach_role_policy,
     "DetachRolePolicy": _detach_role_policy,
     "ListAttachedRolePolicies": _list_attached_role_policies,

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -11772,6 +11772,38 @@ def test_iam_attach_detach_user_policy(iam):
     assert not any(p["PolicyArn"] == policy_arn for p in attached2)
 
 
+def test_iam_list_entities_for_policy(iam):
+    """ListEntitiesForPolicy returns users and roles attached to a policy."""
+    doc = json.dumps({"Version": "2012-10-17", "Statement": []})
+    assume = json.dumps({"Version": "2012-10-17", "Statement": []})
+    policy_arn = iam.create_policy(PolicyName="qa-entities-pol", PolicyDocument=doc)["Policy"]["Arn"]
+    iam.create_user(UserName="qa-entities-user")
+    try:
+        iam.create_role(RoleName="qa-entities-role", AssumeRolePolicyDocument=assume)
+    except ClientError:
+        pass
+    iam.attach_user_policy(UserName="qa-entities-user", PolicyArn=policy_arn)
+    iam.attach_role_policy(RoleName="qa-entities-role", PolicyArn=policy_arn)
+
+    resp = iam.list_entities_for_policy(PolicyArn=policy_arn)
+    user_names = [u["UserName"] for u in resp["PolicyUsers"]]
+    role_names = [r["RoleName"] for r in resp["PolicyRoles"]]
+    assert "qa-entities-user" in user_names
+    assert "qa-entities-role" in role_names
+
+    # Detach user and verify it's removed
+    iam.detach_user_policy(UserName="qa-entities-user", PolicyArn=policy_arn)
+    resp2 = iam.list_entities_for_policy(PolicyArn=policy_arn)
+    user_names2 = [u["UserName"] for u in resp2["PolicyUsers"]]
+    assert "qa-entities-user" not in user_names2
+    assert "qa-entities-role" in [r["RoleName"] for r in resp2["PolicyRoles"]]
+
+    # Test EntityFilter
+    resp3 = iam.list_entities_for_policy(PolicyArn=policy_arn, EntityFilter="Role")
+    assert len(resp3["PolicyRoles"]) >= 1
+    assert len(resp3.get("PolicyUsers", [])) == 0
+
+
 # ---------------------------------------------------------------------------
 # SECRETS MANAGER — edge cases
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# What

- Implement `ListEntitiesForPolicy` IAM API: returns all users, roles, and groups attached to a specified managed policy ARN
- Support `EntityFilter` parameter to scope results to a specific entity type (User, Role, Group)
- Support `PathPrefix` parameter to filter entities by IAM path
- Add integration test covering attach, detach, and entity filter scenarios


P.S. Maybe time to split up the monolithic test file? 😅