### PR TITLE
test(sts): add assume_role and get_access_key_info tests

### DIFF
--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1453,6 +1453,25 @@ def test_sts_get_caller_identity(sts):
     assert resp["Account"] == "000000000000"
 
 
+def test_sts_assume_role_returns_credentials(sts):
+    resp = sts.assume_role(
+        RoleArn="arn:aws:iam::000000000000:role/test-role",
+        RoleSessionName="intg-session",
+    )
+    creds = resp["Credentials"]
+    assert "AccessKeyId" in creds
+    assert "SecretAccessKey" in creds
+    assert "SessionToken" in creds
+    assert "Expiration" in creds
+    assert resp["AssumedRoleUser"]["Arn"]
+
+
+def test_sts_get_access_key_info(sts):
+    resp = sts.get_access_key_info(AccessKeyId="AKIAIOSFODNN7EXAMPLE")
+    assert "Account" in resp
+    assert resp["Account"] == "000000000000"
+
+
 # ========== SecretsManager ==========
 
 


### PR DESCRIPTION
## Summary

Adds the two STS integration tests from #120.

## Changes

- `test_sts_assume_role_returns_credentials`: Calls `sts.assume_role()` and verifies the response contains `AccessKeyId`, `SecretAccessKey`, `SessionToken`, `Expiration`, and an `AssumedRoleUser` ARN.
- `test_sts_get_access_key_info`: Calls `sts.get_access_key_info()` with an example access key and verifies it returns the expected account ID.

Both tests follow the existing pattern in `test_services.py` using the `sts` session fixture.

Fixes #120

This contribution was developed with AI assistance (Claude Code).