### PR TITLE
fix(cognito): default AnalyticsConfiguration to None instead of empty dict

### DIFF
--- a/ministack/services/cognito.py
+++ b/ministack/services/cognito.py
@@ -608,7 +608,7 @@ def _create_user_pool_client(data):
         "AllowedOAuthFlows": data.get("AllowedOAuthFlows", []),
         "AllowedOAuthScopes": data.get("AllowedOAuthScopes", []),
         "AllowedOAuthFlowsUserPoolClient": data.get("AllowedOAuthFlowsUserPoolClient", False),
-        "AnalyticsConfiguration": data.get("AnalyticsConfiguration", {}),
+        "AnalyticsConfiguration": data.get("AnalyticsConfiguration"),
         "PreventUserExistenceErrors": data.get("PreventUserExistenceErrors", "ENABLED"),
         "EnableTokenRevocation": data.get("EnableTokenRevocation", True),
         "EnablePropagateAdditionalUserContextData": data.get("EnablePropagateAdditionalUserContextData", False),


### PR DESCRIPTION
## Summary

- Default `AnalyticsConfiguration` to `None` instead of `{}` in `_create_user_pool_client` so the existing `v is not None` response filter strips it when unset.
- Fixes Terraform error: `Provider produced inconsistent result: analytics_configuration block count changed from 0 to 1`.

Closes #320

## Test plan

- [x] Create a Cognito user pool client via Terraform **without** `analytics_configuration` — verify no inconsistent result error
- [x] Create a Cognito user pool client **with** `analytics_configuration` — verify it is returned correctly in the response