### PR TITLE
fix(sfn): convert PascalCase to camelCase for REST-JSON aws-sdk dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- **SFN REST-JSON PascalCase\u2192camelCase conversion** \u2014 `_dispatch_aws_sdk_rest_json` now converts PascalCase parameter names to camelCase before dispatching. Fixes `BadRequestException: resourceArn is required` when Step Functions dispatches to RDS Data API. Contributed by @jayjanssen.
+
 ## [1.2.7] — 2026-04-12
 
 ### Added

--- a/ministack/services/stepfunctions.py
+++ b/ministack/services/stepfunctions.py
@@ -2472,6 +2472,22 @@ def _dispatch_aws_sdk_query(service_info, service_name, action, input_data):
         raise _ExecutionError("States.Runtime", f"Failed to parse {service_name} XML response")
 
 
+def _pascal_key_to_camel(key):
+    """Convert a single PascalCase key to camelCase: 'ResourceArn' -> 'resourceArn'."""
+    if not key:
+        return key
+    return key[0].lower() + key[1:]
+
+
+def _convert_keys_to_camel(data):
+    """Recursively convert dict keys from PascalCase to camelCase."""
+    if isinstance(data, dict):
+        return {_pascal_key_to_camel(k): _convert_keys_to_camel(v) for k, v in data.items()}
+    if isinstance(data, list):
+        return [_convert_keys_to_camel(v) for v in data]
+    return data
+
+
 def _dispatch_aws_sdk_rest_json(service_info, service_name, action, input_data):
     """Dispatch an aws-sdk integration call to a REST-JSON protocol MiniStack service."""
     from ministack import app
@@ -2490,7 +2506,10 @@ def _dispatch_aws_sdk_rest_json(service_info, service_name, action, input_data):
     action_paths = _REST_JSON_ACTION_PATHS.get(service_key, {})
     path = action_paths.get(pascal_action, f"/{pascal_action}")
 
-    body = json.dumps(input_data or {}).encode("utf-8")
+    # REST-JSON services use camelCase on the wire, but SFN Parameters use
+    # PascalCase.  AWS SFN converts automatically; we must do the same.
+    wire_data = _convert_keys_to_camel(input_data or {})
+    body = json.dumps(wire_data).encode("utf-8")
     headers = {
         "content-type": "application/json",
         "host": f"{service_key}.{REGION}.amazonaws.com",

--- a/tests/test_sfn.py
+++ b/tests/test_sfn.py
@@ -2317,6 +2317,57 @@ def test_sfn_validate_state_machine_definition(sfn):
     assert resp["diagnostics"] == []
 
 
+def test_sfn_rest_json_pascal_to_camel_conversion(sfn, sfn_sync, rds, sm):
+    """PascalCase params in SFN are converted to camelCase for REST-JSON dispatch."""
+    import uuid as _uuid
+
+    cluster_id = f"rdsdata-camel-{_uuid.uuid4().hex[:8]}"
+    sm_name = f"sdk-rdsdata-camel-{_uuid.uuid4().hex[:8]}"
+
+    rds.create_db_cluster(
+        DBClusterIdentifier=cluster_id,
+        Engine="aurora-mysql",
+        MasterUsername="admin",
+        MasterUserPassword="testpass123",
+    )
+    secret_arn = sm.create_secret(
+        Name=f"rdsdata-camel-secret-{_uuid.uuid4().hex[:8]}",
+        SecretString='{"username":"admin","password":"testpass123"}',
+    )["ARN"]
+    cluster_arn = f"arn:aws:rds:us-east-1:000000000000:cluster:{cluster_id}"
+
+    # Use PascalCase keys — the dispatcher must convert them to camelCase
+    definition = json.dumps({
+        "StartAt": "ExecuteSQL",
+        "States": {
+            "ExecuteSQL": {
+                "Type": "Task",
+                "Resource": "arn:aws:states:::aws-sdk:rdsdata:executeStatement",
+                "Parameters": {
+                    "ResourceArn": cluster_arn,
+                    "SecretArn": secret_arn,
+                    "Sql": "SELECT 1",
+                    "Database": "testdb",
+                },
+                "End": True,
+            },
+        },
+    })
+
+    sm_arn = sfn_sync.create_state_machine(
+        name=sm_name,
+        definition=definition,
+        roleArn="arn:aws:iam::000000000000:role/sfn-role",
+    )["stateMachineArn"]
+
+    resp = sfn_sync.start_sync_execution(stateMachineArn=sm_arn, input=json.dumps({}))
+    assert resp["status"] == "SUCCEEDED", f"Execution failed: {resp.get('error')} \u2014 {resp.get('cause')}"
+    output = json.loads(resp["output"])
+    assert "numberOfRecordsUpdated" in output or "records" in output
+
+    sfn_sync.delete_state_machine(stateMachineArn=sm_arn)
+
+
 def test_sfn_validate_state_machine_definition_with_type(sfn):
     """ValidateStateMachineDefinition should accept optional type parameter."""
     definition = json.dumps({


### PR DESCRIPTION
## Summary

Step Functions `aws-sdk:rdsdata:executeStatement` (and other REST-JSON services) failed with `BadRequestException: resourceArn is required` because SFN Parameters use PascalCase (`ResourceArn`, `SecretArn`, `Sql`) but REST-JSON services expect camelCase on the wire (`resourceArn`, `secretArn`, `sql`).

Real AWS Step Functions automatically converts PascalCase to camelCase for REST-JSON dispatches. This PR adds the same conversion.

### Changes

- `_pascal_key_to_camel(key)` — converts a single key: `ResourceArn` → `resourceArn`
- `_convert_keys_to_camel(data)` — recursively converts all dict keys
- `_dispatch_aws_sdk_rest_json` now converts input data before serializing to JSON

Note: named `_pascal_key_to_camel` (not `_pascal_to_camel`) to avoid collision with the existing ECS helper function of the same name (line ~2144) which converts a dict's top-level keys.

## Tests

- 1 new test: creates an RDS cluster + secret, then runs a state machine that calls `aws-sdk:rdsdata:executeStatement` with PascalCase params and verifies success
- All existing SFN tests pass

## Checklist

- [x] Tests added and passing
- [x] CHANGELOG entry added
- [x] Linting passes