### PR TITLE
fix(codebuild): extract project name from ARN in BatchGetProjects lookup

### DIFF
--- a/ministack/services/codebuild.py
+++ b/ministack/services/codebuild.py
@@ -204,7 +204,8 @@ def _batch_get_projects(data):
     found = []
     not_found = []
     for name in names:
-        project = _projects.get(name)
+        lookup = name.rsplit("/", 1)[-1] if name.startswith("arn:aws:codebuild:") else name
+        project = _projects.get(lookup)
         if project:
             found.append(_project_shape(project))
         else:

--- a/tests/test_codebuild.py
+++ b/tests/test_codebuild.py
@@ -40,6 +40,14 @@ def test_codebuild_batch_get_projects(codebuild):
     assert "nonexistent" in resp["projectsNotFound"]
 
 
+def test_codebuild_batch_get_projects_by_arn(codebuild):
+    arn = codebuild.batch_get_projects(names=["test-project"])["projects"][0]["arn"]
+    resp = codebuild.batch_get_projects(names=[arn])
+    assert len(resp["projects"]) == 1
+    assert resp["projects"][0]["name"] == "test-project"
+    assert resp["projectsNotFound"] == []
+
+
 def test_codebuild_list_projects(codebuild):
     resp = codebuild.list_projects()
     assert "test-project" in resp["projects"]


### PR DESCRIPTION
## Summary

- Fix `BatchGetProjects` to handle ARN-format inputs by extracting the project name (everything after the last `/`) before doing the dict lookup.
- The [AWS API](https://docs.aws.amazon.com/codebuild/latest/APIReference/API_BatchGetProjects.html) documents that `names` accepts both names and ARNs, and the Terraform AWS provider always passes the ARN (it stores `d.Id()` as the project ARN after creation).
- Add test `test_codebuild_batch_get_projects_by_arn` to verify ARN-based lookup.

Closes #319

## Test plan

- [x] Existing `test_codebuild_batch_get_projects` passes (name-based lookup unchanged)
- [x] New `test_codebuild_batch_get_projects_by_arn` passes (ARN-based lookup now works)
- [x] All 14 CodeBuild tests pass