### PR TITLE
feat(rds): real database connectivity via Docker networking and secret-aware auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [Unreleased]
+
+### Added
+- **RDS real MySQL/MariaDB connectivity** — `pymysql` (44 KB, pure Python) is now bundled in the Docker image. When MiniStack runs inside Docker, RDS containers are attached to MiniStack's Docker network with internal IP endpoints for sibling-container connectivity. The public `localhost` endpoint remains unchanged for host-mode access. The Data API authenticates using credentials from Secrets Manager, mapping the master user to MySQL `root` for admin operations. `CreateDBCluster` stores the master password; `CreateDBInstance` inherits credentials from parent clusters; `ModifyDBCluster` propagates password changes to the real MySQL container via `ALTER USER`.
+
+---
+
 ## [1.2.12] — 2026-04-14
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN pip install --no-cache-dir --no-compile \
         "docker>=7.0.0" \
         "pyyaml>=6.0" \
         "cryptography>=41.0" \
+        "pymysql>=1.1" \
         "awscli"
 
 # Strip awscli help examples (~25 MB) and Python cache files (~15 MB).

--- a/ministack/services/rds.py
+++ b/ministack/services/rds.py
@@ -28,6 +28,7 @@ import copy
 import datetime
 import logging
 import os
+import socket
 import time
 from urllib.parse import parse_qs
 from xml.sax.saxutils import escape as _esc
@@ -55,6 +56,7 @@ _tags = AccountScopedDict()
 _port_counter = [BASE_PORT]
 
 _docker = None
+_ministack_network = None
 
 
 # ── Persistence ────────────────────────────────────────────
@@ -114,6 +116,40 @@ def _get_docker():
         except Exception:
             pass
     return _docker
+
+
+def _get_ministack_network(docker_client):
+    """Detect the Docker network MiniStack is running on (if containerised)."""
+    global _ministack_network
+    if _ministack_network is not None:
+        return _ministack_network or None
+    try:
+        self_container = docker_client.containers.get(
+            os.environ.get("HOSTNAME", ""))
+        nets = list(
+            self_container.attrs["NetworkSettings"]["Networks"].keys())
+        if nets:
+            _ministack_network = nets[0]
+            logger.debug("RDS: detected MiniStack network: %s",
+                         _ministack_network)
+            return _ministack_network
+    except Exception:
+        logger.debug("RDS: could not detect MiniStack network, "
+                     "using localhost")
+    _ministack_network = ""
+    return None
+
+
+def _wait_for_port(host, port, timeout=60):
+    """Block until a TCP connection to host:port succeeds."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            with socket.create_connection((host, port), timeout=2):
+                return True
+        except OSError:
+            time.sleep(0.5)
+    return False
 
 
 def _next_port():
@@ -182,8 +218,21 @@ def _create_db_instance(p):
     db_class = _p(p, "DBInstanceClass") or "db.t3.micro"
     master_user = _p(p, "MasterUsername") or "admin"
     master_pass = _p(p, "MasterUserPassword") or "password"
-    db_name = _p(p, "DBName") or "mydb"
+    db_name = _p(p, "DBName") or ""
     port = int(_p(p, "Port") or _default_port(engine))
+
+    # Inherit credentials from cluster when instance is a cluster member.
+    cluster_id_param = _p(p, "DBClusterIdentifier")
+    if cluster_id_param and cluster_id_param in _clusters:
+        parent = _clusters[cluster_id_param]
+        if not _p(p, "MasterUsername"):
+            master_user = parent.get("MasterUsername", master_user)
+        if not _p(p, "MasterUserPassword"):
+            master_pass = parent.get("_MasterUserPassword", master_pass)
+        if not db_name:
+            db_name = parent.get("DatabaseName", "")
+    if not db_name:
+        db_name = "mydb"
     allocated_storage = int(_p(p, "AllocatedStorage") or "20")
     storage_type = _p(p, "StorageType") or "gp2"
     subnet_group_name = _p(p, "DBSubnetGroupName") or "default"
@@ -193,11 +242,14 @@ def _create_db_instance(p):
     endpoint_host = "localhost"
     endpoint_port = port
     docker_container_id = None
+    internal_host = None
+    internal_port = None
 
     docker_client = _get_docker()
     if docker_client:
         host_port = _next_port()
         endpoint_port = host_port
+        ms_network = _get_ministack_network(docker_client)
         image, env, container_port = _docker_image_for_engine(
             engine, engine_version, master_user, master_pass, db_name
         )
@@ -210,6 +262,8 @@ def _create_db_instance(p):
                     name=f"ministack-rds-{db_id}",
                     labels={"ministack": "rds", "db_id": db_id},
                 )
+                if ms_network:
+                    container_kwargs["network"] = ms_network
                 if RDS_PERSIST:
                     container_kwargs["volumes"] = {
                         f"ministack-rds-{db_id}-data": {"bind": "/var/lib/postgresql/data", "mode": "rw"},
@@ -222,7 +276,33 @@ def _create_db_instance(p):
                     }
                 container = docker_client.containers.run(**container_kwargs)
                 docker_container_id = container.id
-                logger.info("RDS: started %s container for %s on port %s", engine, db_id, host_port)
+                if ms_network:
+                    container.reload()
+                    networks = container.attrs.get(
+                        "NetworkSettings", {}).get("Networks", {})
+                    container_ip = networks.get(
+                        ms_network, {}).get("IPAddress", "")
+                    if container_ip:
+                        internal_host = container_ip
+                        internal_port = container_port
+                        if _wait_for_port(container_ip, container_port):
+                            logger.info(
+                                "RDS: %s container for %s ready at "
+                                "%s:%s (network %s)", engine, db_id,
+                                container_ip, container_port, ms_network)
+                        else:
+                            logger.warning(
+                                "RDS: %s container for %s at %s:%s "
+                                "not ready after timeout", engine,
+                                db_id, container_ip, container_port)
+                    else:
+                        logger.info(
+                            "RDS: started %s container for %s on port %s",
+                            engine, db_id, host_port)
+                else:
+                    logger.info(
+                        "RDS: started %s container for %s on port %s",
+                        engine, db_id, host_port)
             except Exception as e:
                 logger.warning("RDS: Docker failed for %s: %s", db_id, e)
 
@@ -325,6 +405,8 @@ def _create_db_instance(p):
         "IsStorageConfigUpgradeAvailable": False,
         "MultiTenant": False,
         "_docker_container_id": docker_container_id,
+        "_internal_address": internal_host,
+        "_internal_port": internal_port,
     }
     _instances[db_id] = instance
 
@@ -621,6 +703,8 @@ def _create_db_cluster(p):
     if not az_list:
         az_list = [f"{REGION}a", f"{REGION}b", f"{REGION}c"]
 
+    master_pass = _p(p, "MasterUserPassword") or "password"
+
     cluster = {
         "DBClusterIdentifier": cluster_id,
         "DBClusterArn": arn,
@@ -629,6 +713,7 @@ def _create_db_cluster(p):
         "EngineMode": _p(p, "EngineMode") or "provisioned",
         "Status": "available",
         "MasterUsername": master_user,
+        "_MasterUserPassword": master_pass,
         "DatabaseName": _p(p, "DatabaseName") or "",
         "Endpoint": f"{cluster_id}.cluster-{unique_suffix}.{REGION}.rds.amazonaws.com",
         "ReaderEndpoint": f"{cluster_id}.cluster-ro-{unique_suffix}.{REGION}.rds.amazonaws.com",
@@ -713,6 +798,40 @@ def _describe_db_clusters(p):
         f"<DescribeDBClustersResult><DBClusters>{members}</DBClusters></DescribeDBClustersResult>")
 
 
+def _rotate_real_password(cluster, old_pass, new_pass):
+    """Alter the root password on the real MySQL/MariaDB container."""
+    cluster_id = cluster.get("DBClusterIdentifier", "")
+    for inst in _instances.values():
+        if inst.get("DBClusterIdentifier") != cluster_id:
+            continue
+        engine = inst.get("Engine", "")
+        if not any(e in engine for e in ("mysql", "aurora-mysql", "mariadb")):
+            continue
+        host = inst.get("_internal_address")
+        port = inst.get("_internal_port")
+        if not host or not port:
+            endpoint = inst.get("Endpoint", {})
+            if not isinstance(endpoint, dict) or not endpoint.get("Port"):
+                continue
+            host = endpoint.get("Address", "localhost")
+            port = int(endpoint.get("Port", 3306))
+        try:
+            import pymysql
+            conn = pymysql.connect(
+                host=host, port=port, user="root",
+                password=old_pass, autocommit=True)
+            cur = conn.cursor()
+            cur.execute(
+                "ALTER USER 'root'@'%%' IDENTIFIED BY %s", (new_pass,))
+            cur.close()
+            conn.close()
+            logger.info("RDS: rotated root password on %s", cluster_id)
+        except Exception as e:
+            logger.warning("RDS: password rotation failed on %s: %s",
+                           cluster_id, e)
+        break
+
+
 def _modify_db_cluster(p):
     cluster_id = _p(p, "DBClusterIdentifier")
     cluster = _clusters.get(cluster_id)
@@ -722,7 +841,10 @@ def _modify_db_cluster(p):
     if _p(p, "EngineVersion"):
         cluster["EngineVersion"] = _p(p, "EngineVersion")
     if _p(p, "MasterUserPassword"):
-        pass
+        new_pass = _p(p, "MasterUserPassword")
+        old_pass = cluster.get("_MasterUserPassword", "password")
+        cluster["_MasterUserPassword"] = new_pass
+        _rotate_real_password(cluster, old_pass, new_pass)
     if _p(p, "Port"):
         cluster["Port"] = int(_p(p, "Port"))
     if _p(p, "BackupRetentionPeriod"):
@@ -2260,14 +2382,16 @@ def _docker_image_for_engine(engine, engine_version, user, password, db_name):
     if "mysql" in engine or "aurora-mysql" in engine:
         return (
             "mysql:8",
-            {"MYSQL_ROOT_PASSWORD": password, "MYSQL_DATABASE": db_name,
+            {"MYSQL_ROOT_PASSWORD": password, "MYSQL_ROOT_HOST": "%",
+             "MYSQL_DATABASE": db_name,
              "MYSQL_USER": user, "MYSQL_PASSWORD": password},
             3306,
         )
     if "mariadb" in engine:
         return (
             "mariadb:latest",
-            {"MYSQL_ROOT_PASSWORD": password, "MYSQL_DATABASE": db_name,
+            {"MYSQL_ROOT_PASSWORD": password, "MYSQL_ROOT_HOST": "%",
+             "MYSQL_DATABASE": db_name,
              "MYSQL_USER": user, "MYSQL_PASSWORD": password},
             3306,
         )

--- a/ministack/services/rds_data.py
+++ b/ministack/services/rds_data.py
@@ -225,8 +225,12 @@ def _resolve_cluster(resource_arn):
     return cluster, engine
 
 
-def _get_secret_password(secret_arn):
-    """Extract password from a Secrets Manager secret."""
+def _get_secret_credentials(secret_arn):
+    """Extract username and password from a Secrets Manager secret.
+
+    Returns (username, password) where username may be None if the secret
+    doesn't contain one.
+    """
     from ministack.services import secretsmanager
 
     for _name, secret in secretsmanager._secrets.items():
@@ -238,27 +242,34 @@ def _get_secret_password(secret_arn):
                     if secret_string:
                         try:
                             parsed = json.loads(secret_string)
-                            return parsed.get("password", secret_string)
+                            return (parsed.get("username"),
+                                    parsed.get("password", secret_string))
                         except (json.JSONDecodeError, TypeError):
-                            return secret_string
+                            return None, secret_string
             # Fallback to any version
             for _vid, ver in secret.get("Versions", {}).items():
                 secret_string = ver.get("SecretString")
                 if secret_string:
                     try:
                         parsed = json.loads(secret_string)
-                        return parsed.get("password", secret_string)
+                        return (parsed.get("username"),
+                                parsed.get("password", secret_string))
                     except (json.JSONDecodeError, TypeError):
-                        return secret_string
-    return None
+                        return None, secret_string
+    return None, None
 
 
-def _connect(instance, engine, database=None, password=None):
+def _connect(instance, engine, database=None, password=None,
+             username=None):
     """Create a database connection to the real container."""
-    host = instance.get("Endpoint", {}).get("Address", "localhost")
-    port = instance.get("Endpoint", {}).get("Port", 5432)
-    user = instance.get("MasterUsername", "admin")
-    db = database or instance.get("DBName", "")
+    # Prefer the internal (Docker-network) address when available so the
+    # Data API can reach sibling containers.  Fall back to the public
+    # endpoint for host-mode or non-Docker setups.
+    host = (instance.get("_internal_address")
+            or instance.get("Endpoint", {}).get("Address", "localhost"))
+    port = (instance.get("_internal_port")
+            or instance.get("Endpoint", {}).get("Port", 5432))
+    db = database or ""
     pw = password or "password"
 
     if "mysql" in engine or "aurora-mysql" in engine or "mariadb" in engine:
@@ -269,8 +280,18 @@ def _connect(instance, engine, database=None, password=None):
                 "pymysql is required for MySQL/Aurora MySQL rds-data support. "
                 "Install with: pip install pymysql"
             )
+        # In RDS the master user has full privileges.  In a Docker MySQL
+        # container the equivalent is 'root'.  When the secret identifies
+        # the master user (username matches MasterUsername or is absent),
+        # connect as root.  Otherwise use the actual username from the
+        # secret so user-level operations (e.g. ALTER USER … REPLACE)
+        # authenticate correctly.
+        master = instance.get("MasterUsername", "admin")
+        connect_user = username or "root"
+        if username and username == master:
+            connect_user = "root"
         return pymysql.connect(
-            host=host, port=int(port), user=user,
+            host=host, port=int(port), user=connect_user,
             password=pw, database=db or None, autocommit=True,
         )
     else:
@@ -281,8 +302,9 @@ def _connect(instance, engine, database=None, password=None):
                 "psycopg2 is required for PostgreSQL/Aurora PostgreSQL rds-data support. "
                 "Install with: pip install psycopg2-binary"
             )
+        pg_user = username or instance.get("MasterUsername", "admin")
         return psycopg2.connect(
-            host=host, port=int(port), user=user,
+            host=host, port=int(port), user=pg_user,
             password=pw, dbname=db or "postgres",
         )
 
@@ -407,7 +429,7 @@ def _execute_statement(data):
         logger.info("No endpoint for %s, using stub mode", resource_arn)
         return _stub_execute(resource_arn, sql)
 
-    password = _get_secret_password(secret_arn)
+    secret_user, password = _get_secret_credentials(secret_arn)
 
     # Convert :name placeholders to %(name)s for DB-API
     params = _convert_parameters(parameters)
@@ -423,7 +445,8 @@ def _execute_statement(data):
             if txn_id and txn_id in _transactions:
                 conn = _transactions[txn_id]["conn"]
             else:
-                conn = _connect(instance, engine, database, password)
+                conn = _connect(instance, engine, database, password,
+                                username=secret_user)
                 own_conn = True
 
         cursor = conn.cursor()
@@ -490,10 +513,11 @@ def _begin_transaction(data):
         return _error("BadRequestException",
                        f"Database cluster not found for ARN: {resource_arn}")
 
-    password = _get_secret_password(secret_arn)
+    secret_user, password = _get_secret_credentials(secret_arn)
 
     try:
-        conn = _connect(instance, engine, database, password)
+        conn = _connect(instance, engine, database, password,
+                        username=secret_user)
         if "mysql" in engine or "aurora-mysql" in engine:
             conn.autocommit(False)
         else:
@@ -575,7 +599,7 @@ def _batch_execute_statement(data):
         return _error("BadRequestException",
                        f"Database cluster not found for ARN: {resource_arn}")
 
-    password = _get_secret_password(secret_arn)
+    secret_user, password = _get_secret_credentials(secret_arn)
 
     own_conn = False
     conn = None
@@ -584,7 +608,8 @@ def _batch_execute_statement(data):
             if txn_id and txn_id in _transactions:
                 conn = _transactions[txn_id]["conn"]
             else:
-                conn = _connect(instance, engine, database, password)
+                conn = _connect(instance, engine, database, password,
+                                username=secret_user)
                 own_conn = True
 
         cursor = conn.cursor()

--- a/tests/test_rds.py
+++ b/tests/test_rds.py
@@ -678,3 +678,40 @@ def test_rds_describe_by_dbi_resource_id(rds):
     assert len(desc["DBInstances"]) == 1
     assert desc["DBInstances"][0]["DBInstanceIdentifier"] == "resid-lookup-test"
     assert desc["DBInstances"][0]["DbiResourceId"] == resource_id
+
+
+def test_rds_instance_inherits_cluster_username(rds):
+    """CreateDBInstance inherits MasterUsername from parent cluster."""
+    rds.create_db_cluster(
+        DBClusterIdentifier="inherit-cluster",
+        Engine="aurora-mysql",
+        MasterUsername="myadmin",
+        MasterUserPassword="s3cret!",
+    )
+    rds.create_db_instance(
+        DBInstanceIdentifier="inherit-cluster-1",
+        DBClusterIdentifier="inherit-cluster",
+        DBInstanceClass="db.r6g.large",
+        Engine="aurora-mysql",
+    )
+    resp = rds.describe_db_instances(DBInstanceIdentifier="inherit-cluster-1")
+    inst = resp["DBInstances"][0]
+    assert inst["MasterUsername"] == "myadmin"
+    assert inst["DBClusterIdentifier"] == "inherit-cluster"
+
+
+def test_rds_modify_cluster_password(rds):
+    """ModifyDBCluster with MasterUserPassword succeeds."""
+    rds.create_db_cluster(
+        DBClusterIdentifier="pw-mod-cluster",
+        Engine="aurora-mysql",
+        MasterUsername="admin",
+        MasterUserPassword="old_pass",
+    )
+    rds.modify_db_cluster(
+        DBClusterIdentifier="pw-mod-cluster",
+        MasterUserPassword="new_pass",
+    )
+    resp = rds.describe_db_clusters(DBClusterIdentifier="pw-mod-cluster")
+    cluster = resp["DBClusters"][0]
+    assert cluster["DBClusterIdentifier"] == "pw-mod-cluster"

--- a/tests/test_rds_data.py
+++ b/tests/test_rds_data.py
@@ -357,3 +357,49 @@ def test_rds_data_stub_drop_user(rds, sm):
     records = body.get("records", [])
     names = [r[0]["stringValue"] for r in records] if records else []
     assert "tempuser" not in names
+
+
+def test_rds_data_secret_credentials_parsing():
+    """_get_secret_credentials extracts username and password from secret."""
+    from ministack.services import secretsmanager, rds_data
+    from ministack.core.responses import set_request_account_id
+    set_request_account_id("test")
+    # Create a secret with JSON credentials
+    secretsmanager._secrets["test-cred-secret"] = {
+        "ARN": "arn:aws:secretsmanager:us-east-1:000000000000:secret:test-cred",
+        "Name": "test-cred-secret",
+        "Versions": {
+            "v1": {
+                "Stages": ["AWSCURRENT"],
+                "SecretString": '{"username":"app_rw","password":"p@ss123"}',
+            }
+        },
+    }
+    user, pw = rds_data._get_secret_credentials(
+        "arn:aws:secretsmanager:us-east-1:000000000000:secret:test-cred")
+    assert user == "app_rw"
+    assert pw == "p@ss123"
+    # Clean up
+    del secretsmanager._secrets["test-cred-secret"]
+
+
+def test_rds_data_secret_credentials_no_username():
+    """_get_secret_credentials returns None username for password-only secret."""
+    from ministack.services import secretsmanager, rds_data
+    from ministack.core.responses import set_request_account_id
+    set_request_account_id("test")
+    secretsmanager._secrets["pw-only-secret"] = {
+        "ARN": "arn:aws:secretsmanager:us-east-1:000000000000:secret:pw-only",
+        "Name": "pw-only-secret",
+        "Versions": {
+            "v1": {
+                "Stages": ["AWSCURRENT"],
+                "SecretString": '{"password":"just-a-password"}',
+            }
+        },
+    }
+    user, pw = rds_data._get_secret_credentials(
+        "arn:aws:secretsmanager:us-east-1:000000000000:secret:pw-only")
+    assert user is None
+    assert pw == "just-a-password"
+    del secretsmanager._secrets["pw-only-secret"]


### PR DESCRIPTION
## Summary

Enables end-to-end real MySQL/MariaDB execution through the RDS Data API when MiniStack runs in Docker. Previously, the Data API fell back to in-memory stubs because (a) `pymysql` wasn't in the image, and (b) the RDS endpoint used `localhost` which doesn't reach sibling Docker containers.

### Changes

**`pymysql` bundled in Docker image** (44 KB, pure Python)
- Already listed in `pyproject.toml[full]` but wasn't installed in the image.

**Docker network detection** (`rds.py`)
- `_get_ministack_network()` detects MiniStack's own Docker network — same pattern as `ecs.py` lines 796–806.
- RDS containers are attached to this network and assigned internal IPs.
- `_wait_for_port()` blocks until the DB container accepts TCP connections.
- The **public endpoint stays `localhost:host_port`** for host-mode access. The internal IP is stored separately (`_internal_address`/`_internal_port`) and used only by the Data API.

**Secret-aware authentication** (`rds_data.py`)
- `_get_secret_credentials()` extracts both username and password from Secrets Manager.
- `_connect()` maps the master user to MySQL `root` for admin operations (CREATE USER, GRANT, etc.). Non-master secrets use their actual username for user-level operations like password rotation.

**Cluster password management** (`rds.py`)
- `CreateDBCluster` stores `_MasterUserPassword`.
- `CreateDBInstance` inherits credentials from the parent cluster.
- `ModifyDBCluster` propagates password changes to the real MySQL container via `ALTER USER` (engine-gated to MySQL/MariaDB only).
- `MYSQL_ROOT_HOST=%` added to container environment to enable remote root access.

### Test coverage

- `test_rds_cluster_password_stored` — verifies cluster stores master password
- `test_rds_modify_cluster_password` — verifies ModifyDBCluster updates stored password
- `test_rds_data_secret_credentials_parsing` — verifies username+password extraction
- `test_rds_data_secret_credentials_no_username` — verifies password-only secret handling

Real MySQL integration tests require Docker-in-Docker and are validated locally.