### PR TITLE
release v1.2.16 — KMS ECC key support (SECG_P256K1, NIST P-256/384/52…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,15 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
-## [Unreleased]
+## [1.2.16] — 2026-04-15
+
+### Added
+- **KMS ECC key support** — `CreateKey` now supports `ECC_SECG_P256K1`, `ECC_NIST_P256`, `ECC_NIST_P384`, and `ECC_NIST_P521` key specs with `ECDSA_SHA_256`, `ECDSA_SHA_384`, `ECDSA_SHA_512` signing algorithms. Sign/Verify works for both `RAW` and `DIGEST` message types. `GetPublicKey` returns DER-encoded EC public keys. Contributed by @dvrkn (#335)
 
 ### Fixed
-- **Lambda endpoint URL override** — function-level `AWS_ENDPOINT_URL` environment variables no longer override MiniStack's internal endpoint. When MiniStack runs in Docker with a host-port that differs from the container port (e.g., `4568:4566`), Lambda functions would receive the host-mapped URL which is unreachable from inside the container, causing SDK callbacks to fail with "connection refused". Fix applies to all executor paths: provided runtime, Docker mode, image mode, and warm workers. Contributed by @jayjanssen
-- **SFN callback/activity timeout not scaled** — `SFN_WAIT_SCALE=0` no longer causes `States.Timeout` on activity tasks and `waitForTaskToken` callbacks. The scale factor was incorrectly applied to functional timeouts (which must wait for real work to complete), not just Wait state sleeps and retry intervals. Contributed by @jayjanssen
+- **Lambda endpoint URL override** — function-level `AWS_ENDPOINT_URL` environment variables no longer override MiniStack's internal endpoint. When MiniStack runs in Docker with a host-port that differs from the container port (e.g., `4568:4566`), Lambda functions would receive the host-mapped URL which is unreachable from inside the container, causing SDK callbacks to fail with "connection refused". Fix applies to all executor paths: provided runtime, Docker mode, image mode, and warm workers. Contributed by @jayjanssen (#336)
+- **SFN callback/activity timeout not scaled** — `SFN_WAIT_SCALE=0` no longer causes `States.Timeout` on activity tasks and `waitForTaskToken` callbacks. The scale factor was incorrectly applied to functional timeouts (which must wait for real work to complete), not just Wait state sleeps and retry intervals. Contributed by @jayjanssen (#337)
+- **Init scripts override mounted AWS credentials** — ready.d scripts no longer set `AWS_ACCESS_KEY_ID=test` when the user has mounted `~/.aws/credentials` into the container. The AWS CLI credential chain (env vars > credentials file) meant our defaults stomped on the user's configured profile. Now checks for credentials files at `~/.aws/credentials`, `/root/.aws/credentials`, and `AWS_SHARED_CREDENTIALS_FILE`. Reported by @staranto
 
 ---
 
@@ -25,7 +29,6 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 ## [1.2.14] — 2026-04-15
 
 ### Added
-- **KMS ECC key support** — `CreateKey` now supports `ECC_SECG_P256K1`, `ECC_NIST_P256`, `ECC_NIST_P384`, and `ECC_NIST_P521` key specs with `ECDSA_SHA_256`, `ECDSA_SHA_384`, `ECDSA_SHA_512` signing algorithms. Sign/Verify works for both `RAW` and `DIGEST` message types. `GetPublicKey` returns DER-encoded EC public keys. Contributed by @dvrkn
 - **Cognito federated SAML/OIDC auth flow** — `GET /oauth2/authorize` (redirects to external SAML/OIDC IdP), `POST /saml2/idpresponse` (parses SAML assertion, creates federated user, issues authorization code), and `POST /oauth2/token` now supports `grant_type=authorization_code` for full SSO flow. Also adds `GetIdentityProviderByIdentifier`. Contributed by @prandogabriel (#329)
 - **EC2 AuthorizeSecurityGroup returns rules** — `AuthorizeSecurityGroupIngress` and `AuthorizeSecurityGroupEgress` now return `SecurityGroupRules` in the response with rule IDs, group ownership, protocol, port range, and CIDR details. Required by Terraform AWS provider v6. Reported by @mspiller (#325)
 

--- a/ministack/app.py
+++ b/ministack/app.py
@@ -726,10 +726,18 @@ async def _run_ready_scripts():
     await _wait_for_port(port)
     logger.info('Found %d ready script(s)', len(scripts))
     # Provide sensible defaults so init scripts can use aws cli / boto3
-    # without requiring manual credential configuration.
+    # without requiring manual credential configuration.  Skip credential
+    # defaults when the user has mounted ~/.aws/credentials so the CLI
+    # respects their configured profile.
     script_env = {**os.environ}
-    script_env.setdefault("AWS_ACCESS_KEY_ID", "test")
-    script_env.setdefault("AWS_SECRET_ACCESS_KEY", "test")
+    _creds_paths = [os.path.expanduser("~/.aws"), "/root/.aws"]
+    _custom_creds = os.environ.get("AWS_SHARED_CREDENTIALS_FILE")
+    _has_creds_file = (_custom_creds and os.path.isfile(_custom_creds)) or any(
+        os.path.isfile(os.path.join(d, "credentials")) for d in _creds_paths
+    )
+    if not _has_creds_file:
+        script_env.setdefault("AWS_ACCESS_KEY_ID", "test")
+        script_env.setdefault("AWS_SECRET_ACCESS_KEY", "test")
     script_env.setdefault("AWS_DEFAULT_REGION", os.environ.get("MINISTACK_REGION", "us-east-1"))
     script_env.setdefault("AWS_ENDPOINT_URL", f"http://localhost:{port}")
     for script_path in scripts:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ministack"
-version = "1.2.15"
+version = "1.2.16"
 description = "Free, open-source local AWS emulator — drop-in LocalStack replacement"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
…1), Lambda AWS_ENDPOINT_URL

  override fix, SFN callback/activity timeout fix, init scripts respect mounted ~/.aws/credentials
  (#335, #336, #337)