### PR TITLE
fix(kms): tags and policy not saved on key creation

### DIFF
--- a/ministack/services/kms.py
+++ b/ministack/services/kms.py
@@ -157,7 +157,17 @@ def _create_key(data):
     key_usage = data.get("KeyUsage", "ENCRYPT_DECRYPT")
     description = data.get("Description", "")
     tags = data.get("Tags", [])
-    policy = data.get("Policy", "")
+    policy = data.get("Policy", json.dumps({
+        "Version": "2012-10-17",
+        "Id": "key-default-1",
+        "Statement": [{
+            "Sid": "Enable IAM User Permissions",
+            "Effect": "Allow",
+            "Principal": {"AWS": f"arn:aws:iam::{ACCOUNT_ID}:root"},
+            "Action": "kms:*",
+            "Resource": "*",
+        }],
+    }))
 
     rec = {
         "KeyId": key_id,
@@ -697,17 +707,7 @@ def _get_key_policy(data):
     rec = _resolve_key(data.get("KeyId", ""))
     if not rec:
         return error_response_json("NotFoundException", f"Key {data.get('KeyId', '')} not found", 400)
-    policy = rec.get("Policy", json.dumps({
-        "Version": "2012-10-17",
-        "Id": "key-default-1",
-        "Statement": [{
-            "Sid": "Enable IAM User Permissions",
-            "Effect": "Allow",
-            "Principal": {"AWS": f"arn:aws:iam::{ACCOUNT_ID}:root"},
-            "Action": "kms:*",
-            "Resource": "*",
-        }],
-    }))
+    policy = rec.get("Policy")
     return json_response({"Policy": policy, "PolicyName": "default"})
 
 

--- a/ministack/services/kms.py
+++ b/ministack/services/kms.py
@@ -156,6 +156,8 @@ def _create_key(data):
     key_spec = data.get("KeySpec", data.get("CustomerMasterKeySpec", "SYMMETRIC_DEFAULT"))
     key_usage = data.get("KeyUsage", "ENCRYPT_DECRYPT")
     description = data.get("Description", "")
+    tags = data.get("Tags", [])
+    policy = data.get("Policy", "")
 
     rec = {
         "KeyId": key_id,
@@ -167,6 +169,8 @@ def _create_key(data):
         "Description": description,
         "CreationDate": time.time(),
         "Origin": "AWS_KMS",
+        "Tags": tags,
+        "Policy": policy,
     }
 
     if key_spec == "SYMMETRIC_DEFAULT":

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -17732,6 +17732,8 @@ def test_kms_create_symmetric_key(kms_client):
         KeySpec="SYMMETRIC_DEFAULT",
         KeyUsage="ENCRYPT_DECRYPT",
         Description="test symmetric key",
+        Tags=[{"TagKey": "env", "TagValue": "test"}],
+        Policy="{}",
     )
     meta = resp["KeyMetadata"]
     assert meta["KeyId"]
@@ -17740,6 +17742,13 @@ def test_kms_create_symmetric_key(kms_client):
     assert meta["KeyUsage"] == "ENCRYPT_DECRYPT"
     assert meta["Enabled"] is True
     assert meta["KeyState"] == "Enabled"
+    assert meta["Description"] == "test symmetric key"
+
+    tags = kms_client.list_resource_tags(KeyId=meta["KeyId"])["Tags"]
+    assert {"TagKey": "env", "TagValue": "test"} in tags
+
+    policy = kms_client.get_key_policy(KeyId=meta["KeyId"], PolicyName="default")["Policy"]
+    assert policy == "{}"
 
 
 def test_kms_create_rsa_2048_sign_key(kms_client):


### PR DESCRIPTION
This fixes an endless loop in `aws_kms_key` when creating a key with tags and a policy included.

Additionally, I moved the default key policy statement to the key creation function. It makes more sense there as returning it on get_key_policy.