### PR TITLE
fix: suppress noisy Lambda BrokenPipeError and RDS Data API import warning spam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- **Lambda Runtime API noise** — suppressed `BrokenPipeError` tracebacks from Lambda binaries disconnecting after reading the event. This is benign and expected behavior during native `provided` runtime execution.
+- **RDS Data API warning spam** — the `pymysql` import warning is now logged once per process instead of on every `ExecuteStatement` call.
+
+---
+
 ## [1.2.11] — 2026-04-14
 
 ### Fixed
@@ -14,7 +22,6 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 - **RDS DbiResourceId lookup** — `DescribeDBInstances` and other instance actions now accept `DbiResourceId` (e.g. `db-1AD581BD3647411AACBF`) in addition to the friendly `DBInstanceIdentifier`. Fixes Terraform/OpenTofu state refresh failures. Contributed by @alexanderkrum-next (#305)
 
 ---
-
 ## [1.2.10] — 2026-04-13
 
 ### Added

--- a/ministack/services/lambda_svc.py
+++ b/ministack/services/lambda_svc.py
@@ -1569,7 +1569,15 @@ def _execute_function_provided(func: dict, event: dict) -> dict:
                         self.end_headers()
 
             # Bind to port 0 — OS assigns a free port atomically, no race window
-            server = socketserver.TCPServer(("127.0.0.1", 0), RuntimeAPIHandler)
+            class _QuietTCPServer(socketserver.TCPServer):
+                def handle_error(self, request, client_address):
+                    import sys
+                    _, exc, _ = sys.exc_info()
+                    if isinstance(exc, (BrokenPipeError, ConnectionResetError, ConnectionAbortedError)):
+                        return
+                    super().handle_error(request, client_address)
+
+            server = _QuietTCPServer(("127.0.0.1", 0), RuntimeAPIHandler)
             port = server.server_address[1]
 
             def _serve():

--- a/ministack/services/rds_data.py
+++ b/ministack/services/rds_data.py
@@ -457,7 +457,9 @@ def _execute_statement(data):
     except ImportError as e:
         if own_conn and conn:
             conn.close()
-        logger.warning("DB driver not available, using stub: %s", e)
+        if not getattr(_execute_statement, "_import_warned", False):
+            logger.warning("DB driver not available, using stub: %s", e)
+            _execute_statement._import_warned = True
         return _stub_execute(resource_arn, sql)
     except Exception as e:
         if own_conn and conn:


### PR DESCRIPTION
## Summary

Two log noise fixes for cleaner output during testing:

### Lambda Runtime API — BrokenPipeError suppression

When MiniStack runs a Go Lambda binary via the native `provided` runtime executor, it spins up a minimal HTTP server implementing the Lambda Runtime API. The Go binary calls `GET /invocation/next` to receive the event, processes it, then posts the response and disconnects. Python's `socketserver.TCPServer` sees the closed socket and prints a full `BrokenPipeError` traceback to stderr. This is benign — the Lambda executed successfully — but pollutes logs.

Fix: subclass `TCPServer` with a `handle_error` override that suppresses only connection-related errors (`BrokenPipeError`, `ConnectionResetError`, `ConnectionAbortedError`). Other unexpected errors still surface normally.

### RDS Data API — pymysql import warning

When `pymysql` is not installed (the default in the official Docker image), `_execute_statement` falls back to SQL-aware stubs. Each call logs `WARNING: DB driver not available, using stub: ...`. During an acceptance test run this produces 300+ identical warnings.

Fix: log the warning once per process using a function-attribute guard (`_execute_statement._import_warned`).

## Changes

- `lambda_svc.py`: `_QuietTCPServer` subclass with filtered `handle_error`
- `rds_data.py`: one-shot import warning guard
- `CHANGELOG.md`: entry added

No new dependencies.