### PR TITLE
Fix Step Functions timestamp wire compatibility

### DIFF
--- a/ministack/services/stepfunctions.py
+++ b/ministack/services/stepfunctions.py
@@ -131,6 +131,55 @@ if _restored:
     restore_state(_restored)
 
 
+_TIMESTAMP_RESPONSE_FIELDS = {
+    "creationDate",
+    "redriveDate",
+    "startDate",
+    "stopDate",
+    "timestamp",
+    "updateDate",
+}
+
+
+def _timestamp_response_value(value):
+    """Step Functions models timestamps as JSON numbers, not ISO strings."""
+    if not isinstance(value, str):
+        return value
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
+    except ValueError:
+        return value
+
+
+def _normalize_timestamp_response(payload, field_name=None):
+    if isinstance(payload, dict):
+        return {
+            key: _normalize_timestamp_response(value, key)
+            for key, value in payload.items()
+        }
+    if isinstance(payload, list):
+        return [_normalize_timestamp_response(item, field_name) for item in payload]
+    if field_name in _TIMESTAMP_RESPONSE_FIELDS:
+        return _timestamp_response_value(payload)
+    return payload
+
+
+def _finalize_response(response):
+    """Serialize Step Functions timestamps in the format AWS SDKs expect."""
+    status, headers, body = response
+    if not body:
+        return response
+    try:
+        payload = json.loads(body)
+    except (TypeError, ValueError):
+        return response
+
+    normalized = _normalize_timestamp_response(payload)
+    if normalized == payload:
+        return response
+    return json_response(normalized, status)
+
+
 # ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
@@ -175,8 +224,8 @@ async def handle_request(method, path, headers, body, query_params):
     if not handler:
         return error_response_json("InvalidAction", f"Unknown action: {action}", 400)
     if action == "GetActivityTask":
-        return await _get_activity_task(data)
-    return handler(data)
+        return _finalize_response(await _get_activity_task(data))
+    return _finalize_response(handler(data))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -12285,6 +12285,109 @@ def test_sfn_list_executions_filter(sfn):
     assert all(e["status"] == "SUCCEEDED" for e in succeeded)
 
 
+def test_sfn_timestamp_fields_are_sdk_compatible(sfn, sfn_sync):
+    """SFN timestamp fields must deserialize as datetimes, not fail as strings."""
+    import datetime
+
+    def assert_dt(value, field_name):
+        assert isinstance(value, datetime.datetime), (
+            f"{field_name} should be datetime, got {type(value)}"
+        )
+
+    unique = str(time.time_ns())
+    definition = json.dumps(
+        {
+            "StartAt": "Done",
+            "States": {"Done": {"Type": "Succeed"}},
+        }
+    )
+
+    create = sfn.create_state_machine(
+        name=f"qa-sfn-ts-{unique}",
+        definition=definition,
+        roleArn="arn:aws:iam::000000000000:role/r",
+    )
+    assert_dt(create["creationDate"], "CreateStateMachine.creationDate")
+
+    arn = create["stateMachineArn"]
+    desc = sfn.describe_state_machine(stateMachineArn=arn)
+    assert_dt(desc["creationDate"], "DescribeStateMachine.creationDate")
+
+    updated = sfn.update_state_machine(stateMachineArn=arn, definition=definition)
+    assert_dt(updated["updateDate"], "UpdateStateMachine.updateDate")
+
+    machines = sfn.list_state_machines()["stateMachines"]
+    listed_sm = next(sm for sm in machines if sm["stateMachineArn"] == arn)
+    assert_dt(listed_sm["creationDate"], "ListStateMachines.creationDate")
+
+    start = sfn.start_execution(stateMachineArn=arn, input="{}")
+    assert_dt(start["startDate"], "StartExecution.startDate")
+
+    exec_arn = start["executionArn"]
+    exec_desc = _wait_sfn(sfn, exec_arn)
+    assert_dt(exec_desc["startDate"], "DescribeExecution.startDate")
+    assert_dt(exec_desc["stopDate"], "DescribeExecution.stopDate")
+
+    sm_for_exec = sfn.describe_state_machine_for_execution(executionArn=exec_arn)
+    assert_dt(
+        sm_for_exec["updateDate"],
+        "DescribeStateMachineForExecution.updateDate",
+    )
+
+    executions = sfn.list_executions(stateMachineArn=arn)["executions"]
+    listed_exec = next(ex for ex in executions if ex["executionArn"] == exec_arn)
+    assert_dt(listed_exec["startDate"], "ListExecutions.startDate")
+    assert_dt(listed_exec["stopDate"], "ListExecutions.stopDate")
+
+    history = sfn.get_execution_history(executionArn=exec_arn)["events"]
+    assert history, "GetExecutionHistory should return at least one event"
+    assert_dt(history[0]["timestamp"], "GetExecutionHistory.events[].timestamp")
+
+    sync = sfn_sync.start_sync_execution(stateMachineArn=arn, input="{}")
+    assert_dt(sync["startDate"], "StartSyncExecution.startDate")
+    assert_dt(sync["stopDate"], "StartSyncExecution.stopDate")
+
+    wait_definition = json.dumps(
+        {
+            "StartAt": "Wait",
+            "States": {"Wait": {"Type": "Wait", "Seconds": 60, "End": True}},
+        }
+    )
+    wait_sm = sfn.create_state_machine(
+        name=f"qa-sfn-ts-stop-{unique}",
+        definition=wait_definition,
+        roleArn="arn:aws:iam::000000000000:role/r",
+    )
+    wait_exec = sfn.start_execution(
+        stateMachineArn=wait_sm["stateMachineArn"],
+        input="{}",
+    )
+    stopped = sfn.stop_execution(executionArn=wait_exec["executionArn"], cause="test stop")
+    assert_dt(stopped["stopDate"], "StopExecution.stopDate")
+
+
+def test_sfn_activity_timestamp_fields_are_sdk_compatible(sfn):
+    """SFN activity timestamp fields must deserialize as datetimes."""
+    import datetime
+
+    def assert_dt(value, field_name):
+        assert isinstance(value, datetime.datetime), (
+            f"{field_name} should be datetime, got {type(value)}"
+        )
+
+    unique = str(time.time_ns())
+    created = sfn.create_activity(name=f"qa-sfn-activity-ts-{unique}")
+    assert_dt(created["creationDate"], "CreateActivity.creationDate")
+
+    arn = created["activityArn"]
+    desc = sfn.describe_activity(activityArn=arn)
+    assert_dt(desc["creationDate"], "DescribeActivity.creationDate")
+
+    activities = sfn.list_activities()["activities"]
+    listed = next(act for act in activities if act["activityArn"] == arn)
+    assert_dt(listed["creationDate"], "ListActivities.creationDate")
+
+
 # ---------------------------------------------------------------------------
 # CLOUDWATCH — edge cases
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why
MiniStack Step Functions responses currently return ISO timestamp strings. AWS SDK clients expect JSON timestamp numbers for these fields, so Go SDK v2 and botocore can fail to deserialize responses before workflows even start.

## What
- Normalize Step Functions timestamp fields at the response boundary for state machine, execution, history, sync, stop, and activity APIs
- Keep internal Step Functions state unchanged and apply the wire-format fix centrally in `handle_request`
- Add SDK-facing regression tests covering the affected timestamp-bearing APIs

## Risk Assessment
Low. The change is isolated to Step Functions response serialization, and the internal interpreter and persistence behavior are unchanged.

## References
- Verified with `python3 -m py_compile ministack/services/stepfunctions.py tests/test_services.py`
- Verified with `pytest tests/test_services.py -v --tb=short -k 'sfn or stepfunctions'` (48 passed)

Generated with Codex
