### PR TITLE
Fix for LAMBDA_EXECUTOR being ignored for py/node runtimes

### DIFF
--- a/ministack/services/lambda_svc.py
+++ b/ministack/services/lambda_svc.py
@@ -986,7 +986,12 @@ def _execute_function_docker(func: dict, event: dict) -> dict:
     ``{"body": ..., "log": ..., "error": ...}``.
     """
     if not _docker_available:
-        logger.warning("docker SDK unavailable – falling back to local subprocess executor")
+        
+        if runtime.startswith("python") or runtime.startswith("nodejs"):
+            logger.warning("docker SDK unavailable - falling back to warm executor (node/py detected)")
+            return _execute_function_warm(func, event)
+
+        logger.warning("docker SDK unavailable - falling back to local subprocess executor")
         return _execute_function_local(func, event)
 
     config = func.get("config") or func


### PR DESCRIPTION
This PR contains a fix for LAMBDA_EXECUTOR being ignored if using python or node runtimes.

This came up because internally the warm pool swallows all lambda logs - in localstack previously I was using the docker executor for my nodejs funcs so that I have a clean log output to look at/iterate on.