### PR TITLE
feat: use botocore serializer for query-protocol SFN aws-sdk dispatch

### DIFF
--- a/ministack/services/rds.py
+++ b/ministack/services/rds.py
@@ -1969,16 +1969,33 @@ def _parse_tags(params):
 
 
 def _parse_member_list(params, prefix):
-    """Parse Prefix.member.N style lists from query params."""
+    """Parse list params in either Prefix.member.N or Prefix.<MemberName>.N format.
+
+    The member.N format is used by direct AWS CLI/SDK calls. The <MemberName>.N
+    format is produced by botocore's serializer when dispatched via Step Functions
+    aws-sdk integrations (e.g. SubnetIds.SubnetIdentifier.N).
+    """
     items = []
     i = 1
+    # Try member.N first (direct API calls)
     while True:
         val = _p(params, f"{prefix}.member.{i}")
         if not val:
             break
         items.append(val)
         i += 1
-    return items
+    if items:
+        return items
+    # Fall back to Prefix.<AnyMemberName>.N (botocore serializer format)
+    import re
+    pattern = re.compile(rf"^{re.escape(prefix)}\.([^.]+)\.(\d+)$")
+    numbered = {}
+    for key in params:
+        m = pattern.match(key)
+        if m:
+            idx = int(m.group(2))
+            numbered[idx] = _p(params, key)
+    return [numbered[k] for k in sorted(numbered)] if numbered else []
 
 
 def _parse_filters(params):

--- a/ministack/services/stepfunctions.py
+++ b/ministack/services/stepfunctions.py
@@ -2245,6 +2245,36 @@ def _xml_element_to_dict(element):
     return tag, result
 
 
+def _serialize_query_via_botocore(service_name, action, input_data):
+    """Use botocore's serializer to properly map SDK model param names to wire-format names.
+
+    SFN aws-sdk integrations send parameters using SDK model names (e.g. DbSubnetGroupName)
+    but query-protocol services expect wire-format names (e.g. DBSubnetGroupName). botocore's
+    serializer has the full service model metadata to do this mapping correctly.
+
+    The mapping uses case-insensitive matching because SFN SDK names differ only in casing
+    from botocore model names (e.g. DbSubnetGroupName vs DBSubnetGroupName).
+    """
+    import botocore.session
+    from botocore.serialize import create_serializer
+
+    session = botocore.session.get_session()
+    service_model = session.get_service_model(service_name)
+    pascal_action = action[0].upper() + action[1:] if action else action
+    operation_model = service_model.operation_model(pascal_action)
+
+    # Map SFN SDK-style param names to botocore model names via case-insensitive lookup
+    params = input_data or {}
+    if operation_model.input_shape:
+        members = operation_model.input_shape.members
+        lower_to_model = {name.lower(): name for name in members}
+        params = {lower_to_model.get(k.lower(), k): v for k, v in params.items()}
+
+    serializer = create_serializer(service_model.protocol, include_validation=False)
+    request = serializer.serialize_to_request(params, operation_model)
+    return request.get("body", {}), pascal_action
+
+
 def _dispatch_aws_sdk_query(service_info, service_name, action, input_data):
     """Dispatch an aws-sdk integration call to a query-protocol MiniStack service."""
     import xml.etree.ElementTree as ET
@@ -2259,10 +2289,19 @@ def _dispatch_aws_sdk_query(service_info, service_name, action, input_data):
             f"Service '{service_key}' is not available in MiniStack",
         )
 
-    # Build form-encoded body with Action param
-    form_params = {"Action": action}
-    form_params.update(_flatten_query_params(input_data))
-    body = urlencode(form_params)
+    # Use botocore to serialize params with correct wire-format names.
+    try:
+        serialized_body, pascal_action = _serialize_query_via_botocore(service_name, action, input_data)
+        if isinstance(serialized_body, dict):
+            body = urlencode(serialized_body, doseq=True)
+        else:
+            body = serialized_body
+    except Exception:
+        # Fall back to naive flattening if botocore can't handle this service
+        pascal_action = action[0].upper() + action[1:] if action else action
+        form_params = {"Action": pascal_action}
+        form_params.update(_flatten_query_params(input_data))
+        body = urlencode(form_params)
 
     headers = {
         "content-type": "application/x-www-form-urlencoded",
@@ -2318,7 +2357,7 @@ def _dispatch_aws_sdk_query(service_info, service_name, action, input_data):
         _, result = _xml_element_to_dict(root)
         if isinstance(result, dict):
             # Unwrap the <ActionResult> wrapper if present
-            result_key = f"{action}Result"
+            result_key = f"{pascal_action}Result"
             if result_key in result:
                 result = result[result_key]
             # Drop ResponseMetadata


### PR DESCRIPTION
## Problem

The query-protocol `aws-sdk:*` dispatcher in Step Functions flattens JSON parameters naively into query params. This breaks when SDK model parameter names differ from wire-format names — which is the case for most query-protocol services.

Examples:
- `DbSubnetGroupName` (SDK) → `DBSubnetGroupName` (wire)
- `DbClusterParameterGroupName` → `DBClusterParameterGroupName`
- `SubnetIds` list → `SubnetIds.SubnetIdentifier.N` (not `SubnetIds.member.N`)

## Solution

Use botocore's serializer, which has the full AWS service model metadata, to correctly serialize query-protocol requests. This handles:

1. **Parameter name mapping** via case-insensitive matching from SFN SDK-style names to botocore model names
2. **List member naming** — botocore uses the correct model-specific member names (e.g. `SubnetIdentifier`) instead of generic `member`
3. **Action name casing** — PascalCase from camelCase SFN ARN names (subsumes #204)

Also updates `_parse_member_list` in rds.py to handle both `Prefix.member.N` (direct API) and `Prefix.<MemberName>.N` (botocore serializer) list formats.

Falls back to naive flattening if botocore can't handle a service.

## Dependencies

Adds `botocore` as a runtime dependency (already a transitive dep via `docker` package).

## Testing

- All 1099 existing tests pass
- Verified against a Terraform provider acceptance test suite: parameter groups, subnet groups, and cluster creation all work correctly through SFN dispatch.