### PR TITLE
Run all lambdas in a container with RIE support if LAMBDA_EXECUTOR is set to docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -367,6 +367,9 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 - **Step Functions aws-sdk action casing** — SFN ARNs use camelCase (e.g. `createDBSubnetGroup`) but query-protocol and JSON-protocol services expect PascalCase (`CreateDBSubnetGroup`). Both dispatch paths now capitalize the first letter. Contributed by @jayjanssen (#204, #215).
 - **RDS `_parse_member_list` botocore format** — list parameters dispatched via Step Functions aws-sdk integrations use `Prefix.MemberName.N` format instead of `Prefix.member.N`. The parser now handles both formats.
 
+## Added
+-- **Lambda `invoke` action** - Modified the running of the lambda to always use AWS provided Runtime Interface Emulator images. This way any container image that implements the RIE can be run. Removed the support for running dockers using a wrapper script. Container will be reused if possible. Containers are kept running
+and reference by the sha256 over the code image. In the future this should be a combination of the code image and the config.
 ---
 
 ## [1.1.58] — 2026-04-09

--- a/README.md
+++ b/README.md
@@ -700,6 +700,77 @@ docker run -p 4566:4566 \
   ministackorg/ministack
 ```
 
+### Lambdas in docker
+
+To run lambda in docker, the LAMBDA_EXECUTOR needs to be set to "docker". All lambdas will be run in an
+AWS supplied docker image, following docker images are supported:
+   *  "python3.8": "public.ecr.aws/lambda/python:3.8"
+   *  "python3.9": "public.ecr.aws/lambda/python:3.9"
+   *  "python3.10": "public.ecr.aws/lambda/python:3.10"
+   *  "python3.11": "public.ecr.aws/lambda/python:3.11"
+   *  "python3.12": "public.ecr.aws/lambda/python:3.12"
+   *  "python3.13": "public.ecr.aws/lambda/python:3.13"
+   *  "python3.14": "public.ecr.aws/lambda/python:3.14"
+   *  "nodejs14.x": "public.ecr.aws/lambda/nodejs:14"
+   *  "nodejs16.x": "public.ecr.aws/lambda/nodejs:16"
+   *  "nodejs18.x": "public.ecr.aws/lambda/nodejs:18"
+   *  "nodejs20.x": "public.ecr.aws/lambda/nodejs:20"
+   *  "nodejs22.x": "public.ecr.aws/lambda/nodejs:22"
+   *  "nodejs24.x": "public.ecr.aws/lambda/nodejs:24"
+   *  "provided.al2023": "public.ecr.aws/lambda/provided:al2023"
+   *  "provided.al2": "public.ecr.aws/lambda/provided:al2"
+   *  "provided": "public.ecr.aws/lambda/provided:latest"
+
+Docker containers for lambda are name lambda-<random-hex-16>.
+
+Docker containers are always kept "warm", and reused when possible. This means that containers
+created for lambdas need to be killed manually.
+
+Additionally a volume is needed to mount the code (and extra layers). This must be set with
+the LAMBDA_REMOTE_DOCKER_VOLUME_MOUNT environment variable. This must be a named volume (managed by docker).
+
+If a ministack is not running on the default network, LAMBDA_DOCKER_NETWORK needs to be set, which will attach
+the lambda to this network, making it posssible to access ministack (AWS) resources from the lambda.
+
+Example docker compose file:
+```
+services:
+  ministack:
+    image: ministackorg/ministack:latest
+    container_name: infra_ministack
+    entrypoint: ["python", "-m", "uvicorn", "ministack.app:app", "--host", "0.0.0.0", "--port", "4566"]
+    networks:
+      infra-network:
+    healthcheck:
+      test: "python -c "import urllib.request; urllib.request.urlopen('http://localhost:4566/_ministack/health')" || exit 1"
+      interval: 10s
+      timeout: 2s
+      start_period: 5s
+      retries: 3
+    ports:
+      - "4566:4566"
+    environment:
+      DOCKER_SOCK: ${DOCKER_SOCK:-/var/run/docker.sock}
+      LAMBDA_EXECUTOR: docker
+      LAMBDA_DOCKER_NETWORK: ${COMPOSE_PROJECT_NAME}_infra-network
+      LAMBDA_REMOTE_DOCKER_VOLUME_MOUNT: "{COMPOSE_PROJECT_NAME}_lambda-docker-volume"
+      AWS_DEFAULT_REGION: ${AWS_REGION:-eu-central-1}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-my_secret}
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-my_key}
+      AWS_ENDPOINT_URL: http://localstack:4566
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock"
+      - "lambda-docker-volume:/var/task"
+
+volumes:
+  lambda-docker-volume:
+
+networks:
+  infra-network:
+```
+
+Option prvivileged set to "true" is needed if /var/run/docker.sock is root owned.
+
 ### Lambda Warm Starts
 
 MiniStack keeps Python and Node.js Lambda functions warm between invocations. After the first call (cold start), the handler module stays loaded in a persistent subprocess. Subsequent calls skip the import/require step, matching real AWS warm-start behaviour and making test suites significantly faster.

--- a/ministack/core/lambda_wrapper.py
+++ b/ministack/core/lambda_wrapper.py
@@ -1,0 +1,39 @@
+import sys, os, json
+
+sys.path.insert(0, os.environ["_LAMBDA_CODE_DIR"])
+
+_REAL_STDOUT = sys.__stdout__
+# Match AWS Lambda semantics: logs go to CloudWatch (stderr here),
+# while the Invoke response payload must be clean JSON on stdout.
+sys.stdout = sys.stderr
+
+for _ld in filter(None, os.environ.get("_LAMBDA_LAYERS_DIRS", "").split(os.pathsep)):
+    _py = os.path.join(_ld, "python")
+    if os.path.isdir(_py):
+        sys.path.insert(0, _py)
+    sys.path.insert(0, _ld)
+
+_mod_path = os.environ["_LAMBDA_HANDLER_MODULE"]
+_fn_name  = os.environ["_LAMBDA_HANDLER_FUNC"]
+
+event = json.loads(sys.stdin.read())
+
+class LambdaContext:
+    function_name        = os.environ.get("AWS_LAMBDA_FUNCTION_NAME", "")
+    memory_limit_in_mb   = int(os.environ.get("AWS_LAMBDA_FUNCTION_MEMORY_SIZE", "128"))
+    invoked_function_arn = os.environ.get("_LAMBDA_FUNCTION_ARN", "")
+    aws_request_id       = os.environ.get("AWS_LAMBDA_LOG_STREAM_NAME", "")
+    log_group_name       = "/aws/lambda/" + function_name
+    log_stream_name      = aws_request_id
+
+    @staticmethod
+    def get_remaining_time_in_millis():
+        return int(float(os.environ.get("_LAMBDA_TIMEOUT", "3")) * 1000)
+
+_mod = __import__(_mod_path)
+for _part in _mod_path.split(".")[1:]:
+    _mod = getattr(_mod, _part)
+_result = getattr(_mod, _fn_name)(event, LambdaContext())
+if _result is not None:
+    _REAL_STDOUT.write(json.dumps(_result))
+    _REAL_STDOUT.flush()

--- a/ministack/core/lambda_wrapper_node.js
+++ b/ministack/core/lambda_wrapper_node.js
@@ -1,0 +1,66 @@
+const fs = require('fs');
+const path = require('path');
+const { pathToFileURL } = require('url');
+
+const codeDir = process.env._LAMBDA_CODE_DIR || '/var/task';
+const modPath  = process.env._LAMBDA_HANDLER_MODULE;
+const fnName   = process.env._LAMBDA_HANDLER_FUNC;
+
+// Prepend layer dirs to NODE_PATH
+const layerDirs = (process.env._LAMBDA_LAYERS_DIRS || '').split(path.delimiter).filter(Boolean);
+const nodePaths = layerDirs.map(d => path.join(d, 'nodejs', 'node_modules'))
+                           .concat(layerDirs)
+                           .concat([path.join(codeDir, 'node_modules'), codeDir]);
+module.paths.unshift(...nodePaths);
+
+const context = {
+  functionName:       process.env.AWS_LAMBDA_FUNCTION_NAME || '',
+  memoryLimitInMB:    process.env.AWS_LAMBDA_FUNCTION_MEMORY_SIZE || '128',
+  invokedFunctionArn: process.env._LAMBDA_FUNCTION_ARN || '',
+  awsRequestId:       process.env.AWS_LAMBDA_LOG_STREAM_NAME || '',
+  logGroupName:       '/aws/lambda/' + (process.env.AWS_LAMBDA_FUNCTION_NAME || ''),
+  logStreamName:      process.env.AWS_LAMBDA_LOG_STREAM_NAME || '',
+  getRemainingTimeInMillis: () => parseFloat(process.env._LAMBDA_TIMEOUT || '3') * 1000,
+};
+
+let input = '';
+process.stdin.on('data', d => input += d);
+process.stdin.on('end', async () => {
+  const event = JSON.parse(input);
+  const fullPath = path.resolve(codeDir, modPath);
+  let mod;
+  let resolvedPath;
+  try {
+    resolvedPath = require.resolve(fullPath);
+    mod = require(resolvedPath);
+  } catch (reqErr) {
+    if (reqErr.code === 'ERR_REQUIRE_ESM' && resolvedPath) {
+      mod = await import(pathToFileURL(resolvedPath).href);
+    } else if (reqErr.code === 'MODULE_NOT_FOUND') {
+      const mjsPath = fullPath + '.mjs';
+      const missingHandlerEntry =
+        (reqErr.message && reqErr.message.includes("'" + fullPath + "'")) ||
+        (resolvedPath && reqErr.message && reqErr.message.includes("'" + resolvedPath + "'"));
+      if (missingHandlerEntry && fs.existsSync(mjsPath)) {
+        mod = await import(pathToFileURL(mjsPath).href);
+      } else {
+        throw reqErr;
+      }
+    } else {
+      throw reqErr;
+    }
+  }
+  const handler = mod[fnName] || (mod.default && mod.default[fnName]) || mod.default;
+  if (typeof handler !== 'function') {
+    process.stderr.write(
+      "Handler '" + fnName + "' in module '" + modPath + "' is undefined or not a function"
+    );
+    process.exit(1);
+  }
+  Promise.resolve(handler(event, context)).then(result => {
+    if (result !== undefined) process.stdout.write(JSON.stringify(result));
+  }).catch(err => {
+    process.stderr.write(String(err.stack || err));
+    process.exit(1);
+  });
+});

--- a/ministack/services/lambda_svc.py
+++ b/ministack/services/lambda_svc.py
@@ -29,22 +29,34 @@ import base64
 import copy
 import hashlib
 import importlib
+import io
 import json
 import logging
 import os
+import pathlib
+import random
 import re
 import subprocess
 import tempfile
 import threading
 import time
+import typing
 import zipfile
 from datetime import datetime, timezone
-from typing import Any
 from urllib.parse import unquote
 
-from ministack.core.persistence import load_state, PERSIST_STATE
+from ministack.core.persistence import load_state
 from ministack.core.responses import AccountScopedDict, get_account_id, error_response_json, json_response, new_uuid
 from ministack.core.lambda_runtime import get_or_create_worker, invalidate_worker
+
+if typing.TYPE_CHECKING:
+    from mypy_boto3_lambda.type_defs import FunctionConfigurationResponseTypeDef, FunctionConfigurationTypeDef
+    from mypy_boto3_lambda.literals import RuntimeType
+    from docker.models.containers import Container
+
+    class LambdaConfigType(FunctionConfigurationResponseTypeDef):
+        ImageUri: typing.Optional[str]
+
 
 logger = logging.getLogger("lambda")
 
@@ -53,8 +65,11 @@ LAMBDA_EXECUTOR = os.environ.get("LAMBDA_EXECUTOR", "local").lower()
 LAMBDA_DOCKER_VOLUME_MOUNT = os.environ.get("LAMBDA_REMOTE_DOCKER_VOLUME_MOUNT", "")
 LAMBDA_DOCKER_NETWORK = os.environ.get("LAMBDA_DOCKER_NETWORK", "")
 
+if typing.TYPE_CHECKING:
+    from docker import DockerClient
+
 try:
-    docker_lib: Any = importlib.import_module("docker")
+    docker_lib: "DockerClient" = importlib.import_module("docker")
     _docker_available = True
 except ImportError:
     docker_lib = None
@@ -67,12 +82,32 @@ _function_urls = AccountScopedDict()  # function_name -> FunctionUrlConfig dict
 _poller_started = False
 _poller_lock = threading.Lock()
 
+_containers_lock = threading.Lock()
+
+
+class ContainerScopedDict(AccountScopedDict):
+    def clear(self):
+        """Stop running ccontainers when clear"""
+        with _containers_lock:
+            for containers in self._data.values():
+                for container in containers:
+                    try:
+                        container.stop()
+                        container.remove()
+                    except Exception:
+                        pass
+        super().clear()
+
+
+_containers = ContainerScopedDict()
 
 # ── Persistence ────────────────────────────────────────────
+
 
 def get_state():
     """Return JSON-serializable state. code_zip bytes are base64-encoded."""
     from ministack.core.responses import AccountScopedDict
+
     funcs = AccountScopedDict()
     # Iterate _data directly to capture ALL accounts, not just current request context
     for scoped_key, func in _functions._data.items():
@@ -94,6 +129,7 @@ def get_state():
 def restore_state(data):
     if data:
         from ministack.core.responses import AccountScopedDict
+
         funcs = data.get("functions", {})
         if isinstance(funcs, AccountScopedDict):
             for scoped_key, func in funcs._data.items():
@@ -125,163 +161,12 @@ if _restored:
 # Wrapper script executed inside the subprocess.
 # All configuration is passed through env vars; event data arrives on stdin.
 # ---------------------------------------------------------------------------
-_WRAPPER_SCRIPT = """\
-import sys, os, json
-
-sys.path.insert(0, os.environ["_LAMBDA_CODE_DIR"])
-
-_REAL_STDOUT = sys.__stdout__
-# Match AWS Lambda semantics: logs go to CloudWatch (stderr here),
-# while the Invoke response payload must be clean JSON on stdout.
-sys.stdout = sys.stderr
-
-for _ld in filter(None, os.environ.get("_LAMBDA_LAYERS_DIRS", "").split(os.pathsep)):
-    _py = os.path.join(_ld, "python")
-    if os.path.isdir(_py):
-        sys.path.insert(0, _py)
-    sys.path.insert(0, _ld)
-
-_mod_path = os.environ["_LAMBDA_HANDLER_MODULE"]
-_fn_name  = os.environ["_LAMBDA_HANDLER_FUNC"]
-
-event = json.loads(sys.stdin.read())
-
-class LambdaContext:
-    function_name        = os.environ.get("AWS_LAMBDA_FUNCTION_NAME", "")
-    memory_limit_in_mb   = int(os.environ.get("AWS_LAMBDA_FUNCTION_MEMORY_SIZE", "128"))
-    invoked_function_arn = os.environ.get("_LAMBDA_FUNCTION_ARN", "")
-    aws_request_id       = os.environ.get("AWS_LAMBDA_LOG_STREAM_NAME", "")
-    log_group_name       = "/aws/lambda/" + function_name
-    log_stream_name      = aws_request_id
-
-    @staticmethod
-    def get_remaining_time_in_millis():
-        return int(float(os.environ.get("_LAMBDA_TIMEOUT", "3")) * 1000)
-
-_mod = __import__(_mod_path)
-for _part in _mod_path.split(".")[1:]:
-    _mod = getattr(_mod, _part)
-_result = getattr(_mod, _fn_name)(event, LambdaContext())
-if _result is not None:
-    _REAL_STDOUT.write(json.dumps(_result))
-    _REAL_STDOUT.flush()
-"""
-
-# Docker variant: paths fixed to /var/task (code) and /opt (layers).
-_DOCKER_WRAPPER_SCRIPT = """\
-import sys, os, json
-
-sys.path.insert(0, "/var/task")
-
-_REAL_STDOUT = sys.__stdout__
-# Match AWS Lambda semantics: logs go to CloudWatch (stderr here),
-# while the Invoke response payload must be clean JSON on stdout.
-sys.stdout = sys.stderr
-
-for _ld in filter(None, os.environ.get("_LAMBDA_LAYERS_DIRS", "").split(":")):
-    _py = os.path.join(_ld, "python")
-    if os.path.isdir(_py):
-        sys.path.insert(0, _py)
-    sys.path.insert(0, _ld)
-
-_mod_path = os.environ["_LAMBDA_HANDLER_MODULE"]
-_fn_name  = os.environ["_LAMBDA_HANDLER_FUNC"]
-
-event = json.loads(sys.stdin.read())
-
-class LambdaContext:
-    function_name        = os.environ.get("AWS_LAMBDA_FUNCTION_NAME", "")
-    memory_limit_in_mb   = int(os.environ.get("AWS_LAMBDA_FUNCTION_MEMORY_SIZE", "128"))
-    invoked_function_arn = os.environ.get("_LAMBDA_FUNCTION_ARN", "")
-    aws_request_id       = os.environ.get("AWS_LAMBDA_LOG_STREAM_NAME", "")
-    log_group_name       = "/aws/lambda/" + function_name
-    log_stream_name      = aws_request_id
-
-    @staticmethod
-    def get_remaining_time_in_millis():
-        return int(float(os.environ.get("_LAMBDA_TIMEOUT", "3")) * 1000)
-
-_mod = __import__(_mod_path)
-for _part in _mod_path.split(".")[1:]:
-    _mod = getattr(_mod, _part)
-_result = getattr(_mod, _fn_name)(event, LambdaContext())
-if _result is not None:
-    _REAL_STDOUT.write(json.dumps(_result))
-    _REAL_STDOUT.flush()
-"""
-
+import ministack.core
+_WRAPPER_SCRIPT = (pathlib.Path(ministack.core.__file__).parent / "lambda_wrapper.py").read_text()
 
 # Node.js wrapper — written to the code dir and executed with `node`.
 # Reads event from stdin, calls handler, writes JSON result to stdout.
-_NODE_WRAPPER_SCRIPT = """\
-const fs = require('fs');
-const path = require('path');
-const { pathToFileURL } = require('url');
-
-const codeDir = process.env._LAMBDA_CODE_DIR || '/var/task';
-const modPath  = process.env._LAMBDA_HANDLER_MODULE;
-const fnName   = process.env._LAMBDA_HANDLER_FUNC;
-
-// Prepend layer dirs to NODE_PATH
-const layerDirs = (process.env._LAMBDA_LAYERS_DIRS || '').split(path.delimiter).filter(Boolean);
-const nodePaths = layerDirs.map(d => path.join(d, 'nodejs', 'node_modules'))
-                           .concat(layerDirs)
-                           .concat([path.join(codeDir, 'node_modules'), codeDir]);
-module.paths.unshift(...nodePaths);
-
-const context = {
-  functionName:       process.env.AWS_LAMBDA_FUNCTION_NAME || '',
-  memoryLimitInMB:    process.env.AWS_LAMBDA_FUNCTION_MEMORY_SIZE || '128',
-  invokedFunctionArn: process.env._LAMBDA_FUNCTION_ARN || '',
-  awsRequestId:       process.env.AWS_LAMBDA_LOG_STREAM_NAME || '',
-  logGroupName:       '/aws/lambda/' + (process.env.AWS_LAMBDA_FUNCTION_NAME || ''),
-  logStreamName:      process.env.AWS_LAMBDA_LOG_STREAM_NAME || '',
-  getRemainingTimeInMillis: () => parseFloat(process.env._LAMBDA_TIMEOUT || '3') * 1000,
-};
-
-let input = '';
-process.stdin.on('data', d => input += d);
-process.stdin.on('end', async () => {
-  const event = JSON.parse(input);
-  const fullPath = path.resolve(codeDir, modPath);
-  let mod;
-  let resolvedPath;
-  try {
-    resolvedPath = require.resolve(fullPath);
-    mod = require(resolvedPath);
-  } catch (reqErr) {
-    if (reqErr.code === 'ERR_REQUIRE_ESM' && resolvedPath) {
-      mod = await import(pathToFileURL(resolvedPath).href);
-    } else if (reqErr.code === 'MODULE_NOT_FOUND') {
-      const mjsPath = fullPath + '.mjs';
-      const missingHandlerEntry =
-        (reqErr.message && reqErr.message.includes("'" + fullPath + "'")) ||
-        (resolvedPath && reqErr.message && reqErr.message.includes("'" + resolvedPath + "'"));
-      if (missingHandlerEntry && fs.existsSync(mjsPath)) {
-        mod = await import(pathToFileURL(mjsPath).href);
-      } else {
-        throw reqErr;
-      }
-    } else {
-      throw reqErr;
-    }
-  }
-  const handler = mod[fnName] || (mod.default && mod.default[fnName]) || mod.default;
-  if (typeof handler !== 'function') {
-    process.stderr.write(
-      "Handler '" + fnName + "' in module '" + modPath + "' is undefined or not a function"
-    );
-    process.exit(1);
-  }
-  Promise.resolve(handler(event, context)).then(result => {
-    if (result !== undefined) process.stdout.write(JSON.stringify(result));
-  }).catch(err => {
-    process.stderr.write(String(err.stack || err));
-    process.exit(1);
-  });
-});
-"""
-
+_NODE_WRAPPER_SCRIPT = (pathlib.Path(ministack.core.__file__).parent / "lambda_wrapper_node.js").read_text()
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -352,6 +237,7 @@ def _fetch_code_from_s3(bucket: str, key: str) -> bytes | None:
     """Fetch Lambda code zip from the in-memory S3 service."""
     try:
         from ministack.services import s3 as s3_svc
+
         obj = s3_svc._get_object_data(bucket, key)
         if obj is not None:
             return obj
@@ -360,7 +246,7 @@ def _fetch_code_from_s3(bucket: str, key: str) -> bytes | None:
     return None
 
 
-def _build_config(name: str, data: dict, code_zip: bytes | None = None) -> dict:
+def _build_config(name: str, data: dict, code_zip: bytes | None = None) -> "LambdaConfigType":
     code_size = len(code_zip) if code_zip else 0
     code_sha = base64.b64encode(hashlib.sha256(code_zip).digest()).decode() if code_zip else ""
     is_image = data.get("PackageType", "Zip") == "Image"
@@ -372,33 +258,58 @@ def _build_config(name: str, data: dict, code_zip: bytes | None = None) -> dict:
         elif isinstance(layer, dict):
             layers_cfg.append(layer)
 
-    env = data.get("Environment")
-    if env is not None and "Variables" not in env:
-        env["Variables"] = {}
+    env = data.get("Environment", {"Variables": {}})
 
-    config = {
-        "FunctionName": name,
-        "FunctionArn": _func_arn(name),
-        "Runtime": data.get("Runtime", "" if is_image else "python3.12"),
-        "Role": data.get("Role", f"arn:aws:iam::{get_account_id()}:role/lambda-role"),
-        "Handler": data.get("Handler", "" if is_image else "index.handler"),
-        "CodeSize": code_size,
+    config: "LambdaConfigType" = {
+        "Architectures": data.get("Architectures", ["x86_64"]),
+        "CapacityProviderConfig": {
+            "LambdaManagedInstancesCapacityProviderConfig": {"CapacityProviderArn": "lambda-default"}
+        },
+        "ConfigSha256": data.get("LambdaConfigSha256", ""),
         "CodeSha256": code_sha,
+        "CodeSize": code_size,
+        "DeadLetterConfig": data.get("DeadLetterConfig", {}),
         "Description": data.get("Description", ""),
-        "Timeout": data.get("Timeout", 3),
-        "MemorySize": data.get("MemorySize", 128),
+        "DurableConfig": data.get("DurableConfig", {}),
+        "Environment": env,
+        "EphemeralStorage": data.get("EphemeralStorage", {"Size": 512}),
+        "FileSystemConfigs": data.get("FileSystemConfigs", []),
+        "FunctionArn": _func_arn(name),
+        "FunctionName": name,
+        "Handler": data.get("Handler", "" if is_image else "index.handler"),
+        "ImageConfigResponse": {},
+        "ImageUri": data.get("ImageUri", ""),
+        "KMSKeyArn": data.get("KMSKeyArn", ""),
         "LastModified": _now_iso(),
-        "Version": "$LATEST",
-        "State": "Active",
-        "StateReason": "",
-        "StateReasonCode": "",
         "LastUpdateStatus": "Successful",
         "LastUpdateStatusReason": "",
-        "LastUpdateStatusReasonCode": "",
-        "PackageType": data.get("PackageType", "Zip"),
-        "Architectures": data.get("Architectures", ["x86_64"]),
+        "LastUpdateStatusReasonCode": data.get("LastUpdateStatusReasonCode", ""),
         "Layers": layers_cfg,
+        "LoggingConfig": data.get(
+            "LoggingConfig",
+            {
+                "LogFormat": "Text",
+                "LogGroup": f"/aws/lambda/{name}",
+            },
+        ),
+        "MasterArn": data.get("MasterArn", ""),
+        "MemorySize": data.get("MemorySize", 128),
+        "PackageType": data.get("PackageType", "Zip"),
+        "Role": data.get("Role", f"arn:aws:iam::{get_account_id()}:role/lambda-role"),
+        "Runtime": data.get("Runtime", "" if is_image else "python3.9"),
+        "SigningJobArn": data.get("SigningJobArn", ""),
+        "SigningProfileVersionArn": data.get("SigningProfileVersionArn", ""),
+        "State": "Active",
+        "StateReason": "",
+        "StateReasonCode": data.get("StateReasonCode", "Idle"),
+        "ResponseMetadata": data.get("ResponseMetadata", {}),
+        "RevisionId": new_uuid(),
+        "RuntimeVersionConfig": data.get("RuntimeVersionConfig", {}),
+        "SnapStart": {"ApplyOn": "None", "OptimizationStatus": "Off"},
+        "TenancyConfig": data.get("TenancyConfig", {}),
+        "Timeout": data.get("Timeout", 3),
         "TracingConfig": data.get("TracingConfig", {"Mode": "PassThrough"}),
+        "Version": "$LATEST",
         "VpcConfig": data.get(
             "VpcConfig",
             {
@@ -407,29 +318,8 @@ def _build_config(name: str, data: dict, code_zip: bytes | None = None) -> dict:
                 "VpcId": "",
             },
         ),
-        "KMSKeyArn": data.get("KMSKeyArn", ""),
-        "RevisionId": new_uuid(),
-        "EphemeralStorage": data.get("EphemeralStorage", {"Size": 512}),
-        "SnapStart": {"ApplyOn": "None", "OptimizationStatus": "Off"},
-        "LoggingConfig": data.get(
-            "LoggingConfig",
-            {
-                "LogFormat": "Text",
-                "LogGroup": f"/aws/lambda/{name}",
-            },
-        ),
-        "RuntimeVersionConfig": {
-            "RuntimeVersionArn": "",
-        },
     }
-    if env is not None:
-        config["Environment"] = env
-    dlc = data.get("DeadLetterConfig")
-    if dlc and dlc.get("TargetArn"):
-        config["DeadLetterConfig"] = dlc
     return config
-
-
 
 
 def _qp_first(query_params: dict, key: str, default: str = "") -> str:
@@ -980,7 +870,7 @@ async def _invoke(name: str, event: dict, headers: dict, path_qualifier: str | N
 
     # RequestResponse — execute in worker thread so nested SDK calls
     # from the Lambda process can still reach this ASGI server.
-    result = await asyncio.to_thread(_execute_function, exec_record, event)
+    result = await asyncio.to_thread(_execute_function, exec_record, event, async_mode=False)
 
     resp_headers: dict = {
         "Content-Type": "application/json",
@@ -1009,35 +899,30 @@ async def _invoke(name: str, event: dict, headers: dict, path_qualifier: str | N
 # Runtime → Docker image mapping
 # ---------------------------------------------------------------------------
 
-_RUNTIME_IMAGE_MAP: dict[str, str] = {
-    "python3.8": "python:3.8-slim",
-    "python3.9": "python:3.9-slim",
-    "python3.10": "python:3.10-slim",
-    "python3.11": "python:3.11-slim",
-    "python3.12": "python:3.12-slim",
-    "python3.13": "python:3.13-slim",
-    "nodejs14.x": "node:14-slim",
-    "nodejs16.x": "node:16-slim",
-    "nodejs18.x": "node:18-slim",
-    "nodejs20.x": "node:20-slim",
+
+_RUNTIME_IMAGE_MAP: "dict[RuntimeType, str]" = {
+    "python3.8": "public.ecr.aws/lambda/python:3.8",
+    "python3.9": "public.ecr.aws/lambda/python:3.9",
+    "python3.10": "public.ecr.aws/lambda/python:3.10",
+    "python3.11": "public.ecr.aws/lambda/python:3.11",
+    "python3.12": "public.ecr.aws/lambda/python:3.12",
+    "python3.13": "public.ecr.aws/lambda/python:3.13",
+    "python3.14": "public.ecr.aws/lambda/python:3.14",
+    "nodejs14.x": "public.ecr.aws/lambda/nodejs:14",
+    "nodejs16.x": "public.ecr.aws/lambda/nodejs:16",
+    "nodejs18.x": "public.ecr.aws/lambda/nodejs:18",
+    "nodejs20.x": "public.ecr.aws/lambda/nodejs:20",
+    "nodejs22.x": "public.ecr.aws/lambda/nodejs:22",
+    "nodejs24.x": "public.ecr.aws/lambda/nodejs:24",
     "provided.al2023": "public.ecr.aws/lambda/provided:al2023",
     "provided.al2": "public.ecr.aws/lambda/provided:al2",
     "provided": "public.ecr.aws/lambda/provided:al2023",
 }
 
 
-def _docker_image_for_runtime(runtime: str) -> str | None:
-    if runtime in _RUNTIME_IMAGE_MAP:
-        return _RUNTIME_IMAGE_MAP[runtime]
-    if runtime.startswith("python"):
-        ver = runtime.replace("python", "")
-        return f"python:{ver}-slim"
-    if runtime.startswith("nodejs"):
-        ver = runtime.replace("nodejs", "").rstrip(".x")
-        return f"node:{ver}-slim"
-    if runtime.startswith("provided"):
-        return "public.ecr.aws/lambda/provided:al2023"
-    return None
+class LambdaFunc(typing.TypedDict):
+    config: "LambdaConfigType"
+    code_zip: bytes | None
 
 
 # ---------------------------------------------------------------------------
@@ -1045,269 +930,286 @@ def _docker_image_for_runtime(runtime: str) -> str | None:
 # ---------------------------------------------------------------------------
 
 
-def _execute_function_docker(func: dict, event: dict) -> dict:
-    """Execute a Lambda function inside a Docker container.
+def _get_function_code(config: "LambdaConfigType") -> str:
+    "Get a unique path for lambda with package type zip"
+    func_name = config["FunctionName"]
+    sha256 = config["CodeSha256"]
+    return f"/var/task/{func_name}/{sha256}-code"
 
-    Mirrors the subprocess executor's interface: returns
-    ``{"body": ..., "log": ..., "error": ...}``.
+
+def _get_image_key(config: "LambdaConfigType") -> str:
+    "Get a unique path for a lambda with package type image"
+    if (image_uri := config.get("ImageUri")) is None:
+        raise ValueError("ImageUri is required for Image package type")
+    version = config["Version"]
+    return f"/var/task/{image_uri}/{version}"
+
+
+def _execute_function_docker_rie(func: LambdaFunc, event: dict, async_mode: bool = True) -> dict:
     """
-    config = func.get("config") or func
-    runtime = config.get("Runtime", "python3.12")
-
+    Execute docker using AWS Runtime Interface Emulator (RIE). This allows us to
+    run the Lambda function in an environment very close to the actual Lambda
+    runtime, using the same base images and emulation layer as AWS.
+    If there is a running one, which is not doing something, we will
+    reuse it.
+    """
     if not _docker_available:
-        
-        if runtime.startswith("python") or runtime.startswith("nodejs"):
-            logger.warning("docker SDK unavailable - falling back to warm executor (node/py detected)")
-            return _execute_function_warm(func, event)
-
-        logger.warning("docker SDK unavailable - falling back to local subprocess executor")
-        return _execute_function_local(func, event)
-
-    code_zip = func.get("code_zip")
-    if not code_zip:
-        return {"body": {"statusCode": 200, "body": "Mock response - no code deployed"}}
-
-    handler = config["Handler"]
-    timeout = config.get("Timeout", 3)
-    env_vars = config.get("Environment", {}).get("Variables", {})
-
-    image = _docker_image_for_runtime(runtime)
-    if image is None:
         return {
             "body": {
-                "statusCode": 200,
-                "body": f"Mock response - {runtime} not supported for docker execution",
+                "errorMessage": "Docker is required for Image-based Lambda functions",
+                "errorType": "Runtime.DockerUnavailable",
             },
+            "error": True,
         }
+    config = func["config"]
+    func_name = config["FunctionName"]
+    version = config["Version"]
+    # Need to modify key for package type image.
+    container_key = _get_function_code(config) if config["PackageType"] == "Zip" else _get_image_key(config)
+    with _containers_lock:
+        _containers.setdefault(container_key, [])
+        # Gert a local copy
+        containers = _containers[container_key].copy()
 
-    is_provided = runtime.startswith("provided")
-    is_node = runtime.startswith("nodejs")
-    if not runtime.startswith("python") and not is_node and not is_provided:
-        return {
-            "body": {
-                "statusCode": 200,
-                "body": f"Mock response - {runtime} docker wrapper only supports Python, Node.js, and provided runtimes",
-            },
-        }
+    # Shuffle order to divide the load
+    random.shuffle(containers)
 
-    try:
-        client = docker_lib.from_env()
-    except Exception as exc:
-        logger.warning("Cannot connect to Docker daemon (%s) – falling back to local subprocess", exc)
-        return _execute_function_local(func, event)
+    for container in containers:
+        container.reload()
+        if container.status == "running":
+            try:
+                ret = _invoke_function_in_running_container(container, event, async_mode=async_mode, tries=1)
+                logger.info("Successfully reused container for function %s (version: %s)", func_name, version)
+                return ret
+            except Exception as e:
+                logger.info(
+                    "Could not reuse container (most likely busy) for function %s (version: %s): %s",
+                    func_name,
+                    version,
+                    e,
+                )
+    container, ret = _invoke_function_in_container(func, event, async_mode=async_mode)
+    if container:
+        with _containers_lock:
+            _containers[container_key].append(container)
+    logger.info("Started container for function %s (version: %s)", func_name, version)
+    return ret
 
-    container = None
-    try:
-        with tempfile.TemporaryDirectory() as tmpdir:
-            # Extract code zip
-            zip_path = os.path.join(tmpdir, "code.zip")
-            with open(zip_path, "wb") as f:
-                f.write(code_zip)
-            code_dir = os.path.join(tmpdir, "code")
-            os.makedirs(code_dir)
-            with zipfile.ZipFile(zip_path) as zf:
-                zf.extractall(code_dir)
 
-            # Extract layers
-            layers_dirs: list[str] = []
-            for layer_ref in config.get("Layers", []):
-                layer_arn_str = layer_ref if isinstance(layer_ref, str) else layer_ref.get("Arn", "")
-                layer_zip = _resolve_layer_zip(layer_arn_str)
-                if layer_zip:
-                    layer_dir = os.path.join(tmpdir, f"layer_{len(layers_dirs)}")
-                    os.makedirs(layer_dir)
-                    lzip_path = os.path.join(tmpdir, f"layer_{len(layers_dirs)}.zip")
-                    with open(lzip_path, "wb") as lf:
-                        lf.write(layer_zip)
-                    with zipfile.ZipFile(lzip_path) as lzf:
-                        lzf.extractall(layer_dir)
-                    layers_dirs.append(layer_dir)
+def _get_aws_endpoint_url() -> str | None:
+    return _normalize_endpoint_url(
+        os.environ.get(
+            "AWS_ENDPOINT_URL",
+            _normalize_endpoint_url(
+                os.environ.get("AWS_ENDPOINT_URL", _normalize_endpoint_url(os.environ.get("LOCALSTACK_HOSTNAME", "")))
+            ),
+        )
+    )
 
-            if not is_provided:
-                if "." not in handler:
-                    return {"body": {"errorMessage": f"Invalid handler format: {handler}", "errorType": "Runtime.InvalidEntrypoint"}, "error": True}
-                module_name, func_name = handler.rsplit(".", 1)
 
-            # Build volume mounts
-            volumes: dict = {}
-            host_code_dir = LAMBDA_DOCKER_VOLUME_MOUNT or code_dir
-            volumes[host_code_dir] = {"bind": "/var/task", "mode": "ro"}
+def _invoke_function_in_container(
+    func: LambdaFunc, event: dict, async_mode: bool = True, tries=5
+) -> "tuple[Container | None, dict]":
+    config = func["config"]
+    func_name = config["FunctionName"]
+    runtime = config["Runtime"]
+    sha256 = config["CodeSha256"]
+    code_zip = func["code_zip"]
 
-            container_layer_dirs: list[str] = []
-            for idx, ld in enumerate(layers_dirs):
-                container_path = f"/opt/layer_{idx}"
-                volumes[ld] = {"bind": container_path, "mode": "ro"}
-                container_layer_dirs.append(container_path)
+    running_ministack_in_container = os.path.exists("/run/.containerenv") or os.path.exists("/.dockerenv")
 
-            # Build environment
-            container_env: dict[str, str] = {
-                "AWS_DEFAULT_REGION": REGION,
-                "AWS_REGION": REGION,
-                "AWS_ACCESS_KEY_ID": os.environ.get("AWS_ACCESS_KEY_ID", "test"),
-                "AWS_SECRET_ACCESS_KEY": os.environ.get("AWS_SECRET_ACCESS_KEY", "test"),
-                "AWS_SESSION_TOKEN": os.environ.get("AWS_SESSION_TOKEN", ""),
-                "AWS_LAMBDA_FUNCTION_NAME": config["FunctionName"],
-                "AWS_LAMBDA_FUNCTION_MEMORY_SIZE": str(config["MemorySize"]),
-                "AWS_LAMBDA_FUNCTION_VERSION": config.get("Version", "$LATEST"),
-                "AWS_LAMBDA_LOG_STREAM_NAME": new_uuid(),
-                "_LAMBDA_FUNCTION_ARN": config["FunctionArn"],
-                "_LAMBDA_TIMEOUT": str(timeout),
-                "_LAMBDA_LAYERS_DIRS": ":".join(container_layer_dirs),
-            }
-            if not is_provided:
-                container_env["_LAMBDA_HANDLER_MODULE"] = module_name
-                container_env["_LAMBDA_HANDLER_FUNC"] = func_name
-            else:
-                container_env["LAMBDA_TASK_ROOT"] = "/var/task"
-                container_env["_HANDLER"] = handler
-            container_env.update(env_vars)
-            # Override AWS_ENDPOINT_URL *after* function env vars so the
-            # Lambda container always calls back to this MiniStack
-            # instance, not a host-mapped port.
-            endpoint = _normalize_endpoint_url(os.environ.get("AWS_ENDPOINT_URL", ""))
-            if not endpoint:
-                endpoint = _normalize_endpoint_url(env_vars.get("AWS_ENDPOINT_URL", ""))
-            if not endpoint:
-                endpoint = _normalize_endpoint_url(env_vars.get("LOCALSTACK_HOSTNAME", ""))
-            if endpoint:
-                container_env["AWS_ENDPOINT_URL"] = endpoint
-
-            event_file = os.path.join(code_dir, "_event.json")
-            with open(event_file, "w") as ef:
-                ef.write(json.dumps(event))
-
-            if is_provided:
-                # provided runtimes: use AWS Lambda RIE built into the provided image.
-                # The RIE entrypoint runs /var/runtime/bootstrap, while user
-                # code is expected at /var/task.  Mount the code dir to both
-                # paths using docker.types.Mount (the volumes dict can't bind
-                # the same host path to two container paths).
-                import urllib.request
-                bootstrap_path = os.path.join(code_dir, "bootstrap")
-                if os.path.exists(bootstrap_path):
-                    os.chmod(bootstrap_path, 0o755)
-                mounts = [
-                    docker_lib.types.Mount("/var/task", host_code_dir, type="bind", read_only=True),
-                    docker_lib.types.Mount("/var/runtime", host_code_dir, type="bind", read_only=True),
-                ]
-                for idx, ld in enumerate(layers_dirs):
-                    mounts.append(docker_lib.types.Mount(f"/opt/layer_{idx}", ld, type="bind", read_only=True))
-                run_kwargs: dict = {
-                    "image": image, "command": ["bootstrap"],
-                    "environment": container_env, "mounts": mounts,
-                    "ports": {"8080/tcp": None}, "detach": True, "stdin_open": False,
-                }
-                if LAMBDA_DOCKER_NETWORK:
-                    run_kwargs["network"] = LAMBDA_DOCKER_NETWORK
-                container = client.containers.run(**run_kwargs)
-                try:
-                    import time as _time
-                    for _attempt in range(30):
-                        _time.sleep(0.5)
-                        container.reload()
-                        if container.status != "running":
-                            break
-                        try:
-                            if LAMBDA_DOCKER_NETWORK:
-                                networks = container.attrs.get("NetworkSettings", {}).get("Networks", {})
-                                container_ip = networks.get(LAMBDA_DOCKER_NETWORK, {}).get("IPAddress", "")
-                                if container_ip:
-                                    rie_url = f"http://{container_ip}:8080/2015-03-31/functions/function/invocations"
-                                else:
-                                    continue
-                            else:
-                                ports = container.ports.get("8080/tcp") or []
-                                if not ports:
-                                    continue
-                                rie_url = f"http://127.0.0.1:{ports[0]['HostPort']}/2015-03-31/functions/function/invocations"
-                            req = urllib.request.Request(rie_url, data=json.dumps(event).encode(),
-                                                        headers={"Content-Type": "application/json"})
-                            resp = urllib.request.urlopen(req, timeout=timeout)
-                            body = resp.read().decode("utf-8", errors="replace")
-                            try:
-                                parsed = json.loads(body)
-                            except json.JSONDecodeError:
-                                parsed = body
-                            logs = container.logs(stdout=True, stderr=True).decode("utf-8", errors="replace").strip()
-                            return {"body": parsed, "log": logs}
-                        except (urllib.error.URLError, ConnectionRefusedError, OSError):
-                            continue
-                    stdout = container.logs(stdout=True, stderr=True).decode("utf-8", errors="replace").strip()
-                    return {"body": {"errorMessage": f"provided runtime failed: {stdout[:500]}", "errorType": "Runtime.ExitError"}, "error": True, "log": stdout}
-                finally:
-                    try:
-                        container.stop(timeout=2)
-                    except Exception:
-                        pass
-                    try:
-                        container.remove(force=True)
-                    except Exception:
-                        pass
-            elif is_node:
-                wrapper_path = os.path.join(code_dir, "_wrapper.js")
-                with open(wrapper_path, "w") as wf:
-                    wf.write(_NODE_WRAPPER_SCRIPT)
-                run_cmd = ["sh", "-c", "node /var/task/_wrapper.js < /var/task/_event.json"]
-            else:
-                wrapper_path = os.path.join(code_dir, "_wrapper.py")
-                with open(wrapper_path, "w") as wf:
-                    wf.write(_DOCKER_WRAPPER_SCRIPT)
-                run_cmd = ["sh", "-c", "python3 /var/task/_wrapper.py < /var/task/_event.json"]
-
-            container = client.containers.run(
-                image,
-                command=run_cmd,
-                environment=container_env,
-                volumes=volumes,
-                network_mode="host",
-                detach=True,
-                stdin_open=False,
-            )
-
-            result = container.wait(timeout=timeout)
-            exit_code = result.get("StatusCode", -1)
-            stdout = container.logs(stdout=True, stderr=False).decode("utf-8", errors="replace").strip()
-            stderr = container.logs(stdout=False, stderr=True).decode("utf-8", errors="replace").strip()
-
-            if exit_code == 0:
-                if not stdout:
-                    return {"body": None, "log": stderr}
-                try:
-                    return {"body": json.loads(stdout), "log": stderr}
-                except json.JSONDecodeError:
-                    return {"body": stdout, "log": stderr}
-            else:
-                return {
+    mounts = []
+    env_vars = config["Environment"].get("Variables") or {}
+    match config["PackageType"]:
+        case "Zip":
+            image = _RUNTIME_IMAGE_MAP[runtime]
+            if code_zip is None:
+                return None, {
                     "body": {
-                        "errorMessage": stderr or "Unknown error",
-                        "errorType": "Runtime.HandlerError",
+                        "errorMessage": "No code found for Zip package type",
+                        "errorType": "Runtime.NoCode",
                     },
                     "error": True,
-                    "log": stderr,
+                }
+            function_code = _get_function_code(config)
+            # We need volume mount for the code.
+            if not LAMBDA_DOCKER_VOLUME_MOUNT:
+                return None, {
+                    "body": {
+                        "errorMessage": "LAMBDA_DOCKER_VOLUME_MOUNT must be set to use lambda Docker execution",
+                        "errorType": "Runtime.MissingConfiguration",
+                    },
+                    "error": True,
                 }
 
-    except Exception as exc:
-        if "timed out" in str(exc).lower() or "read timed out" in str(exc).lower():
-            return {
-                "body": {
-                    "errorMessage": f"Task timed out after {timeout}.00 seconds",
-                    "errorType": "Runtime.ExitError",
-                },
-                "error": True,
-                "log": "",
-            }
-        logger.error("Lambda docker execution error: %s", exc)
-        return {
-            "body": {"errorMessage": str(exc), "errorType": type(exc).__name__},
-            "error": True,
-            "log": "",
+            if running_ministack_in_container and not LAMBDA_DOCKER_NETWORK:
+                raise RuntimeError(
+                    "LAMBDA_DOCKER_NETWORK must be set when running inside a container to use lambda Docker execution"
+                )
+            if not os.path.exists(function_code):
+                os.makedirs(function_code)
+                with zipfile.ZipFile(io.BytesIO(code_zip)) as zf:
+                    zf.extractall(function_code)
+            # Need the mount to be read-write for RIE to work, but we can set the
+            # container side to read-only
+            mounts.append(
+                dict(
+                    type="volume",
+                    source=LAMBDA_DOCKER_VOLUME_MOUNT,
+                    target="/var/task",
+                    volume_subpath=function_code[1:],
+                    read_only=True,
+                )
+            )
+            function_code_abs = os.path.abspath(function_code)
+            env_vars.update(
+                {
+                    "LAMBDA_TASK_ROOT": function_code_abs,
+                    "AWS_LAMBDA_FUNCTION_NAME": config["FunctionName"],
+                    "AWS_LAMBDA_FUNCTION_MEMORY_SIZE": str(config.get("MemorySize", 128)),
+                    "AWS_LAMBDA_FUNCTION_VERSION": config.get("Version", "$LATEST"),
+                }
+            )
+        case "Image":
+            image_uri = config.get("ImageUri")
+            # We need volume mount for the layers.
+            if config["Layers"] and not LAMBDA_DOCKER_VOLUME_MOUNT:
+                return None, {
+                    "body": {
+                        "errorMessage": "LAMBDA_DOCKER_VOLUME_MOUNT must be set to use lambda Docker execution",
+                        "errorType": "Runtime.MissingConfiguration",
+                    },
+                    "error": True,
+                }
+            if not image_uri:
+                return None, {
+                    "body": {
+                        "errorMessage": "ImageUri is required for Image package type",
+                        "errorType": "InvalidConfiguration",
+                    },
+                    "error": True,
+                }
+            image = image_uri
+            env_vars = {}
+
+    def _wait_for_container_running(container: "Container", timeout: int = 30, interval: float = 0.2):
+        start = time.time()
+        while time.time() - start < timeout:
+            container.reload()
+            if container.status == "running":
+                break
+            time.sleep(interval)
+        else:
+            raise TimeoutError("Container did not reach running state")
+
+    # If we have layers, we need to extract them and mount them under /opt
+    if config.get("Layers"):
+        function_layers = f"/var/task/{func_name}/{sha256}-layers"
+        if not os.path.exists(function_layers):
+            os.mkdir(function_layers)
+            for layer_ref in config["Layers"]:
+                layer_arn_str = layer_ref.get("Arn", "")
+                layer_zip = _resolve_layer_zip(layer_arn_str)
+                if layer_zip:
+                    layer_name = function_layers + "/" + layer_arn_str.split(":")[-1]
+                    with zipfile.ZipFile(io.BytesIO(layer_zip)) as zf:
+                        zf.extractall(layer_name)
+
+        mounts.append(
+            dict(
+                type="volume",
+                source=LAMBDA_DOCKER_VOLUME_MOUNT,
+                target="/opt",
+                volume_subpath=function_layers[1:],
+                read_only=True,
+            )
+        )
+    # Set the task root
+    env_vars.update(
+        {
+            "AWS_DEFAULT_REGION": REGION,
+            "AWS_REGION": REGION,
+            "AWS_ACCESS_KEY_ID": os.environ.get("AWS_ACCESS_KEY_ID", "test"),
+            "AWS_SECRET_ACCESS_KEY": os.environ.get("AWS_SECRET_ACCESS_KEY", "test"),
+            "AWS_LAMBDA_LOG_STREAM_NAME": new_uuid(),
         }
-    finally:
-        if container is not None:
+    )
+    if endpoint := _get_aws_endpoint_url():
+        env_vars["AWS_ENDPOINT_URL"] = endpoint
+    container_port = "8080"
+    # mounts is not documented, therefore use kwargs.
+    run_kwargs: dict = {
+        "image": image,
+        "environment": env_vars,
+        "mounts": mounts,
+        "mem_limit": f"{config['MemorySize']}m",
+        "detach": True,
+        "stdin_open": False,
+    }
+    if running_ministack_in_container:
+        run_kwargs["network"] = LAMBDA_DOCKER_NETWORK
+    else:
+        run_kwargs["network_mode"] = "host"
+        run_kwargs["ports"] = {f"{container_port}/tcp": None}
+
+    client = docker_lib.from_env()
+    container: "Container" = client.containers.run(
+        command=[config["Handler"]], name=f"lambda_{random.randbytes(8).hex()}", **run_kwargs
+    )
+    _wait_for_container_running(container)
+    return container, _invoke_function_in_running_container(container, event, async_mode=async_mode, tries=tries)
+
+
+def _invoke_function_in_running_container(
+    container: "Container", event: dict, async_mode: bool = True, tries=5
+) -> dict:
+    import urllib.request
+    import urllib.error
+
+    container_port = "8080"
+    running_ministack_in_container = os.path.exists("/run/.containerenv") or os.path.exists("/.dockerenv")
+    localstack_hostname = os.getenv("LOCALSTACK_HOSTNAME") or "localhost"
+    if running_ministack_in_container:
+        host_name = container.name
+        host_port = container_port
+    else:
+        ports = container.ports[container_port]
+        host_port = ports[0]["HostPort"]
+        host_name = localstack_hostname
+    headers = {
+        "Content-Type": "application/json",
+    }
+    if async_mode:
+        headers["X-Amz-Invocation-Type"] = "Event"
+    try:
+        for retry in range(tries):
+            time.sleep(0.1 * (2**retry))
             try:
-                container.remove(force=True)
-            except Exception:
-                pass
+                rie_url = f"http://{host_name}:{host_port}/2015-03-31/functions/function/invocations"
+                req = urllib.request.Request(rie_url, data=json.dumps(event).encode(), headers=headers)
+                resp = urllib.request.urlopen(req)
+                body = resp.read().decode("utf-8", errors="replace")
+                try:
+                    ret = {"body": json.loads(body)}
+                except json.JSONDecodeError:
+                    ret = {"body": body}
+
+                if async_mode:
+                    logs = container.logs(stdout=True, stderr=True).decode("utf-8", errors="replace").strip()
+                    ret["log"] = logs
+                logger.debug("Invocation successful for container %s: %s", container.name, ret)
+                return ret
+            except (urllib.error.URLError, ConnectionRefusedError, OSError):
+                logger.debug("Failed to connect to RIE endpoint, retrying... (%d)", retry + 1)
+        else:
+            raise Exception("Failed to connect to RIE endpoint after multiple retries")
+    except (urllib.error.URLError, ConnectionRefusedError, OSError):
+        stdout = container.logs(stdout=True, stderr=True).decode("utf-8", errors="replace").strip()
+        return {
+            "body": {"errorMessage": f"provided runtime failed: {stdout[:500]}", "errorType": "Runtime.ExitError"},
+            "error": True,
+            "log": stdout,
+        }
 
 
 # ---------------------------------------------------------------------------
@@ -1315,19 +1217,14 @@ def _execute_function_docker(func: dict, event: dict) -> dict:
 # ---------------------------------------------------------------------------
 
 
-def _execute_function(func: dict, event: dict) -> dict:
+def _execute_function(func: dict, event: dict, async_mode: bool = True) -> dict:
     """Dispatch to warm worker pool (Python + Node.js) or Docker executor."""
-    config = func.get("config") or func
-
-    # Image-based Lambda — always Docker
-    if config.get("PackageType") == "Image" and config.get("ImageUri"):
-        return _execute_function_image(func, event)
-
-    runtime = config.get("Runtime", "python3.12")
 
     if LAMBDA_EXECUTOR == "docker":
-        return _execute_function_docker(func, event)
+        return _execute_function_docker_rie(func, event, async_mode=async_mode)  # type: ignore
 
+    config: LambdaConfigType = func["config"]
+    runtime = config.get("Runtime", "python3.9")
     # provided runtimes (Go, Rust, etc.) — use native binary execution
     if runtime.startswith("provided"):
         return _execute_function_provided(func, event)
@@ -1369,116 +1266,6 @@ def _execute_function_warm(func: dict, event: dict) -> dict:
         }
 
 
-# ---------------------------------------------------------------------------
-# Function execution – Docker Image mode (PackageType: Image)
-# ---------------------------------------------------------------------------
-
-
-def _execute_function_image(func: dict, event: dict) -> dict:
-    """Execute a Lambda function from a user-provided Docker image.
-
-    The image must contain the Lambda Runtime Interface Client (RIC) or
-    Runtime Interface Emulator (RIE) listening on port 8080.
-    """
-    if not _docker_available:
-        return {"body": {"errorMessage": "Docker is required for Image-based Lambda functions", "errorType": "Runtime.DockerUnavailable"}, "error": True}
-
-    config = func.get("config") or func
-    image_uri = config.get("ImageUri", "")
-    timeout = config.get("Timeout", 30)
-    env_vars = config.get("Environment", {}).get("Variables", {})
-
-    try:
-        client = docker_lib.from_env()
-    except Exception as exc:
-        return {"body": {"errorMessage": f"Cannot connect to Docker: {exc}", "errorType": "Runtime.DockerError"}, "error": True}
-
-    # Use image locally if available, otherwise pull
-    try:
-        client.images.get(image_uri)
-        logger.info("Using local Lambda image: %s", image_uri)
-    except docker_lib.errors.ImageNotFound:
-        try:
-            logger.info("Pulling Lambda image: %s", image_uri)
-            client.images.pull(image_uri)
-        except Exception as exc:
-            return {"body": {"errorMessage": f"Failed to pull image {image_uri}: {exc}", "errorType": "Runtime.ImagePullError"}, "error": True}
-
-    container_env = {
-        "AWS_DEFAULT_REGION": REGION,
-        "AWS_REGION": REGION,
-        "AWS_ACCESS_KEY_ID": os.environ.get("AWS_ACCESS_KEY_ID", "test"),
-        "AWS_SECRET_ACCESS_KEY": os.environ.get("AWS_SECRET_ACCESS_KEY", "test"),
-        "AWS_LAMBDA_FUNCTION_NAME": config["FunctionName"],
-        "AWS_LAMBDA_FUNCTION_MEMORY_SIZE": str(config.get("MemorySize", 128)),
-        "AWS_LAMBDA_FUNCTION_VERSION": config.get("Version", "$LATEST"),
-        "AWS_LAMBDA_LOG_STREAM_NAME": new_uuid(),
-    }
-    container_env.update(env_vars)
-    # Override AWS_ENDPOINT_URL *after* function env vars so the
-    # Lambda container always calls back to this MiniStack instance.
-    endpoint = _normalize_endpoint_url(os.environ.get("AWS_ENDPOINT_URL", ""))
-    if not endpoint:
-        endpoint = _normalize_endpoint_url(env_vars.get("AWS_ENDPOINT_URL", ""))
-    if endpoint:
-        container_env["AWS_ENDPOINT_URL"] = endpoint
-
-    run_kwargs = {
-        "image": image_uri,
-        "environment": container_env,
-        "ports": {"8080/tcp": None},
-        "detach": True,
-    }
-    if LAMBDA_DOCKER_NETWORK:
-        run_kwargs["network"] = LAMBDA_DOCKER_NETWORK
-
-    container = client.containers.run(**run_kwargs)
-    try:
-        import time as _time
-        import urllib.request
-        for _attempt in range(int(timeout * 2) + 10):
-            _time.sleep(0.5)
-            container.reload()
-            if container.status != "running":
-                break
-            try:
-                if LAMBDA_DOCKER_NETWORK:
-                    networks = container.attrs.get("NetworkSettings", {}).get("Networks", {})
-                    container_ip = networks.get(LAMBDA_DOCKER_NETWORK, {}).get("IPAddress", "")
-                    if container_ip:
-                        rie_url = f"http://{container_ip}:8080/2015-03-31/functions/function/invocations"
-                    else:
-                        continue
-                else:
-                    ports = container.ports.get("8080/tcp") or []
-                    if not ports:
-                        continue
-                    rie_url = f"http://127.0.0.1:{ports[0]['HostPort']}/2015-03-31/functions/function/invocations"
-                req = urllib.request.Request(rie_url, data=json.dumps(event).encode(),
-                                            headers={"Content-Type": "application/json"})
-                resp = urllib.request.urlopen(req, timeout=timeout)
-                body = resp.read().decode("utf-8", errors="replace")
-                try:
-                    parsed = json.loads(body)
-                except json.JSONDecodeError:
-                    parsed = body
-                logs = container.logs(stdout=True, stderr=True).decode("utf-8", errors="replace").strip()
-                return {"body": parsed, "log": logs}
-            except (urllib.error.URLError, ConnectionRefusedError, OSError):
-                continue
-        stdout = container.logs(stdout=True, stderr=True).decode("utf-8", errors="replace").strip()
-        return {"body": {"errorMessage": f"Image Lambda failed: {stdout[:500]}", "errorType": "Runtime.ExitError"}, "error": True, "log": stdout}
-    finally:
-        try:
-            container.stop(timeout=2)
-        except Exception:
-            pass
-        try:
-            container.remove(force=True)
-        except Exception:
-            pass
-
-
 def _execute_function_provided(func: dict, event: dict) -> dict:
     """Execute a provided-runtime Lambda (Go/Rust binary) via a minimal Lambda Runtime API."""
     config = func.get("config") or func
@@ -1492,6 +1279,7 @@ def _execute_function_provided(func: dict, event: dict) -> dict:
     try:
         import http.server
         import socketserver
+
         with tempfile.TemporaryDirectory() as tmpdir:
             # Extract bootstrap binary
             zip_path = os.path.join(tmpdir, "code.zip")
@@ -1541,8 +1329,7 @@ def _execute_function_provided(func: dict, event: dict) -> dict:
                     if "/runtime/invocation/next" in self.path:
                         self.send_response(200)
                         self.send_header("Lambda-Runtime-Aws-Request-Id", request_id)
-                        self.send_header("Lambda-Runtime-Deadline-Ms",
-                                         str(int((time.time() + timeout) * 1000)))
+                        self.send_header("Lambda-Runtime-Deadline-Ms", str(int((time.time() + timeout) * 1000)))
                         self.send_header("Content-Type", "application/json")
                         self.end_headers()
                         self.wfile.write(event_json.encode())
@@ -1641,7 +1428,11 @@ def _execute_function_provided(func: dict, event: dict) -> dict:
                     try:
                         _, stderr_out = proc.communicate(timeout=5)
                         if stderr_out:
-                            logger.info("Lambda %s stderr: %s", config.get("FunctionName", "?"), stderr_out.decode("utf-8", errors="replace")[:500])
+                            logger.info(
+                                "Lambda %s stderr: %s",
+                                config.get("FunctionName", "?"),
+                                stderr_out.decode("utf-8", errors="replace")[:500],
+                            )
                     except Exception:
                         pass
                     if result_holder["error"]:
@@ -1654,7 +1445,13 @@ def _execute_function_provided(func: dict, event: dict) -> dict:
                     proc.kill()
                     stdout, stderr = proc.communicate(timeout=5)
                     logs = (stdout.decode("utf-8", errors="replace") + stderr.decode("utf-8", errors="replace")).strip()
-                    return {"body": {"errorMessage": f"Lambda timed out after {timeout}s: {logs[:500]}", "errorType": "Runtime.ExitError"}, "error": True}
+                    return {
+                        "body": {
+                            "errorMessage": f"Lambda timed out after {timeout}s: {logs[:500]}",
+                            "errorType": "Runtime.ExitError",
+                        },
+                        "error": True,
+                    }
             finally:
                 server.shutdown()
 
@@ -1723,7 +1520,13 @@ def _execute_function_local(func: dict, event: dict) -> dict:
                                 os.symlink(src, dst)
 
             if "." not in handler:
-                return {"body": {"errorMessage": f"Invalid handler format: {handler}", "errorType": "Runtime.InvalidEntrypoint"}, "error": True}
+                return {
+                    "body": {
+                        "errorMessage": f"Invalid handler format: {handler}",
+                        "errorType": "Runtime.InvalidEntrypoint",
+                    },
+                    "error": True,
+                }
             module_name, func_name = handler.rsplit(".", 1)
 
             if is_node:
@@ -2818,22 +2621,24 @@ def _poll_sqs():
         records = []
         for msg in batch:
             first_recv = msg.get("first_receive_at") or now
-            records.append({
-                "messageId": msg["id"],
-                "receiptHandle": msg["receipt_handle"],
-                "body": msg["body"],
-                "attributes": {
-                    "ApproximateReceiveCount": str(msg.get("receive_count", 1)),
-                    "SentTimestamp": str(int(msg["sent_at"] * 1000)),
-                    "SenderId": get_account_id(),
-                    "ApproximateFirstReceiveTimestamp": str(int(first_recv * 1000)),
-                },
-                "messageAttributes": msg.get("message_attributes", {}),
-                "md5OfBody": msg.get("md5_body") or msg.get("md5") or "",
-                "eventSource": "aws:sqs",
-                "eventSourceARN": source_arn,
-                "awsRegion": REGION,
-            })
+            records.append(
+                {
+                    "messageId": msg["id"],
+                    "receiptHandle": msg["receipt_handle"],
+                    "body": msg["body"],
+                    "attributes": {
+                        "ApproximateReceiveCount": str(msg.get("receive_count", 1)),
+                        "SentTimestamp": str(int(msg["sent_at"] * 1000)),
+                        "SenderId": get_account_id(),
+                        "ApproximateFirstReceiveTimestamp": str(int(first_recv * 1000)),
+                    },
+                    "messageAttributes": msg.get("message_attributes", {}),
+                    "md5OfBody": msg.get("md5_body") or msg.get("md5") or "",
+                    "eventSource": "aws:sqs",
+                    "eventSourceARN": source_arn,
+                    "awsRegion": REGION,
+                }
+            )
 
         event = {"Records": records}
         result = _execute_function(_functions[func_name], event)
@@ -2845,7 +2650,11 @@ def _poll_sqs():
             esm["LastProcessingResult"] = "FAILED"
             logger.warning(
                 "ESM: Lambda %s failed processing SQS batch from %s (errorType=%s errorMessage=%s)\n%s",
-                func_name, queue_name, err_type, err_msg, result.get("log", ""),
+                func_name,
+                queue_name,
+                err_type,
+                err_msg,
+                result.get("log", ""),
             )
         else:
             # Check for ReportBatchItemFailures — partial batch response
@@ -2876,8 +2685,13 @@ def _poll_sqs():
             n_failed = len(batch) - len(succeeded)
             if n_failed:
                 esm["LastProcessingResult"] = f"OK - {len(succeeded)} records, {n_failed} partial failures"
-                logger.info("ESM: Lambda %s processed %d SQS messages from %s (%d partial failures)",
-                            func_name, len(succeeded), queue_name, n_failed)
+                logger.info(
+                    "ESM: Lambda %s processed %d SQS messages from %s (%d partial failures)",
+                    func_name,
+                    len(succeeded),
+                    queue_name,
+                    n_failed,
+                )
             else:
                 esm["LastProcessingResult"] = f"OK - {len(batch)} records"
                 logger.info("ESM: Lambda %s processed %d SQS messages from %s", func_name, len(batch), queue_name)
@@ -2924,7 +2738,7 @@ def _poll_kinesis():
                 continue
 
             pos = positions[shard_id]
-            raw_records = shard["records"][pos:pos + batch_size]
+            raw_records = shard["records"][pos : pos + batch_size]
             if not raw_records:
                 continue
 
@@ -2942,22 +2756,24 @@ def _poll_kinesis():
                 else:
                     data_b64 = base64.b64encode(str(data_val).encode("utf-8")).decode("ascii")
 
-                records.append({
-                    "kinesis": {
-                        "kinesisSchemaVersion": "1.0",
-                        "partitionKey": r["PartitionKey"],
-                        "sequenceNumber": r["SequenceNumber"],
-                        "data": data_b64,
-                        "approximateArrivalTimestamp": r["ApproximateArrivalTimestamp"],
-                    },
-                    "eventSource": "aws:kinesis",
-                    "eventVersion": "1.0",
-                    "eventID": f"{shard_id}:{r['SequenceNumber']}",
-                    "eventName": "aws:kinesis:record",
-                    "invokeIdentityArn": f"arn:aws:iam::{get_account_id()}:role/lambda-role",
-                    "awsRegion": REGION,
-                    "eventSourceARN": source_arn,
-                })
+                records.append(
+                    {
+                        "kinesis": {
+                            "kinesisSchemaVersion": "1.0",
+                            "partitionKey": r["PartitionKey"],
+                            "sequenceNumber": r["SequenceNumber"],
+                            "data": data_b64,
+                            "approximateArrivalTimestamp": r["ApproximateArrivalTimestamp"],
+                        },
+                        "eventSource": "aws:kinesis",
+                        "eventVersion": "1.0",
+                        "eventID": f"{shard_id}:{r['SequenceNumber']}",
+                        "eventName": "aws:kinesis:record",
+                        "invokeIdentityArn": f"arn:aws:iam::{get_account_id()}:role/lambda-role",
+                        "awsRegion": REGION,
+                        "eventSourceARN": source_arn,
+                    }
+                )
 
             event = {"Records": records}
             result = _execute_function(_functions[func_name], event)
@@ -2969,7 +2785,12 @@ def _poll_kinesis():
                 esm["LastProcessingResult"] = "FAILED"
                 logger.warning(
                     "ESM: Lambda %s failed processing Kinesis batch from %s/%s (errorType=%s errorMessage=%s)\n%s",
-                    func_name, stream_name, shard_id, err_type, err_msg, result.get("log", ""),
+                    func_name,
+                    stream_name,
+                    shard_id,
+                    err_type,
+                    err_msg,
+                    result.get("log", ""),
                 )
             else:
                 positions[shard_id] = pos + len(raw_records)
@@ -2979,7 +2800,10 @@ def _poll_kinesis():
                     logger.info("ESM: Lambda %s output:\n%s", func_name, log_output)
                 logger.info(
                     "ESM: Lambda %s processed %d Kinesis records from %s/%s",
-                    func_name, len(raw_records), stream_name, shard_id,
+                    func_name,
+                    len(raw_records),
+                    stream_name,
+                    shard_id,
                 )
 
 
@@ -3018,7 +2842,7 @@ def _poll_dynamodb_streams():
             pos = _dynamodb_stream_positions[esm_id]
 
         batch_size = esm.get("BatchSize", 100)
-        batch = table_records[pos:pos + batch_size]
+        batch = table_records[pos : pos + batch_size]
         if not batch:
             continue
 
@@ -3032,7 +2856,11 @@ def _poll_dynamodb_streams():
             esm["LastProcessingResult"] = "FAILED"
             logger.warning(
                 "ESM: Lambda %s failed processing DynamoDB stream batch from %s (errorType=%s errorMessage=%s)\n%s",
-                func_name, table_name, err_type, err_msg, result.get("log", ""),
+                func_name,
+                table_name,
+                err_type,
+                err_msg,
+                result.get("log", ""),
             )
         else:
             with _dynamodb_stream_positions_lock:
@@ -3043,7 +2871,9 @@ def _poll_dynamodb_streams():
                 logger.info("ESM: Lambda %s output:\n%s", func_name, log_output)
             logger.info(
                 "ESM: Lambda %s processed %d DynamoDB stream records from %s",
-                func_name, len(batch), table_name,
+                func_name,
+                len(batch),
+                table_name,
             )
 
 
@@ -3121,4 +2951,5 @@ def reset():
     _function_urls.clear()
     _kinesis_positions.clear()
     _dynamodb_stream_positions.clear()
+    _containers.clear()
     lambda_runtime.reset()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dev = [
     "psycopg2-binary>=2.9",
     "pymysql>=1.1",
     "ruff>=0.4",
+    "mypy-boto3-lambda (>=1.42.85,<2.0.0)",
 ]
 
 [project.urls]
@@ -87,3 +88,4 @@ ignore = [
 [tool.coverage.run]
 source = ["ministack"]
 omit = ["tests/*"]
+


### PR DESCRIPTION
Currently a mix of docker runtime images is used, which has the following disadvantages.
* Using wrappers to start the code
* Does not mimic close enough to what AWS does
* Incompatible libraries, libs for slim are not the same as for AWS images
* Not a unified way of running AWS lambdas
Single advantage is speed, a slim image for python much smaller.

In this branch unified the lambda handling by always using the AWS docker images with RIE (Runtime Interface Emulator).
Named volumes (sub paths) are mounted for the code (/var/task) and for layers (/opt).
There should be not difference in running a python or a nodejs container.