### PR TITLE
fix(ec2): DescribeTags filter support, correct resource type mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [1.1.61] — 2026-04-10
+
+### Fixed
+- **EC2 `DescribeTags` ignores filters** — `DescribeTags` returned every tag for every resource regardless of `Filter` parameters. Terraform's `aws_instance` resource sends `resource-id` and `key` filters when reading launch template tags; receiving unrelated tags caused "too many results: wanted 1, got 3". Now respects `resource-id`, `resource-type`, `key`, and `value` filters. Reported by @m7w.
+- **EC2 `DescribeTags` returns wrong `resourceType`** — resources with prefixes `acl-`, `nat-`, `dopt-`, `eigw-`, `lt-`, `pl-`, `vgw-`, `cgw-`, `ami-`, `tgw-` were returned as generic `"resource"` instead of their correct types (`network-acl`, `natgateway`, `launch-template`, etc.). Reported by @m7w.
+- **Lambda container networking in DinD** — when MiniStack runs inside a Docker container (DinD via socket mount), `127.0.0.1` refers to the MiniStack container itself, not the Docker host where the Lambda container's port is mapped. When `LAMBDA_DOCKER_NETWORK` is set, Lambda invocations now resolve the container's IP on the shared network and connect directly on port 8080. Contributed by @DaviReisVieira. Fixes #228.
+
+---
+
 ## [1.1.60] — 2026-04-09
 
 ### Added

--- a/ministack/services/ec2.py
+++ b/ministack/services/ec2.py
@@ -1237,10 +1237,24 @@ def _delete_tags(p):
 
 
 def _describe_tags(p):
+    filters = _parse_filters(p)
+    filter_resource_ids = set(filters.get("resource-id", []))
+    filter_resource_types = set(filters.get("resource-type", []))
+    filter_keys = set(filters.get("key", []))
+    filter_values = set(filters.get("value", []))
+
     items = ""
     for rid, tag_list in _tags.items():
+        if filter_resource_ids and rid not in filter_resource_ids:
+            continue
         resource_type = _guess_resource_type(rid)
+        if filter_resource_types and resource_type not in filter_resource_types:
+            continue
         for tag in tag_list:
+            if filter_keys and tag["Key"] not in filter_keys:
+                continue
+            if filter_values and tag.get("Value", "") not in filter_values:
+                continue
             items += f"""<item>
                 <resourceId>{rid}</resourceId>
                 <resourceType>{resource_type}</resourceType>
@@ -1918,28 +1932,32 @@ def _now_ts():
 
 
 def _guess_resource_type(resource_id):
-    if resource_id.startswith("i-"):
-        return "instance"
-    if resource_id.startswith("sg-"):
-        return "security-group"
-    if resource_id.startswith("vpc-"):
-        return "vpc"
-    if resource_id.startswith("subnet-"):
-        return "subnet"
-    if resource_id.startswith("igw-"):
-        return "internet-gateway"
-    if resource_id.startswith("eipalloc-"):
-        return "elastic-ip"
-    if resource_id.startswith("rtb-"):
-        return "route-table"
-    if resource_id.startswith("eni-"):
-        return "network-interface"
-    if resource_id.startswith("vpce-"):
-        return "vpc-endpoint"
-    if resource_id.startswith("vol-"):
-        return "volume"
-    if resource_id.startswith("snap-"):
-        return "snapshot"
+    _PREFIX_MAP = {
+        "i-": "instance",
+        "sg-": "security-group",
+        "vpc-": "vpc",
+        "subnet-": "subnet",
+        "igw-": "internet-gateway",
+        "eipalloc-": "elastic-ip",
+        "rtb-": "route-table",
+        "eni-": "network-interface",
+        "vpce-": "vpc-endpoint",
+        "vol-": "volume",
+        "snap-": "snapshot",
+        "acl-": "network-acl",
+        "nat-": "natgateway",
+        "dopt-": "dhcp-options",
+        "eigw-": "egress-only-internet-gateway",
+        "lt-": "launch-template",
+        "pl-": "managed-prefix-list",
+        "vgw-": "vpn-gateway",
+        "cgw-": "customer-gateway",
+        "ami-": "image",
+        "tgw-": "transit-gateway",
+    }
+    for prefix, rtype in _PREFIX_MAP.items():
+        if resource_id.startswith(prefix):
+            return rtype
     return "resource"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ministack"
-version = "1.1.60"
+version = "1.1.61"
 description = "Free, open-source local AWS emulator — drop-in LocalStack replacement"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -1130,3 +1130,46 @@ def test_ec2_default_subnets_three_azs(ec2):
     for s in subnets:
         assert s["DefaultForAz"] is True
         assert s["MapPublicIpOnLaunch"] is True
+
+
+def test_describe_tags_filters(ec2):
+    """DescribeTags respects resource-id and key filters."""
+    # Create two instances and tag them differently
+    r1 = ec2.run_instances(ImageId="ami-test1", InstanceType="t2.micro", MinCount=1, MaxCount=1)
+    r2 = ec2.run_instances(ImageId="ami-test2", InstanceType="t2.micro", MinCount=1, MaxCount=1)
+    id1 = r1["Instances"][0]["InstanceId"]
+    id2 = r2["Instances"][0]["InstanceId"]
+
+    ec2.create_tags(Resources=[id1], Tags=[{"Key": "Name", "Value": "first"}, {"Key": "Env", "Value": "prod"}])
+    ec2.create_tags(Resources=[id2], Tags=[{"Key": "Name", "Value": "second"}])
+
+    # Filter by resource-id — should only return tags for id1
+    resp = ec2.describe_tags(Filters=[{"Name": "resource-id", "Values": [id1]}])
+    tags = resp["Tags"]
+    assert all(t["ResourceId"] == id1 for t in tags)
+    assert len(tags) == 2
+
+    # Filter by key — should return "Env" tag only for id1
+    resp = ec2.describe_tags(Filters=[{"Name": "key", "Values": ["Env"]}])
+    tags = resp["Tags"]
+    assert all(t["Key"] == "Env" for t in tags)
+    assert any(t["ResourceId"] == id1 for t in tags)
+
+    # Filter by resource-id + key — should return exactly one tag
+    resp = ec2.describe_tags(Filters=[
+        {"Name": "resource-id", "Values": [id1]},
+        {"Name": "key", "Values": ["Name"]},
+    ])
+    tags = resp["Tags"]
+    assert len(tags) == 1
+    assert tags[0]["ResourceId"] == id1
+    assert tags[0]["Key"] == "Name"
+    assert tags[0]["Value"] == "first"
+
+    # Filter by resource-id that has no tags — should return empty
+    resp = ec2.describe_tags(Filters=[{"Name": "resource-id", "Values": ["i-doesnotexist"]}])
+    assert len(resp["Tags"]) == 0
+
+    # All tags have correct resource type
+    resp = ec2.describe_tags(Filters=[{"Name": "resource-id", "Values": [id1, id2]}])
+    assert all(t["ResourceType"] == "instance" for t in resp["Tags"])


### PR DESCRIPTION
DescribeTags was ignoring all Filter parameters and returning every tag for every resource. This caused Terraform's aws_instance to fail with "too many results" when receiving unrelated tags.

Now respects resource-id, resource-type, key, and value filters. Also adds missing resource type prefixes (acl-, nat-, lt-, etc.) that were previously incorrectly returned as generic "resource".