### PR TITLE
fix(autoscaling): add DescribeScalingActivities action

### DIFF
--- a/ministack/services/autoscaling.py
+++ b/ministack/services/autoscaling.py
@@ -5,7 +5,7 @@ All in-memory, no actual instance scaling.
 
 Supports:
   ASG:       CreateAutoScalingGroup, DescribeAutoScalingGroups, UpdateAutoScalingGroup,
-             DeleteAutoScalingGroup, DescribeAutoScalingInstances
+             DeleteAutoScalingGroup, DescribeAutoScalingInstances, DescribeScalingActivities
   LC:        CreateLaunchConfiguration, DescribeLaunchConfigurations, DeleteLaunchConfiguration
   Policies:  PutScalingPolicy, DescribePolicies, DeletePolicy
   Hooks:     PutLifecycleHook, DescribeLifecycleHooks, DeleteLifecycleHook,
@@ -206,6 +206,11 @@ def _delete_asg(p):
 def _describe_asg_instances(p):
     return _xml(200, "DescribeAutoScalingInstancesResponse",
                 "<DescribeAutoScalingInstancesResult><AutoScalingInstances/></DescribeAutoScalingInstancesResult>")
+
+
+def _describe_scaling_activities(p):
+    return _xml(200, "DescribeScalingActivitiesResponse",
+                "<DescribeScalingActivitiesResult><Activities/></DescribeScalingActivitiesResult>")
 
 
 # ---------------------------------------------------------------------------
@@ -465,6 +470,7 @@ _ACTION_MAP = {
     "UpdateAutoScalingGroup": _update_asg,
     "DeleteAutoScalingGroup": _delete_asg,
     "DescribeAutoScalingInstances": _describe_asg_instances,
+    "DescribeScalingActivities": _describe_scaling_activities,
     "CreateLaunchConfiguration": _create_lc,
     "DescribeLaunchConfigurations": _describe_lcs,
     "DeleteLaunchConfiguration": _delete_lc,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -283,3 +283,7 @@ def sd():
 @pytest.fixture(scope="session")
 def codebuild():
     return make_client("codebuild")
+
+@pytest.fixture(scope="session")
+def autoscaling():
+    return make_client("autoscaling")

--- a/tests/test_autoscaling.py
+++ b/tests/test_autoscaling.py
@@ -1,0 +1,44 @@
+from botocore.exceptions import ClientError
+
+
+def test_autoscaling_describe_scaling_activities_empty(autoscaling):
+    """DescribeScalingActivities returns an empty list when no ASG exists."""
+    resp = autoscaling.describe_scaling_activities()
+    assert resp["Activities"] == []
+
+
+def test_autoscaling_create_and_describe_asg(autoscaling):
+    name = "test-asg-basic"
+    autoscaling.create_auto_scaling_group(
+        AutoScalingGroupName=name,
+        MinSize=0,
+        MaxSize=1,
+        DesiredCapacity=0,
+        AvailabilityZones=["us-east-1a"],
+        LaunchConfigurationName="dummy-lc",
+    )
+    resp = autoscaling.describe_auto_scaling_groups(AutoScalingGroupNames=[name])
+    groups = resp["AutoScalingGroups"]
+    assert len(groups) == 1
+    assert groups[0]["AutoScalingGroupName"] == name
+    assert groups[0]["MinSize"] == 0
+    assert groups[0]["MaxSize"] == 1
+
+    autoscaling.delete_auto_scaling_group(AutoScalingGroupName=name)
+
+
+def test_autoscaling_describe_scaling_activities_after_create(autoscaling):
+    """Terraform polls DescribeScalingActivities right after ASG creation."""
+    name = "test-asg-activities"
+    autoscaling.create_auto_scaling_group(
+        AutoScalingGroupName=name,
+        MinSize=0,
+        MaxSize=1,
+        DesiredCapacity=0,
+        AvailabilityZones=["us-east-1a"],
+        LaunchConfigurationName="dummy-lc",
+    )
+    resp = autoscaling.describe_scaling_activities(AutoScalingGroupName=name)
+    assert resp["Activities"] == []
+
+    autoscaling.delete_auto_scaling_group(AutoScalingGroupName=name)


### PR DESCRIPTION
## Summary

- Add a `DescribeScalingActivities` handler to the AutoScaling service that returns an empty `<Activities/>` list.
- Terraform's AWS provider polls this action after creating an `aws_autoscaling_group` to wait for capacity. Without it, MiniStack returns `InvalidAction`, causing a timeout error.

Closes #312

## Test plan

- [x] Verified the bug: `aws autoscaling describe-scaling-activities` returns `InvalidAction` before the fix
- [x] Verified the fix: same command returns `{"Activities": []}` after the fix
- [x] Full test suite: 494 passed (1 pre-existing flaky ECS test unrelated to this change)