### PR TITLE
fix(sfn): don't scale activity/callback timeouts with SFN_WAIT_SCALE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- **SFN callback/activity timeout not scaled** — `SFN_WAIT_SCALE=0` no longer causes `States.Timeout` on activity tasks and `waitForTaskToken` callbacks. The scale factor was incorrectly applied to functional timeouts (which must wait for real work to complete), not just Wait state sleeps and retry intervals. Contributed by @jayjanssen
+
+---
+
 ## [1.2.15] — 2026-04-15
 
 ### Fixed

--- a/ministack/services/stepfunctions.py
+++ b/ministack/services/stepfunctions.py
@@ -1284,7 +1284,7 @@ def _invoke_activity(resource, input_data):
         "input": json.dumps(input_data),
     })
 
-    timeout = _scaled_timeout(99999)
+    timeout = 99999
     if not evt.wait(timeout=timeout):
         _task_tokens.pop(token, None)
         raise _ExecutionError("States.Timeout", "Activity task timed out waiting for worker")
@@ -1319,7 +1319,7 @@ def _invoke_with_callback(resource, input_data, token, state_def):
         except _ExecutionError:
             pass
 
-    timeout = _scaled_timeout(state_def.get("TimeoutSeconds", 99999))
+    timeout = state_def.get("TimeoutSeconds", 99999)
     if not evt.wait(timeout=timeout):
         _task_tokens.pop(token, None)
         raise _ExecutionError("States.Timeout",
@@ -1496,14 +1496,6 @@ def _scaled_sleep(seconds):
     scaled = seconds * _SFN_WAIT_SCALE
     if scaled > 0:
         time.sleep(scaled)
-
-
-def _scaled_timeout(seconds):
-    """Scale a blocking-wait timeout.  Returns at least 0.01 so Event.wait()
-    never blocks forever when scale is 0."""
-    if _SFN_WAIT_SCALE == 0:
-        return 0.01
-    return max(seconds * _SFN_WAIT_SCALE, 0.01)
 
 
 def _sleep_until(iso_ts):

--- a/tests/test_sfn.py
+++ b/tests/test_sfn.py
@@ -2603,6 +2603,76 @@ def test_sfn_aws_sdk_error_prefix_in_failed_execution(sfn, sfn_sync):
 
     sfn_sync.delete_state_machine(stateMachineArn=sm_arn)
 
+def test_sfn_wait_scale_zero_does_not_timeout_lambda_tasks(sfn, lam):
+    """SFN_WAIT_SCALE=0 must not cause Lambda Task states to timeout.
+
+    _scaled_timeout was previously applied to activity and callback waits,
+    causing 0.01s timeouts that raced against Lambda execution.  Task
+    states that invoke Lambda synchronously should be unaffected by the
+    wait scale factor.
+    """
+    import urllib.request
+
+    endpoint = os.environ.get("MINISTACK_ENDPOINT", "http://localhost:4566")
+
+    def _set_wait_scale(val):
+        req = urllib.request.Request(
+            f"{endpoint}/_ministack/config",
+            data=json.dumps({"stepfunctions._SFN_WAIT_SCALE": val}).encode(),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        urllib.request.urlopen(req, timeout=5)
+
+    # Create a Lambda that sleeps briefly to simulate real work.
+    code = (
+        "import time\n"
+        "def handler(event, context):\n"
+        "    time.sleep(0.5)\n"
+        "    return {'done': True}\n"
+    )
+    lam.create_function(
+        FunctionName="sfn-timeout-test-fn",
+        Runtime="python3.11",
+        Role=_LAMBDA_ROLE,
+        Handler="index.handler",
+        Code={"ZipFile": _make_zip(code)},
+    )
+    fn_arn = f"arn:aws:lambda:us-east-1:000000000000:function:sfn-timeout-test-fn"
+
+    _set_wait_scale(0)
+    try:
+        definition = json.dumps({
+            "StartAt": "CallLambda",
+            "States": {
+                "CallLambda": {
+                    "Type": "Task",
+                    "Resource": fn_arn,
+                    "End": True,
+                },
+            },
+        })
+        sm = sfn.create_state_machine(
+            name="qa-sfn-timeout-test",
+            definition=definition,
+            roleArn="arn:aws:iam::000000000000:role/R",
+        )
+        sm_arn = sm["stateMachineArn"]
+
+        exec_resp = sfn.start_execution(stateMachineArn=sm_arn, input="{}")
+        desc = _wait_sfn(sfn, exec_resp["executionArn"], timeout=10)
+
+        assert desc["status"] == "SUCCEEDED", (
+            f"Lambda Task should succeed with SFN_WAIT_SCALE=0, "
+            f"got {desc['status']}"
+        )
+        assert json.loads(desc["output"]) == {"done": True}
+
+        sfn.delete_state_machine(stateMachineArn=sm_arn)
+    finally:
+        _set_wait_scale(1.0)
+
+
 def test_sfn_wait_scale_zero_skips_wait(sfn):
     """SFN_WAIT_SCALE=0 skips Wait state sleeps entirely.
 


### PR DESCRIPTION
## Problem

`SFN_WAIT_SCALE=0` causes `States.Timeout` on activity tasks and `waitForTaskToken` callbacks. Any callback or activity that takes longer than 10ms fails.

## Root Cause

The v1.2.12 release commit (#318) applied `_scaled_timeout()` to activity task and callback waits:

```python
timeout = _scaled_timeout(99999)        # with scale=0 → 0.01s
if not evt.wait(timeout=timeout): ...   # times out immediately
```

These are **functional timeouts** that must wait for real work to complete (Lambda execution, external callbacks). They are not artificial delays like Wait states or retry intervals.

## Fix

Revert to unscaled timeouts for the two affected call sites:
- `_invoke_activity()` — activity task wait
- `_invoke_with_callback()` — `waitForTaskToken` pattern

Remove the now-unused `_scaled_timeout()` function. `_scaled_sleep()` for Wait states and retry intervals remains unchanged.

## Test

`test_sfn_wait_scale_zero_does_not_timeout_lambda_tasks` — sets `SFN_WAIT_SCALE=0`, runs an SFN that invokes a Lambda with a 0.5s sleep, and asserts it succeeds without `States.Timeout`.