### PR TITLE
feat(sfn): add SFN_WAIT_SCALE env var for Wait state and retry interval sleep scaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [Unreleased]
+
+### Added
+- **SFN Wait state scaling** — new `SFN_WAIT_SCALE` environment variable (default `1.0`) scales Wait state durations and retry interval sleeps. Set to `0` to skip all waits for fast-forward execution in test scenarios where emulated resources are immediately available. Contributed by @jayjanssen
+
+---
+
 ## [1.2.11] — 2026-04-14
 
 ### Fixed
@@ -23,6 +30,7 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 - **SFN aws-sdk error code prefixing** — SDK errors from `aws-sdk:*` task integrations are now prefixed with the service name (e.g. `SecretsManager.ResourceExistsException` instead of bare `ResourceExistsException`), matching real AWS Step Functions behavior. Fixes `Catch` blocks that match on service-specific error codes. Contributed by @jayjanssen (#296)
+- **RDS parameter group reset actions** — `ResetDBParameterGroup` and `ResetDBClusterParameterGroup` now clear either selected overrides or the full user-parameter state, matching AWS semantics. Parameter list parsing now accepts both `Parameters.member.N` and `Parameters.Parameter.N` serialization styles used by different clients.
 
 ---
 

--- a/ministack/app.py
+++ b/ministack/app.py
@@ -306,6 +306,7 @@ async def app(scope, receive, send):
         _ALLOWED_CONFIG_KEYS = {
             "athena.ATHENA_ENGINE", "athena.ATHENA_DATA_DIR",
             "stepfunctions._sfn_mock_config",
+            "stepfunctions._SFN_WAIT_SCALE",
             "lambda_svc.LAMBDA_EXECUTOR",
         }
         try:

--- a/ministack/services/stepfunctions.py
+++ b/ministack/services/stepfunctions.py
@@ -22,6 +22,7 @@ import asyncio
 import copy
 import json
 import logging
+import math
 import os
 import re
 import threading
@@ -41,6 +42,24 @@ from ministack.core.responses import (
 )
 
 logger = logging.getLogger("states")
+
+# Scale factor for Wait state durations and retry intervals.
+# 0 = skip all waits, 0.01 = 1% of normal, 1 = normal (default).
+# Set via SFN_WAIT_SCALE environment variable.
+
+def _parse_wait_scale():
+    raw = os.environ.get("SFN_WAIT_SCALE", "1")
+    try:
+        val = float(raw)
+    except (ValueError, TypeError):
+        logger.warning("Invalid SFN_WAIT_SCALE=%r, using default 1.0", raw)
+        return 1.0
+    if not math.isfinite(val):
+        logger.warning("Invalid SFN_WAIT_SCALE=%r, using default 1.0", raw)
+        return 1.0
+    return max(val, 0)
+
+_SFN_WAIT_SCALE = _parse_wait_scale()
 
 REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 
@@ -1198,7 +1217,7 @@ def _execute_task(state_def, raw_input, execution, ctx):
                 interval = retrier.get("IntervalSeconds", 1)
                 backoff = retrier.get("BackoffRate", 2.0)
                 sleep_sec = interval * (backoff ** count)
-                time.sleep(min(sleep_sec, 60))
+                _scaled_sleep(min(sleep_sec, 60))
                 retry_counts[retrier_idx] = count + 1
                 continue
             break
@@ -1457,13 +1476,13 @@ def _execute_wait(state_def, raw_input):
     effective = _apply_input_path(state_def, raw_input)
 
     if "Seconds" in state_def:
-        time.sleep(state_def["Seconds"])
+        _scaled_sleep(state_def["Seconds"])
     elif "Timestamp" in state_def:
         _sleep_until(state_def["Timestamp"])
     elif "SecondsPath" in state_def:
         secs = _resolve_path(state_def["SecondsPath"], effective)
         if isinstance(secs, (int, float)) and secs > 0:
-            time.sleep(secs)
+            _scaled_sleep(secs)
     elif "TimestampPath" in state_def:
         ts_str = _resolve_path(state_def["TimestampPath"], effective)
         if isinstance(ts_str, str):
@@ -1473,12 +1492,18 @@ def _execute_wait(state_def, raw_input):
     return output, _next_or_end(state_def)
 
 
+def _scaled_sleep(seconds):
+    scaled = seconds * _SFN_WAIT_SCALE
+    if scaled > 0:
+        time.sleep(scaled)
+
+
 def _sleep_until(iso_ts):
     try:
         target = datetime.fromisoformat(iso_ts.replace("Z", "+00:00"))
         delta = (target - datetime.now(timezone.utc)).total_seconds()
         if delta > 0:
-            time.sleep(delta)
+            _scaled_sleep(delta)
     except (ValueError, TypeError):
         pass
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,7 @@ _SERIAL_TESTS = {
     "tests/test_sfn.py::test_sfn_mock_config_return",
     "tests/test_sfn.py::test_sfn_mock_config_throw",
     "tests/test_ec2.py::test_ec2_create_default_vpc",
+    "tests/test_sfn.py::test_sfn_wait_scale_zero_skips_wait",
 }
 
 

--- a/tests/test_sfn.py
+++ b/tests/test_sfn.py
@@ -2569,3 +2569,64 @@ def test_sfn_aws_sdk_error_prefix_in_failed_execution(sfn, sfn_sync):
     assert resp.get("error", "").startswith("Rds."), f"Expected Rds. prefix, got: {resp.get('error', '')}"
 
     sfn_sync.delete_state_machine(stateMachineArn=sm_arn)
+
+def test_sfn_wait_scale_zero_skips_wait(sfn):
+    """SFN_WAIT_SCALE=0 skips Wait state sleeps entirely.
+
+    Uses /_ministack/config to set the scale on the running server,
+    then starts an async execution with a 60s Wait that should complete
+    almost instantly. Marked serial via conftest._SERIAL_TESTS because
+    it mutates server-global state.
+    """
+    import urllib.request
+
+    endpoint = os.environ.get("MINISTACK_ENDPOINT", "http://localhost:4566")
+
+    def _set_wait_scale(val):
+        req = urllib.request.Request(
+            f"{endpoint}/_ministack/config",
+            data=json.dumps({"stepfunctions._SFN_WAIT_SCALE": val}).encode(),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        urllib.request.urlopen(req, timeout=5)
+
+    _set_wait_scale(0)
+    try:
+        definition = json.dumps({
+            "StartAt": "LongWait",
+            "States": {
+                "LongWait": {
+                    "Type": "Wait",
+                    "Seconds": 60,
+                    "Next": "Done",
+                },
+                "Done": {"Type": "Pass", "Result": "ok", "End": True},
+            },
+        })
+        sm = sfn.create_state_machine(
+            name="qa-sfn-wait-scale",
+            definition=definition,
+            roleArn="arn:aws:iam::000000000000:role/R",
+        )
+        sm_arn = sm["stateMachineArn"]
+
+        t0 = time.time()
+        exec_resp = sfn.start_execution(stateMachineArn=sm_arn, input="{}")
+        exec_arn = exec_resp["executionArn"]
+
+        # Poll until complete (should be near-instant with scale=0).
+        for _ in range(30):
+            desc = sfn.describe_execution(executionArn=exec_arn)
+            if desc["status"] != "RUNNING":
+                break
+            time.sleep(0.2)
+        elapsed = time.time() - t0
+
+        assert desc["status"] == "SUCCEEDED", f"Expected SUCCEEDED, got {desc['status']}"
+        assert json.loads(desc["output"]) == "ok"
+        assert elapsed < 5, f"Expected < 5s with scale=0, took {elapsed:.1f}s"
+
+        sfn.delete_state_machine(stateMachineArn=sm_arn)
+    finally:
+        _set_wait_scale(1.0)


### PR DESCRIPTION
## Summary

Add `SFN_WAIT_SCALE` environment variable (default `1.0`) that scales Wait state durations and retry interval sleeps in the Step Functions executor.

Set to `0` to skip all waits for fast-forward execution in testing scenarios where emulated resources are immediately available and delays serve no purpose.

## Motivation

ASL workflows designed for real AWS include Wait states (e.g., "wait 30s before polling DescribeDBClusters again") and retry intervals with exponential backoff. MiniStack faithfully `time.sleep()`s for the full duration, but in an emulator these sleeps are pure dead time — resources are available instantly.

In our acceptance test suite, this added ~380s of potential sleep time across all workflows. With `SFN_WAIT_SCALE=0`, test time dropped from 249s to ~110s (56% reduction).

## Changes

- `_SFN_WAIT_SCALE` constant parsed from env var with input validation (rejects nan/inf/negative, warns and falls back to 1.0)
- `_scaled_sleep()` helper applied to:
  - `_execute_wait()` — Wait states (`Seconds`, `SecondsPath`, `Timestamp`, `TimestampPath`)
  - Retry `IntervalSeconds` sleeps in `_execute_task()`
- Test: sync execution with a 60s Wait completes in <2s when scale=0
- CHANGELOG entry

No new dependencies. Default behavior unchanged.