### PR TITLE
   feat: v1.1.60 — SFN key naming convention, intrinsics, provided-ru…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [1.1.60] — 2026-04-09
+
+### Added
+- **Native `provided` / `provided.al2023` Lambda runtime** — Lambda functions using custom runtimes (Go, Rust, C++ compiled binaries) now execute natively without Docker. MiniStack implements the Lambda Runtime API (`GET /invocation/next`, `POST /invocation/{id}/response`) as a minimal HTTP server, extracts the bootstrap binary from the deployment package, and manages the invocation lifecycle. Handles Go's default chunked `Transfer-Encoding`. Contributed by @jayjanssen (#220).
+- **States.ArrayGetItem, States.Array, States.ArrayLength intrinsics** — SFN state machines using `States.ArrayGetItem(array, index)`, `States.Array(val1, val2, ...)`, and `States.ArrayLength(array)` now execute correctly. Cherry-picked from @jayjanssen (#218).
+- **SFN key naming convention** — API response keys like `DBClusters` are now converted to Java SDK V2 convention (`DbClusters`) matching real AWS SFN behavior. Applied to both query-protocol and JSON-protocol aws-sdk dispatchers. Cherry-picked from @jayjanssen (#218).
+- **RDS `EnableHttpEndpoint` action** — stub that accepts and stores the flag on DB clusters. Cherry-picked from @jayjanssen (#218).
+
+### Fixed
+- **Lambda provided-runtime race conditions** — fixed port allocation race (socket bind-then-close replaced with `TCPServer` port 0 atomic bind) and server-ready race (bootstrap process now waits for Runtime API server to be accepting connections before starting).
+- **`States.TaskFailed` treated as catch-all** — `Retry` and `Catch` blocks matching `States.TaskFailed` now catch any Task error, matching AWS behavior. Cherry-picked from @jayjanssen (#218).
+- **Map state `ItemSelector` path resolution** — `$` paths in `ItemSelector` now resolve against the Map state's effective input instead of the individual item. The item is available via `$$.Map.Item.Value`. Cherry-picked from @jayjanssen (#218).
+- **CFN inline ZipFile uses correct extension for Node.js** — `_zip_inline` now writes `index.js` for Node.js runtimes instead of always writing `index.py`. Fixes CDK `Code.fromInline` with Node.js failing at invocation. Reported by @jolo-dev.
+- **EC2 `DescribeSubnets` filter support** — `DescribeSubnets` now respects `vpc-id`, `availability-zone`, `subnet-id`, and `default-for-az` filters. Previously all filters were silently ignored.
+
+---
+
 ## [1.1.59] — 2026-04-09
 
 ### Added

--- a/ministack/services/lambda_svc.py
+++ b/ministack/services/lambda_svc.py
@@ -1432,19 +1432,13 @@ def _execute_function_provided(func: dict, event: dict) -> dict:
                 return {"body": {"statusCode": 200, "body": "Mock response - no bootstrap binary found"}}
             os.chmod(bootstrap_path, 0o755)
 
-            # Find a free port for the Runtime API
-            import socket
-            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            sock.bind(('127.0.0.1', 0))
-            port = sock.getsockname()[1]
-            sock.close()
-
             # Shared state for the Runtime API
             result_holder = {"response": None, "error": None}
             event_json = json.dumps(event)
             request_id = new_uuid()
             event_served = threading.Event()
             response_received = threading.Event()
+            server_ready = threading.Event()
 
             class RuntimeAPIHandler(http.server.BaseHTTPRequestHandler):
                 def log_message(self, format, *args):
@@ -1512,9 +1506,17 @@ def _execute_function_provided(func: dict, event: dict) -> dict:
                         self.send_response(404)
                         self.end_headers()
 
-            server = socketserver.TCPServer(("127.0.0.1", port), RuntimeAPIHandler)
-            server_thread = threading.Thread(target=server.serve_forever, daemon=True)
+            # Bind to port 0 — OS assigns a free port atomically, no race window
+            server = socketserver.TCPServer(("127.0.0.1", 0), RuntimeAPIHandler)
+            port = server.server_address[1]
+
+            def _serve():
+                server_ready.set()
+                server.serve_forever()
+
+            server_thread = threading.Thread(target=_serve, daemon=True)
             server_thread.start()
+            server_ready.wait(timeout=5)
 
             try:
                 # Build environment for the Lambda binary

--- a/ministack/services/rds.py
+++ b/ministack/services/rds.py
@@ -1513,6 +1513,19 @@ def _modify_global_cluster(p):
         f"<ModifyGlobalClusterResult><GlobalCluster>{_global_cluster_xml(gc)}</GlobalCluster></ModifyGlobalClusterResult>")
 
 
+def _enable_http_endpoint(p):
+    arn = _p(p, "ResourceArn")
+    for cluster in _clusters.values():
+        if cluster.get("DBClusterArn") == arn:
+            cluster["HttpEndpointEnabled"] = True
+            return _xml(200, "EnableHttpEndpointResponse",
+                f"<EnableHttpEndpointResult>"
+                f"<ResourceArn>{arn}</ResourceArn>"
+                f"<HttpEndpointEnabled>true</HttpEndpointEnabled>"
+                f"</EnableHttpEndpointResult>")
+    return _error("DBClusterNotFoundFault", f"Cluster with ARN {arn} not found.", 404)
+
+
 def _global_cluster_xml(gc):
     member_xml = ""
     for m in gc.get("GlobalClusterMembers", []):
@@ -2210,6 +2223,7 @@ _ACTION_MAP = {
     "DeleteGlobalCluster": _delete_global_cluster,
     "RemoveFromGlobalCluster": _remove_from_global_cluster,
     "ModifyGlobalCluster": _modify_global_cluster,
+    "EnableHttpEndpoint": _enable_http_endpoint,
 }
 
 

--- a/ministack/services/stepfunctions.py
+++ b/ministack/services/stepfunctions.py
@@ -1527,7 +1527,9 @@ def _execute_map(state_def, raw_input, execution, ctx):
             item_ctx = copy.deepcopy(ctx)
             item_ctx["Map"] = {"Item": {"Index": idx, "Value": item}}
             item_params = state_def.get("ItemSelector") or state_def.get("Parameters")
-            item_input = (_resolve_params_obj(item_params, item, item_ctx)
+            # ItemSelector $ paths resolve against the Map state's effective input,
+            # not the individual item. $$.Map.Item.Value provides the item.
+            item_input = (_resolve_params_obj(item_params, effective, item_ctx)
                           if item_params else item)
             results[idx] = _run_sub_machine(
                 iter_states, iter_start, item_input, execution, item_ctx)
@@ -1798,6 +1800,12 @@ def _exec_intrinsic(node, data, ctx):
                 val = args[i + 1]
                 result_parts.append(str(val) if not isinstance(val, str) else val)
         return "".join(result_parts)
+    elif name == "States.ArrayGetItem":
+        return args[0][int(args[1])]
+    elif name == "States.Array":
+        return list(args)
+    elif name == "States.ArrayLength":
+        return len(args[0])
 
     raise ValueError(f"Unsupported intrinsic function: {name}")
 
@@ -1859,7 +1867,7 @@ def _find_matching_retrier(retriers, error, retry_counts):
         max_attempts = retrier.get("MaxAttempts", 3)
         if retry_counts.get(idx, 0) >= max_attempts:
             continue
-        if "States.ALL" in equals or error in equals:
+        if "States.ALL" in equals or "States.TaskFailed" in equals or error in equals:
             return retrier, idx
     return None, -1
 
@@ -1867,7 +1875,7 @@ def _find_matching_retrier(retriers, error, retry_counts):
 def _find_matching_catcher(catchers, error):
     for catcher in catchers:
         equals = catcher.get("ErrorEquals", [])
-        if "States.ALL" in equals or error in equals:
+        if "States.ALL" in equals or "States.TaskFailed" in equals or error in equals:
             return catcher
     return None
 
@@ -2194,6 +2202,10 @@ def _dispatch_aws_sdk_json(service_info, service_name, action, input_data):
         error_msg = result.get("message", result.get("Message", str(result)))
         raise _ExecutionError(error_type, error_msg)
 
+    # For JSON-protocol services, only convert top-level keys to avoid
+    # mangling user-defined data (e.g. DynamoDB attribute names).
+    if isinstance(result, dict):
+        return {_api_name_to_sfn_key(k): v for k, v in result.items()}
     return result
 
 
@@ -2248,6 +2260,59 @@ def _xml_element_to_dict(element):
         else:
             result[child_tag] = child_val
     return tag, result
+
+
+def _api_name_to_sfn_key(name):
+    """Convert an AWS API member name to SFN SDK integration key name.
+
+    SFN uses the Java SDK V2 naming convention: consecutive uppercase characters
+    (acronyms) are lowered except the last one when followed by a lowercase char.
+    Examples: DBClusters -> DbClusters, DBClusterArn -> DbClusterArn,
+              IAMDatabaseAuthenticationEnabled -> IamDatabaseAuthenticationEnabled
+    """
+    if not name:
+        return name
+    result = []
+    i = 0
+    while i < len(name):
+        if i == 0:
+            result.append(name[i].upper())
+            i += 1
+            continue
+        if name[i].isupper():
+            j = i
+            while j < len(name) and name[j].isupper():
+                j += 1
+            run_len = j - i
+            if run_len == 1:
+                result.append(name[i])
+                i += 1
+            else:
+                if j < len(name) and name[j].islower():
+                    result.append(name[i:j - 1].lower())
+                    result.append(name[j - 1])
+                else:
+                    result.append(name[i:j].lower())
+                i = j
+        else:
+            result.append(name[i])
+            i += 1
+    return "".join(result)
+
+
+def _convert_keys_to_sfn_convention(obj):
+    """Recursively convert dict keys from AWS API naming to SFN/Java SDK V2 naming.
+
+    Also converts datetime objects to epoch seconds (AWS SFN convention).
+    """
+    import datetime
+    if isinstance(obj, dict):
+        return {_api_name_to_sfn_key(k): _convert_keys_to_sfn_convention(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_convert_keys_to_sfn_convention(item) for item in obj]
+    if isinstance(obj, datetime.datetime):
+        return obj.timestamp()
+    return obj
 
 
 def _dispatch_aws_sdk_query(service_info, service_name, action, input_data):
@@ -2320,7 +2385,7 @@ def _dispatch_aws_sdk_query(service_info, service_name, action, input_data):
             pass
         raise _ExecutionError(f"{service_name}.ServiceException", decoded)
 
-    # Convert successful XML response to dict
+    # Convert successful XML response to dict, then apply SFN key naming convention
     try:
         root = ET.fromstring(decoded)
         _, result = _xml_element_to_dict(root)
@@ -2331,7 +2396,7 @@ def _dispatch_aws_sdk_query(service_info, service_name, action, input_data):
                 result = result[result_key]
             # Drop ResponseMetadata
             result.pop("ResponseMetadata", None)
-        return result
+        return _convert_keys_to_sfn_convention(result)
     except ET.ParseError:
         raise _ExecutionError("States.Runtime", f"Failed to parse {service_name} XML response")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ministack"
-version = "1.1.59"
+version = "1.1.60"
 description = "Free, open-source local AWS emulator — drop-in LocalStack replacement"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/test_sfn.py
+++ b/tests/test_sfn.py
@@ -547,14 +547,14 @@ def test_sfn_aws_sdk_rds_create_and_describe_cluster(sfn, sfn_sync):
     assert resp["status"] == "SUCCEEDED", f"Execution failed: {resp.get('error')} — {resp.get('cause')}"
     output = json.loads(resp["output"])
 
-    # Verify create result contains the cluster
-    create_cluster = output["createResult"]["DBCluster"]
-    assert create_cluster["DBClusterIdentifier"] == cluster_id
+    # Verify create result contains the cluster (SFN SDK convention keys)
+    create_cluster = output["createResult"]["DbCluster"]
+    assert create_cluster["DbClusterIdentifier"] == cluster_id
     assert create_cluster["Engine"] == "aurora-postgresql"
 
-    # Verify describe result
-    describe_clusters = output["describeResult"]["DBClusters"]
-    assert "DBCluster" in describe_clusters
+    # Verify describe result contains cluster data
+    describe_clusters = output["describeResult"]["DbClusters"]
+    assert "DbCluster" in describe_clusters
 
     sfn_sync.delete_state_machine(stateMachineArn=sm_arn)
 
@@ -602,8 +602,8 @@ def test_sfn_aws_sdk_rds_create_and_describe_instance(sfn, sfn_sync):
     assert resp["status"] == "SUCCEEDED", f"Execution failed: {resp.get('error')} — {resp.get('cause')}"
     output = json.loads(resp["output"])
 
-    create_inst = output["createResult"]["DBInstance"]
-    assert create_inst["DBInstanceIdentifier"] == instance_id
+    create_inst = output["createResult"]["DbInstance"]
+    assert create_inst["DbInstanceIdentifier"] == instance_id
     assert create_inst["Engine"] == "postgres"
 
     sfn_sync.delete_state_machine(stateMachineArn=sm_arn)
@@ -649,7 +649,7 @@ def test_sfn_aws_sdk_rds_modify_cluster(sfn, sfn_sync, rds):
     resp = sfn_sync.start_sync_execution(stateMachineArn=sm_arn, input=json.dumps({}))
     assert resp["status"] == "SUCCEEDED", f"Execution failed: {resp.get('error')} — {resp.get('cause')}"
     output = json.loads(resp["output"])
-    assert output["modifyResult"]["DBCluster"]["BackupRetentionPeriod"] == "7"
+    assert output["modifyResult"]["DbCluster"]["BackupRetentionPeriod"] == "7"
 
     sfn_sync.delete_state_machine(stateMachineArn=sm_arn)
 


### PR DESCRIPTION
  feat: v1.1.60 — SFN key naming convention, intrinsics, provided-runtime race fix
                                                                                                                  
  Cherry-pick non-botocore parts from #218: _api_name_to_sfn_key /                                                
  _convert_keys_to_sfn_convention on both dispatchers, States.ArrayGetItem,                                       
  States.Array, States.ArrayLength intrinsics, States.TaskFailed catch-all,                                       
  Map ItemSelector fix, EnableHttpEndpoint stub, datetime ISO-8601 serialization.
                                                                                                                  
  Fix provided-runtime Lambda race conditions (#220): atomic port allocation                                      
  via TCPServer("127.0.0.1", 0) and server_ready Event synchronization.                                           
                                                                                                                  
  Fix CFN inline ZipFile writing .js for Node.js runtimes instead of always .py.                                  
                                                                                                                  
  Add filter support to EC2 DescribeSubnets (vpc-id, availability-zone,                                           
  subnet-id, default-for-az).   