### PR TITLE
  fixes: v1.1.62 — SFN acronym mapper, API Gateway v2 fixes, Lambda Do…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,20 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+---
+
+## [1.1.62] — 2026-04-10
+
 ### Added
-- **SFN query-protocol acronym mapper** — Step Functions `aws-sdk:*` integrations now correctly convert SDK-style parameter names (e.g. `DbSubnetGroupName`) to wire-format names (`DBSubnetGroupName`) for query-protocol services (RDS, EC2, IAM, STS, etc.). Uses a static acronym mapping — no botocore dependency. Contributed by @jayjanssen.
+- **SFN query-protocol acronym mapper** — Step Functions `aws-sdk:*` integrations now correctly convert SDK-style parameter names (e.g. `DbSubnetGroupName`) to wire-format names (`DBSubnetGroupName`) for query-protocol services (RDS, EC2, IAM, STS, etc.). Uses a static acronym mapping — no botocore dependency. Contributed by @jayjanssen (#235).
 
 ### Fixed
-- **API Gateway v1/v2 returns mock response for Node.js Lambdas** — `_invoke_lambda_proxy` in both `apigateway.py` (v2) and `apigateway_v1.py` (v1) only dispatched to the warm worker pool for Python runtimes. Node.js Lambdas received a hardcoded `"Mock response"` instead of being executed, even though the warm worker pool in `lambda_runtime.py` already supports Node.js. Now checks for both `python` and `nodejs` runtimes.
-- **API Gateway v2 missing `pathParameters` in Lambda event** — Routes with path parameters (e.g. `GET /items/{itemId}`) did not extract parameter values into the Lambda proxy event's `pathParameters` field. Handlers received `undefined` instead of `{ "itemId": "..." }`. Now extracts parameters from both `{param}` and `{proxy+}` route templates.
-- **API Gateway v2 `queryStringParameters` incorrect for multi-value params** — Multi-value query parameters (e.g. `?tag=a&tag=b`) were passed as Python lists instead of comma-joined strings. Now joins values with commas (`"tag": "a,b"`) matching the AWS API Gateway v2 payload format 2.0 spec.
-- **API Gateway v2 `rawQueryString` stringified lists** — Multi-value query parameters were rendered as `tag=['a', 'b']` instead of `tag=a&tag=b`. Now expands repeated keys correctly.
-- **Lambda Docker executor fails for `provided` runtimes** — `_execute_function_docker()` mounted Lambda code only at `/var/task` and overrode CMD to `["/var/task/bootstrap"]`, but the AWS RIE entrypoint (`/lambda-entrypoint.sh`) in `public.ecr.aws/lambda/provided:al2023` expects the bootstrap binary at `/var/runtime/bootstrap`. Now mounts code at both `/var/task` and `/var/runtime` (matching real AWS layout) and passes `"bootstrap"` as CMD so the RIE finds the handler correctly. Contributed by @jayjanssen.
+- **API Gateway v1/v2 returns mock response for Node.js Lambdas** — `_invoke_lambda_proxy` in both `apigateway.py` (v2) and `apigateway_v1.py` (v1) only dispatched to the warm worker pool for Python runtimes. Node.js Lambdas received a hardcoded `"Mock response"` instead of being executed. Now checks for both `python` and `nodejs` runtimes. Contributed by @bognari (#234).
+- **API Gateway v2 missing `pathParameters` in Lambda event** — Routes with path parameters (e.g. `GET /items/{itemId}`) did not extract parameter values into the Lambda proxy event's `pathParameters` field. Now extracts parameters from both `{param}` and `{proxy+}` route templates. Contributed by @bognari (#239).
+- **API Gateway v2 `queryStringParameters` incorrect for multi-value params** — Multi-value query parameters (e.g. `?tag=a&tag=b`) were passed as Python lists instead of comma-joined strings. Now joins values with commas (`"tag": "a,b"`) matching the AWS API Gateway v2 payload format 2.0 spec. Contributed by @bognari (#239).
+- **API Gateway v2 `rawQueryString` stringified lists** — Multi-value query parameters were rendered as `tag=['a', 'b']` instead of `tag=a&tag=b`. Now expands repeated keys correctly. Contributed by @bognari (#239).
+- **Lambda Docker executor fails for `provided` runtimes** — `_execute_function_docker()` mounted Lambda code only at `/var/task` and overrode CMD to `["/var/task/bootstrap"]`, but the AWS RIE entrypoint expects the bootstrap binary at `/var/runtime/bootstrap`. Now mounts code at both `/var/task` and `/var/runtime` and passes `"bootstrap"` as CMD. Contributed by @jayjanssen (#232).
+- **Lambda `print()` / `console.log()` output lost in warm worker pool** — Python handler `print()` wrote to stdout, colliding with the JSON-line protocol between worker and host. Now redirects Python stdout to stderr (matching the existing Node.js worker behavior). Worker `invoke()` drains stderr after each invocation and returns it as `log`. ESM success paths (SQS, Kinesis, DynamoDB Streams) now emit handler output to the MiniStack log. Direct `Invoke` with `LogType=Tail` returns the output in `X-Amz-Log-Result`. Reported by @PerhapsJack.
 
 ---
 ## [1.1.61] — 2026-04-10

--- a/ministack/core/lambda_runtime.py
+++ b/ministack/core/lambda_runtime.py
@@ -30,6 +30,10 @@ _PYTHON_WORKER_SCRIPT = '''
 import sys, json, importlib, traceback, os
 
 def run():
+    # Redirect print() to stderr so stdout stays clean for JSON-line protocol
+    _real_stdout = sys.stdout
+    sys.stdout = sys.stderr
+
     init = json.loads(sys.stdin.readline())
     code_dir = init["code_dir"]
     module_name = init["module"]
@@ -40,11 +44,11 @@ def run():
     try:
         mod = importlib.import_module(module_name)
         handler_fn = getattr(mod, handler_name)
-        sys.stdout.write(json.dumps({"status": "ready", "cold": True}) + "\\n")
-        sys.stdout.flush()
+        _real_stdout.write(json.dumps({"status": "ready", "cold": True}) + "\\n")
+        _real_stdout.flush()
     except Exception as e:
-        sys.stdout.write(json.dumps({"status": "error", "error": str(e)}) + "\\n")
-        sys.stdout.flush()
+        _real_stdout.write(json.dumps({"status": "error", "error": str(e)}) + "\\n")
+        _real_stdout.flush()
         return
 
     while True:
@@ -60,10 +64,10 @@ def run():
         })()
         try:
             result = handler_fn(event, context)
-            sys.stdout.write(json.dumps({"status": "ok", "result": result}) + "\\n")
+            _real_stdout.write(json.dumps({"status": "ok", "result": result}) + "\\n")
         except Exception as e:
-            sys.stdout.write(json.dumps({"status": "error", "error": str(e), "trace": traceback.format_exc()}) + "\\n")
-        sys.stdout.flush()
+            _real_stdout.write(json.dumps({"status": "error", "error": str(e), "trace": traceback.format_exc()}) + "\\n")
+        _real_stdout.flush()
 
 run()
 '''
@@ -372,6 +376,18 @@ class Worker:
         self._start_time = time.time()
         logger.info("Lambda worker spawned for %s (%s, cold start)", self.func_name, runtime)
 
+    def _drain_stderr(self) -> str:
+        """Read any available stderr output without blocking."""
+        import select
+        lines = []
+        if self._proc and self._proc.stderr:
+            while select.select([self._proc.stderr], [], [], 0)[0]:
+                line = self._proc.stderr.readline()
+                if not line:
+                    break
+                lines.append(line.rstrip("\n"))
+        return "\n".join(lines)
+
     def invoke(self, event: dict, request_id: str) -> dict:
         with self._lock:
             cold = self._cold
@@ -400,6 +416,7 @@ class Worker:
                         try:
                             response = json.loads(response_line)
                             response["cold_start"] = cold
+                            response["log"] = self._drain_stderr()
                             return response
                         except json.JSONDecodeError:
                             continue

--- a/ministack/services/lambda_svc.py
+++ b/ministack/services/lambda_svc.py
@@ -1293,7 +1293,7 @@ def _execute_function_warm(func: dict, event: dict) -> dict:
         worker = get_or_create_worker(func_name, config, code_zip)
         result = worker.invoke(event, new_uuid())
         if result.get("status") == "ok":
-            return {"body": result.get("result"), "log": ""}
+            return {"body": result.get("result"), "log": result.get("log", "")}
         else:
             return {
                 "body": {
@@ -2756,6 +2756,9 @@ def _poll_sqs():
             receipt_handles = {msg["receipt_handle"] for msg in batch if msg.get("receipt_handle")}
             _sqs._delete_messages_for_esm(queue_url, receipt_handles)
             esm["LastProcessingResult"] = f"OK - {len(batch)} records"
+            log_output = result.get("log", "")
+            if log_output:
+                logger.info("ESM: Lambda %s output:\n%s", func_name, log_output)
             logger.info("ESM: Lambda %s processed %d SQS messages from %s", func_name, len(batch), queue_name)
 
 
@@ -2847,6 +2850,9 @@ def _poll_kinesis():
             else:
                 positions[shard_id] = pos + len(raw_records)
                 esm["LastProcessingResult"] = f"OK - {len(raw_records)} records"
+                log_output = result.get("log", "")
+                if log_output:
+                    logger.info("ESM: Lambda %s output:\n%s", func_name, log_output)
                 logger.info(
                     "ESM: Lambda %s processed %d Kinesis records from %s/%s",
                     func_name, len(raw_records), stream_name, shard_id,
@@ -2908,6 +2914,9 @@ def _poll_dynamodb_streams():
             with _dynamodb_stream_positions_lock:
                 _dynamodb_stream_positions[esm_id] = pos + len(batch)
             esm["LastProcessingResult"] = f"OK - {len(batch)} records"
+            log_output = result.get("log", "")
+            if log_output:
+                logger.info("ESM: Lambda %s output:\n%s", func_name, log_output)
             logger.info(
                 "ESM: Lambda %s processed %d DynamoDB stream records from %s",
                 func_name, len(batch), table_name,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ministack"
-version = "1.1.61"
+version = "1.1.62"
 description = "Free, open-source local AWS emulator — drop-in LocalStack replacement"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
  - stepfunctions.py: static acronym mapper (_sfn_key_to_api_name, _convert_params_to_api_names)                             
    converts SDK-style params to wire-format before query-protocol dispatch. @jayjanssen (#235)                              
  - apigateway.py, apigateway_v1.py: dispatch Node.js Lambdas to warm worker pool. @bognari (#234)                           
  - apigateway.py: populate pathParameters in v2 proxy event, fix queryStringParameters                                      
    comma-join and rawQueryString expansion. @bognari (#239)                                                                 
  - lambda_svc.py: Docker provided-runtime executor mounts code at /var/task + /var/runtime,                                 
    passes "bootstrap" as CMD. @jayjanssen (#232)                                                                            
  - lambda_runtime.py: redirect Python worker print() to stderr, drain stderr after each                                     
    invocation, return handler output as log. ESM success paths now emit handler output.                                     
  - pyproject.toml: version bump 1.1.61 → 1.1.62                                                                             
  - CHANGELOG.md: v1.1.62 entry (1 Added, 6 Fixed)                                                                           
  - 1,133 tests pass, 1 skipped (docker-only)   