### PR TITLE
feat: static acronym mapper for SFN query-protocol param name conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,13 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- **SFN query-protocol acronym mapper** — Step Functions `aws-sdk:*` integrations now correctly convert SDK-style parameter names (e.g. `DbSubnetGroupName`) to wire-format names (`DBSubnetGroupName`) for query-protocol services (RDS, EC2, IAM, STS, etc.). Uses a static acronym mapping — no botocore dependency. Contributed by @jayjanssen.
+
 ### Fixed
 - **Lambda Docker executor fails for `provided` runtimes** — `_execute_function_docker()` mounted Lambda code only at `/var/task` and overrode CMD to `["/var/task/bootstrap"]`, but the AWS RIE entrypoint (`/lambda-entrypoint.sh`) in `public.ecr.aws/lambda/provided:al2023` expects the bootstrap binary at `/var/runtime/bootstrap`. Now mounts code at both `/var/task` and `/var/runtime` (matching real AWS layout) and passes `"bootstrap"` as CMD so the RIE finds the handler correctly. Contributed by @jayjanssen.
 
 ---
-
 ## [1.1.61] — 2026-04-10
 
 ### Fixed

--- a/ministack/services/stepfunctions.py
+++ b/ministack/services/stepfunctions.py
@@ -2262,6 +2262,40 @@ def _xml_element_to_dict(element):
     return tag, result
 
 
+# Known AWS acronyms that appear as uppercase runs in wire-format names.
+# Used by _sfn_key_to_api_name to reverse the Java SDK V2 naming convention.
+# Excludes Arn/Id (single uppercase in wire format) and Http/Https/Ec2
+# (contain digits or are mixed-case in wire format, not pure acronym runs).
+_AWS_ACRONYMS = frozenset({
+    "Db", "Iam", "Vpc", "Ssl", "Kms", "Ttl", "Io", "Az",
+    "Ebs", "Ssh", "Mfa", "Dns", "Acl",
+    "Tcp", "Udp", "Iops", "Ca", "Sg",
+})
+
+
+def _sfn_key_to_api_name(name):
+    """Convert SFN SDK key name to AWS wire-format name.
+
+    Reverses _api_name_to_sfn_key: expands known acronyms back to uppercase.
+    Examples: DbClusters -> DBClusters, KmsKeyId -> KMSKeyId,
+              VpcSecurityGroupIds -> VPCSecurityGroupIds
+    """
+    if not name:
+        return name
+    import re
+    tokens = re.findall(r"[A-Z][a-z]*|[a-z]+|[0-9]+", name)
+    return "".join(t.upper() if t in _AWS_ACRONYMS else t for t in tokens)
+
+
+def _convert_params_to_api_names(data):
+    """Recursively convert SFN SDK-style param names to AWS wire-format names."""
+    if isinstance(data, dict):
+        return {_sfn_key_to_api_name(k): _convert_params_to_api_names(v) for k, v in data.items()}
+    if isinstance(data, list):
+        return [_convert_params_to_api_names(item) for item in data]
+    return data
+
+
 def _api_name_to_sfn_key(name):
     """Convert an AWS API member name to SFN SDK integration key name.
 
@@ -2329,12 +2363,14 @@ def _dispatch_aws_sdk_query(service_info, service_name, action, input_data):
             f"Service '{service_key}' is not available in MiniStack",
         )
 
-    # Build form-encoded body with Action param.
     # SFN ARNs use camelCase (e.g. createDBSubnetGroup) but query-protocol
     # services expect PascalCase (CreateDBSubnetGroup).
     pascal_action = action[0].upper() + action[1:] if action else action
+    # Convert SFN SDK-style param names (DbSubnetGroupName) to wire-format
+    # names (DBSubnetGroupName) before flattening to query params.
+    wire_data = _convert_params_to_api_names(input_data)
     form_params = {"Action": pascal_action}
-    form_params.update(_flatten_query_params(input_data))
+    form_params.update(_flatten_query_params(wire_data))
     body = urlencode(form_params)
 
     headers = {

--- a/tests/test_sfn.py
+++ b/tests/test_sfn.py
@@ -2077,3 +2077,137 @@ def test_sfn_aws_sdk_json_pascal_case(sfn, sfn_sync, sm):
     assert output["SecretString"] == "my-secret-value"
     # Cleanup
     sm.delete_secret(SecretId="sfn-pascal-json-secret", ForceDeleteWithoutRecovery=True)
+
+
+def test_sfn_aws_sdk_query_acronym_param_mapping(sfn, sfn_sync, rds):
+    """SFN aws-sdk query dispatch maps SDK-style param names to wire-format names."""
+    import uuid as _uuid
+    cluster_id = f"acronym-test-{_uuid.uuid4().hex[:8]}"
+    sm_name = f"sdk-acronym-{_uuid.uuid4().hex[:8]}"
+
+    definition = json.dumps({
+        "StartAt": "CreateCluster",
+        "States": {
+            "CreateCluster": {
+                "Type": "Task",
+                "Resource": "arn:aws:states:::aws-sdk:rds:createDBCluster",
+                "Parameters": {
+                    "DbClusterIdentifier": cluster_id,
+                    "Engine": "aurora-postgresql",
+                    "MasterUsername": "admin",
+                    "MasterUserPassword": "testpass123",
+                },
+                "ResultPath": "$.createResult",
+                "Next": "DescribeClusters",
+            },
+            "DescribeClusters": {
+                "Type": "Task",
+                "Resource": "arn:aws:states:::aws-sdk:rds:describeDBClusters",
+                "Parameters": {
+                    "DbClusterIdentifier": cluster_id,
+                },
+                "ResultPath": "$.describeResult",
+                "End": True,
+            },
+        },
+    })
+
+    sm_arn = sfn_sync.create_state_machine(
+        name=sm_name,
+        definition=definition,
+        roleArn="arn:aws:iam::000000000000:role/sfn-role",
+    )["stateMachineArn"]
+
+    resp = sfn_sync.start_sync_execution(stateMachineArn=sm_arn, input=json.dumps({}))
+    assert resp["status"] == "SUCCEEDED", f"Execution failed: {resp.get('error')} — {resp.get('cause')}"
+    output = json.loads(resp["output"])
+
+    create_cluster = output["createResult"]["DbCluster"]
+    assert create_cluster["DbClusterIdentifier"] == cluster_id
+    assert create_cluster["Engine"] == "aurora-postgresql"
+
+    sfn_sync.delete_state_machine(stateMachineArn=sm_arn)
+
+
+def test_sfn_key_to_api_name_must_convert():
+    """Verify _sfn_key_to_api_name expands known acronyms to uppercase."""
+    from ministack.services.stepfunctions import _sfn_key_to_api_name
+
+    cases = [
+        ("DbSubnetGroupName", "DBSubnetGroupName"),
+        ("DbClusterIdentifier", "DBClusterIdentifier"),
+        ("DbClusterArn", "DBClusterArn"),
+        ("IamDatabaseAuthenticationEnabled", "IAMDatabaseAuthenticationEnabled"),
+        ("DomainIamRoleName", "DomainIAMRoleName"),
+        ("CaCertificateIdentifier", "CACertificateIdentifier"),
+        ("VpcSecurityGroupIds", "VPCSecurityGroupIds"),
+        ("KmsKeyId", "KMSKeyId"),
+        ("SslMode", "SSLMode"),
+        ("EbsOptimized", "EBSOptimized"),
+        ("IoOptimizedNextAllowedModificationTime", "IOOptimizedNextAllowedModificationTime"),
+        ("DnsName", "DNSName"),
+        ("AzMode", "AZMode"),
+        ("TtlSeconds", "TTLSeconds"),
+        ("SgId", "SGId"),
+        ("AclName", "ACLName"),
+    ]
+    for sfn, expected in cases:
+        assert _sfn_key_to_api_name(sfn) == expected, f"{sfn} → expected {expected}"
+
+
+def test_sfn_key_to_api_name_must_not_convert():
+    """Verify _sfn_key_to_api_name leaves non-acronym names unchanged."""
+    from ministack.services.stepfunctions import _sfn_key_to_api_name
+
+    cases = [
+        "Engine", "MasterUsername", "Port", "SubnetIds",
+        "HttpEndpointEnabled", "StorageEncrypted", "DeletionProtection",
+        "BackupRetentionPeriod", "PreferredBackupWindow",
+    ]
+    for name in cases:
+        assert _sfn_key_to_api_name(name) == name, f"{name} should be unchanged"
+
+
+def test_sfn_key_to_api_name_idempotent():
+    """Verify _sfn_key_to_api_name is idempotent on wire-format names."""
+    from ministack.services.stepfunctions import _sfn_key_to_api_name
+
+    wire_names = [
+        "DBSubnetGroupName", "IAMDatabaseAuthenticationEnabled",
+        "VPCSecurityGroupIds", "KMSKeyId", "CACertificateIdentifier",
+    ]
+    for name in wire_names:
+        assert _sfn_key_to_api_name(name) == name, f"{name} should be idempotent"
+
+
+def test_sfn_key_to_api_name_round_trip():
+    """Verify _sfn_key_to_api_name correctly reverses _api_name_to_sfn_key."""
+    from ministack.services.stepfunctions import _api_name_to_sfn_key, _sfn_key_to_api_name
+
+    wire_names = [
+        "DBSubnetGroupName", "DBClusterIdentifier", "DBClusterArn",
+        "IAMDatabaseAuthenticationEnabled", "VPCSecurityGroupIds",
+        "KMSKeyId", "SSLMode", "EBSOptimized", "IOOptimizedNextAllowedModificationTime",
+        "CACertificateIdentifier", "DNSName", "AZMode", "TTLSeconds",
+        "Engine", "MasterUsername", "Port", "SubnetIds", "HttpEndpointEnabled",
+    ]
+    for wire in wire_names:
+        sfn = _api_name_to_sfn_key(wire)
+        back = _sfn_key_to_api_name(sfn)
+        assert back == wire, f"Round-trip failed: {wire} → {sfn} → {back}"
+
+
+def test_convert_params_to_api_names_nested():
+    """Verify _convert_params_to_api_names handles nested dicts and lists."""
+    from ministack.services.stepfunctions import _convert_params_to_api_names
+
+    result = _convert_params_to_api_names({
+        "DbClusterIdentifier": "my-cluster",
+        "VpcSecurityGroupIds": [{"SgId": "sg-123"}],
+        "Tags": [{"Key": "env", "Value": "test"}],
+    })
+    assert result == {
+        "DBClusterIdentifier": "my-cluster",
+        "VPCSecurityGroupIds": [{"SGId": "sg-123"}],
+        "Tags": [{"Key": "env", "Value": "test"}],
+    }


### PR DESCRIPTION
## Summary

Step Functions `aws-sdk:*` integrations send parameters using Java SDK V2 naming (e.g. `DbSubnetGroupName`) but query-protocol services expect wire-format names (e.g. `DBSubnetGroupName`). This PR adds a lightweight static acronym mapper to convert parameter names before dispatch.

Replaces the botocore-based serializer from #214 (now closed) per feedback from @Nahuel990 — uses a curated acronym set instead of a runtime botocore dependency.

## Changes

- Add `_AWS_ACRONYMS` frozenset with 17 known AWS acronyms (`DB`, `IAM`, `VPC`, `SSL`, `KMS`, etc.)
- Add `_sfn_key_to_api_name()` — reverse of `_api_name_to_sfn_key()`, expands acronyms back to uppercase
- Add `_convert_params_to_api_names()` — recursive dict/list key converter
- Apply conversion in `_dispatch_aws_sdk_query()` before flattening to query params
- CHANGELOG entry

## Design Decisions

- **Excluded `Arn`, `Id`**: These appear as single uppercase chars in wire format (`DBClusterArn`, `KmsKeyId`), not as uppercase runs (`DBClusterARN`)
- **Excluded `Http`, `Https`, `Ec2`**: Mixed-case or digit-containing in wire format, not pure acronym runs
- **Idempotent**: Wire-format names pass through unchanged (single-letter tokens don't match any acronym)

## Tests

- **must-convert**: 16 acronym expansion cases
- **must-not-convert**: 9 names that should be unchanged
- **idempotent**: 5 wire-format names that should pass through
- **round-trip**: 18 `_api_name_to_sfn_key` → `_sfn_key_to_api_name` conversions
- **nested structures**: recursive dict/list conversion
- **integration**: SFN dispatching RDS `CreateDBCluster` with SDK-style param names

All 1125 tests pass (only pre-existing `cbor2` skip).