### PR TITLE
Fix Windows compatibility for Lambda functions

### DIFF
--- a/ministack/core/lambda_runtime.py
+++ b/ministack/core/lambda_runtime.py
@@ -16,6 +16,7 @@ import tempfile
 import threading
 import time
 import zipfile
+import queue
 
 logger = logging.getLogger("lambda_runtime")
 
@@ -328,6 +329,16 @@ class Worker:
         self._lock = threading.Lock()
         self._cold = True
         self._start_time = None
+        self._stderr_queue: queue.Queue = queue.Queue()
+        self._stderr_thread: threading.Thread | None = None
+
+    def _read_stderr(self):
+        """Background daemon thread: continuously drain stderr into queue."""
+        try:
+            for line in self._proc.stderr:
+                self._stderr_queue.put(line.rstrip("\n"))
+        except Exception:
+            pass
 
     def _spawn(self):
         """Extract zip and start worker process."""
@@ -449,6 +460,12 @@ class Worker:
             env=spawn_env,
         )
 
+        self._stderr_queue = queue.Queue()
+        self._stderr_thread = threading.Thread(
+            target=self._read_stderr, daemon=True, name=f"stderr-{self.func_name}"
+        )
+        self._stderr_thread.start()        
+
         init = {
             "code_dir": code_dir,
             "module": module_name,
@@ -489,15 +506,13 @@ class Worker:
         logger.info("Lambda worker spawned for %s (%s, cold start)", self.func_name, runtime)
 
     def _drain_stderr(self) -> str:
-        """Read any available stderr output without blocking."""
-        import select
+        """Collect all currently available stderr lines (non-blocking)."""
         lines = []
-        if self._proc and self._proc.stderr:
-            while select.select([self._proc.stderr], [], [], 0)[0]:
-                line = self._proc.stderr.readline()
-                if not line:
-                    break
-                lines.append(line.rstrip("\n"))
+        try:
+            while True:
+                lines.append(self._stderr_queue.get_nowait())
+        except queue.Empty:
+            pass
         return "\n".join(lines)
 
     def invoke(self, event: dict, request_id: str) -> dict:

--- a/ministack/services/cloudformation/provisioners.py
+++ b/ministack/services/cloudformation/provisioners.py
@@ -939,6 +939,7 @@ def _lambda_esm_create(logical_id, props, stack_name):
         "FunctionResponseTypes": props.get("FunctionResponseTypes", []),
     }
     _lambda_svc._esms[esm_id] = esm
+    _lambda_svc._ensure_poller()
     return esm_id, {"UUID": esm_id}
 
 

--- a/ministack/services/lambda_svc.py
+++ b/ministack/services/lambda_svc.py
@@ -114,6 +114,8 @@ def restore_state(data):
         _layers.update(data.get("layers", {}))
         _esms.update(data.get("esms", {}))
         _function_urls.update(data.get("function_urls", {}))
+        if _esms:
+            _ensure_poller()
 
 
 _restored = load_state("lambda")

--- a/tests/test_lambda.py
+++ b/tests/test_lambda.py
@@ -512,6 +512,35 @@ def test_lambda_warm_start(lam, apigw):
     apigw.delete_api(ApiId=api_id)
     lam.delete_function(FunctionName=fname)
 
+def test_lambda_warm_invoke_with_stderr_logging(lam):
+    """Warm invoke should succeed repeatedly even when the worker writes to stderr."""
+    fname = f"lam-warm-stderr-{_uuid_mod.uuid4().hex[:8]}"
+    code = (
+        "import sys\n"
+        "def handler(event, context):\n"
+        "    print(f'log:{event.get(\"n\", 0)}')\n"
+        "    return {'statusCode': 200, 'value': event.get('n', 0)}\n"
+    )
+
+    lam.create_function(
+        FunctionName=fname,
+        Runtime="python3.12",
+        Role=_LAMBDA_ROLE,
+        Handler="index.handler",
+        Code={"ZipFile": _make_zip(code)},
+    )
+
+    try:
+        first = lam.invoke(FunctionName=fname, Payload=json.dumps({"n": 1}))
+        second = lam.invoke(FunctionName=fname, Payload=json.dumps({"n": 2}))
+
+        assert first["StatusCode"] == 200
+        assert second["StatusCode"] == 200
+        assert json.loads(first["Payload"].read())["value"] == 1
+        assert json.loads(second["Payload"].read())["value"] == 2
+    finally:
+        lam.delete_function(FunctionName=fname)
+
 def test_lambda_nodejs_create_and_invoke(lam):
     lam.create_function(
         FunctionName="lam-node-basic",


### PR DESCRIPTION
This pull request introduces a more robust, windows compatible and non-blocking approach to capturing and handling `stderr` output from Lambda worker processes in the `ministack` runtime. It replaces the previous polling method with a dedicated background thread and queue, ensuring that `stderr` output is drained efficiently and does not interfere with repeated Lambda invocations. Additionally, a new test verifies the reliability of warm Lambda invocations even when the worker writes to `stderr`.

**Testing:**

* Added a new test, `test_lambda_warm_invoke_with_stderr_logging`, to verify that repeated (warm) Lambda invocations succeed even when the worker process writes to `stderr`. This helps ensure the stability of the new logging approach.

**Simple Lambda running on windows vis Python**
```JS
exports.handler = async () => { console.log('Hello, CDK!'); };
```

**Before:**

```json
{
  "errorMessage": "[WinError 10038] An operation was attempted on something that is not a socket",
  "errorType": "Runtime.HandlerError"
}
```

**After:**

```
Hello, CDK!
```