### PR TITLE
feat(lambda): support Node.js ESM (.mjs) handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ### Added
 - **SFN query-protocol acronym mapper** — Step Functions `aws-sdk:*` integrations now correctly convert SDK-style parameter names (e.g. `DbSubnetGroupName`) to wire-format names (`DBSubnetGroupName`) for query-protocol services (RDS, EC2, IAM, STS, etc.). Uses a static acronym mapping — no botocore dependency. Contributed by @jayjanssen.
+- **Node.js ESM (.mjs) handler support** — Lambda handlers using ES modules (`.mjs` files with `export` syntax) are now loaded via dynamic `import()` when `require()` fails. Both the warm worker pool (`_NODEJS_WORKER_SCRIPT`) and the subprocess executor (`_NODE_WRAPPER_SCRIPT`) fall back to `import()` for `.mjs` files or when `ERR_REQUIRE_ESM` is encountered, matching AWS Lambda's native ESM support.
 
 ### Fixed
 - **API Gateway v1/v2 returns mock response for Node.js Lambdas** — `_invoke_lambda_proxy` in both `apigateway.py` (v2) and `apigateway_v1.py` (v1) only dispatched to the warm worker pool for Python runtimes. Node.js Lambdas received a hardcoded `"Mock response"` instead of being executed, even though the warm worker pool in `lambda_runtime.py` already supports Node.js. Now checks for both `python` and `nodejs` runtimes.

--- a/ministack/core/lambda_runtime.py
+++ b/ministack/core/lambda_runtime.py
@@ -189,8 +189,34 @@ rl.on("line", async (line) => {
       patchAwsSdk();
       try {
         const fullPath = path.resolve(code_dir, modPath);
-        const mod = require(fullPath);
-        handlerFn = mod[handlerName];
+        let mod;
+        let resolvedPath;
+        try {
+          resolvedPath = require.resolve(fullPath);
+        } catch (resolveErr) {
+          if (resolveErr.code === "MODULE_NOT_FOUND") {
+            const fs = require("fs");
+            const mjsPath = fullPath + ".mjs";
+            if (fs.existsSync(mjsPath)) {
+              resolvedPath = mjsPath;
+            } else {
+              throw resolveErr;
+            }
+          } else {
+            throw resolveErr;
+          }
+        }
+        try {
+          mod = require(resolvedPath);
+        } catch (reqErr) {
+          if (reqErr.code === "ERR_REQUIRE_ESM") {
+            const { pathToFileURL } = require("url");
+            mod = await import(pathToFileURL(resolvedPath).href);
+          } else {
+            throw reqErr;
+          }
+        }
+        handlerFn = mod[handlerName] || (mod.default && mod.default[handlerName]) || mod.default;
         if (typeof handlerFn !== "function") {
           process.stdout.write(JSON.stringify({
             status: "error",

--- a/ministack/services/lambda_svc.py
+++ b/ministack/services/lambda_svc.py
@@ -216,6 +216,7 @@ if _result is not None:
 _NODE_WRAPPER_SCRIPT = """\
 const fs = require('fs');
 const path = require('path');
+const { pathToFileURL } = require('url');
 
 const codeDir = process.env._LAMBDA_CODE_DIR || '/var/task';
 const modPath  = process.env._LAMBDA_HANDLER_MODULE;
@@ -240,10 +241,38 @@ const context = {
 
 let input = '';
 process.stdin.on('data', d => input += d);
-process.stdin.on('end', () => {
+process.stdin.on('end', async () => {
   const event = JSON.parse(input);
-  const mod = require(path.resolve(codeDir, modPath));
-  const handler = mod[fnName];
+  const fullPath = path.resolve(codeDir, modPath);
+  let mod;
+  let resolvedPath;
+  try {
+    resolvedPath = require.resolve(fullPath);
+    mod = require(resolvedPath);
+  } catch (reqErr) {
+    if (reqErr.code === 'ERR_REQUIRE_ESM' && resolvedPath) {
+      mod = await import(pathToFileURL(resolvedPath).href);
+    } else if (reqErr.code === 'MODULE_NOT_FOUND') {
+      const mjsPath = fullPath + '.mjs';
+      const missingHandlerEntry =
+        (reqErr.message && reqErr.message.includes("'" + fullPath + "'")) ||
+        (resolvedPath && reqErr.message && reqErr.message.includes("'" + resolvedPath + "'"));
+      if (missingHandlerEntry && fs.existsSync(mjsPath)) {
+        mod = await import(pathToFileURL(mjsPath).href);
+      } else {
+        throw reqErr;
+      }
+    } else {
+      throw reqErr;
+    }
+  }
+  const handler = mod[fnName] || (mod.default && mod.default[fnName]) || mod.default;
+  if (typeof handler !== 'function') {
+    process.stderr.write(
+      "Handler '" + fnName + "' in module '" + modPath + "' is undefined or not a function"
+    );
+    process.exit(1);
+  }
   Promise.resolve(handler(event, context)).then(result => {
     if (result !== undefined) process.stdout.write(JSON.stringify(result));
   }).catch(err => {

--- a/tests/test_lambda.py
+++ b/tests/test_lambda.py
@@ -1453,3 +1453,104 @@ def test_apigwv2_nodejs_lambda_proxy(lam, apigw):
             lam.delete_function(FunctionName=fname)
         except ClientError:
             pass
+
+
+def test_lambda_nodejs_esm_mjs_handler(lam):
+    """Node.js .mjs (ESM) handlers should be loaded via dynamic import() fallback.
+
+    Creates a ZIP with two .mjs files:
+      - utils.mjs: exports a helper function using ESM `export` syntax
+      - index.mjs: imports utils.mjs via ESM `import` statement and uses it
+
+    This verifies that:
+      1. .mjs files are loaded via import() instead of require()
+      2. ESM import/export syntax works between modules
+      3. The handler's return value is correctly propagated
+    """
+    fname = f"lam-esm-{_uuid_mod.uuid4().hex[:8]}"
+
+    utils_code = (
+        "export function greet(name) {\n"
+        "  return `Hello, ${name} from ESM!`;\n"
+        "}\n"
+        "\n"
+        "export const VERSION = '1.0.0';\n"
+    )
+
+    handler_code = (
+        "import { greet, VERSION } from './utils.mjs';\n"
+        "\n"
+        "export const handler = async (event) => {\n"
+        "  const name = event.name || 'World';\n"
+        "  return {\n"
+        "    statusCode: 200,\n"
+        "    body: JSON.stringify({\n"
+        "      message: greet(name),\n"
+        "      version: VERSION,\n"
+        "      esm: true,\n"
+        "    }),\n"
+        "  };\n"
+        "};\n"
+    )
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as z:
+        z.writestr("index.mjs", handler_code)
+        z.writestr("utils.mjs", utils_code)
+
+    lam.create_function(
+        FunctionName=fname,
+        Runtime="nodejs20.x",
+        Role=_LAMBDA_ROLE,
+        Handler="index.handler",
+        Code={"ZipFile": buf.getvalue()},
+    )
+    try:
+        resp = lam.invoke(
+            FunctionName=fname,
+            Payload=json.dumps({"name": "MiniStack"}),
+        )
+        assert resp["StatusCode"] == 200
+        assert "FunctionError" not in resp, f"Lambda error: {resp['Payload'].read().decode()}"
+        payload = json.loads(resp["Payload"].read())
+        assert payload["statusCode"] == 200
+        body = json.loads(payload["body"])
+        assert body["message"] == "Hello, MiniStack from ESM!"
+        assert body["version"] == "1.0.0"
+        assert body["esm"] is True
+    finally:
+        lam.delete_function(FunctionName=fname)
+
+
+def test_lambda_nodejs_esm_type_module(lam):
+    """Node.js ESM via package.json type:module should trigger ERR_REQUIRE_ESM fallback."""
+    fname = f"lam-esm-type-{_uuid_mod.uuid4().hex[:8]}"
+
+    handler_code = (
+        "export const handler = async (event) => ({\n"
+        "  statusCode: 200,\n"
+        "  body: 'type-module-works',\n"
+        "});\n"
+    )
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as z:
+        z.writestr("index.js", handler_code)
+        z.writestr("package.json", '{"type": "module"}')
+
+    lam.create_function(
+        FunctionName=fname,
+        Runtime="nodejs20.x",
+        Role=_LAMBDA_ROLE,
+        Handler="index.handler",
+        Code={"ZipFile": buf.getvalue()},
+    )
+    try:
+        resp = lam.invoke(FunctionName=fname, Payload=b"{}")
+        assert resp["StatusCode"] == 200
+        assert "FunctionError" not in resp, f"Lambda error: {resp['Payload'].read().decode()}"
+        payload = json.loads(resp["Payload"].read())
+        assert payload["statusCode"] == 200
+        assert payload["body"] == "type-module-works"
+    finally:
+        lam.delete_function(FunctionName=fname)


### PR DESCRIPTION
## Summary

Lambda handlers using ES modules (`.mjs` files with `export` syntax) could not be loaded because both the warm worker pool and the subprocess executor used `require()` exclusively, which cannot load ESM modules.

## Changes

**`ministack/core/lambda_runtime.py`** (`_NODEJS_WORKER_SCRIPT`):
- Handler loading now tries `require()` first, then falls back to dynamic `import()` when `MODULE_NOT_FOUND` or `ERR_REQUIRE_ESM` is encountered
- Resolves handler from named exports, `default[handlerName]`, or `default` — matching AWS Lambda's ESM resolution

**`ministack/services/lambda_svc.py`** (`_NODE_WRAPPER_SCRIPT`):
- Same `require()` → `import()` fallback
- `process.stdin.on('end')` callback made `async` to support `await import()`

**`tests/test_lambda.py`**:
- Added `test_lambda_nodejs_esm_mjs_handler` with two `.mjs` files:
  - `utils.mjs`: exports a helper function and constant using ESM `export` syntax
  - `index.mjs`: imports from `utils.mjs` via ESM `import` statement
- Verifies ESM import/export between modules works end-to-end

## Motivation

AWS Lambda natively supports `.mjs` handlers. Our Node.js backend uses ESM exclusively (all `.mjs` files). Without this fix, MiniStack's warm worker and subprocess executor fail with `MODULE_NOT_FOUND` for any `.mjs` handler.

## Test plan

- [x] `pytest tests/test_lambda.py -v -k "esm_mjs"` — new test passes
- [x] `pytest tests/test_lambda.py -v` — all 70 tests pass, 1 skipped (docker-only)
- [x] Verified with real-world ESM Lambda handlers using `import`/`export` between modules