### PR TITLE
fix: support list-stored SSM tags in ListTagsForResource

### DIFF
--- a/ministack/services/ssm.py
+++ b/ministack/services/ssm.py
@@ -483,8 +483,16 @@ def _list_tags_for_resource(data):
     else:
         arn = resource_id
 
-    tag_dict = _tags.get(arn, {})
-    tag_list = [{"Key": k, "Value": v} for k, v in tag_dict.items()]
+    tags = _tags.get(arn, {})
+
+    if isinstance(tags, list):
+        tag_list = [
+            {"Key": t.get("Key"), "Value": t.get("Value")}
+            for t in tags
+            if isinstance(t, dict) and "Key" in t and "Value" in t
+        ]
+    else:
+        tag_list = [{"Key": k, "Value": v} for k, v in tags.items()]
 
     return json_response({"TagList": tag_list})
 

--- a/tests/test_ssm.py
+++ b/tests/test_ssm.py
@@ -131,6 +131,21 @@ def test_ssm_tags_v2(ssm):
     assert "team" not in tag_map2
     assert tag_map2["env"] == "staging"
 
+
+def test_ssm_list_tags_handles_put_parameter_tag_format(ssm):
+    ssm.put_parameter(
+        Name="/ssm2/tag/from-put",
+        Value="v",
+        Type="String",
+        Tags=[{"Key": "env", "Value": "test"}, {"Key": "service", "Value": "api"}],
+    )
+
+    resp = ssm.list_tags_for_resource(
+        ResourceType="Parameter", ResourceId="/ssm2/tag/from-put"
+    )
+    tag_map = {t["Key"]: t["Value"] for t in resp["TagList"]}
+    assert tag_map == {"env": "test", "service": "api"}
+
 def test_ssm_label_parameter_version(ssm):
     import uuid as _uuid
 


### PR DESCRIPTION
Fixes #249

PutParameter stores tags as a list of {Key, Value} entries, while ListTagsForResource was assuming a dict and calling .items(). This update handles both storage shapes without changing existing behavior for dict-backed tags. Added a regression test for the PutParameter(..., Tags=...) path to make sure list-tags keeps working.

Greetings, saschabuehrle
