### PR TITLE
feat(rds-data): SQL-aware stubs for database/user/grant tracking in mock environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [Unreleased]
+
+### Added
+- **RDS Data API SQL-aware stubs** — when no real database endpoint is available, `ExecuteStatement` now tracks `CREATE/DROP DATABASE`, `CREATE/DROP USER`, and `GRANT/REVOKE` statements in memory per cluster. Verification queries (`SELECT schema_name FROM information_schema.schemata`, `SELECT FROM mysql.user`, `SHOW GRANTS FOR`) return tracked state. Enables acceptance testing of database provisioning workflows without Docker-in-Docker. Connection errors also fall back to stubs instead of returning 400. Contributed by @jayjanssen.
+
 ## [1.2.7] — 2026-04-12
 
 ### Added

--- a/ministack/services/rds_data.py
+++ b/ministack/services/rds_data.py
@@ -7,6 +7,7 @@ Routes SQL to real database containers managed by the RDS service emulator.
 import json
 import logging
 import os
+import re
 import threading
 import uuid
 
@@ -20,6 +21,12 @@ REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 _transactions: dict = {}
 _lock = threading.Lock()
 
+# In-memory tracking for stub mode: remember databases/users created via SQL.
+# Keyed by cluster identifier.
+_stub_databases: dict = {}   # cluster_id -> set of database names
+_stub_users: dict = {}       # cluster_id -> set of usernames
+_stub_grants: dict = {}      # cluster_id -> {username -> list of grant strings}
+
 
 def _error(code, message, status=400):
     return error_response_json(code, message, status)
@@ -32,6 +39,157 @@ def _stub_success():
         "generatedFields": [],
         "records": [],
     })
+
+
+def _cluster_id_from_arn(resource_arn):
+    """Extract cluster identifier from an ARN."""
+    parts = resource_arn.split(":")
+    if len(parts) >= 7:
+        return parts[6]
+    return resource_arn
+
+
+_CREATE_DB_RE = re.compile(
+    r"CREATE\s+DATABASE\s+(?:IF\s+NOT\s+EXISTS\s+)?`?(\w+)`?", re.IGNORECASE)
+_CREATE_USER_RE = re.compile(
+    r"CREATE\s+USER\s+(?:IF\s+NOT\s+EXISTS\s+)?'([^']+)'", re.IGNORECASE)
+_DROP_USER_RE = re.compile(
+    r"DROP\s+USER\s+(?:IF\s+EXISTS\s+)?'([^']+)'", re.IGNORECASE)
+_DROP_DB_RE = re.compile(
+    r"DROP\s+DATABASE\s+(?:IF\s+EXISTS\s+)?`?(\w+)`?", re.IGNORECASE)
+_GRANT_RE = re.compile(
+    r"(GRANT\s+.+?\s+TO\s+'([^']+)'.*)", re.IGNORECASE | re.DOTALL)
+_REVOKE_RE = re.compile(
+    r"REVOKE\s+.+?\s+FROM\s+'([^']+)'", re.IGNORECASE | re.DOTALL)
+_SHOW_DATABASES_RE = re.compile(
+    r"SHOW\s+DATABASES", re.IGNORECASE)
+_SELECT_SCHEMATA_RE = re.compile(
+    r"SELECT\s+schema_name\s+FROM\s+information_schema\.schemata", re.IGNORECASE)
+_SELECT_USER_RE = re.compile(
+    r"SELECT\s+.*FROM\s+mysql\.user\s+WHERE\s+User\s*=\s*'([^']+)'", re.IGNORECASE)
+_SHOW_GRANTS_RE = re.compile(
+    r"SHOW\s+GRANTS\s+FOR\s+'([^']+)'", re.IGNORECASE)
+
+
+def _stub_execute(resource_arn, sql):
+    """Handle SQL in stub mode: track creates, respond to queries."""
+    cid = _cluster_id_from_arn(resource_arn)
+
+    # Track CREATE DATABASE
+    m = _CREATE_DB_RE.search(sql)
+    if m:
+        _stub_databases.setdefault(cid, set()).add(m.group(1))
+        logger.info("Stub: tracked CREATE DATABASE %s on %s", m.group(1), cid)
+        return _stub_success()
+
+    # Track CREATE USER
+    m = _CREATE_USER_RE.search(sql)
+    if m:
+        _stub_users.setdefault(cid, set()).add(m.group(1))
+        logger.info("Stub: tracked CREATE USER %s on %s", m.group(1), cid)
+        return _stub_success()
+
+    # Track DROP USER
+    m = _DROP_USER_RE.search(sql)
+    if m:
+        _stub_users.get(cid, set()).discard(m.group(1))
+        _stub_grants.get(cid, {}).pop(m.group(1), None)
+        logger.info("Stub: tracked DROP USER %s on %s", m.group(1), cid)
+        return _stub_success()
+
+    # Track DROP DATABASE
+    m = _DROP_DB_RE.search(sql)
+    if m:
+        _stub_databases.get(cid, set()).discard(m.group(1))
+        logger.info("Stub: tracked DROP DATABASE %s on %s", m.group(1), cid)
+        return _stub_success()
+
+    # Track GRANT
+    m = _GRANT_RE.search(sql)
+    if m:
+        grant_str, username = m.group(1).strip(), m.group(2)
+        _stub_grants.setdefault(cid, {}).setdefault(username, []).append(grant_str)
+        logger.info("Stub: tracked GRANT for %s on %s", username, cid)
+        return _stub_success()
+
+    # Track REVOKE
+    m = _REVOKE_RE.search(sql)
+    if m:
+        username = m.group(1)
+        _stub_grants.get(cid, {}).pop(username, None)
+        logger.info("Stub: tracked REVOKE for %s on %s", username, cid)
+        return _stub_success()
+
+    # Respond to SHOW DATABASES
+    if _SHOW_DATABASES_RE.search(sql):
+        dbs = _stub_databases.get(cid, set())
+        # Always include system databases
+        all_dbs = {"information_schema", "mysql", "performance_schema", "sys"} | dbs
+        records = [[{"stringValue": db}] for db in sorted(all_dbs)]
+        return json_response({
+            "numberOfRecordsUpdated": 0,
+            "generatedFields": [],
+            "records": records,
+        })
+
+    # Respond to SELECT schema_name FROM information_schema.schemata ...
+    if _SELECT_SCHEMATA_RE.search(sql):
+        dbs = _stub_databases.get(cid, set())
+        all_dbs = {"information_schema", "mysql", "performance_schema", "sys"} | dbs
+        # Filter by WHERE clause if present
+        in_match = re.search(r"WHERE\s+schema_name\s+IN\s*\(([^)]+)\)", sql, re.IGNORECASE)
+        eq_match = re.search(r"WHERE\s+schema_name\s*=\s*'([^']+)'", sql, re.IGNORECASE)
+        if in_match:
+            requested = {s.strip().strip("'\"") for s in in_match.group(1).split(",")}
+            matching = all_dbs & requested
+        elif eq_match:
+            name = eq_match.group(1)
+            matching = {name} if name in all_dbs else set()
+        else:
+            matching = all_dbs
+        records = [[{"stringValue": db}] for db in sorted(matching)]
+        return json_response({
+            "numberOfRecordsUpdated": 0,
+            "generatedFields": [],
+            "records": records,
+        })
+
+    # Respond to SELECT ... FROM mysql.user WHERE User = '...'
+    m = _SELECT_USER_RE.search(sql)
+    if m:
+        username = m.group(1)
+        users = _stub_users.get(cid, set())
+        if username in users:
+            # Check if it's asking for a specific column (privilege check)
+            col_match = re.match(r"SELECT\s+(\w+)\s+FROM", sql, re.IGNORECASE)
+            if col_match and col_match.group(1).lower() != "user":
+                # Privilege column query — return "Y" for any privilege
+                return json_response({
+                    "numberOfRecordsUpdated": 0,
+                    "generatedFields": [],
+                    "records": [[{"stringValue": "Y"}]],
+                })
+            return json_response({
+                "numberOfRecordsUpdated": 0,
+                "generatedFields": [],
+                "records": [[{"stringValue": username}]],
+            })
+        return _stub_success()
+
+    # Respond to SHOW GRANTS FOR '...'
+    m = _SHOW_GRANTS_RE.search(sql)
+    if m:
+        username = m.group(1)
+        grants = _stub_grants.get(cid, {}).get(username, [])
+        records = [[{"stringValue": g}] for g in grants]
+        return json_response({
+            "numberOfRecordsUpdated": 0,
+            "generatedFields": [],
+            "records": records,
+        })
+
+    # Default stub
+    return _stub_success()
 
 
 def _resolve_cluster(resource_arn):
@@ -246,8 +404,8 @@ def _execute_statement(data):
     # Clusters have Endpoint as a string (hostname); instances have it as a dict.
     endpoint = instance.get("Endpoint", {})
     if isinstance(endpoint, str) or not endpoint.get("Port"):
-        logger.info("No endpoint for %s, returning stub success", resource_arn)
-        return _stub_success()
+        logger.info("No endpoint for %s, using stub mode", resource_arn)
+        return _stub_execute(resource_arn, sql)
 
     password = _get_secret_password(secret_arn)
 
@@ -299,11 +457,19 @@ def _execute_statement(data):
     except ImportError as e:
         if own_conn and conn:
             conn.close()
-        logger.warning("DB driver not available, returning stub: %s", e)
-        return _stub_success()
+        logger.warning("DB driver not available, using stub: %s", e)
+        return _stub_execute(resource_arn, sql)
     except Exception as e:
         if own_conn and conn:
             conn.close()
+        # Connection errors (e.g. when RDS containers are not reachable from
+        # within the MiniStack container) should fall back to stubs rather than
+        # failing the caller.  This covers LAMBDA_EXECUTOR=local where the
+        # MySQL sidecar container is not network-accessible.
+        err_str = str(e)
+        if "Can't connect" in err_str or "Connection refused" in err_str:
+            logger.warning("DB connection failed, using stub: %s", e)
+            return _stub_execute(resource_arn, sql)
         return _error("BadRequestException", f"Database error: {e}")
 
 
@@ -462,3 +628,6 @@ def reset():
             except Exception:
                 pass
         _transactions.clear()
+    _stub_databases.clear()
+    _stub_users.clear()
+    _stub_grants.clear()

--- a/tests/test_rds_data.py
+++ b/tests/test_rds_data.py
@@ -245,3 +245,115 @@ def test_convert_parameters_empty_value():
 
     result = _convert_parameters([{"name": "x", "value": {}}])
     assert result["x"] is None
+
+
+# ── Stub mode tests ────────────────────────────────────────
+
+def _setup_stub_cluster(rds, sm):
+    """Create an RDS cluster (no real DB container) and a secret for stub testing."""
+    import uuid as _uuid
+    cluster_id = f"stub-test-{_uuid.uuid4().hex[:8]}"
+    rds.create_db_cluster(
+        DBClusterIdentifier=cluster_id,
+        Engine="aurora-mysql",
+        MasterUsername="admin",
+        MasterUserPassword="testpass123",
+    )
+    secret_arn = sm.create_secret(
+        Name=f"stub-secret-{_uuid.uuid4().hex[:8]}",
+        SecretString='{"username":"admin","password":"testpass123"}',
+    )["ARN"]
+    cluster_arn = f"arn:aws:rds:{REGION}:{ACCOUNT_ID}:cluster:{cluster_id}"
+    return cluster_arn, secret_arn
+
+
+def _exec(cluster_arn, secret_arn, sql):
+    """Execute a SQL statement via the stub and return (status, body)."""
+    return _raw_post("/Execute", {
+        "resourceArn": cluster_arn,
+        "secretArn": secret_arn,
+        "sql": sql,
+    })
+
+
+def test_rds_data_stub_create_and_query_databases(rds, sm):
+    """CREATE DATABASE via stub, then query information_schema.schemata."""
+    cluster_arn, secret_arn = _setup_stub_cluster(rds, sm)
+
+    status, _ = _exec(cluster_arn, secret_arn, "CREATE DATABASE myappdb")
+    assert status == 200
+
+    status, body = _exec(
+        cluster_arn, secret_arn,
+        "SELECT schema_name FROM information_schema.schemata WHERE schema_name IN ('myappdb')",
+    )
+    assert status == 200
+    names = [r[0]["stringValue"] for r in body.get("records", [])]
+    assert "myappdb" in names
+
+
+def test_rds_data_stub_create_and_query_users(rds, sm):
+    """CREATE USER via stub, then query mysql.user."""
+    cluster_arn, secret_arn = _setup_stub_cluster(rds, sm)
+
+    status, _ = _exec(cluster_arn, secret_arn, "CREATE USER 'appuser'@'%' IDENTIFIED BY 'pass'")
+    assert status == 200
+
+    status, body = _exec(
+        cluster_arn, secret_arn,
+        "SELECT User FROM mysql.user WHERE User='appuser'",
+    )
+    assert status == 200
+    names = [r[0]["stringValue"] for r in body.get("records", [])]
+    assert "appuser" in names
+
+
+def test_rds_data_stub_grant_and_show_grants(rds, sm):
+    """GRANT privileges, then SHOW GRANTS FOR."""
+    cluster_arn, secret_arn = _setup_stub_cluster(rds, sm)
+
+    _exec(cluster_arn, secret_arn, "CREATE USER 'grantee'@'%' IDENTIFIED BY 'pass'")
+    status, _ = _exec(
+        cluster_arn, secret_arn,
+        "GRANT ALL PRIVILEGES ON mydb.* TO 'grantee'@'%'",
+    )
+    assert status == 200
+
+    status, body = _exec(cluster_arn, secret_arn, "SHOW GRANTS FOR 'grantee'")
+    assert status == 200
+    grants = [r[0]["stringValue"] for r in body.get("records", [])]
+    assert any("GRANT" in g and "grantee" in g for g in grants)
+
+
+def test_rds_data_stub_drop_database(rds, sm):
+    """CREATE then DROP DATABASE, verify gone from queries."""
+    cluster_arn, secret_arn = _setup_stub_cluster(rds, sm)
+
+    _exec(cluster_arn, secret_arn, "CREATE DATABASE dropme")
+    _exec(cluster_arn, secret_arn, "DROP DATABASE dropme")
+
+    status, body = _exec(
+        cluster_arn, secret_arn,
+        "SELECT schema_name FROM information_schema.schemata WHERE schema_name = 'dropme'",
+    )
+    assert status == 200
+    names = [r[0]["stringValue"] for r in body.get("records", [])]
+    assert "dropme" not in names
+
+
+def test_rds_data_stub_drop_user(rds, sm):
+    """CREATE then DROP USER, verify gone from queries."""
+    cluster_arn, secret_arn = _setup_stub_cluster(rds, sm)
+
+    _exec(cluster_arn, secret_arn, "CREATE USER 'tempuser'@'%' IDENTIFIED BY 'pass'")
+    _exec(cluster_arn, secret_arn, "DROP USER 'tempuser'@'%'")
+
+    status, body = _exec(
+        cluster_arn, secret_arn,
+        "SELECT User FROM mysql.user WHERE User='tempuser'",
+    )
+    assert status == 200
+    # Should return no records (empty records list from _stub_success)
+    records = body.get("records", [])
+    names = [r[0]["stringValue"] for r in records] if records else []
+    assert "tempuser" not in names


### PR DESCRIPTION
## Summary

When no real database endpoint is available (e.g. `LAMBDA_EXECUTOR=local` where MySQL sidecars aren't network-accessible), the RDS Data API currently returns a minimal stub success for all `ExecuteStatement` calls. This makes it impossible to verify database provisioning workflows — verification queries always return empty results.

This PR upgrades the stub fallback to track SQL state in memory:

### DDL tracking

| SQL | Effect |
|-----|--------|
| `CREATE DATABASE foo` | Adds `foo` to tracked databases for the cluster |
| `DROP DATABASE foo` | Removes `foo` from tracked databases |
| `CREATE USER 'app_rw'` | Adds `app_rw` to tracked users |
| `DROP USER 'app_rw'` | Removes `app_rw` and their grants |
| `GRANT ... TO 'app_rw'` | Records the grant string |
| `REVOKE ... FROM 'app_rw'` | Removes grants for the user |

### Verification queries

| Query | Response |
|-------|----------|
| `SELECT schema_name FROM information_schema.schemata` | Returns tracked databases + system DBs |
| `SELECT ... FROM mysql.user WHERE User = '...'` | Returns user if tracked |
| `SHOW GRANTS FOR '...'` | Returns tracked grant strings |
| `SHOW DATABASES` | Returns tracked databases + system DBs |

### Connection error fallback

Connection errors (`Can't connect to MySQL server`, `Connection refused`) now fall back to stubs instead of returning 400. This covers environments where RDS containers aren't reachable from within the MiniStack container.

All tracking is keyed by cluster identifier (extracted from the resource ARN) and cleared on `/_ministack/reset`.

## Tests

- 5 new tests covering create/query/drop for databases, users, and grants
- All existing RDS Data API tests pass

## Checklist

- [x] Tests added and passing
- [x] CHANGELOG entry added
- [x] Linting passes
- [x] State cleared in `reset()`