### PR TITLE
feat: support .py init scripts and bundle AWS CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,35 @@
+FROM python:3.12-alpine AS builder
+
+RUN pip install --no-cache-dir --no-compile \
+        uvicorn==0.30.6 \
+        "cbor2>=5.4.0" \
+        "defusedxml>=0.7" \
+        "docker>=7.0.0" \
+        "pyyaml>=6.0" \
+        "cryptography>=41.0" \
+        "awscli"
+
+# Strip awscli help examples (~25 MB) and Python cache files (~15 MB).
+RUN rm -rf /usr/local/lib/python3.12/site-packages/awscli/examples \
+    && find /usr/local/lib/python3.12/site-packages -type d -name '__pycache__' -exec rm -rf {} + 2>/dev/null \
+    && rm -rf /usr/local/lib/python3.12/site-packages/pip*.dist-info \
+    && rm -rf /usr/local/lib/python3.12/site-packages/pip*
+
 FROM python:3.12-alpine
 
 LABEL maintainer="MiniStack" \
       description="Local AWS Service Emulator — drop-in LocalStack replacement"
 
 # Upgrade base packages to pick up latest security patches.
-RUN apk upgrade --no-cache && apk add --no-cache nodejs aws-cli && rm -f /usr/bin/wget /bin/wget
+RUN apk upgrade --no-cache && apk add --no-cache nodejs && rm -f /usr/bin/wget /bin/wget
 
 WORKDIR /opt/ministack
 
-# Install all Python dependencies.
-RUN pip install --no-cache-dir --upgrade pip && \
-    pip install --no-cache-dir \
-        uvicorn==0.30.6 \
-        "cbor2>=5.4.0" \
-        "defusedxml>=0.7" \
-        "docker>=7.0.0" \
-        "pyyaml>=6.0" \
-        "cryptography>=41.0"
+# Copy cleaned Python packages and CLI entrypoints from builder.
+COPY --from=builder /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
+COPY --from=builder /usr/local/bin/aws /usr/local/bin/aws
+COPY --from=builder /usr/local/bin/aws_completer /usr/local/bin/aws_completer
+COPY --from=builder /usr/local/bin/uvicorn /usr/local/bin/uvicorn
 
 COPY ministack/ ministack/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="MiniStack" \
       description="Local AWS Service Emulator — drop-in LocalStack replacement"
 
 # Upgrade base packages to pick up latest security patches.
-RUN apk upgrade --no-cache && apk add --no-cache nodejs && rm -f /usr/bin/wget /bin/wget
+RUN apk upgrade --no-cache && apk add --no-cache nodejs aws-cli && rm -f /usr/bin/wget /bin/wget
 
 WORKDIR /opt/ministack
 
@@ -16,8 +16,7 @@ RUN pip install --no-cache-dir --upgrade pip && \
         "defusedxml>=0.7" \
         "docker>=7.0.0" \
         "pyyaml>=6.0" \
-        "cryptography>=41.0" \
-        "awscli"
+        "cryptography>=41.0"
 
 COPY ministack/ ministack/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,8 @@ RUN pip install --no-cache-dir --upgrade pip && \
         "defusedxml>=0.7" \
         "docker>=7.0.0" \
         "pyyaml>=6.0" \
-        "cryptography>=41.0"
+        "cryptography>=41.0" \
+        "awscli"
 
 COPY ministack/ ministack/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ LABEL maintainer="MiniStack" \
       description="Local AWS Service Emulator — drop-in LocalStack replacement"
 
 # Upgrade base packages to pick up latest security patches.
-RUN apk upgrade --no-cache && apk add --no-cache nodejs && rm -f /usr/bin/wget /bin/wget
+RUN apk upgrade --no-cache && apk add --no-cache nodejs bash && rm -f /usr/bin/wget /bin/wget
 
 WORKDIR /opt/ministack
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,9 @@ COPY --from=builder /usr/local/bin/aws /usr/local/bin/aws
 COPY --from=builder /usr/local/bin/aws_completer /usr/local/bin/aws_completer
 COPY --from=builder /usr/local/bin/uvicorn /usr/local/bin/uvicorn
 
+COPY bin/awslocal /usr/local/bin/awslocal
+RUN chmod +x /usr/local/bin/awslocal
+
 COPY ministack/ ministack/
 
 RUN addgroup -S ministack && adduser -S ministack -G ministack

--- a/README.md
+++ b/README.md
@@ -633,8 +633,8 @@ MiniStack supports two types of init scripts, with LocalStack-compatible paths:
 
 | Phase | MiniStack path | LocalStack-compatible path |
 |-------|----------------|---------------------------|
-| Pre-start | `/docker-entrypoint-initaws.d/*.sh` | `/etc/localstack/init/boot.d/*.sh` |
-| Post-ready | `/docker-entrypoint-initaws.d/ready.d/*.sh` | `/etc/localstack/init/ready.d/*.sh` |
+| Pre-start | `/docker-entrypoint-initaws.d/*.{sh,py}` | `/etc/localstack/init/boot.d/*.{sh,py}` |
+| Post-ready | `/docker-entrypoint-initaws.d/ready.d/*.{sh,py}` | `/etc/localstack/init/ready.d/*.{sh,py}` |
 
 Scripts from both paths are merged, deduplicated by filename, and run in alphabetical order.
 If the same filename exists in both paths, the MiniStack-native path takes priority.

--- a/ministack/app.py
+++ b/ministack/app.py
@@ -694,7 +694,7 @@ async def _wait_for_port(port, timeout=30):
 
 
 async def _run_ready_scripts():
-    """Execute .sh scripts from ready.d directories after the server is ready."""
+    """Execute .sh/.py scripts from ready.d directories after the server is ready."""
     scripts = _collect_scripts('/docker-entrypoint-initaws.d/ready.d', '/etc/localstack/init/ready.d')
     if not scripts:
         return
@@ -704,8 +704,9 @@ async def _run_ready_scripts():
     for script_path in scripts:
         logger.info('Running ready script: %s', script_path)
         try:
+            cmd = [sys.executable, script_path] if script_path.endswith('.py') else ['sh', script_path]
             proc = await asyncio.create_subprocess_exec(
-                'sh', script_path,
+                *cmd,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 env=os.environ,
@@ -726,19 +727,19 @@ async def _run_ready_scripts():
 
 
 def _collect_scripts(*dirs):
-    """Collect .sh scripts from multiple directories, deduped by filename."""
+    """Collect .sh/.py scripts from multiple directories, deduped by filename."""
     seen = {}
     for d in dirs:
         if not os.path.isdir(d):
             continue
         for f in sorted(os.listdir(d)):
-            if f.endswith('.sh') and f not in seen:
+            if f.endswith(('.sh', '.py')) and f not in seen:
                 seen[f] = os.path.join(d, f)
     return [seen[f] for f in sorted(seen)]
 
 
 def _run_init_scripts():
-    """Execute .sh scripts from init directories in alphabetical order."""
+    """Execute .sh/.py scripts from init directories in alphabetical order."""
     scripts = _collect_scripts('/docker-entrypoint-initaws.d', '/etc/localstack/init/boot.d')
     if not scripts:
         return
@@ -746,8 +747,9 @@ def _run_init_scripts():
     for script_path in scripts:
         logger.info("Running init script: %s", script_path)
         try:
+            cmd = [sys.executable, script_path] if script_path.endswith('.py') else ["sh", script_path]
             result = subprocess.run(
-                ["sh", script_path], env=os.environ,
+                cmd, env=os.environ,
                 capture_output=True, text=True, timeout=300,
             )
             if result.stdout:

--- a/tests/test_init_scripts.py
+++ b/tests/test_init_scripts.py
@@ -1,5 +1,6 @@
 """Tests for init script collection and execution from multiple directories (.sh and .py)."""
 
+import os
 import sys
 
 from ministack.app import _collect_scripts, _run_init_scripts
@@ -74,7 +75,7 @@ def test_collect_scripts_alphabetical_order(tmp_path):
     (tmp_path / "02-middle.sh").write_text("")
 
     result = _collect_scripts(str(tmp_path))
-    names = [r.split("/")[-1] for r in result]
+    names = [os.path.basename(r) for r in result]
     assert names == ["01-first.sh", "02-middle.sh", "03-last.sh"]
 
 
@@ -94,7 +95,7 @@ def test_collect_scripts_mixed_sort_order(tmp_path):
     (tmp_path / "02-migrate.py").write_text("")
 
     result = _collect_scripts(str(tmp_path))
-    names = [r.split("/")[-1] for r in result]
+    names = [os.path.basename(r) for r in result]
     assert names == ["01-setup.sh", "02-migrate.py", "03-cleanup.sh"]
 
 
@@ -107,7 +108,7 @@ def test_collect_scripts_ignores_non_script_files(tmp_path):
 
     result = _collect_scripts(str(tmp_path))
     assert len(result) == 2
-    names = [r.split("/")[-1] for r in result]
+    names = [os.path.basename(r) for r in result]
     assert names == ["01-seed.sh", "02-migrate.py"]
 
 

--- a/tests/test_init_scripts.py
+++ b/tests/test_init_scripts.py
@@ -1,6 +1,8 @@
-"""Tests for init script collection from multiple directories."""
+"""Tests for init script collection and execution from multiple directories (.sh and .py)."""
 
-from ministack.app import _collect_scripts
+import sys
+
+from ministack.app import _collect_scripts, _run_init_scripts
 
 
 def test_collect_scripts_single_dir(tmp_path):
@@ -74,3 +76,67 @@ def test_collect_scripts_alphabetical_order(tmp_path):
     result = _collect_scripts(str(tmp_path))
     names = [r.split("/")[-1] for r in result]
     assert names == ["01-first.sh", "02-middle.sh", "03-last.sh"]
+
+
+def test_collect_scripts_py_files(tmp_path):
+    (tmp_path / "01-seed.sh").write_text("#!/bin/sh\necho seed")
+    (tmp_path / "02-migrate.py").write_text("print('migrate')")
+
+    result = _collect_scripts(str(tmp_path))
+    assert len(result) == 2
+    assert result[0].endswith("01-seed.sh")
+    assert result[1].endswith("02-migrate.py")
+
+
+def test_collect_scripts_mixed_sort_order(tmp_path):
+    (tmp_path / "03-cleanup.sh").write_text("")
+    (tmp_path / "01-setup.sh").write_text("")
+    (tmp_path / "02-migrate.py").write_text("")
+
+    result = _collect_scripts(str(tmp_path))
+    names = [r.split("/")[-1] for r in result]
+    assert names == ["01-setup.sh", "02-migrate.py", "03-cleanup.sh"]
+
+
+def test_collect_scripts_ignores_non_script_files(tmp_path):
+    (tmp_path / "01-seed.sh").write_text("")
+    (tmp_path / "02-migrate.py").write_text("")
+    (tmp_path / "readme.md").write_text("")
+    (tmp_path / "config.json").write_text("")
+    (tmp_path / "notes.txt").write_text("")
+
+    result = _collect_scripts(str(tmp_path))
+    assert len(result) == 2
+    names = [r.split("/")[-1] for r in result]
+    assert names == ["01-seed.sh", "02-migrate.py"]
+
+
+def test_init_scripts_uses_correct_interpreter(tmp_path, monkeypatch):
+    sh_script = tmp_path / "01-setup.sh"
+    py_script = tmp_path / "02-migrate.py"
+    sh_script.write_text("#!/bin/sh\necho hi")
+    py_script.write_text("print('hi')")
+
+    monkeypatch.setattr(
+        'ministack.app._collect_scripts',
+        lambda *a: [str(sh_script), str(py_script)]
+    )
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        class Result:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+        return Result()
+
+    monkeypatch.setattr('subprocess.run', fake_run)
+
+    _run_init_scripts()
+
+    assert calls[0][0] == "sh"
+    assert calls[0][1] == str(sh_script)
+    assert calls[1][0] == sys.executable
+    assert calls[1][1] == str(py_script)


### PR DESCRIPTION
## Summary

Two additions that complete the init script experience for LocalStack drop-in compatibility:

1. **`.py` init script support** — Init scripts can now be `.py` files (executed with the container's Python interpreter) alongside `.sh` files, matching [LocalStack's behavior](https://docs.localstack.cloud/references/init-hooks/).
2. **AWS CLI bundled in image** — Init scripts commonly call `aws` commands to seed resources. The CLI is now included so scripts work out of the box.

## Changes

- **`ministack/app.py`** — `_collect_scripts()` now accepts `.sh` and `.py` files. Both `_run_init_scripts()` and `_run_ready_scripts()` select the interpreter based on extension: `sh` for `.sh`, `sys.executable` for `.py`.
- **`Dockerfile`** — Add `awscli` to pip install.
- **`README.md`** — Update path table to show `*.{sh,py}`.
- **`tests/test_init_scripts.py`** — 4 new tests: `.py` discovery, mixed sort order, non-script file filtering, and interpreter dispatch verification (11 total).

## Test plan

- [x] `pytest tests/test_init_scripts.py -v` — 11/11 passing
- [ ] Docker build succeeds with `aws` command available
- [ ] Mount a `.py` init script, start container, confirm it executes with Python

Ref #269