### PR TITLE
fix(ssm): normalize PutParameter tags to dict format

### DIFF
--- a/ministack/services/ssm.py
+++ b/ministack/services/ssm.py
@@ -166,7 +166,7 @@ def _put_parameter(data):
     _parameter_history[name].append(history_entry)
 
     if data.get("Tags"):
-        _tags[arn] = data["Tags"]
+        _tags[arn] = {t["Key"]: t["Value"] for t in data["Tags"]}
 
     logger.info("SSM PutParameter: %s v%s type=%s", name, version, param_type)
     return json_response({"Version": version, "Tier": record["Tier"]})

--- a/tests/test_ssm.py
+++ b/tests/test_ssm.py
@@ -161,6 +161,55 @@ def test_ssm_add_remove_tags(ssm):
     assert "team" not in tag_map2
     assert tag_map2.get("env") == "prod"
 
+def test_ssm_put_parameter_with_tags_then_list(ssm):
+    """PutParameter with Tags must be readable via ListTagsForResource (GH-249)."""
+    import uuid as _uuid
+
+    pname = f"/intg/put-tags/{_uuid.uuid4().hex[:8]}"
+    ssm.put_parameter(
+        Name=pname,
+        Value="tagged-value",
+        Type="String",
+        Tags=[{"Key": "env", "Value": "prod"}, {"Key": "team", "Value": "backend"}],
+    )
+    tags = ssm.list_tags_for_resource(ResourceType="Parameter", ResourceId=pname)
+    tag_map = {t["Key"]: t["Value"] for t in tags["TagList"]}
+    assert tag_map.get("env") == "prod"
+    assert tag_map.get("team") == "backend"
+
+
+def test_ssm_put_parameter_tags_work_with_add_and_remove(ssm):
+    """Tags set via PutParameter must be compatible with AddTags/RemoveTags (GH-249)."""
+    import uuid as _uuid
+
+    pname = f"/intg/put-tags-compat/{_uuid.uuid4().hex[:8]}"
+    ssm.put_parameter(
+        Name=pname,
+        Value="v1",
+        Type="String",
+        Tags=[{"Key": "env", "Value": "dev"}],
+    )
+    # AddTagsToResource on top of PutParameter tags
+    ssm.add_tags_to_resource(
+        ResourceType="Parameter",
+        ResourceId=pname,
+        Tags=[{"Key": "team", "Value": "platform"}],
+    )
+    tags = ssm.list_tags_for_resource(ResourceType="Parameter", ResourceId=pname)
+    tag_map = {t["Key"]: t["Value"] for t in tags["TagList"]}
+    assert tag_map.get("env") == "dev"
+    assert tag_map.get("team") == "platform"
+
+    # RemoveTagsFromResource on PutParameter-created tag
+    ssm.remove_tags_from_resource(
+        ResourceType="Parameter", ResourceId=pname, TagKeys=["env"]
+    )
+    tags2 = ssm.list_tags_for_resource(ResourceType="Parameter", ResourceId=pname)
+    tag_map2 = {t["Key"]: t["Value"] for t in tags2["TagList"]}
+    assert "env" not in tag_map2
+    assert tag_map2.get("team") == "platform"
+
+
 def test_ssm_get_parameter_history(ssm):
     """GetParameterHistory returns all versions of a parameter."""
     ssm.put_parameter(Name="/qa/ssm/hist", Value="v1", Type="String")


### PR DESCRIPTION
## Summary

- **Fixes #249** — `ListTagsForResource` fails with `AttributeError: 'list' object has no attribute 'items'` after `PutParameter` with `Tags`
- `PutParameter` stored tags as the raw AWS SDK list (`[{"Key": k, "Value": v}]`), while `AddTagsToResource`, `RemoveTagsFromResource`, and `ListTagsForResource` all expect a Python dict (`{k: v}`)
- Normalizes incoming tags to dict format at write time (1-line fix), consistent with all other SSM tag operations

## Approach

The fix converts tags at the **writer** (`PutParameter`) rather than patching each reader/modifier individually. This ensures `AddTagsToResource` and `RemoveTagsFromResource` also work correctly on tags created via `PutParameter` — not just `ListTagsForResource`.

See also #252 which patches only the reader side, leaving `AddTagsToResource`/`RemoveTagsFromResource` broken for `PutParameter`-created tags.

## Test plan

- [x] Added `test_ssm_put_parameter_with_tags_then_list` — direct reproduction of #249
- [x] Added `test_ssm_put_parameter_tags_work_with_add_and_remove` — cross-operation compatibility (Add/Remove on PutParameter-created tags)
- [x] Full SSM test suite passes (18/18)
- [x] Verified against hikari-core E2E test suite (458 tests, 62 suites)