### PR TITLE
feat: support LocalStack init script paths for drop-in compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,12 @@ COPY ministack/ ministack/
 
 RUN addgroup -S ministack && adduser -S ministack -G ministack
 RUN mkdir -p /tmp/ministack-data/s3 && chown -R ministack:ministack /tmp/ministack-data
-RUN mkdir -p /docker-entrypoint-initaws.d && chown ministack:ministack /docker-entrypoint-initaws.d
+RUN mkdir -p /docker-entrypoint-initaws.d/ready.d \
+             /etc/localstack/init/boot.d \
+             /etc/localstack/init/ready.d && \
+    chown -R ministack:ministack /docker-entrypoint-initaws.d /etc/localstack
 VOLUME /docker-entrypoint-initaws.d
+VOLUME /etc/localstack/init
 
 ENV GATEWAY_PORT=4566 \
     LOG_LEVEL=INFO \

--- a/README.md
+++ b/README.md
@@ -609,15 +609,28 @@ ecs.stop_task(cluster="dev", task=task_arn)
 
 ### Startup Scripts
 
-MiniStack supports two types of init scripts:
+MiniStack supports two types of init scripts, with LocalStack-compatible paths:
 
-- **`/docker-entrypoint-initaws.d/*.sh`** — run before the server starts (for installing tools)
-- **`/docker-entrypoint-initaws.d/ready.d/*.sh`** — run after the server is ready and accepting connections (for seeding AWS resources)
+| Phase | MiniStack path | LocalStack-compatible path |
+|-------|----------------|---------------------------|
+| Pre-start | `/docker-entrypoint-initaws.d/*.sh` | `/etc/localstack/init/boot.d/*.sh` |
+| Post-ready | `/docker-entrypoint-initaws.d/ready.d/*.sh` | `/etc/localstack/init/ready.d/*.sh` |
+
+Scripts from both paths are merged, deduplicated by filename, and run in alphabetical order.
+If the same filename exists in both paths, the MiniStack-native path takes priority.
 
 ```bash
 # ready.d/01-create-resources.sh
 aws --endpoint-url=http://localhost:4566 s3 mb s3://my-bucket
 aws --endpoint-url=http://localhost:4566 sqs create-queue --queue-name my-queue
+```
+
+**Docker Compose** — mount scripts at either path:
+```yaml
+volumes:
+  - ./init-scripts:/docker-entrypoint-initaws.d           # ministack-native
+  # OR
+  - ./init-scripts:/etc/localstack/init                    # localstack-compatible
 ```
 
 ### Athena SQL Engines

--- a/ministack/app.py
+++ b/ministack/app.py
@@ -693,18 +693,14 @@ async def _wait_for_port(port, timeout=30):
 
 
 async def _run_ready_scripts():
-    """Execute .sh scripts from /docker-entrypoint-initaws.d/ready.d/ after the server is ready."""
-    ready_dir = '/docker-entrypoint-initaws.d/ready.d'
-    if not os.path.isdir(ready_dir):
-        return
-    scripts = sorted(f for f in os.listdir(ready_dir) if f.endswith('.sh'))
+    """Execute .sh scripts from ready.d directories after the server is ready."""
+    scripts = _collect_scripts('/docker-entrypoint-initaws.d/ready.d', '/etc/localstack/init/ready.d')
     if not scripts:
         return
     port = int(_resolve_port())
     await _wait_for_port(port)
-    logger.info('Found %d ready script(s) in %s', len(scripts), ready_dir)
-    for script in scripts:
-        script_path = os.path.join(ready_dir, script)
+    logger.info('Found %d ready script(s)', len(scripts))
+    for script_path in scripts:
         logger.info('Running ready script: %s', script_path)
         try:
             proc = await asyncio.create_subprocess_exec(
@@ -728,17 +724,25 @@ async def _run_ready_scripts():
             logger.error('Failed to execute ready script %s: %s', script_path, e)
 
 
+def _collect_scripts(*dirs):
+    """Collect .sh scripts from multiple directories, deduped by filename."""
+    seen = {}
+    for d in dirs:
+        if not os.path.isdir(d):
+            continue
+        for f in sorted(os.listdir(d)):
+            if f.endswith('.sh') and f not in seen:
+                seen[f] = os.path.join(d, f)
+    return [seen[f] for f in sorted(seen)]
+
+
 def _run_init_scripts():
-    """Execute .sh scripts from /docker-entrypoint-initaws.d/ in alphabetical order."""
-    init_dir = "/docker-entrypoint-initaws.d"
-    if not os.path.isdir(init_dir):
-        return
-    scripts = sorted(f for f in os.listdir(init_dir) if f.endswith(".sh"))
+    """Execute .sh scripts from init directories in alphabetical order."""
+    scripts = _collect_scripts('/docker-entrypoint-initaws.d', '/etc/localstack/init/boot.d')
     if not scripts:
         return
-    logger.info("Found %d init script(s) in %s", len(scripts), init_dir)
-    for script in scripts:
-        script_path = os.path.join(init_dir, script)
+    logger.info("Found %d init script(s)", len(scripts))
+    for script_path in scripts:
         logger.info("Running init script: %s", script_path)
         try:
             result = subprocess.run(

--- a/tests/test_init_scripts.py
+++ b/tests/test_init_scripts.py
@@ -1,0 +1,76 @@
+"""Tests for init script collection from multiple directories."""
+
+from ministack.app import _collect_scripts
+
+
+def test_collect_scripts_single_dir(tmp_path):
+    (tmp_path / "01-seed.sh").write_text("#!/bin/sh\necho seed")
+    (tmp_path / "02-setup.sh").write_text("#!/bin/sh\necho setup")
+    (tmp_path / "notes.txt").write_text("not a script")
+
+    result = _collect_scripts(str(tmp_path))
+    assert len(result) == 2
+    assert result[0].endswith("01-seed.sh")
+    assert result[1].endswith("02-setup.sh")
+
+
+def test_collect_scripts_multiple_dirs(tmp_path):
+    dir1 = tmp_path / "native"
+    dir2 = tmp_path / "compat"
+    dir1.mkdir()
+    dir2.mkdir()
+
+    (dir1 / "01-seed.sh").write_text("#!/bin/sh\necho native")
+    (dir2 / "02-extra.sh").write_text("#!/bin/sh\necho compat")
+
+    result = _collect_scripts(str(dir1), str(dir2))
+    assert len(result) == 2
+    assert result[0].endswith("01-seed.sh")
+    assert result[1].endswith("02-extra.sh")
+
+
+def test_collect_scripts_dedup_first_dir_wins(tmp_path):
+    dir1 = tmp_path / "native"
+    dir2 = tmp_path / "compat"
+    dir1.mkdir()
+    dir2.mkdir()
+
+    (dir1 / "01-seed.sh").write_text("#!/bin/sh\necho native")
+    (dir2 / "01-seed.sh").write_text("#!/bin/sh\necho compat")
+
+    result = _collect_scripts(str(dir1), str(dir2))
+    assert len(result) == 1
+    assert str(dir1) in result[0]  # native path wins
+
+
+def test_collect_scripts_missing_dir(tmp_path):
+    existing = tmp_path / "exists"
+    existing.mkdir()
+    (existing / "01-seed.sh").write_text("#!/bin/sh\necho hi")
+
+    result = _collect_scripts("/nonexistent/path", str(existing))
+    assert len(result) == 1
+    assert result[0].endswith("01-seed.sh")
+
+
+def test_collect_scripts_empty_dirs(tmp_path):
+    empty = tmp_path / "empty"
+    empty.mkdir()
+
+    result = _collect_scripts(str(empty))
+    assert result == []
+
+
+def test_collect_scripts_no_dirs():
+    result = _collect_scripts("/nonexistent/a", "/nonexistent/b")
+    assert result == []
+
+
+def test_collect_scripts_alphabetical_order(tmp_path):
+    (tmp_path / "03-last.sh").write_text("")
+    (tmp_path / "01-first.sh").write_text("")
+    (tmp_path / "02-middle.sh").write_text("")
+
+    result = _collect_scripts(str(tmp_path))
+    names = [r.split("/")[-1] for r in result]
+    assert names == ["01-first.sh", "02-middle.sh", "03-last.sh"]


### PR DESCRIPTION
## Summary

Adds support for LocalStack-compatible init script paths (`/etc/localstack/init/boot.d/` and `/etc/localstack/init/ready.d/`) alongside the existing MiniStack-native paths, enabling drop-in compatibility for frameworks that hardcode the LocalStack directory structure.

**Motivation:** The Quarkus Amazon Services project ([quarkiverse/quarkus-amazon-services#2070](https://github.com/quarkiverse/quarkus-amazon-services/pull/2070)) is blocked from adopting MiniStack because it hardcodes `/etc/localstack/init/ready.d/` for readiness scripts. This change unblocks that adoption path and any other tool that assumes LocalStack's directory layout.

## Changes

- **`ministack/app.py`** — Extract `_collect_scripts(*dirs)` helper that scans multiple directories, deduplicates by filename (first directory wins), and returns sorted paths. Both `_run_init_scripts()` and `_run_ready_scripts()` now use it to scan MiniStack-native and LocalStack-compatible paths.
- **`Dockerfile`** — Create `/etc/localstack/init/boot.d/` and `/etc/localstack/init/ready.d/` at build time, declare as VOLUME for mount support.
- **`README.md`** — Document both path sets with a comparison table and Docker Compose mount example.
- **`tests/test_init_scripts.py`** — 7 unit tests covering single-dir, multi-dir, dedup, missing dirs, empty dirs, and sort order.

## Path mapping

| Phase | MiniStack path | LocalStack-compatible path |
|-------|----------------|---------------------------|
| Pre-start | `/docker-entrypoint-initaws.d/*.sh` | `/etc/localstack/init/boot.d/*.sh` |
| Post-ready | `/docker-entrypoint-initaws.d/ready.d/*.sh` | `/etc/localstack/init/ready.d/*.sh` |

`start.d` and `shutdown.d` are out of scope — can be added as a follow-up if needed.

## Test plan

- [x] `pytest tests/test_init_scripts.py -v` — 7/7 passing
- [ ] Docker build succeeds and both directory structures exist in image
- [ ] Mount a script at `/etc/localstack/init/ready.d/01-test.sh`, start container, confirm execution

Closes #269