### PR TITLE
feat: CDK bootstrap (KMS/IAM/ECR), ECS timestamp fix, SFN nested sync…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [1.1.44] — 2026-04-06
+
+### Added
+- **CFN `AWS::IAM::ManagedPolicy`, `AWS::KMS::Key`, `AWS::KMS::Alias`** — completes full CDK bootstrap support. All 9 resource types in the CDKToolkit stack now work.
+- **Step Functions nested `startExecution.sync`** — parent workflows can now invoke child state machines synchronously via `arn:aws:states:::states:startExecution.sync` and `.sync:2`. Output shape matches AWS (`.sync` = JSON string, `.sync:2` = parsed JSON). Contributed by @jayjanssen (#157)
+
+### Fixed
+- **API Gateway v2 `lastUpdatedDate` returned as ISO8601 string** — Stage and Deployment `lastUpdatedDate` was returning Unix timestamp (number), causing Terraform deserialization failure on `aws_apigatewayv2_stage`. Reported by @hmarcuzzo (#132)
+- **ECS timestamp wire format** — all ECS timestamp fields (`createdAt`, `startedAt`, `stoppedAt`, etc.) now return epoch numbers instead of ISO strings. Fixes SDK deserialization for Go, Java, and other typed SDKs
+
+### Tests
+- 4 new tests: EMR instance fleets, ECS timestamp format, API GW v2 stage timestamps, CDK bootstrap full stack
+
+---
+
 ## [1.1.43] — 2026-04-06
 
 ### Added

--- a/ministack/services/apigateway.py
+++ b/ministack/services/apigateway.py
@@ -571,7 +571,7 @@ def _create_stage(api_id, data):
         "stageName": stage_name,
         "autoDeploy": data.get("autoDeploy", False),
         "createdDate": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
-        "lastUpdatedDate": int(time.time()),
+        "lastUpdatedDate": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
         "stageVariables": data.get("stageVariables", {}),
         "description": data.get("description", ""),
         "defaultRouteSettings": data.get("defaultRouteSettings", {}),
@@ -601,7 +601,7 @@ def _update_stage(api_id, stage_name, data):
               "defaultRouteSettings", "routeSettings"):
         if k in data:
             stage[k] = data[k]
-    stage["lastUpdatedDate"] = int(time.time())
+    stage["lastUpdatedDate"] = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
     return _apigw_response(stage)
 
 

--- a/ministack/services/cloudformation/provisioners.py
+++ b/ministack/services/cloudformation/provisioners.py
@@ -28,6 +28,7 @@ import ministack.services.appsync as _appsync
 import ministack.services.secretsmanager as _sm
 import ministack.services.cognito as _cognito
 import ministack.services.ecr as _ecr
+import ministack.services.kms as _kms
 
 
 logger = logging.getLogger("cloudformation")
@@ -1295,6 +1296,69 @@ def _ecr_repo_delete(physical_id, props):
     _ecr._repositories.pop(physical_id, None)
 
 
+# --- IAM ManagedPolicy provisioner ---
+
+def _iam_managed_policy_create(logical_id, props, stack_name):
+    name = props.get("ManagedPolicyName", f"{stack_name}-{logical_id}")
+    arn = f"arn:aws:iam::{ACCOUNT_ID}:policy/{name}"
+    policy_doc = props.get("PolicyDocument", {})
+    _iam_sts._policies[arn] = {
+        "PolicyName": name,
+        "PolicyId": new_uuid().replace("-", "")[:21].upper(),
+        "Arn": arn,
+        "Path": props.get("Path", "/"),
+        "DefaultVersionId": "v1",
+        "AttachmentCount": 0,
+        "IsAttachable": True,
+        "Description": props.get("Description", ""),
+        "CreateDate": __import__("time").strftime("%Y-%m-%dT%H:%M:%SZ", __import__("time").gmtime()),
+        "UpdateDate": __import__("time").strftime("%Y-%m-%dT%H:%M:%SZ", __import__("time").gmtime()),
+        "PolicyVersions": [{"Document": json.dumps(policy_doc) if isinstance(policy_doc, dict) else policy_doc, "VersionId": "v1", "IsDefaultVersion": True}],
+    }
+    return arn, {"Arn": arn}
+
+
+def _iam_managed_policy_delete(physical_id, props):
+    _iam_sts._policies.pop(physical_id, None)
+
+
+# --- KMS resource provisioners ---
+
+def _kms_key_create(logical_id, props, stack_name):
+    key_id = new_uuid()
+    arn = f"arn:aws:kms:{REGION}:{ACCOUNT_ID}:key/{key_id}"
+    _kms._keys[key_id] = {
+        "KeyId": key_id,
+        "Arn": arn,
+        "KeyState": "Enabled",
+        "Enabled": True,
+        "KeySpec": "SYMMETRIC_DEFAULT",
+        "KeyUsage": props.get("KeyUsage", "ENCRYPT_DECRYPT"),
+        "Description": props.get("Description", ""),
+        "CreationDate": __import__("time").time(),
+        "Origin": "AWS_KMS",
+        "_symmetric_key": __import__("os").urandom(32),
+        "EncryptionAlgorithms": ["SYMMETRIC_DEFAULT"],
+        "SigningAlgorithms": [],
+    }
+    return key_id, {"Arn": arn, "KeyId": key_id}
+
+
+def _kms_key_delete(physical_id, props):
+    _kms._keys.pop(physical_id, None)
+
+
+def _kms_alias_create(logical_id, props, stack_name):
+    alias_name = props.get("AliasName", f"alias/{stack_name}-{logical_id}")
+    target_key = props.get("TargetKeyId", "")
+    _kms._aliases[alias_name] = target_key
+    return alias_name, {}
+
+
+def _kms_alias_delete(physical_id, props):
+    _kms._aliases.pop(physical_id, None)
+
+
 # Resource Handler Registry
 # ===========================================================================
 
@@ -1336,4 +1400,7 @@ _RESOURCE_HANDLERS = {
     "AWS::Cognito::IdentityPool": {"create": _cognito_identity_pool_create, "delete": _cognito_identity_pool_delete},
     "AWS::Cognito::UserPoolDomain": {"create": _cognito_user_pool_domain_create, "delete": _cognito_user_pool_domain_delete},
     "AWS::ECR::Repository": {"create": _ecr_repo_create, "delete": _ecr_repo_delete},
+    "AWS::IAM::ManagedPolicy": {"create": _iam_managed_policy_create, "delete": _iam_managed_policy_delete},
+    "AWS::KMS::Key": {"create": _kms_key_create, "delete": _kms_key_delete},
+    "AWS::KMS::Alias": {"create": _kms_alias_create, "delete": _kms_alias_delete},
 }

--- a/ministack/services/ecs.py
+++ b/ministack/services/ecs.py
@@ -120,6 +120,47 @@ def _iso():
 # Request routing
 # ---------------------------------------------------------------------------
 
+_ECS_TIMESTAMP_FIELDS = {
+    "createdAt", "startedAt", "stoppedAt", "registeredAt",
+    "deregisteredAt", "updatedAt", "lastModified", "runningAt",
+    "pullStartedAt", "pullStoppedAt", "executionStoppedAt",
+}
+
+
+def _ts_to_epoch(value):
+    if not isinstance(value, str):
+        return value
+    try:
+        from datetime import datetime, timezone
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
+    except (ValueError, TypeError):
+        return value
+
+
+def _normalize_ecs_timestamps(payload, field_name=None):
+    if isinstance(payload, dict):
+        return {k: _normalize_ecs_timestamps(v, k) for k, v in payload.items()}
+    if isinstance(payload, list):
+        return [_normalize_ecs_timestamps(item, field_name) for item in payload]
+    if field_name in _ECS_TIMESTAMP_FIELDS:
+        return _ts_to_epoch(payload)
+    return payload
+
+
+def _finalize_ecs_response(response):
+    status, headers_resp, body = response
+    if not body:
+        return response
+    try:
+        payload = json.loads(body)
+    except (TypeError, ValueError):
+        return response
+    normalized = _normalize_ecs_timestamps(payload)
+    if normalized == payload:
+        return response
+    return json_response(normalized, status)
+
+
 async def handle_request(method, path, headers, body, query_params):
     try:
         data = json.loads(body) if body else {}
@@ -134,13 +175,13 @@ async def handle_request(method, path, headers, body, query_params):
     target = headers.get("x-amz-target", "") or headers.get("X-Amz-Target", "")
     if target:
         action = target.split(".")[-1]
-        return _dispatch_action(action, data)
+        return _finalize_ecs_response(_dispatch_action(action, data))
 
     parts = [p for p in path.strip("/").split("/") if p]
     if not parts:
         return error_response_json("InvalidRequest", "Missing path", 400)
 
-    return _dispatch_path(method, parts, data)
+    return _finalize_ecs_response(_dispatch_path(method, parts, data))
 
 
 def _dispatch_action(action, data):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ministack"
-version = "1.1.43"
+version = "1.1.44"
 description = "Free, open-source local AWS emulator — drop-in LocalStack replacement"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -19885,3 +19885,130 @@ def test_cloudfront_tags(cloudfront):
     tag_keys = [t["Key"] for t in tags["Tags"]["Items"]]
     assert "env" in tag_keys
     assert "team" not in tag_keys
+
+
+# ---------------------------------------------------------------------------
+# EMR v1.1.44 — instance fleets
+# ---------------------------------------------------------------------------
+
+def test_emr_instance_fleets(emr):
+    """AddInstanceFleet / ListInstanceFleets / ModifyInstanceFleet."""
+    resp = emr.run_job_flow(
+        Name="fleet-test-v44",
+        ReleaseLabel="emr-6.15.0",
+        Instances={
+            "KeepJobFlowAliveWhenNoSteps": True,
+            "InstanceFleets": [
+                {"InstanceFleetType": "MASTER", "Name": "master-fleet",
+                 "TargetOnDemandCapacity": 1,
+                 "InstanceTypeConfigs": [{"InstanceType": "m5.xlarge"}]},
+            ],
+        },
+        JobFlowRole="EMR_EC2_DefaultRole",
+        ServiceRole="EMR_DefaultRole",
+    )
+    cluster_id = resp["JobFlowId"]
+
+    # Add a CORE fleet
+    add_resp = emr.add_instance_fleet(
+        ClusterId=cluster_id,
+        InstanceFleet={
+            "InstanceFleetType": "CORE", "Name": "core-fleet",
+            "TargetOnDemandCapacity": 2,
+            "InstanceTypeConfigs": [{"InstanceType": "m5.xlarge"}],
+        },
+    )
+    fleet_id = add_resp["InstanceFleetId"]
+    assert fleet_id
+
+    # List fleets
+    fleets = emr.list_instance_fleets(ClusterId=cluster_id)
+    fleet_types = [f["InstanceFleetType"] for f in fleets["InstanceFleets"]]
+    assert "MASTER" in fleet_types
+    assert "CORE" in fleet_types
+
+    emr.terminate_job_flows(JobFlowIds=[cluster_id])
+
+
+# ---------------------------------------------------------------------------
+# v1.1.44 — timestamp wire format tests
+# ---------------------------------------------------------------------------
+
+def test_ecs_timestamps_are_epoch(ecs):
+    """ECS timestamps should be epoch numbers, not ISO strings."""
+    ecs.create_cluster(clusterName="ts-test-v44")
+    clusters = ecs.describe_clusters(clusters=["ts-test-v44"])
+    registered = clusters["clusters"][0].get("registeredContainerInstancesCount", 0)
+    # registeredAt might not be present on cluster, test on task def
+    ecs.register_task_definition(
+        family="ts-td-v44",
+        containerDefinitions=[{"name": "app", "image": "nginx", "memory": 256}],
+    )
+    td = ecs.describe_task_definition(taskDefinition="ts-td-v44")
+    registered_at = td["taskDefinition"].get("registeredAt")
+    if registered_at is not None:
+        from datetime import datetime
+        assert isinstance(registered_at, datetime), f"registeredAt should be datetime, got {type(registered_at)}"
+
+
+def test_apigw_v2_stage_timestamps(apigw):
+    """API Gateway v2 Stage timestamps should be ISO8601 (datetime)."""
+    from datetime import datetime
+    api = apigw.create_api(Name="ts-stage-v44", ProtocolType="HTTP")
+    api_id = api["ApiId"]
+    stage = apigw.create_stage(ApiId=api_id, StageName="test-stage")
+    assert isinstance(stage["CreatedDate"], datetime), f"CreatedDate should be datetime, got {type(stage['CreatedDate'])}"
+    assert isinstance(stage["LastUpdatedDate"], datetime), f"LastUpdatedDate should be datetime, got {type(stage['LastUpdatedDate'])}"
+    apigw.delete_api(ApiId=api_id)
+
+
+def test_cfn_cdk_bootstrap_resources(cfn, s3, ecr):
+    """CDK bootstrap template resources: S3 + ECR + IAM Role + KMS Key + SSM Parameter."""
+    template = {
+        "AWSTemplateFormatVersion": "2010-09-09",
+        "Resources": {
+            "StagingBucket": {
+                "Type": "AWS::S3::Bucket",
+                "Properties": {"BucketName": "cdk-bootstrap-v44"},
+            },
+            "ContainerRepo": {
+                "Type": "AWS::ECR::Repository",
+                "Properties": {"RepositoryName": "cdk-assets-v44"},
+            },
+            "DeployRole": {
+                "Type": "AWS::IAM::Role",
+                "Properties": {
+                    "RoleName": "cdk-deploy-v44",
+                    "AssumeRolePolicyDocument": {"Version": "2012-10-17", "Statement": []},
+                },
+            },
+            "FileKey": {
+                "Type": "AWS::KMS::Key",
+                "Properties": {"Description": "CDK file assets key"},
+            },
+            "KeyAlias": {
+                "Type": "AWS::KMS::Alias",
+                "Properties": {"AliasName": "alias/cdk-key-v44", "TargetKeyId": "dummy"},
+            },
+            "BootstrapVersion": {
+                "Type": "AWS::SSM::Parameter",
+                "Properties": {"Name": "/cdk-bootstrap/v44/version", "Type": "String", "Value": "27"},
+            },
+            "DeployPolicy": {
+                "Type": "AWS::IAM::ManagedPolicy",
+                "Properties": {"ManagedPolicyName": "cdk-policy-v44", "PolicyDocument": {"Version": "2012-10-17", "Statement": []}},
+            },
+        },
+    }
+    cfn.create_stack(StackName="CDKToolkit-v44", TemplateBody=json.dumps(template))
+    import time as _t; _t.sleep(2)
+    stack = cfn.describe_stacks(StackName="CDKToolkit-v44")["Stacks"][0]
+    assert stack["StackStatus"] == "CREATE_COMPLETE"
+
+    # Verify resources
+    buckets = [b["Name"] for b in s3.list_buckets()["Buckets"]]
+    assert "cdk-bootstrap-v44" in buckets
+    repos = [r["repositoryName"] for r in ecr.describe_repositories()["repositories"]]
+    assert "cdk-assets-v44" in repos
+
+    cfn.delete_stack(StackName="CDKToolkit-v44")


### PR DESCRIPTION
- CFN: AWS::IAM::ManagedPolicy, AWS::KMS::Key, AWS::KMS::Alias — full CDK bootstrap support                      
  - SFN: nested startExecution.sync and .sync:2 (@jayjanssen #157)                                                 
  - Fix: API Gateway v2 Stage lastUpdatedDate ISO8601 (@hmarcuzzo #132)                                            
  - Fix: ECS timestamps return epoch numbers instead of ISO strings                                                
  - 4 new tests: EMR fleets, ECS timestamps, APIGW v2 stage, CDK bootstrap stack 