### PR TITLE
fix(lambda): use container IP instead of 127.0.0.1 when LAMBDA_DOCKER_NETWORK is set

### DIFF
--- a/ministack/services/lambda_svc.py
+++ b/ministack/services/lambda_svc.py
@@ -1149,11 +1149,18 @@ def _execute_function_docker(func: dict, event: dict) -> dict:
                         if container.status != "running":
                             break
                         try:
-                            ports = container.ports.get("8080/tcp") or []
-                            if not ports:
-                                continue
-                            host_port = ports[0]["HostPort"]
-                            rie_url = f"http://127.0.0.1:{host_port}/2015-03-31/functions/function/invocations"
+                            if LAMBDA_DOCKER_NETWORK:
+                                networks = container.attrs.get("NetworkSettings", {}).get("Networks", {})
+                                container_ip = networks.get(LAMBDA_DOCKER_NETWORK, {}).get("IPAddress", "")
+                                if container_ip:
+                                    rie_url = f"http://{container_ip}:8080/2015-03-31/functions/function/invocations"
+                                else:
+                                    continue
+                            else:
+                                ports = container.ports.get("8080/tcp") or []
+                                if not ports:
+                                    continue
+                                rie_url = f"http://127.0.0.1:{ports[0]['HostPort']}/2015-03-31/functions/function/invocations"
                             req = urllib.request.Request(rie_url, data=json.dumps(event).encode(),
                                                         headers={"Content-Type": "application/json"})
                             resp = urllib.request.urlopen(req, timeout=timeout)
@@ -1374,11 +1381,18 @@ def _execute_function_image(func: dict, event: dict) -> dict:
             if container.status != "running":
                 break
             try:
-                ports = container.ports.get("8080/tcp") or []
-                if not ports:
-                    continue
-                host_port = ports[0]["HostPort"]
-                rie_url = f"http://127.0.0.1:{host_port}/2015-03-31/functions/function/invocations"
+                if LAMBDA_DOCKER_NETWORK:
+                    networks = container.attrs.get("NetworkSettings", {}).get("Networks", {})
+                    container_ip = networks.get(LAMBDA_DOCKER_NETWORK, {}).get("IPAddress", "")
+                    if container_ip:
+                        rie_url = f"http://{container_ip}:8080/2015-03-31/functions/function/invocations"
+                    else:
+                        continue
+                else:
+                    ports = container.ports.get("8080/tcp") or []
+                    if not ports:
+                        continue
+                    rie_url = f"http://127.0.0.1:{ports[0]['HostPort']}/2015-03-31/functions/function/invocations"
                 req = urllib.request.Request(rie_url, data=json.dumps(event).encode(),
                                             headers={"Content-Type": "application/json"})
                 resp = urllib.request.urlopen(req, timeout=timeout)


### PR DESCRIPTION
## Summary

- **Fixes Image-based and provided-runtime Lambda invocations failing in Docker-in-Docker setups** (when MiniStack itself runs inside a container)
- When `LAMBDA_DOCKER_NETWORK` is set, uses the Lambda container's network IP directly on port 8080 instead of `127.0.0.1:{host_port}`, which is unreachable from inside another container
- Both affected code paths fixed: `_execute_function_image` and the provided-runtime path in `_execute_function_docker`

Closes #228

## Root Cause

`127.0.0.1` refers to the MiniStack container itself, not the Docker host where the Lambda container's port is mapped. Since both containers share `LAMBDA_DOCKER_NETWORK`, we can resolve the Lambda container's IP via `container.attrs["NetworkSettings"]["Networks"]` and connect directly.

## Changes

In `ministack/services/lambda_svc.py`, two code paths build the RIE URL for Lambda invocation:

**Before** (both paths):
```python
ports = container.ports.get("8080/tcp") or []
host_port = ports[0]["HostPort"]
rie_url = f"http://127.0.0.1:{host_port}/2015-03-31/functions/function/invocations"
```

**After** (both paths):
```python
if LAMBDA_DOCKER_NETWORK:
    networks = container.attrs.get("NetworkSettings", {}).get("Networks", {})
    container_ip = networks.get(LAMBDA_DOCKER_NETWORK, {}).get("IPAddress", "")
    if container_ip:
        rie_url = f"http://{container_ip}:8080/2015-03-31/functions/function/invocations"
    else:
        continue  # IP not yet assigned, retry
else:
    ports = container.ports.get("8080/tcp") or []
    if not ports:
        continue
    rie_url = f"http://127.0.0.1:{ports[0]['HostPort']}/2015-03-31/functions/function/invocations"
```

## Test plan

- [ ] Start MiniStack via `docker-compose` with `LAMBDA_DOCKER_NETWORK` set
- [ ] Deploy an Image-based Lambda and invoke it — should succeed instead of timing out
- [ ] Deploy a provided-runtime Lambda and invoke it — should succeed instead of timing out
- [ ] Run MiniStack **without** `LAMBDA_DOCKER_NETWORK` — verify existing `127.0.0.1` behavior still works
- [ ] Run `ruff check ministack/services/lambda_svc.py` — no new lint errors introduced