### PR TITLE
fix: increase keep-alive timeout to 75s for Go/Java SDK compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [1.2.3] — 2026-04-11
+
+### Fixed
+- **Go SDK v2 `failed to close HTTP response body` warning** — uvicorn's default keep-alive timeout (5s) was too short for Go/Java SDK connection pools (~90s idle). Increased to 75s to match AWS ALB defaults. Affected all services, most visible with DynamoDB health checks. Reported by @mspiller (#249)
+- **SSM inline tags regression test** — added test for `PutParameter` with inline `Tags` followed by `ListTagsForResource`. Contributed by @bognari 
+---
+
 ## [1.2.2] — 2026-04-11
 
 ### Fixed

--- a/ministack/app.py
+++ b/ministack/app.py
@@ -870,7 +870,8 @@ def main():
         proc = subprocess.Popen(
             [sys.executable, "-m", "uvicorn", "ministack.app:app",
              "--host", "0.0.0.0", "--port", str(port),
-             "--log-level", LOG_LEVEL.lower()],
+             "--log-level", LOG_LEVEL.lower(),
+             "--timeout-keep-alive", "75"],
             stdout=log_fh,
             stderr=subprocess.STDOUT,
             start_new_session=True,
@@ -896,7 +897,7 @@ def main():
 
     signal.signal(signal.SIGTERM, lambda *_: (_cleanup(), sys.exit(0)))
     try:
-        uvicorn.run("ministack.app:app", host="0.0.0.0", port=port, log_level=LOG_LEVEL.lower())
+        uvicorn.run("ministack.app:app", host="0.0.0.0", port=port, log_level=LOG_LEVEL.lower(), timeout_keep_alive=75)
     finally:
         _cleanup()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ministack"
-version = "1.2.2"
+version = "1.2.3"
 description = "Free, open-source local AWS emulator — drop-in LocalStack replacement"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
bump timeout in server to match idle time Go/Java SDK (75seconds)