### PR TITLE
fix: Terraform AWS provider v5.x compatibility (Lambda, DynamoDB, SFN, ESM)

### DIFF
--- a/ministack/services/dynamodb.py
+++ b/ministack/services/dynamodb.py
@@ -225,9 +225,15 @@ def _create_table(data):
 
     gsis = copy.deepcopy(data.get("GlobalSecondaryIndexes", []))
     lsis = copy.deepcopy(data.get("LocalSecondaryIndexes", []))
+    billing_mode = data.get("BillingMode", "PROVISIONED")
+    gsi_default_throughput = (
+        {"ReadCapacityUnits": 0, "WriteCapacityUnits": 0}
+        if billing_mode == "PAY_PER_REQUEST"
+        else {"ReadCapacityUnits": 5, "WriteCapacityUnits": 5}
+    )
     for gsi in gsis:
         gsi.setdefault("IndexStatus", "ACTIVE")
-        gsi.setdefault("ProvisionedThroughput", {"ReadCapacityUnits": 5, "WriteCapacityUnits": 5})
+        gsi.setdefault("ProvisionedThroughput", gsi_default_throughput)
         gsi["IndexArn"] = f"arn:aws:dynamodb:{REGION}:{get_account_id()}:table/{name}/index/{gsi['IndexName']}"
         gsi["IndexSizeBytes"] = 0
         gsi["ItemCount"] = 0
@@ -251,7 +257,9 @@ def _create_table(data):
         "TableId": new_uuid(),
         "GlobalSecondaryIndexes": gsis,
         "LocalSecondaryIndexes": lsis,
-        "ProvisionedThroughput": data.get("ProvisionedThroughput", {"ReadCapacityUnits": 5, "WriteCapacityUnits": 5}),
+        "ProvisionedThroughput": {"ReadCapacityUnits": 0, "WriteCapacityUnits": 0}
+            if data.get("BillingMode") == "PAY_PER_REQUEST"
+            else data.get("ProvisionedThroughput", {"ReadCapacityUnits": 5, "WriteCapacityUnits": 5}),
         "BillingModeSummary": {"BillingMode": data.get("BillingMode", "PROVISIONED")},
         "StreamSpecification": data.get("StreamSpecification"),
         "SSEDescription": data.get("SSESpecification"),
@@ -302,6 +310,8 @@ def _update_table(data):
         table["ProvisionedThroughput"] = data["ProvisionedThroughput"]
     if "BillingMode" in data:
         table["BillingModeSummary"] = {"BillingMode": data["BillingMode"]}
+        if data["BillingMode"] == "PAY_PER_REQUEST":
+            table["ProvisionedThroughput"] = {"ReadCapacityUnits": 0, "WriteCapacityUnits": 0}
     if "AttributeDefinitions" in data:
         table["AttributeDefinitions"] = data["AttributeDefinitions"]
     if "StreamSpecification" in data:
@@ -311,7 +321,13 @@ def _update_table(data):
         if "Create" in update:
             gsi_def = copy.deepcopy(update["Create"])
             gsi_def.setdefault("IndexStatus", "ACTIVE")
-            gsi_def.setdefault("ProvisionedThroughput", {"ReadCapacityUnits": 5, "WriteCapacityUnits": 5})
+            current_billing = table.get("BillingModeSummary", {}).get("BillingMode", "PROVISIONED")
+            gsi_def.setdefault(
+                "ProvisionedThroughput",
+                {"ReadCapacityUnits": 0, "WriteCapacityUnits": 0}
+                if current_billing == "PAY_PER_REQUEST"
+                else {"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
+            )
             gsi_def["IndexArn"] = f"arn:aws:dynamodb:{REGION}:{get_account_id()}:table/{name}/index/{gsi_def['IndexName']}"
             gsi_def["IndexSizeBytes"] = 0
             gsi_def["ItemCount"] = 0

--- a/ministack/services/lambda_svc.py
+++ b/ministack/services/lambda_svc.py
@@ -682,7 +682,7 @@ def _create_function(data: dict):
         config["ImageUri"] = image_uri
         config["PackageType"] = "Image"
         if "ImageConfig" in data:
-            config["ImageConfig"] = data["ImageConfig"]
+            config["ImageConfigResponse"] = {"ImageConfig": data["ImageConfig"]}
 
     _functions[name] = {
         "config": config,
@@ -871,10 +871,11 @@ def _update_config(name: str, data: dict):
         "VpcConfig",
         "Architectures",
         "FileSystemConfigs",
-        "ImageConfig",
     ):
         if key in data:
             config[key] = data[key]
+    if "ImageConfig" in data:
+        config["ImageConfigResponse"] = {"ImageConfig": data["ImageConfig"]}
     config["LastModified"] = _now_iso()
     config["LastUpdateStatus"] = "Successful"
     config["RevisionId"] = new_uuid()

--- a/ministack/services/lambda_svc.py
+++ b/ministack/services/lambda_svc.py
@@ -334,6 +334,7 @@ def _fetch_code_from_s3(bucket: str, key: str) -> bytes | None:
 def _build_config(name: str, data: dict, code_zip: bytes | None = None) -> dict:
     code_size = len(code_zip) if code_zip else 0
     code_sha = base64.b64encode(hashlib.sha256(code_zip).digest()).decode() if code_zip else ""
+    is_image = data.get("PackageType", "Zip") == "Image"
 
     layers_cfg = []
     for layer in data.get("Layers", []):
@@ -351,9 +352,9 @@ def _build_config(name: str, data: dict, code_zip: bytes | None = None) -> dict:
     return {
         "FunctionName": name,
         "FunctionArn": _func_arn(name),
-        "Runtime": data.get("Runtime", "python3.9"),
+        "Runtime": data.get("Runtime", "" if is_image else "python3.9"),
         "Role": data.get("Role", f"arn:aws:iam::{get_account_id()}:role/lambda-role"),
-        "Handler": data.get("Handler", "index.handler"),
+        "Handler": data.get("Handler", "" if is_image else "index.handler"),
         "CodeSize": code_size,
         "CodeSha256": code_sha,
         "Description": data.get("Description", ""),
@@ -380,7 +381,7 @@ def _build_config(name: str, data: dict, code_zip: bytes | None = None) -> dict:
                 "VpcId": "",
             },
         ),
-        "DeadLetterConfig": data.get("DeadLetterConfig", {"TargetArn": ""}),
+        "DeadLetterConfig": data.get("DeadLetterConfig", {}),
         "KMSKeyArn": data.get("KMSKeyArn", ""),
         "RevisionId": new_uuid(),
         "EphemeralStorage": data.get("EphemeralStorage", {"Size": 512}),
@@ -680,6 +681,8 @@ def _create_function(data: dict):
     if image_uri:
         config["ImageUri"] = image_uri
         config["PackageType"] = "Image"
+        if "ImageConfig" in data:
+            config["ImageConfig"] = data["ImageConfig"]
 
     _functions[name] = {
         "config": config,
@@ -2550,13 +2553,19 @@ def _delete_provisioned_concurrency(func_name: str, qualifier: str):
 # ---------------------------------------------------------------------------
 
 
+def _esm_response(esm: dict) -> dict:
+    """Return ESM dict without internal-only fields."""
+    return {k: v for k, v in esm.items() if k != "FunctionName"}
+
+
 def _create_esm(data: dict):
     esm_id = new_uuid()
     func_name = _resolve_name(data.get("FunctionName", ""))
+    event_source_arn = data.get("EventSourceArn", "")
 
     esm = {
         "UUID": esm_id,
-        "EventSourceArn": data.get("EventSourceArn", ""),
+        "EventSourceArn": event_source_arn,
         "FunctionArn": _func_arn(func_name),
         "FunctionName": func_name,
         "State": "Enabled",
@@ -2565,13 +2574,14 @@ def _create_esm(data: dict):
         "MaximumBatchingWindowInSeconds": data.get("MaximumBatchingWindowInSeconds", 0),
         "LastModified": time.time(),
         "LastProcessingResult": "No records processed",
-        "StartingPosition": data.get("StartingPosition", "LATEST"),
         "Enabled": True,
         "FunctionResponseTypes": data.get("FunctionResponseTypes", []),
     }
+    if ":sqs:" not in event_source_arn:
+        esm["StartingPosition"] = data.get("StartingPosition", "LATEST")
     _esms[esm_id] = esm
     _ensure_poller()
-    return json_response(esm, 202)
+    return json_response(_esm_response(esm), 202)
 
 
 def _get_esm(esm_id: str):
@@ -2582,7 +2592,7 @@ def _get_esm(esm_id: str):
             f"The resource you requested does not exist. (Service: Lambda, Status Code: 404, Request ID: {new_uuid()})",
             404,
         )
-    return json_response(esm)
+    return json_response(_esm_response(esm))
 
 
 def _list_esms(query_params: dict):
@@ -2605,7 +2615,7 @@ def _list_esms(query_params: dict):
                 break
 
     page = result[start : start + max_items]
-    resp: dict = {"EventSourceMappings": page}
+    resp: dict = {"EventSourceMappings": [_esm_response(e) for e in page]}
     if start + max_items < len(result):
         resp["NextMarker"] = page[-1]["UUID"] if page else ""
     return json_response(resp)
@@ -2640,7 +2650,7 @@ def _update_esm(esm_id: str, data: dict):
         esm["FunctionName"] = new_name
         esm["FunctionArn"] = _func_arn(new_name)
     esm["LastModified"] = time.time()
-    return json_response(esm)
+    return json_response(_esm_response(esm))
 
 
 def _delete_esm(esm_id: str):
@@ -2652,7 +2662,7 @@ def _delete_esm(esm_id: str):
             404,
         )
     esm["State"] = "Deleting"
-    return json_response(esm, 202)
+    return json_response(_esm_response(esm), 202)
 
 
 # ---------------------------------------------------------------------------

--- a/ministack/services/stepfunctions.py
+++ b/ministack/services/stepfunctions.py
@@ -219,6 +219,7 @@ async def handle_request(method, path, headers, body, query_params):
         "ListActivities": _list_activities,
         "GetActivityTask": _get_activity_task,
         "TestState": _test_state,
+        "ValidateStateMachineDefinition": _validate_state_machine_definition,
     }
 
     handler = handlers.get(action)
@@ -933,6 +934,14 @@ def _test_state(data):
         result["inspectionData"] = inspection_data
 
     return json_response(result)
+
+
+# ---------------------------------------------------------------------------
+# ValidateStateMachineDefinition API
+# ---------------------------------------------------------------------------
+
+def _validate_state_machine_definition(data):
+    return json_response({"result": "OK", "diagnostics": []})
 
 
 # ===================================================================

--- a/tests/test_dynamodb.py
+++ b/tests/test_dynamodb.py
@@ -1164,3 +1164,117 @@ def test_dynamodb_query_filter_legacy(ddb):
     for item in resp["Items"]:
         assert item["status"]["S"] == "active"
 
+
+# ---------------------------------------------------------------------------
+# Terraform compatibility tests
+# ---------------------------------------------------------------------------
+
+
+def test_dynamodb_pay_per_request_provisioned_throughput(ddb):
+    """PAY_PER_REQUEST tables must return ProvisionedThroughput with zero values."""
+    tname = "tf-compat-ondemand"
+    try:
+        ddb.delete_table(TableName=tname)
+    except ClientError:
+        pass
+    ddb.create_table(
+        TableName=tname,
+        KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
+        AttributeDefinitions=[{"AttributeName": "pk", "AttributeType": "S"}],
+        BillingMode="PAY_PER_REQUEST",
+    )
+    try:
+        desc = ddb.describe_table(TableName=tname)["Table"]
+        pt = desc["ProvisionedThroughput"]
+        assert pt["ReadCapacityUnits"] == 0, \
+            f"Expected ReadCapacityUnits=0 for PAY_PER_REQUEST, got {pt['ReadCapacityUnits']}"
+        assert pt["WriteCapacityUnits"] == 0, \
+            f"Expected WriteCapacityUnits=0 for PAY_PER_REQUEST, got {pt['WriteCapacityUnits']}"
+    finally:
+        ddb.delete_table(TableName=tname)
+
+
+def test_dynamodb_provisioned_keeps_capacity(ddb):
+    """PROVISIONED tables must keep their configured throughput values."""
+    tname = "tf-compat-provisioned"
+    try:
+        ddb.delete_table(TableName=tname)
+    except ClientError:
+        pass
+    ddb.create_table(
+        TableName=tname,
+        KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
+        AttributeDefinitions=[{"AttributeName": "pk", "AttributeType": "S"}],
+        BillingMode="PROVISIONED",
+        ProvisionedThroughput={"ReadCapacityUnits": 10, "WriteCapacityUnits": 5},
+    )
+    try:
+        desc = ddb.describe_table(TableName=tname)["Table"]
+        pt = desc["ProvisionedThroughput"]
+        assert pt["ReadCapacityUnits"] == 10
+        assert pt["WriteCapacityUnits"] == 5
+    finally:
+        ddb.delete_table(TableName=tname)
+
+
+def test_dynamodb_pay_per_request_gsi_zero_throughput(ddb):
+    """GSIs on PAY_PER_REQUEST tables must have zero ProvisionedThroughput."""
+    tname = "tf-compat-ondemand-gsi"
+    try:
+        ddb.delete_table(TableName=tname)
+    except ClientError:
+        pass
+    ddb.create_table(
+        TableName=tname,
+        KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
+        AttributeDefinitions=[
+            {"AttributeName": "pk", "AttributeType": "S"},
+            {"AttributeName": "gsi_key", "AttributeType": "S"},
+        ],
+        BillingMode="PAY_PER_REQUEST",
+        GlobalSecondaryIndexes=[
+            {
+                "IndexName": "gsi-test",
+                "KeySchema": [{"AttributeName": "gsi_key", "KeyType": "HASH"}],
+                "Projection": {"ProjectionType": "ALL"},
+            }
+        ],
+    )
+    try:
+        desc = ddb.describe_table(TableName=tname)["Table"]
+        gsis = desc.get("GlobalSecondaryIndexes", [])
+        assert len(gsis) == 1, f"Expected 1 GSI, got {len(gsis)}"
+        gsi_pt = gsis[0]["ProvisionedThroughput"]
+        assert gsi_pt["ReadCapacityUnits"] == 0, \
+            f"Expected GSI ReadCapacityUnits=0 for PAY_PER_REQUEST, got {gsi_pt['ReadCapacityUnits']}"
+        assert gsi_pt["WriteCapacityUnits"] == 0, \
+            f"Expected GSI WriteCapacityUnits=0 for PAY_PER_REQUEST, got {gsi_pt['WriteCapacityUnits']}"
+    finally:
+        ddb.delete_table(TableName=tname)
+
+
+def test_dynamodb_update_to_pay_per_request_zeroes_throughput(ddb):
+    """Updating billing mode to PAY_PER_REQUEST should zero out throughput."""
+    tname = "tf-compat-update-billing"
+    try:
+        ddb.delete_table(TableName=tname)
+    except ClientError:
+        pass
+    ddb.create_table(
+        TableName=tname,
+        KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
+        AttributeDefinitions=[{"AttributeName": "pk", "AttributeType": "S"}],
+        BillingMode="PROVISIONED",
+        ProvisionedThroughput={"ReadCapacityUnits": 10, "WriteCapacityUnits": 5},
+    )
+    try:
+        ddb.update_table(TableName=tname, BillingMode="PAY_PER_REQUEST")
+        desc = ddb.describe_table(TableName=tname)["Table"]
+        pt = desc["ProvisionedThroughput"]
+        assert pt["ReadCapacityUnits"] == 0, \
+            f"Expected ReadCapacityUnits=0 after switching to PAY_PER_REQUEST, got {pt['ReadCapacityUnits']}"
+        assert pt["WriteCapacityUnits"] == 0, \
+            f"Expected WriteCapacityUnits=0 after switching to PAY_PER_REQUEST, got {pt['WriteCapacityUnits']}"
+    finally:
+        ddb.delete_table(TableName=tname)
+

--- a/tests/test_lambda.py
+++ b/tests/test_lambda.py
@@ -1453,3 +1453,202 @@ def test_apigwv2_nodejs_lambda_proxy(lam, apigw):
             lam.delete_function(FunctionName=fname)
         except ClientError:
             pass
+
+
+# ---------------------------------------------------------------------------
+# Terraform compatibility tests
+# ---------------------------------------------------------------------------
+
+
+def test_lambda_image_no_default_runtime_handler(lam):
+    """Image-based functions must not get default runtime/handler values."""
+    fname = "tf-compat-image-no-defaults"
+    try:
+        lam.delete_function(FunctionName=fname)
+    except ClientError:
+        pass
+    resp = lam.create_function(
+        FunctionName=fname,
+        PackageType="Image",
+        Code={"ImageUri": "my-repo/my-image:latest"},
+        Role=_LAMBDA_ROLE,
+        Timeout=30,
+    )
+    try:
+        assert resp["PackageType"] == "Image"
+        assert resp["Runtime"] == "", f"Expected empty Runtime for Image, got {resp['Runtime']!r}"
+        assert resp["Handler"] == "", f"Expected empty Handler for Image, got {resp['Handler']!r}"
+    finally:
+        lam.delete_function(FunctionName=fname)
+
+
+def test_lambda_image_preserves_image_config(lam):
+    """ImageConfig provided at creation must be preserved in the GetFunction response."""
+    fname = "tf-compat-image-config"
+    try:
+        lam.delete_function(FunctionName=fname)
+    except ClientError:
+        pass
+    lam.create_function(
+        FunctionName=fname,
+        PackageType="Image",
+        Code={"ImageUri": "my-repo/my-image:latest"},
+        Role=_LAMBDA_ROLE,
+        ImageConfig={"Command": ["main.lambda_handler"]},
+    )
+    try:
+        get_resp = lam.get_function(FunctionName=fname)
+        cfg = get_resp["Configuration"]
+        assert "ImageConfigResponse" in cfg, "ImageConfigResponse missing from get_function response"
+        assert cfg["ImageConfigResponse"]["ImageConfig"]["Command"] == ["main.lambda_handler"]
+    finally:
+        lam.delete_function(FunctionName=fname)
+
+
+def test_lambda_empty_dead_letter_config(lam):
+    """Functions without DeadLetterConfig must return empty dict, not {TargetArn: ''}."""
+    fname = "tf-compat-no-dlc"
+    try:
+        lam.delete_function(FunctionName=fname)
+    except ClientError:
+        pass
+    resp = lam.create_function(
+        FunctionName=fname,
+        Runtime="python3.9",
+        Handler="index.handler",
+        Role=_LAMBDA_ROLE,
+        Code={"ZipFile": _make_zip(_LAMBDA_CODE)},
+    )
+    try:
+        dlc = resp.get("DeadLetterConfig", {})
+        assert dlc == {} or "TargetArn" not in dlc or dlc.get("TargetArn") == "", \
+            f"Expected empty DeadLetterConfig, got {dlc!r}"
+        assert dlc.get("TargetArn") is None or dlc == {}, \
+            f"DeadLetterConfig should not have TargetArn when unconfigured, got {dlc!r}"
+    finally:
+        lam.delete_function(FunctionName=fname)
+
+
+def test_esm_sqs_no_starting_position(lam, sqs):
+    """SQS event source mappings must not include StartingPosition."""
+    fname = "tf-compat-esm-sqs"
+    try:
+        lam.delete_function(FunctionName=fname)
+    except ClientError:
+        pass
+    lam.create_function(
+        FunctionName=fname,
+        Runtime="python3.9",
+        Handler="index.handler",
+        Role=_LAMBDA_ROLE,
+        Code={"ZipFile": _make_zip(_LAMBDA_CODE)},
+    )
+    q_url = sqs.create_queue(QueueName="tf-compat-esm-queue")["QueueUrl"]
+    q_arn = sqs.get_queue_attributes(
+        QueueUrl=q_url, AttributeNames=["QueueArn"]
+    )["Attributes"]["QueueArn"]
+
+    esm_uuid = None
+    try:
+        resp = lam.create_event_source_mapping(
+            EventSourceArn=q_arn,
+            FunctionName=fname,
+            BatchSize=5,
+            Enabled=True,
+        )
+        esm_uuid = resp["UUID"]
+        assert "StartingPosition" not in resp, \
+            f"SQS ESM should not have StartingPosition, got {resp.get('StartingPosition')!r}"
+
+        get_resp = lam.get_event_source_mapping(UUID=esm_uuid)
+        assert "StartingPosition" not in get_resp, \
+            "StartingPosition should not appear in get_event_source_mapping for SQS"
+    finally:
+        if esm_uuid:
+            lam.delete_event_source_mapping(UUID=esm_uuid)
+        lam.delete_function(FunctionName=fname)
+        sqs.delete_queue(QueueUrl=q_url)
+
+
+def test_esm_kinesis_has_starting_position(lam, kin):
+    """Kinesis event source mappings must include StartingPosition."""
+    fname = "tf-compat-esm-kinesis"
+    stream_name = "tf-compat-esm-stream"
+    try:
+        lam.delete_function(FunctionName=fname)
+    except ClientError:
+        pass
+    try:
+        kin.delete_stream(StreamName=stream_name, EnforceConsumerDeletion=True)
+    except ClientError:
+        pass
+
+    lam.create_function(
+        FunctionName=fname,
+        Runtime="python3.9",
+        Handler="index.handler",
+        Role=_LAMBDA_ROLE,
+        Code={"ZipFile": _make_zip(_LAMBDA_CODE)},
+    )
+    kin.create_stream(StreamName=stream_name, ShardCount=1)
+    stream_arn = kin.describe_stream(
+        StreamName=stream_name
+    )["StreamDescription"]["StreamARN"]
+
+    esm_uuid = None
+    try:
+        resp = lam.create_event_source_mapping(
+            EventSourceArn=stream_arn,
+            FunctionName=fname,
+            StartingPosition="TRIM_HORIZON",
+            BatchSize=100,
+            Enabled=True,
+        )
+        esm_uuid = resp["UUID"]
+        assert "StartingPosition" in resp, "Kinesis ESM must include StartingPosition"
+        assert resp["StartingPosition"] == "TRIM_HORIZON"
+    finally:
+        if esm_uuid:
+            lam.delete_event_source_mapping(UUID=esm_uuid)
+        lam.delete_function(FunctionName=fname)
+        try:
+            kin.delete_stream(StreamName=stream_name, EnforceConsumerDeletion=True)
+        except ClientError:
+            pass
+
+
+def test_esm_response_no_function_name_field(lam, sqs):
+    """ESM API responses should contain FunctionArn but not FunctionName (matching AWS)."""
+    fname = "tf-compat-esm-no-fname"
+    try:
+        lam.delete_function(FunctionName=fname)
+    except ClientError:
+        pass
+    lam.create_function(
+        FunctionName=fname,
+        Runtime="python3.9",
+        Handler="index.handler",
+        Role=_LAMBDA_ROLE,
+        Code={"ZipFile": _make_zip(_LAMBDA_CODE)},
+    )
+    q_url = sqs.create_queue(QueueName="tf-compat-esm-fname-queue")["QueueUrl"]
+    q_arn = sqs.get_queue_attributes(
+        QueueUrl=q_url, AttributeNames=["QueueArn"]
+    )["Attributes"]["QueueArn"]
+
+    esm_uuid = None
+    try:
+        resp = lam.create_event_source_mapping(
+            EventSourceArn=q_arn,
+            FunctionName=fname,
+            BatchSize=5,
+            Enabled=True,
+        )
+        esm_uuid = resp["UUID"]
+        assert "FunctionArn" in resp, "ESM response must include FunctionArn"
+        assert fname in resp["FunctionArn"], "FunctionArn must contain the function name"
+    finally:
+        if esm_uuid:
+            lam.delete_event_source_mapping(UUID=esm_uuid)
+        lam.delete_function(FunctionName=fname)
+        sqs.delete_queue(QueueUrl=q_url)

--- a/tests/test_sfn.py
+++ b/tests/test_sfn.py
@@ -2211,3 +2211,35 @@ def test_convert_params_to_api_names_nested():
         "VPCSecurityGroupIds": [{"SGId": "sg-123"}],
         "Tags": [{"Key": "env", "Value": "test"}],
     }
+
+
+# ---------------------------------------------------------------------------
+# Terraform compatibility tests
+# ---------------------------------------------------------------------------
+
+
+def test_sfn_validate_state_machine_definition(sfn):
+    """ValidateStateMachineDefinition must return OK (required by Terraform v5.42.0+)."""
+    definition = json.dumps({
+        "StartAt": "Pass",
+        "States": {"Pass": {"Type": "Succeed"}},
+    })
+    resp = sfn.validate_state_machine_definition(definition=definition)
+    assert resp["result"] == "OK"
+    assert resp["diagnostics"] == []
+
+
+def test_sfn_validate_state_machine_definition_with_type(sfn):
+    """ValidateStateMachineDefinition should accept optional type parameter."""
+    definition = json.dumps({
+        "StartAt": "Hello",
+        "States": {
+            "Hello": {"Type": "Pass", "Result": "world", "End": True},
+        },
+    })
+    resp = sfn.validate_state_machine_definition(
+        definition=definition,
+        type="STANDARD",
+    )
+    assert resp["result"] == "OK"
+    assert isinstance(resp["diagnostics"], list)


### PR DESCRIPTION
## Summary

Fixes five incompatibilities when using MiniStack with **Terraform AWS provider v5.100.0** that caused perpetual drift, apply failures, or complete blockers for resource creation.

Closes #241

### Changes

- **Lambda Image-based functions**: Don't inject default `runtime`/`handler` for `package_type = "Image"` functions, preserve `ImageConfig` in create response, return empty `{}` instead of `{"TargetArn": ""}` for unconfigured `DeadLetterConfig`
- **ESM StartingPosition**: Omit `StartingPosition` from SQS event source mappings (only valid for Kinesis/DynamoDB Streams)
- **ESM FunctionName normalization**: Strip internal `FunctionName` field from ESM API responses (real AWS only returns `FunctionArn`)
- **DynamoDB PAY_PER_REQUEST**: Return `ProvisionedThroughput: {ReadCapacityUnits: 0, WriteCapacityUnits: 0}` for on-demand tables and their GSIs (matching real AWS behavior)
- **Step Functions ValidateStateMachineDefinition**: Implement stub API that returns `{"result": "OK", "diagnostics": []}` — required by Terraform AWS provider v5.42.0+

### Files changed

- `ministack/services/lambda_svc.py` — Issues #1, #2, #5
- `ministack/services/dynamodb.py` — Issue #3
- `ministack/services/stepfunctions.py` — Issue #4

## Test plan

- [x] All 89 Lambda tests pass
- [x] All 64 DynamoDB tests pass
- [x] All 70 Step Functions tests pass
- [x] 0 regressions across 223 tests
- [x] Linting clean (no new warnings)