### PR TITLE
release v1.2.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,18 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
-## [Unreleased]
+## [1.2.17] — 2026-04-15
 
 ### Added
-- **Transfer Family** — new service: CreateServer, DescribeServer, DeleteServer, ListServers, CreateUser, DescribeUser, DeleteUser, ListUsers, ImportSshPublicKey, DeleteSshPublicKey. 10 operations covering SFTP server/user management with SSH key rotation and LOGICAL home directory mappings to S3. 19 integration tests.
+- **Transfer Family service** — new service with 10 operations: CreateServer, DescribeServer, DeleteServer, ListServers, CreateUser, DescribeUser, DeleteUser, ListUsers, ImportSshPublicKey, DeleteSshPublicKey. SFTP server/user management with SSH key rotation and LOGICAL home directory mappings to S3. Contributed by @mjdavidson (#330)
+
 ### Fixed
-- **Cognito `cognito:groups` missing from tokens** — `initiate_auth` and `admin_initiate_auth` now include the `cognito:groups` claim in both access and ID tokens when the user belongs to one or more groups. Real AWS Cognito includes this claim automatically; MiniStack was not threading the already-populated `_groups` list through to the JWT builder.
+- **Cognito `cognito:groups` missing from tokens** — `initiate_auth` and `admin_initiate_auth` now include the `cognito:groups` claim in both access and ID tokens when the user belongs to one or more groups. Contributed by @subrotosanyal (#342)
+- **Cognito AccessToken missing `scope` claim** — AccessToken now includes `scope: "aws.cognito.signin.user.admin"`, matching real AWS Cognito. Libraries validating OAuth2 scopes no longer fail.
+- **Lambda default runtime updated to python3.12** — AWS blocked new `python3.9` function creation since Dec 15 2025. All defaults and tests updated. Zip deployments without `Runtime` now return `InvalidParameterValueException`. Contributed by @AdigaAkhil (#339)
+- **Ready.d scripts use `MINISTACK_HOST`** — `AWS_ENDPOINT_URL` in init scripts now uses `MINISTACK_HOST` instead of hardcoded `localhost`. Contributed by @AdigaAkhil (#339)
+- **Docker Compose version field removed** — silences Compose v2 deprecation warning. Contributed by @AdigaAkhil (#339)
+- **Ruff target-version corrected** — reverted to `py310` to match `requires-python = ">=3.10"`.
 
 ---
 

--- a/ministack/services/cognito.py
+++ b/ministack/services/cognito.py
@@ -284,6 +284,7 @@ def _fake_token(sub: str, pool_id: str, client_id: str, token_type: str = "acces
         claims["client_id"] = client_id
         claims["auth_time"] = now
         claims["origin_jti"] = origin_jti
+        claims["scope"] = "aws.cognito.signin.user.admin"
         if username:
             claims["username"] = username
         if groups:

--- a/ministack/services/ec2.py
+++ b/ministack/services/ec2.py
@@ -2271,7 +2271,22 @@ def _parse_ip_permissions(params, prefix):
             cidr = _p(params, f"{prefix}.{i}.IpRanges.{j}.CidrIp")
             if not cidr:
                 break
-            rule["IpRanges"].append({"CidrIp": cidr})
+            entry = {"CidrIp": cidr}
+            desc = _p(params, f"{prefix}.{i}.IpRanges.{j}.Description")
+            if desc:
+                entry["Description"] = desc
+            rule["IpRanges"].append(entry)
+            j += 1
+        j = 1
+        while True:
+            cidr6 = _p(params, f"{prefix}.{i}.Ipv6Ranges.{j}.CidrIpv6")
+            if not cidr6:
+                break
+            entry = {"CidrIpv6": cidr6}
+            desc = _p(params, f"{prefix}.{i}.Ipv6Ranges.{j}.Description")
+            if desc:
+                entry["Description"] = desc
+            rule["Ipv6Ranges"].append(entry)
             j += 1
         rules.append(rule)
         i += 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ministack"
-version = "1.2.16"
+version = "1.2.17"
 description = "Free, open-source local AWS emulator — drop-in LocalStack replacement"
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -67,7 +67,7 @@ python_functions = ["test_*"]
 
 [tool.ruff]
 line-length = 120
-target-version = "py312"
+target-version = "py310"
 
 [tool.ruff.lint]
 select = ["E", "F", "I"]

--- a/tests/test_cognito.py
+++ b/tests/test_cognito.py
@@ -1517,7 +1517,67 @@ def test_cognito_groups_in_auth_tokens(cognito_idp):
     access_claims = _decode_jwt_payload(result["AccessToken"])
     assert "cognito:groups" in access_claims, "cognito:groups missing from access token"
     assert sorted(access_claims["cognito:groups"]) == ["admin", "readers"]
+    assert "scope" in access_claims, "scope missing from access token"
+    assert access_claims["scope"] == "aws.cognito.signin.user.admin"
 
     id_claims = _decode_jwt_payload(result["IdToken"])
     assert "cognito:groups" in id_claims, "cognito:groups missing from id token"
     assert sorted(id_claims["cognito:groups"]) == ["admin", "readers"]
+
+
+def test_cognito_access_token_scope_no_groups(cognito_idp):
+    """AccessToken includes scope claim even when user has no groups."""
+    import base64
+    pid = cognito_idp.create_user_pool(PoolName="ScopePool")["UserPool"]["Id"]
+    cid = cognito_idp.create_user_pool_client(
+        UserPoolId=pid, ClientName="scope-app",
+        ExplicitAuthFlows=["ALLOW_USER_PASSWORD_AUTH", "ALLOW_REFRESH_TOKEN_AUTH"],
+    )["UserPoolClient"]["ClientId"]
+    cognito_idp.admin_create_user(
+        UserPoolId=pid, Username="scopeuser",
+        TemporaryPassword="Temp1234!", MessageAction="SUPPRESS",
+    )
+    cognito_idp.admin_set_user_password(
+        UserPoolId=pid, Username="scopeuser", Password="Scope1234!", Permanent=True,
+    )
+    auth = cognito_idp.initiate_auth(
+        ClientId=cid, AuthFlow="USER_PASSWORD_AUTH",
+        AuthParameters={"USERNAME": "scopeuser", "PASSWORD": "Scope1234!"},
+    )
+    payload = auth["AuthenticationResult"]["AccessToken"].split(".")[1]
+    payload += "=" * (4 - len(payload) % 4)
+    claims = json.loads(base64.urlsafe_b64decode(payload))
+    assert claims["scope"] == "aws.cognito.signin.user.admin"
+    assert "cognito:groups" not in claims  # no groups = no claim
+
+
+def test_cognito_admin_set_password_by_sub(cognito_idp):
+    """AdminSetUserPassword works with sub UUID, not just username."""
+    pid = cognito_idp.create_user_pool(PoolName="SubPassPool")["UserPool"]["Id"]
+    cognito_idp.admin_create_user(
+        UserPoolId=pid, Username="subpassuser",
+        UserAttributes=[{"Name": "email", "Value": "subpass@test.com"}],
+    )
+    user = cognito_idp.admin_get_user(UserPoolId=pid, Username="subpassuser")
+    sub = next(a["Value"] for a in user["UserAttributes"] if a["Name"] == "sub")
+    # Set password using sub UUID
+    cognito_idp.admin_set_user_password(
+        UserPoolId=pid, Username=sub, Password="NewPass1234!", Permanent=True,
+    )
+    # Verify user still accessible
+    user2 = cognito_idp.admin_get_user(UserPoolId=pid, Username=sub)
+    assert user2["Username"] == "subpassuser"
+
+
+def test_cognito_admin_disable_by_sub(cognito_idp):
+    """AdminDisableUser works with sub UUID."""
+    pid = cognito_idp.create_user_pool(PoolName="SubDisPool")["UserPool"]["Id"]
+    cognito_idp.admin_create_user(
+        UserPoolId=pid, Username="subdisuser",
+        UserAttributes=[{"Name": "email", "Value": "subdis@test.com"}],
+    )
+    user = cognito_idp.admin_get_user(UserPoolId=pid, Username="subdisuser")
+    sub = next(a["Value"] for a in user["UserAttributes"] if a["Name"] == "sub")
+    cognito_idp.admin_disable_user(UserPoolId=pid, Username=sub)
+    user2 = cognito_idp.admin_get_user(UserPoolId=pid, Username=sub)
+    assert user2["Enabled"] is False

--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -1340,3 +1340,21 @@ def test_ec2_authorize_sg_egress_returns_rules(ec2):
     assert len(rules) >= 1
     assert rules[0]["IsEgress"] is True
     assert rules[0]["CidrIpv4"] == "0.0.0.0/0"
+
+
+def test_ec2_authorize_sg_ingress_ipv6(ec2):
+    """AuthorizeSecurityGroupIngress returns rules with CidrIpv6."""
+    vpc = ec2.create_vpc(CidrBlock="10.97.0.0/16")["Vpc"]
+    sg = ec2.create_security_group(
+        GroupName="sgr-ipv6-test", Description="test", VpcId=vpc["VpcId"])
+    resp = ec2.authorize_security_group_ingress(
+        GroupId=sg["GroupId"],
+        IpPermissions=[{
+            "IpProtocol": "tcp", "FromPort": 443, "ToPort": 443,
+            "Ipv6Ranges": [{"CidrIpv6": "::/0"}],
+        }],
+    )
+    assert resp.get("Return") is True
+    rules = resp.get("SecurityGroupRules", [])
+    assert len(rules) >= 1
+    assert rules[0]["CidrIpv6"] == "::/0"

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -1295,3 +1295,99 @@ def test_s3_event_to_sqs(s3, sqs):
     assert "Messages" in msgs and len(msgs["Messages"]) >= 1
     del_body = json.loads(msgs["Messages"][0]["Body"])
     assert del_body["Records"][0]["eventName"].startswith("ObjectRemoved:")
+
+
+def test_s3_lifecycle_transition_round_trip(s3):
+    """PUT lifecycle with Transition, verify GET returns canonical XML with correct fields."""
+    bucket = "intg-s3-lc-transition"
+    s3.create_bucket(Bucket=bucket)
+    s3.put_bucket_lifecycle_configuration(
+        Bucket=bucket,
+        LifecycleConfiguration={
+            "Rules": [{
+                "ID": "archive-rule",
+                "Status": "Enabled",
+                "Filter": {"Prefix": "data/"},
+                "Transitions": [
+                    {"Days": 30, "StorageClass": "STANDARD_IA"},
+                    {"Days": 90, "StorageClass": "GLACIER"},
+                ],
+                "Expiration": {"Days": 365},
+            }]
+        },
+    )
+    resp = s3.get_bucket_lifecycle_configuration(Bucket=bucket)
+    rule = resp["Rules"][0]
+    assert rule["ID"] == "archive-rule"
+    assert rule["Status"] == "Enabled"
+    assert rule["Filter"]["Prefix"] == "data/"
+    transitions = rule["Transitions"]
+    assert len(transitions) == 2
+    assert transitions[0]["Days"] == 30
+    assert transitions[0]["StorageClass"] == "STANDARD_IA"
+    assert transitions[1]["Days"] == 90
+    assert transitions[1]["StorageClass"] == "GLACIER"
+    assert rule["Expiration"]["Days"] == 365
+
+
+def test_s3_lifecycle_noncurrent_version(s3):
+    """PUT lifecycle with NoncurrentVersionExpiration, verify round-trip."""
+    bucket = "intg-s3-lc-noncurrent"
+    s3.create_bucket(Bucket=bucket)
+    s3.put_bucket_lifecycle_configuration(
+        Bucket=bucket,
+        LifecycleConfiguration={
+            "Rules": [{
+                "ID": "noncurrent-cleanup",
+                "Status": "Enabled",
+                "Filter": {"Prefix": ""},
+                "NoncurrentVersionExpiration": {"NoncurrentDays": 30},
+            }]
+        },
+    )
+    resp = s3.get_bucket_lifecycle_configuration(Bucket=bucket)
+    rule = resp["Rules"][0]
+    assert rule["NoncurrentVersionExpiration"]["NoncurrentDays"] == 30
+
+
+def test_s3_lifecycle_multiple_rules(s3):
+    """Multiple lifecycle rules survive PUT/GET round-trip."""
+    bucket = "intg-s3-lc-multi"
+    s3.create_bucket(Bucket=bucket)
+    s3.put_bucket_lifecycle_configuration(
+        Bucket=bucket,
+        LifecycleConfiguration={
+            "Rules": [
+                {"ID": "rule-1", "Status": "Enabled", "Filter": {"Prefix": "a/"}, "Expiration": {"Days": 10}},
+                {"ID": "rule-2", "Status": "Disabled", "Filter": {"Prefix": "b/"}, "Expiration": {"Days": 20}},
+                {"ID": "rule-3", "Status": "Enabled", "Filter": {"Prefix": "c/"}, "Expiration": {"Days": 30}},
+            ]
+        },
+    )
+    resp = s3.get_bucket_lifecycle_configuration(Bucket=bucket)
+    assert len(resp["Rules"]) == 3
+    ids = [r["ID"] for r in resp["Rules"]]
+    assert "rule-1" in ids
+    assert "rule-2" in ids
+    assert "rule-3" in ids
+    disabled = [r for r in resp["Rules"] if r["ID"] == "rule-2"][0]
+    assert disabled["Status"] == "Disabled"
+
+
+def test_s3_lifecycle_abort_multipart(s3):
+    """AbortIncompleteMultipartUpload round-trip."""
+    bucket = "intg-s3-lc-abort"
+    s3.create_bucket(Bucket=bucket)
+    s3.put_bucket_lifecycle_configuration(
+        Bucket=bucket,
+        LifecycleConfiguration={
+            "Rules": [{
+                "ID": "abort-uploads",
+                "Status": "Enabled",
+                "Filter": {"Prefix": ""},
+                "AbortIncompleteMultipartUpload": {"DaysAfterInitiation": 7},
+            }]
+        },
+    )
+    resp = s3.get_bucket_lifecycle_configuration(Bucket=bucket)
+    assert resp["Rules"][0]["AbortIncompleteMultipartUpload"]["DaysAfterInitiation"] == 7


### PR DESCRIPTION
  - Transfer Family service: 10 operations, SFTP server/user/SSH key management (#330)                  
  - Cognito cognito:groups claim in access and ID tokens (#342)
  - Cognito scope claim on AccessToken                                                                  
  - Lambda default runtime python3.9 → python3.12, Runtime validation (#339)                            
  - Ready.d scripts use MINISTACK_HOST instead of localhost (#339)                                      
  - Docker Compose version field removed (#339)                                                         
  - Ruff target-version reverted to py310                                                               
  - 11 new tests: S3 lifecycle XML round-trip, Cognito scope/sub, EC2 SG IPv6