### PR TITLE
feat: bundle pymysql in Docker image for RDS Data API MySQL connectivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [Unreleased]
+
+### Added
+- **pymysql bundled in Docker image** — `pymysql` (44 KB, pure Python) is now installed in the official image, enabling the RDS Data API to connect to MySQL/Aurora MySQL containers that MiniStack already spawns for RDS instances. Previously required a custom image or fell back to in-memory stubs. Contributed by @jayjanssen
+
+---
+
 ## [1.2.11] — 2026-04-14
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN pip install --no-cache-dir --no-compile \
         "docker>=7.0.0" \
         "pyyaml>=6.0" \
         "cryptography>=41.0" \
+        "pymysql>=1.1" \
         "awscli"
 
 # Strip awscli help examples (~25 MB) and Python cache files (~15 MB).


### PR DESCRIPTION
## Summary

Add `pymysql>=1.1` to the Docker image's pip install. It's already listed in `pyproject.toml[full]` but was not installed in the Dockerfile.

## Why

MiniStack already spawns real `mysql:8` Docker containers when you create RDS instances/clusters. The RDS Data API service (`rds_data.py`, added in #193) already has full connection logic using `pymysql` — it just falls back to in-memory stubs because the package is missing from the image.

This is the only missing piece preventing real SQL execution against MiniStack's RDS containers via the Data API.

## Impact

- **Image size**: +44 KB (pure Python wheel, no C extensions)
- **No code changes**: `rds_data.py` already imports pymysql with a try/except guard
- **Backward compatible**: stubs still work as fallback when DB containers aren't reachable

## Note

There's a separate networking issue when MiniStack runs inside Docker — the spawned MySQL containers are siblings on the host Docker network, not reachable at `localhost` from inside the MiniStack container. That's a separate fix. This PR unblocks the case where MiniStack runs natively or when the networking is configured correctly.