### PR TITLE
fix(cognito): include cognito:groups claim in access and ID tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- **Cognito `cognito:groups` missing from tokens** — `initiate_auth` and `admin_initiate_auth` now include the `cognito:groups` claim in both access and ID tokens when the user belongs to one or more groups. Real AWS Cognito includes this claim automatically; MiniStack was not threading the already-populated `_groups` list through to the JWT builder.
+
+---
+
 ## [1.2.16] — 2026-04-15
 
 ### Added

--- a/ministack/services/cognito.py
+++ b/ministack/services/cognito.py
@@ -247,7 +247,8 @@ def _identity_id(pool_id: str) -> str:
 
 
 def _fake_token(sub: str, pool_id: str, client_id: str, token_type: str = "access",
-                 username: str = "", user_attrs: dict | None = None) -> str:
+                 username: str = "", user_attrs: dict | None = None,
+                 groups: list[str] | None = None) -> str:
     """Return a JWT signed with the RSA key when cryptography is available."""
     header = base64.urlsafe_b64encode(
         json.dumps({"alg": "RS256", "kid": "ministack-key-1"}).encode()
@@ -269,6 +270,8 @@ def _fake_token(sub: str, pool_id: str, client_id: str, token_type: str = "acces
         claims["origin_jti"] = origin_jti
         if username:
             claims["cognito:username"] = username
+        if groups:
+            claims["cognito:groups"] = groups
         # Include user attributes in IdToken
         if user_attrs:
             for k, v in user_attrs.items():
@@ -283,6 +286,8 @@ def _fake_token(sub: str, pool_id: str, client_id: str, token_type: str = "acces
         claims["origin_jti"] = origin_jti
         if username:
             claims["username"] = username
+        if groups:
+            claims["cognito:groups"] = groups
     else:
         # RefreshToken — opaque in real AWS, but we use a JWT stub for simplicity
         claims["client_id"] = client_id
@@ -1129,10 +1134,11 @@ def _build_auth_result(pool_id: str, client_id: str, user: dict) -> dict:
     attrs = _attr_list_to_dict(user.get("Attributes", []))
     sub = attrs.get("sub", user["Username"])
     username = user.get("Username", "")
+    groups = user.get("_groups", [])
     return {
-        "AccessToken": _fake_token(sub, pool_id, client_id, "access", username=username),
+        "AccessToken": _fake_token(sub, pool_id, client_id, "access", username=username, groups=groups),
         "IdToken": _fake_token(sub, pool_id, client_id, "id", username=username,
-                               user_attrs=attrs),
+                               user_attrs=attrs, groups=groups),
         "RefreshToken": _fake_token(sub, pool_id, client_id, "refresh"),
         "TokenType": "Bearer",
         "ExpiresIn": 3600,

--- a/tests/test_cognito.py
+++ b/tests/test_cognito.py
@@ -1479,3 +1479,45 @@ def test_cognito_federated_user_idempotent(cognito_idp):
     all_users = cognito_idp.list_users(UserPoolId=pid)["Users"]
     repeat_users = [u for u in all_users if u["Username"] == "TestSAML_repeat@example.com"]
     assert len(repeat_users) == 1
+
+
+def test_cognito_groups_in_auth_tokens(cognito_idp):
+    """cognito:groups claim must appear in both access and ID tokens."""
+    pid = cognito_idp.create_user_pool(PoolName="GroupTokenPool")["UserPool"]["Id"]
+    cid = cognito_idp.create_user_pool_client(
+        UserPoolId=pid,
+        ClientName="GroupTokenApp",
+        ExplicitAuthFlows=["ALLOW_USER_PASSWORD_AUTH", "ALLOW_REFRESH_TOKEN_AUTH"],
+    )["UserPoolClient"]["ClientId"]
+
+    cognito_idp.create_group(UserPoolId=pid, GroupName="admin")
+    cognito_idp.create_group(UserPoolId=pid, GroupName="readers")
+    cognito_idp.admin_create_user(
+        UserPoolId=pid, Username="groupuser",
+        TemporaryPassword="Temp1234!", MessageAction="SUPPRESS",
+    )
+    cognito_idp.admin_set_user_password(
+        UserPoolId=pid, Username="groupuser", Password="Group1234!", Permanent=True,
+    )
+    cognito_idp.admin_add_user_to_group(UserPoolId=pid, Username="groupuser", GroupName="admin")
+    cognito_idp.admin_add_user_to_group(UserPoolId=pid, Username="groupuser", GroupName="readers")
+
+    auth = cognito_idp.initiate_auth(
+        ClientId=cid,
+        AuthFlow="USER_PASSWORD_AUTH",
+        AuthParameters={"USERNAME": "groupuser", "PASSWORD": "Group1234!"},
+    )
+    result = auth["AuthenticationResult"]
+
+    def _decode_jwt_payload(token):
+        payload = token.split(".")[1]
+        payload += "=" * (4 - len(payload) % 4)
+        return json.loads(base64.urlsafe_b64decode(payload))
+
+    access_claims = _decode_jwt_payload(result["AccessToken"])
+    assert "cognito:groups" in access_claims, "cognito:groups missing from access token"
+    assert sorted(access_claims["cognito:groups"]) == ["admin", "readers"]
+
+    id_claims = _decode_jwt_payload(result["IdToken"])
+    assert "cognito:groups" in id_claims, "cognito:groups missing from id token"
+    assert sorted(id_claims["cognito:groups"]) == ["admin", "readers"]


### PR DESCRIPTION
https://github.com/ministackorg/ministack/issues/341
## Summary

- `initiate_auth` / `admin_initiate_auth` now include the `cognito:groups` claim in both access and ID tokens when the user belongs to one or more groups
- Real AWS Cognito includes this claim automatically; MiniStack was not threading the already-populated `user["_groups"]` list through to the JWT builder
- Two-line fix: `_build_auth_result` reads `_groups` and passes it to `_fake_token`, which adds `cognito:groups` to both token types

## Problem

Applications that use `cognito:groups` for role-based access control (the standard AWS Cognito pattern) get tokens without group claims from MiniStack, even though `admin_add_user_to_group` correctly populates the internal `_groups` list.

## Changes

| File | Change |
|------|--------|
| `ministack/services/cognito.py` | Add `groups` param to `_fake_token`; set `cognito:groups` claim for access + id tokens; read `_groups` in `_build_auth_result` |
| `tests/test_cognito.py` | New `test_cognito_groups_in_auth_tokens` — creates user in 2 groups, authenticates, asserts claim present in both tokens |
| `CHANGELOG.md` | Added entry under `[Unreleased]` |

## Test plan

- [x] Confirmed bug on unpatched image: `cognito:groups` = `*** NOT PRESENT ***`
- [x] Rebuilt image with fix: `cognito:groups` = `['admin']` in both tokens
- [x] All 72 cognito tests pass (71 existing + 1 new)
- [x] Backward-compatible — `groups` defaults to `None`, existing callers unaffected