### PR TITLE
feat: REST-JSON aws-sdk dispatcher + rdsdata SFN alias + RDS Data API stub fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,12 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ### Added
 - **SFN query-protocol acronym mapper** — Step Functions `aws-sdk:*` integrations now correctly convert SDK-style parameter names (e.g. `DbSubnetGroupName`) to wire-format names (`DBSubnetGroupName`) for query-protocol services (RDS, EC2, IAM, STS, etc.). Uses a static acronym mapping — no botocore dependency. Contributed by @jayjanssen.
+- **REST-JSON `aws-sdk:*` dispatcher** — Step Functions can now dispatch `aws-sdk:rdsdata:*` actions (e.g. `executeStatement`, `beginTransaction`) to the RDS Data API service via a new REST-JSON protocol handler. Uses a static action→path mapping — no botocore dependency. Contributed by @jayjanssen.
 
 ### Fixed
 - **API Gateway v1/v2 returns mock response for Node.js Lambdas** — `_invoke_lambda_proxy` in both `apigateway.py` (v2) and `apigateway_v1.py` (v1) only dispatched to the warm worker pool for Python runtimes. Node.js Lambdas received a hardcoded `"Mock response"` instead of being executed, even though the warm worker pool in `lambda_runtime.py` already supports Node.js. Now checks for both `python` and `nodejs` runtimes.
 - **Lambda Docker executor fails for `provided` runtimes** — `_execute_function_docker()` mounted Lambda code only at `/var/task` and overrode CMD to `["/var/task/bootstrap"]`, but the AWS RIE entrypoint (`/lambda-entrypoint.sh`) in `public.ecr.aws/lambda/provided:al2023` expects the bootstrap binary at `/var/runtime/bootstrap`. Now mounts code at both `/var/task` and `/var/runtime` (matching real AWS layout) and passes `"bootstrap"` as CMD so the RIE finds the handler correctly. Contributed by @jayjanssen.
+- **RDS Data API stub fallback** — `ExecuteStatement` now returns a stub success response instead of a 400 error when the target cluster has no Docker-backed database endpoint or the database driver is unavailable. Real database errors still propagate as errors. Contributed by @jayjanssen.
 
 ---
 ## [1.1.61] — 2026-04-10

--- a/ministack/services/rds_data.py
+++ b/ministack/services/rds_data.py
@@ -25,6 +25,15 @@ def _error(code, message, status=400):
     return error_response_json(code, message, status)
 
 
+def _stub_success():
+    """Return a minimal successful ExecuteStatement response for mock environments."""
+    return json_response({
+        "numberOfRecordsUpdated": 0,
+        "generatedFields": [],
+        "records": [],
+    })
+
+
 def _resolve_cluster(resource_arn):
     """Find RDS cluster and a member instance from a resourceArn."""
     from ministack.services import rds
@@ -233,12 +242,12 @@ def _execute_statement(data):
         return _error("BadRequestException",
                        f"Database cluster not found for ARN: {resource_arn}")
 
-    # Check if instance has a real endpoint (Docker container running)
+    # Check if instance has a real endpoint (Docker container running).
+    # Clusters have Endpoint as a string (hostname); instances have it as a dict.
     endpoint = instance.get("Endpoint", {})
-    if not endpoint.get("Port"):
-        return _error("BadRequestException",
-                       "No database endpoint available. "
-                       "RDS Data API requires Docker-backed RDS instances.")
+    if isinstance(endpoint, str) or not endpoint.get("Port"):
+        logger.info("No endpoint for %s, returning stub success", resource_arn)
+        return _stub_success()
 
     password = _get_secret_password(secret_arn)
 
@@ -290,7 +299,8 @@ def _execute_statement(data):
     except ImportError as e:
         if own_conn and conn:
             conn.close()
-        return _error("BadRequestException", str(e))
+        logger.warning("DB driver not available, returning stub: %s", e)
+        return _stub_success()
     except Exception as e:
         if own_conn and conn:
             conn.close()

--- a/ministack/services/stepfunctions.py
+++ b/ministack/services/stepfunctions.py
@@ -2140,9 +2140,23 @@ _AWS_SDK_SERVICE_MAP = {
     "iam": {"protocol": "query"},
     "sts": {"protocol": "query"},
     "cloudwatch": {"protocol": "query", "service_key": "monitoring"},
+    # REST-JSON services: path-based routing with JSON body
+    "rdsdata": {"protocol": "rest-json", "service_key": "rds-data"},
     # REST services (not yet supported via aws-sdk dispatcher)
     "s3": {"protocol": "rest"},
     "lambda": {"protocol": "rest"},
+}
+
+# Static action→path maps for REST-JSON services.
+# Avoids a botocore runtime dependency for path resolution.
+_REST_JSON_ACTION_PATHS = {
+    "rds-data": {
+        "ExecuteStatement": "/Execute",
+        "BatchExecuteStatement": "/BatchExecute",
+        "BeginTransaction": "/BeginTransaction",
+        "CommitTransaction": "/CommitTransaction",
+        "RollbackTransaction": "/RollbackTransaction",
+    },
 }
 
 
@@ -2437,6 +2451,67 @@ def _dispatch_aws_sdk_query(service_info, service_name, action, input_data):
         raise _ExecutionError("States.Runtime", f"Failed to parse {service_name} XML response")
 
 
+def _dispatch_aws_sdk_rest_json(service_info, service_name, action, input_data):
+    """Dispatch an aws-sdk integration call to a REST-JSON protocol MiniStack service."""
+    from ministack import app
+
+    service_key = service_info.get("service_key", service_name)
+    handler = app.SERVICE_HANDLERS.get(service_key)
+    if not handler:
+        raise _ExecutionError(
+            "States.Runtime",
+            f"Service '{service_key}' is not available in MiniStack",
+        )
+
+    pascal_action = action[0].upper() + action[1:] if action else action
+
+    # Look up the REST path from the static map; fall back to /<Action>
+    action_paths = _REST_JSON_ACTION_PATHS.get(service_key, {})
+    path = action_paths.get(pascal_action, f"/{pascal_action}")
+
+    body = json.dumps(input_data or {}).encode("utf-8")
+    headers = {
+        "content-type": "application/json",
+        "host": f"{service_key}.{REGION}.amazonaws.com",
+        "authorization": (
+            f"AWS4-HMAC-SHA256 Credential=test/20260101/{REGION}/{service_key}/aws4_request"
+        ),
+    }
+
+    coro = handler("POST", path, headers, body, {})
+    try:
+        coro.send(None)
+    except StopIteration as stop:
+        status, resp_headers, resp_body = stop.value
+    else:
+        coro.close()
+        loop = asyncio.new_event_loop()
+        try:
+            status, resp_headers, resp_body = loop.run_until_complete(
+                handler("POST", path, headers, body, {})
+            )
+        finally:
+            loop.close()
+
+    decoded = resp_body.decode("utf-8") if isinstance(resp_body, bytes) else resp_body
+
+    if status >= 400:
+        try:
+            err_data = json.loads(decoded)
+            code = err_data.get("code") or err_data.get("__type", "ServiceException")
+            msg = err_data.get("message") or err_data.get("Message") or decoded
+            raise _ExecutionError(code, msg)
+        except _ExecutionError:
+            raise
+        except Exception:
+            raise _ExecutionError(f"{service_name}.ServiceException", decoded)
+
+    try:
+        return json.loads(decoded) if decoded else {}
+    except (json.JSONDecodeError, TypeError):
+        return decoded
+
+
 def _invoke_aws_sdk_integration(resource, input_data):
     """Dispatch arn:aws:states:::aws-sdk:<service>:<action> to the target MiniStack service."""
     # Parse service and action from ARN
@@ -2460,6 +2535,8 @@ def _invoke_aws_sdk_integration(resource, input_data):
         return _dispatch_aws_sdk_json(service_info, service_name, action, input_data)
     elif protocol == "query":
         return _dispatch_aws_sdk_query(service_info, service_name, action, input_data)
+    elif protocol == "rest-json":
+        return _dispatch_aws_sdk_rest_json(service_info, service_name, action, input_data)
     else:
         raise _ExecutionError(
             "States.Runtime",

--- a/tests/test_sfn.py
+++ b/tests/test_sfn.py
@@ -2211,3 +2211,93 @@ def test_convert_params_to_api_names_nested():
         "VPCSecurityGroupIds": [{"SGId": "sg-123"}],
         "Tags": [{"Key": "env", "Value": "test"}],
     }
+
+
+def test_sfn_aws_sdk_rdsdata_execute_statement(sfn, sfn_sync, rds, sm):
+    """SFN aws-sdk:rdsdata:executeStatement dispatches via REST-JSON protocol."""
+    import uuid as _uuid
+    cluster_id = f"rdsdata-sfn-{_uuid.uuid4().hex[:8]}"
+    sm_name = f"sdk-rdsdata-{_uuid.uuid4().hex[:8]}"
+
+    rds.create_db_cluster(
+        DBClusterIdentifier=cluster_id,
+        Engine="aurora-mysql",
+        MasterUsername="admin",
+        MasterUserPassword="testpass123",
+    )
+    secret_arn = sm.create_secret(
+        Name=f"rdsdata-secret-{_uuid.uuid4().hex[:8]}",
+        SecretString='{"username":"admin","password":"testpass123"}',
+    )["ARN"]
+    cluster_arn = f"arn:aws:rds:us-east-1:000000000000:cluster:{cluster_id}"
+
+    definition = json.dumps({
+        "StartAt": "ExecuteSQL",
+        "States": {
+            "ExecuteSQL": {
+                "Type": "Task",
+                "Resource": "arn:aws:states:::aws-sdk:rdsdata:executeStatement",
+                "Parameters": {
+                    "resourceArn": cluster_arn,
+                    "secretArn": secret_arn,
+                    "sql": "SELECT 1",
+                    "database": "testdb",
+                },
+                "End": True,
+            },
+        },
+    })
+
+    sm_arn = sfn_sync.create_state_machine(
+        name=sm_name,
+        definition=definition,
+        roleArn="arn:aws:iam::000000000000:role/sfn-role",
+    )["stateMachineArn"]
+
+    resp = sfn_sync.start_sync_execution(stateMachineArn=sm_arn, input=json.dumps({}))
+    assert resp["status"] == "SUCCEEDED", f"Execution failed: {resp.get('error')} — {resp.get('cause')}"
+    output = json.loads(resp["output"])
+    assert "numberOfRecordsUpdated" in output or "records" in output
+
+    sfn_sync.delete_state_machine(stateMachineArn=sm_arn)
+
+
+def test_sfn_aws_sdk_rdsdata_unknown_action_fails(sfn, sfn_sync):
+    """SFN aws-sdk:rdsdata with unknown action fails with deterministic error."""
+    import uuid as _uuid
+    sm_name = f"sdk-rdsdata-bad-{_uuid.uuid4().hex[:8]}"
+
+    definition = json.dumps({
+        "StartAt": "BadAction",
+        "States": {
+            "BadAction": {
+                "Type": "Task",
+                "Resource": "arn:aws:states:::aws-sdk:rdsdata:notARealAction",
+                "Parameters": {"resourceArn": "arn:aws:rds:us-east-1:000000000000:cluster:fake"},
+                "End": True,
+            },
+        },
+    })
+
+    sm_arn = sfn_sync.create_state_machine(
+        name=sm_name,
+        definition=definition,
+        roleArn="arn:aws:iam::000000000000:role/sfn-role",
+    )["stateMachineArn"]
+
+    resp = sfn_sync.start_sync_execution(stateMachineArn=sm_arn, input=json.dumps({}))
+    assert resp["status"] == "FAILED"
+
+    sfn_sync.delete_state_machine(stateMachineArn=sm_arn)
+
+
+def test_sfn_aws_sdk_rdsdata_path_mapping():
+    """Verify REST-JSON action→path mappings are correct for rds-data."""
+    from ministack.services.stepfunctions import _REST_JSON_ACTION_PATHS
+
+    rds_data_paths = _REST_JSON_ACTION_PATHS["rds-data"]
+    assert rds_data_paths["ExecuteStatement"] == "/Execute"
+    assert rds_data_paths["BatchExecuteStatement"] == "/BatchExecute"
+    assert rds_data_paths["BeginTransaction"] == "/BeginTransaction"
+    assert rds_data_paths["CommitTransaction"] == "/CommitTransaction"
+    assert rds_data_paths["RollbackTransaction"] == "/RollbackTransaction"


### PR DESCRIPTION
## Summary

Add REST-JSON protocol support to the SFN `aws-sdk:*` task dispatcher, enabling Step Functions to call RDS Data API via `arn:aws:states:::aws-sdk:rdsdata:executeStatement`.

This is independent of #235 (acronym mapper) — no shared code or dependencies between them.

## Changes

### Step Functions (`stepfunctions.py`)
- Register `rdsdata` in `_AWS_SDK_SERVICE_MAP` with `rest-json` protocol and `rds-data` service key
- Add `_REST_JSON_ACTION_PATHS` static map for RDS Data API endpoints (`ExecuteStatement` → `/Execute`, etc.)
- Add `_dispatch_aws_sdk_rest_json()` — path-based routing with JSON body, no botocore dependency
- Route `rest-json` protocol in `_invoke_aws_sdk_integration()`

### RDS Data API (`rds_data.py`)
- Add `_stub_success()` helper for mock environments
- Return stub success (instead of 400) when cluster has no Docker endpoint or DB driver is missing
- Real database errors still propagate as errors (not stubbed)
- Handle cluster `Endpoint` being a string (hostname) vs dict (instance)

### CHANGELOG
- Entry added

## Design Decisions

- **Static path map vs botocore**: RDS Data API paths aren't derivable from action names (`ExecuteStatement` → `/Execute`), so a static map is needed. Using botocore at runtime was rejected upstream per #214 feedback.
- **Stub fallback scope**: Only stubs on missing endpoint or missing driver (`ImportError`). Generic `except Exception` still returns a real error — per code review feedback, masking real DB failures would hide bugs in workflows.

## Tests

- **Happy path**: SFN dispatching `aws-sdk:rdsdata:executeStatement` end-to-end (creates cluster + secret, executes via SFN, verifies stub response)
- **Unknown action**: `aws-sdk:rdsdata:notARealAction` fails deterministically
- **Path mapping**: Unit test verifying all 5 RDS Data API action→path mappings

All 1122 tests pass (only pre-existing `cbor2` skip).