### PR TITLE
fix(apigateway): invoke Node.js Lambdas via warm worker in v1/v2 proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Fixed
+- **API Gateway v1/v2 returns mock response for Node.js Lambdas** — `_invoke_lambda_proxy` in both `apigateway.py` (v2) and `apigateway_v1.py` (v1) only dispatched to the warm worker pool for Python runtimes. Node.js Lambdas received a hardcoded `"Mock response"` instead of being executed, even though the warm worker pool in `lambda_runtime.py` already supports Node.js. Now checks for both `python` and `nodejs` runtimes.
 - **Lambda Docker executor fails for `provided` runtimes** — `_execute_function_docker()` mounted Lambda code only at `/var/task` and overrode CMD to `["/var/task/bootstrap"]`, but the AWS RIE entrypoint (`/lambda-entrypoint.sh`) in `public.ecr.aws/lambda/provided:al2023` expects the bootstrap binary at `/var/runtime/bootstrap`. Now mounts code at both `/var/task` and `/var/runtime` (matching real AWS layout) and passes `"bootstrap"` as CMD so the RIE finds the handler correctly. Contributed by @jayjanssen.
 
 ---

--- a/ministack/services/apigateway.py
+++ b/ministack/services/apigateway.py
@@ -365,7 +365,8 @@ async def _invoke_lambda_proxy(integration, api_id, stage, path, method, headers
     func_data = lambda_svc._functions[func_name]
     code_zip = func_data.get("code_zip")
 
-    if code_zip and func_data["config"]["Runtime"].startswith("python"):
+    runtime = func_data["config"].get("Runtime", "")
+    if code_zip and runtime.startswith(("python", "nodejs")):
         worker = get_or_create_worker(func_name, func_data["config"], code_zip)
         result = await asyncio.to_thread(worker.invoke, event, new_uuid())
         if result.get("status") == "error":

--- a/ministack/services/apigateway_v1.py
+++ b/ministack/services/apigateway_v1.py
@@ -235,7 +235,8 @@ async def _call_lambda(func_name, event):
     func_data = lambda_svc._functions[func_name]
     code_zip = func_data.get("code_zip")
 
-    if code_zip and func_data["config"]["Runtime"].startswith("python"):
+    runtime = func_data["config"].get("Runtime", "")
+    if code_zip and runtime.startswith(("python", "nodejs")):
         worker = get_or_create_worker(func_name, func_data["config"], code_zip)
         result = await asyncio.to_thread(worker.invoke, event, new_uuid())
         if result.get("status") == "error":

--- a/tests/test_lambda.py
+++ b/tests/test_lambda.py
@@ -1399,3 +1399,57 @@ def test_lambda_provided_runtime_docker_invoke(lam):
         assert payload["body"] == "hello from provided"
     finally:
         lam.delete_function(FunctionName=func_name)
+
+
+def test_apigwv2_nodejs_lambda_proxy(lam, apigw):
+    """API Gateway v2 HTTP API should invoke Node.js Lambda via warm worker, not return mock."""
+    import urllib.request as _urlreq
+    import uuid as _uuid
+    from botocore.exceptions import ClientError
+
+    fname = f"apigwv2-node-{_uuid.uuid4().hex[:8]}"
+    api_id = None
+    code = (
+        "exports.handler = async (event) => ({"
+        " statusCode: 200,"
+        " body: JSON.stringify({ route: event.routeKey, method: event.requestContext.http.method })"
+        "});"
+    )
+    try:
+        lam.create_function(
+            FunctionName=fname,
+            Runtime="nodejs20.x",
+            Role="arn:aws:iam::000000000000:role/test-role",
+            Handler="index.handler",
+            Code={"ZipFile": _make_zip_js(code, "index.js")},
+        )
+        api_id = apigw.create_api(Name=f"v2-node-{fname}", ProtocolType="HTTP")["ApiId"]
+        int_id = apigw.create_integration(
+            ApiId=api_id,
+            IntegrationType="AWS_PROXY",
+            IntegrationUri=f"arn:aws:lambda:us-east-1:000000000000:function:{fname}",
+            PayloadFormatVersion="2.0",
+        )["IntegrationId"]
+        apigw.create_route(ApiId=api_id, RouteKey="GET /test", Target=f"integrations/{int_id}")
+        apigw.create_stage(ApiId=api_id, StageName="$default")
+
+        req = _urlreq.Request(
+            f"http://{api_id}.execute-api.localhost:{_EXECUTE_PORT}/$default/test",
+            method="GET",
+        )
+        req.add_header("Host", f"{api_id}.execute-api.localhost:{_EXECUTE_PORT}")
+        resp = _urlreq.urlopen(req).read().decode()
+        body = json.loads(resp)
+
+        assert body.get("route") == "GET /test", f"Expected handler result, got: {resp}"
+        assert body.get("method") == "GET"
+    finally:
+        if api_id is not None:
+            try:
+                apigw.delete_api(ApiId=api_id)
+            except ClientError:
+                pass
+        try:
+            lam.delete_function(FunctionName=fname)
+        except ClientError:
+            pass


### PR DESCRIPTION
## Summary

API Gateway v1 and v2 `_invoke_lambda_proxy` only dispatched to the warm worker pool for Python runtimes. Node.js Lambdas received a hardcoded `"Mock response"` instead of being executed — even though `lambda_runtime.py` already supports Node.js via `_NODEJS_WORKER_SCRIPT`.

## Changes

- **`ministack/services/apigateway.py`** (v2): `startswith("python")` → `startswith(("python", "nodejs"))`
- **`ministack/services/apigateway_v1.py`** (v1): same fix
- **`tests/test_lambda.py`**: added `test_apigwv2_nodejs_lambda_proxy` — creates a Node.js Lambda behind an API Gateway v2 HTTP API route and verifies the actual handler response is returned

## Motivation

We use MiniStack with Terraform to deploy a Node.js Lambda backend (API Gateway v2 HTTP API + ~25 Lambda functions). Direct `aws lambda invoke` worked correctly, but requests through the API Gateway execute-api endpoint returned `"Mock response"` for all Node.js handlers.

The root cause is a runtime check in both `_invoke_lambda_proxy` functions that only matches `"python"`:

```python
# Before:
if code_zip and func_data["config"]["Runtime"].startswith("python"):

# After:
if code_zip and runtime.startswith(("python", "nodejs")):
```

## Test plan

- [x] `pytest tests/test_lambda.py -v -k "apigwv2_nodejs"` — new test passes
- [x] `pytest tests/test_lambda.py -v` — all 69 existing tests pass, 1 skipped (docker-only)
- [x] Verified end-to-end: Terraform-deployed Node.js Lambda returns real handler response via API Gateway v2