### PR TITLE
fix(sfn): XML response fidelity — numeric/boolean coercion, list-wrapper detection, empty list handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- **SFN query-protocol XML response fidelity** — `_xml_element_to_dict` now coerces known numeric fields to integers, boolean fields to booleans, and detects list-wrapper elements to produce JSON arrays even with a single child. Empty self-closing list wrappers return `[]` instead of `""`. Contributed by @jayjanssen.
+
 ## [1.2.7] — 2026-04-12
 
 ### Added

--- a/ministack/services/stepfunctions.py
+++ b/ministack/services/stepfunctions.py
@@ -2270,19 +2270,98 @@ def _flatten_query_params(data, prefix=""):
     return params
 
 
+# Fields in AWS XML responses that should be coerced to native types in JSON.
+# Only fields that Step Functions consumers rely on being non-string.
+_XML_NUMERIC_FIELDS = frozenset({
+    "Port", "BackupRetentionPeriod", "AllocatedStorage", "Iops",
+    "MonitoringInterval", "PromotionTier", "DbInstancePort",
+    "MaxAllocatedStorage", "StorageThroughput",
+})
+# Empty self-closing XML elements that should become [] not "".
+_XML_LIST_WRAPPER_TAGS = frozenset({
+    "Parameters", "DBClusterMembers", "VpcSecurityGroups",
+    "AvailabilityZones", "Subnets", "ReadReplicaDBInstanceIdentifiers",
+    "ReadReplicaDBClusterIdentifiers", "DBSecurityGroups",
+    "OptionGroupMemberships", "StatusInfos", "DomainMemberships",
+    "AssociatedRoles", "TagList", "ProcessorFeatures",
+    "EnabledCloudwatchLogsExports", "GlobalClusterMembers",
+    "DBParameterGroups", "DBInstances", "DBClusters",
+    "SupportedNetworkTypes",
+})
+_XML_BOOLEAN_FIELDS = frozenset({
+    "MultiAZ", "Multiaz", "StorageEncrypted", "DeletionProtection",
+    "PubliclyAccessible", "AutoMinorVersionUpgrade",
+    "CopyTagsToSnapshot", "IamDatabaseAuthenticationEnabled",
+    "PerformanceInsightsEnabled", "HttpEndpointEnabled",
+    "CrossAccountClone", "CustomerOwnedIpEnabled",
+    "IsStorageConfigUpgradeAvailable", "IsWriter",
+})
+
+
 def _xml_element_to_dict(element):
     """Convert an XML element tree to a JSON-friendly dict.
 
     Strips namespace prefixes.  Repeated child tags become lists.
     Leaf text nodes become strings.
+
+    AWS query-protocol list convention: when a parent element contains only
+    children that all share the same tag (e.g. ``<DBClusters><DBCluster>...
+    </DBCluster></DBClusters>`` or ``<member>...</member>``), the parent is
+    treated as a **list wrapper** and its value becomes a JSON array — even
+    when there is only a single child.  This matches the real AWS SDK
+    behaviour that Step Functions consumers rely on (``DbClusters[0]``).
     """
     # Strip namespace
     tag = element.tag.split("}")[-1] if "}" in element.tag else element.tag
 
     children = list(element)
     if not children:
-        # Leaf node
-        return tag, (element.text or "")
+        text = element.text or ""
+        # Empty self-closing tags that are known list wrappers should become
+        # empty arrays, not empty strings (e.g. <Parameters/> → []).
+        if not text and tag in _XML_LIST_WRAPPER_TAGS:
+            return tag, []
+        # Leaf node — keep as string by default.  Only coerce specific known
+        # numeric/boolean fields that Step Functions consumers rely on (e.g.
+        # Port must be an integer for JSON unmarshal into int64).
+        if text and tag in _XML_NUMERIC_FIELDS:
+            try:
+                return tag, int(text)
+            except ValueError:
+                try:
+                    return tag, float(text)
+                except ValueError:
+                    pass
+        if text and tag in _XML_BOOLEAN_FIELDS:
+            if text == "true":
+                return tag, True
+            if text == "false":
+                return tag, False
+        return tag, text
+
+    # Detect list-wrapper elements: all children share the same tag name AND
+    # the parent looks like a plural wrapper (e.g. DBClusters→DBCluster,
+    # AvailabilityZones→AvailabilityZone) or children use the generic
+    # "member" tag.  We require either multiple children OR a plural naming
+    # pattern to avoid false positives on single-child result wrappers like
+    # <CreateDBClusterParameterGroupResult><DBClusterParameterGroup>...</>
+    child_tags = {(c.tag.split("}")[-1] if "}" in c.tag else c.tag) for c in children}
+    if len(child_tags) == 1:
+        child_tag_name = next(iter(child_tags))
+        is_member = child_tag_name == "member"
+        is_plural = (
+            tag.endswith(child_tag_name + "s")
+            or tag == child_tag_name + "s"
+            or tag.endswith("Ids") and child_tag_name == "Id"
+        )
+        has_multiple = len(children) > 1
+        if is_member or is_plural or has_multiple:
+            # Treat as a list.
+            items = []
+            for child in children:
+                _, child_val = _xml_element_to_dict(child)
+                items.append(child_val)
+            return tag, items
 
     result = {}
     for child in children:

--- a/tests/test_sfn.py
+++ b/tests/test_sfn.py
@@ -552,9 +552,10 @@ def test_sfn_aws_sdk_rds_create_and_describe_cluster(sfn, sfn_sync):
     assert create_cluster["DbClusterIdentifier"] == cluster_id
     assert create_cluster["Engine"] == "aurora-postgresql"
 
-    # Verify describe result contains cluster data
+    # Verify describe result contains cluster data (list-wrapper fidelity)
     describe_clusters = output["describeResult"]["DbClusters"]
-    assert "DbCluster" in describe_clusters
+    assert isinstance(describe_clusters, list)
+    assert len(describe_clusters) >= 1
 
     sfn_sync.delete_state_machine(stateMachineArn=sm_arn)
 
@@ -649,7 +650,60 @@ def test_sfn_aws_sdk_rds_modify_cluster(sfn, sfn_sync, rds):
     resp = sfn_sync.start_sync_execution(stateMachineArn=sm_arn, input=json.dumps({}))
     assert resp["status"] == "SUCCEEDED", f"Execution failed: {resp.get('error')} — {resp.get('cause')}"
     output = json.loads(resp["output"])
-    assert output["modifyResult"]["DbCluster"]["BackupRetentionPeriod"] == "7"
+    assert output["modifyResult"]["DbCluster"]["BackupRetentionPeriod"] == 7
+
+    sfn_sync.delete_state_machine(stateMachineArn=sm_arn)
+
+def test_sfn_xml_list_wrapper_single_element(sfn, sfn_sync):
+    """DescribeDBClusters returns a JSON list even when only one cluster exists."""
+    import uuid as _uuid
+
+    cluster_id = f"sfn-wrap-{_uuid.uuid4().hex[:8]}"
+    sm_name = f"sdk-rds-wrap-{_uuid.uuid4().hex[:8]}"
+
+    definition = json.dumps({
+        "StartAt": "CreateCluster",
+        "States": {
+            "CreateCluster": {
+                "Type": "Task",
+                "Resource": "arn:aws:states:::aws-sdk:rds:CreateDBCluster",
+                "Parameters": {
+                    "DBClusterIdentifier": cluster_id,
+                    "Engine": "aurora-postgresql",
+                    "MasterUsername": "admin",
+                    "MasterUserPassword": "testpass123",
+                },
+                "ResultPath": "$.createResult",
+                "Next": "DescribeClusters",
+            },
+            "DescribeClusters": {
+                "Type": "Task",
+                "Resource": "arn:aws:states:::aws-sdk:rds:DescribeDBClusters",
+                "Parameters": {
+                    "DBClusterIdentifier": cluster_id,
+                },
+                "ResultPath": "$.describeResult",
+                "Next": "Done",
+            },
+            "Done": {"Type": "Succeed"},
+        },
+    })
+
+    sm_arn = sfn_sync.create_state_machine(
+        name=sm_name,
+        definition=definition,
+        roleArn="arn:aws:iam::000000000000:role/sfn-role",
+    )["stateMachineArn"]
+
+    resp = sfn_sync.start_sync_execution(stateMachineArn=sm_arn, input=json.dumps({}))
+    assert resp["status"] == "SUCCEEDED", f"Execution failed: {resp.get('error')} — {resp.get('cause')}"
+    output = json.loads(resp["output"])
+
+    # Even with a single cluster, DbClusters must be a list (not a dict).
+    db_clusters = output["describeResult"]["DbClusters"]
+    assert isinstance(db_clusters, list), f"Expected list, got {type(db_clusters)}: {db_clusters}"
+    assert len(db_clusters) == 1
+    assert db_clusters[0]["DbClusterIdentifier"] == cluster_id
 
     sfn_sync.delete_state_machine(stateMachineArn=sm_arn)
 


### PR DESCRIPTION
## Summary

Improves `_xml_element_to_dict` in the SFN query-protocol `aws-sdk:*` dispatcher to match real AWS SDK JSON response shapes. Fixes Go SDK unmarshal errors when Step Functions dispatches to query-protocol services (RDS, EC2, IAM, etc.).

### Changes

**1. Selective numeric type coercion** — Whitelist-based coercion for fields like `Port`, `BackupRetentionPeriod`, `AllocatedStorage` that AWS SDKs expect as integers. Avoids blanket coercion that would break string fields like `ParameterValue`.

**2. Selective boolean type coercion** — Whitelist for fields like `DeletionProtection`, `StorageEncrypted`, `MultiAZ` that AWS SDKs expect as booleans.

**3. List-wrapper detection** — When a parent XML element contains only children sharing the same tag (e.g. `<DBClusters><DBCluster>...</DBCluster></DBClusters>`), the parent is treated as a JSON array — even with a single child. Detects plural naming patterns (`DBClusters→DBCluster`) and `member` tags. Avoids false positives on result wrappers like `<CreateDBClusterParameterGroupResult><DBClusterParameterGroup>`.

**4. Empty list-wrapper handling** — Self-closing tags like `<Parameters/>` return `[]` instead of `""` when they're known list wrappers. Fixes Go SDK unmarshal error: `cannot unmarshal string into Go struct field of type []Parameter`.

### Why whitelists?

Blanket type coercion breaks user data fields — e.g. `ParameterValue="5"` must remain a string, not become an integer. The whitelists contain only AWS-defined structural fields where the SDK contract requires a specific type.

## Tests

- 2 existing test assertions updated to match correct types
- 1 new test for single-element list-wrapper detection
- All existing SFN tests pass

## Checklist

- [x] Tests added and passing
- [x] CHANGELOG entry added
- [x] Linting passes