### PR TITLE
fix(rds): parameter group persistence with ApplyMethod, Source filter, and engine version family fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [Unreleased]
+
+### Added
+- **RDS parameter group persistence** — `ModifyDBParameterGroup` and `ModifyDBClusterParameterGroup` now store `ApplyMethod` alongside parameter values. `DescribeDBParameters` and `DescribeDBClusterParameters` return stored parameters with `Source` filter support (`user`, `engine-default`). Custom parameters beyond engine defaults are included.
+
+### Fixed
+- **RDS `DescribeDBEngineVersions` family prefix** — `DBParameterGroupFamily` no longer double-prefixes the engine name (e.g. `aurora-mysqlaurora-mysql8.0` → `aurora-mysql8.0`). Contributed by @jayjanssen.
+
+---
+
 ## [1.2.7] — 2026-04-12
 
 ### Added

--- a/ministack/services/rds.py
+++ b/ministack/services/rds.py
@@ -957,15 +957,26 @@ def _describe_db_parameters(p):
     if not pg:
         return _error("DBParameterGroupNotFoundFault", f"Parameter group {name} not found.", 404)
 
+    source_filter = _p(p, "Source")  # "user", "engine-default", or None (all)
+
     family = pg.get("DBParameterGroupFamily", "")
     default_params = _default_parameters_for_family(family)
 
     custom = pg.get("Parameters", {})
+    default_names = {p["name"] for p in default_params}
     params_xml = ""
     for param in default_params:
         pname = param["name"]
-        value = custom.get(pname, param.get("default", ""))
+        cval = custom.get(pname)
+        if isinstance(cval, dict):
+            value = cval.get("ParameterValue", param.get("default", ""))
+            apply_method = cval.get("ApplyMethod", "pending-reboot")
+        else:
+            value = cval if cval is not None else param.get("default", "")
+            apply_method = "pending-reboot"
         source = "user" if pname in custom else "engine-default"
+        if source_filter and source != source_filter:
+            continue
         params_xml += f"""<Parameter>
             <ParameterName>{pname}</ParameterName>
             <ParameterValue>{value}</ParameterValue>
@@ -974,7 +985,29 @@ def _describe_db_parameters(p):
             <ApplyType>{param.get('apply_type', 'dynamic')}</ApplyType>
             <DataType>{param.get('data_type', 'string')}</DataType>
             <IsModifiable>{str(param.get('modifiable', True)).lower()}</IsModifiable>
-            <ApplyMethod>pending-reboot</ApplyMethod>
+            <ApplyMethod>{apply_method}</ApplyMethod>
+        </Parameter>"""
+    # Include custom parameters not in the defaults
+    for pname, cval in custom.items():
+        if pname in default_names:
+            continue
+        if source_filter and source_filter != "user":
+            continue
+        if isinstance(cval, dict):
+            value = cval.get("ParameterValue", "")
+            apply_method = cval.get("ApplyMethod", "immediate")
+        else:
+            value = cval if cval is not None else ""
+            apply_method = "immediate"
+        params_xml += f"""<Parameter>
+            <ParameterName>{pname}</ParameterName>
+            <ParameterValue>{value}</ParameterValue>
+            <Description></Description>
+            <Source>user</Source>
+            <ApplyType>dynamic</ApplyType>
+            <DataType>string</DataType>
+            <IsModifiable>true</IsModifiable>
+            <ApplyMethod>{apply_method}</ApplyMethod>
         </Parameter>"""
 
     return _xml(200, "DescribeDBParametersResponse",
@@ -992,11 +1025,15 @@ def _modify_param_group(p):
         return _error("DBParameterGroupNotFoundFault", f"Parameter group {name} not found.", 404)
 
     params = pg.setdefault("Parameters", {})
+    prefix = "Parameters.member"
+    if not _p(p, "Parameters.member.1.ParameterName"):
+        prefix = "Parameters.Parameter"
     idx = 1
-    while _p(p, f"Parameters.member.{idx}.ParameterName"):
-        pname = _p(p, f"Parameters.member.{idx}.ParameterName")
-        pvalue = _p(p, f"Parameters.member.{idx}.ParameterValue")
-        params[pname] = pvalue
+    while _p(p, f"{prefix}.{idx}.ParameterName"):
+        pname = _p(p, f"{prefix}.{idx}.ParameterName")
+        pvalue = _p(p, f"{prefix}.{idx}.ParameterValue")
+        apply_method = _p(p, f"{prefix}.{idx}.ApplyMethod") or "immediate"
+        params[pname] = {"ParameterValue": pvalue, "ApplyMethod": apply_method}
         idx += 1
 
     return _xml(200, "ModifyDBParameterGroupResponse",
@@ -1069,12 +1106,34 @@ def _delete_db_cluster_param_group(p):
 
 def _describe_db_cluster_parameters(p):
     name = _p(p, "DBClusterParameterGroupName")
+    source_filter = _p(p, "Source")
     pg = _db_cluster_param_groups.get(name)
     if not pg:
         return _error("DBParameterGroupNotFoundFault",
             f"DB cluster parameter group {name} not found.", 404)
+    params = pg.get("Parameters", {})
+    # When filtering by source, treat all stored params as "user" source.
+    # If filter is "engine-default" and we have no defaults list, return empty.
+    if source_filter and source_filter != "user":
+        params = {}
+    if not params:
+        return _xml(200, "DescribeDBClusterParametersResponse",
+            "<DescribeDBClusterParametersResult><Parameters/></DescribeDBClusterParametersResult>")
+    members = []
+    for pname, pinfo in params.items():
+        pvalue = pinfo.get("ParameterValue", "")
+        apply_method = pinfo.get("ApplyMethod", "immediate")
+        members.append(
+            f"<Parameter>"
+            f"<ParameterName>{pname}</ParameterName>"
+            f"<ParameterValue>{pvalue}</ParameterValue>"
+            f"<ApplyMethod>{apply_method}</ApplyMethod>"
+            f"<IsModifiable>true</IsModifiable>"
+            f"<ApplyType>dynamic</ApplyType>"
+            f"</Parameter>"
+        )
     return _xml(200, "DescribeDBClusterParametersResponse",
-        "<DescribeDBClusterParametersResult><Parameters/></DescribeDBClusterParametersResult>")
+        f"<DescribeDBClusterParametersResult><Parameters>{''.join(members)}</Parameters></DescribeDBClusterParametersResult>")
 
 
 def _modify_db_cluster_param_group(p):
@@ -1085,11 +1144,15 @@ def _modify_db_cluster_param_group(p):
             f"DB cluster parameter group {name} not found.", 404)
 
     params = pg.setdefault("Parameters", {})
+    prefix = "Parameters.member"
+    if not _p(p, "Parameters.member.1.ParameterName"):
+        prefix = "Parameters.Parameter"
     idx = 1
-    while _p(p, f"Parameters.member.{idx}.ParameterName"):
-        pname = _p(p, f"Parameters.member.{idx}.ParameterName")
-        pvalue = _p(p, f"Parameters.member.{idx}.ParameterValue")
-        params[pname] = pvalue
+    while _p(p, f"{prefix}.{idx}.ParameterName"):
+        pname = _p(p, f"{prefix}.{idx}.ParameterName")
+        pvalue = _p(p, f"{prefix}.{idx}.ParameterValue")
+        apply_method = _p(p, f"{prefix}.{idx}.ApplyMethod") or "immediate"
+        params[pname] = {"ParameterValue": pvalue, "ApplyMethod": apply_method}
         idx += 1
 
     return _xml(200, "ModifyDBClusterParameterGroupResponse",
@@ -1588,7 +1651,7 @@ def _describe_engine_versions(p):
         members += f"""<DBEngineVersion>
             <Engine>{engine}</Engine>
             <EngineVersion>{ver}</EngineVersion>
-            <DBParameterGroupFamily>{engine}{family}</DBParameterGroupFamily>
+            <DBParameterGroupFamily>{family}</DBParameterGroupFamily>
             <DBEngineDescription>{engine.replace('-', ' ').title()}</DBEngineDescription>
             <DBEngineVersionDescription>{engine} {ver}</DBEngineVersionDescription>
             <ValidUpgradeTarget/>

--- a/tests/test_rds.py
+++ b/tests/test_rds.py
@@ -446,6 +446,88 @@ def test_rds_global_cluster_modify(rds):
             pass
 
 
+
+def test_rds_modify_and_describe_db_parameters(rds):
+    """ModifyDBParameterGroup stores ApplyMethod; DescribeDBParameters returns it with Source filter."""
+    rds.create_db_parameter_group(
+        DBParameterGroupName="test-param-persist",
+        DBParameterGroupFamily="mysql8.0",
+        Description="param persistence test",
+    )
+    rds.modify_db_parameter_group(
+        DBParameterGroupName="test-param-persist",
+        Parameters=[
+            {
+                "ParameterName": "max_connections",
+                "ParameterValue": "200",
+                "ApplyMethod": "immediate",
+            },
+            {
+                "ParameterName": "custom_param_xyz",
+                "ParameterValue": "hello",
+                "ApplyMethod": "pending-reboot",
+            },
+        ],
+    )
+    # Describe with Source=user - should only return modified params
+    resp = rds.describe_db_parameters(
+        DBParameterGroupName="test-param-persist", Source="user"
+    )
+    params = resp["Parameters"]
+    names = [p["ParameterName"] for p in params]
+    assert "max_connections" in names
+    assert "custom_param_xyz" in names
+    mc = next(p for p in params if p["ParameterName"] == "max_connections")
+    assert mc["ParameterValue"] == "200"
+    assert mc["ApplyMethod"] == "immediate"
+    cp = next(p for p in params if p["ParameterName"] == "custom_param_xyz")
+    assert cp["ParameterValue"] == "hello"
+    assert cp["ApplyMethod"] == "pending-reboot"
+
+
+def test_rds_modify_and_describe_cluster_parameters(rds):
+    """ModifyDBClusterParameterGroup stores ApplyMethod; DescribeDBClusterParameters returns it."""
+    rds.create_db_cluster_parameter_group(
+        DBClusterParameterGroupName="test-cparam-persist",
+        DBParameterGroupFamily="aurora-mysql8.0",
+        Description="cluster param persistence test",
+    )
+    rds.modify_db_cluster_parameter_group(
+        DBClusterParameterGroupName="test-cparam-persist",
+        Parameters=[
+            {
+                "ParameterName": "innodb_lock_wait_timeout",
+                "ParameterValue": "60",
+                "ApplyMethod": "immediate",
+            },
+        ],
+    )
+    resp = rds.describe_db_cluster_parameters(
+        DBClusterParameterGroupName="test-cparam-persist", Source="user"
+    )
+    params = resp["Parameters"]
+    assert len(params) >= 1
+    p = next(p for p in params if p["ParameterName"] == "innodb_lock_wait_timeout")
+    assert p["ParameterValue"] == "60"
+    assert p["ApplyMethod"] == "immediate"
+    # engine-default filter should return empty when no defaults are tracked
+    resp2 = rds.describe_db_cluster_parameters(
+        DBClusterParameterGroupName="test-cparam-persist", Source="engine-default"
+    )
+    assert len(resp2["Parameters"]) == 0
+
+
+def test_rds_describe_engine_versions_family(rds):
+    """DBParameterGroupFamily should not double-prefix the engine name."""
+    resp = rds.describe_db_engine_versions(Engine="aurora-mysql")
+    versions = resp["DBEngineVersions"]
+    assert len(versions) >= 1
+    for v in versions:
+        family = v["DBParameterGroupFamily"]
+        # Should be e.g. "aurora-mysql8.0", not "aurora-mysqlaurora-mysql8.0"
+        assert not family.startswith("aurora-mysqlaurora-"), f"Double-prefixed family: {family}"
+
+
 def test_rds_parse_member_list_both_formats():
     """_parse_member_list handles both Prefix.member.N and Prefix.MemberName.N formats."""
     from ministack.services.rds import _parse_member_list


### PR DESCRIPTION
## Summary

Three related fixes to RDS parameter group handling:

### 1. Parameter persistence with ApplyMethod

`ModifyDBParameterGroup` and `ModifyDBClusterParameterGroup` now store `ApplyMethod` alongside parameter values (as `{ParameterValue, ApplyMethod}` dicts). Previously only the raw value string was stored, losing `ApplyMethod`.

### 2. Source filter support

`DescribeDBParameters` and `DescribeDBClusterParameters` now support the `Source` filter parameter (`user`, `engine-default`). Custom parameters are correctly identified as `Source=user`, and custom parameters not in the engine defaults are included in the response.

### 3. DescribeDBEngineVersions family fix

`DBParameterGroupFamily` was constructed as `{engine}{family}` but the `family` string already includes the engine prefix (e.g. `aurora-mysql8.0`), producing garbled values like `aurora-mysqlaurora-mysql8.0`. Fixed to use just `{family}`.

## Tests

- `test_rds_modify_and_describe_db_parameters` — modify with ApplyMethod, describe with Source=user filter
- `test_rds_modify_and_describe_cluster_parameters` — same for cluster parameter groups
- `test_rds_describe_engine_versions_family` — verify no double-prefix

## Checklist

- [x] Tests added and passing
- [x] CHANGELOG entry added
- [x] Linting passes