### PR TITLE
Add AWS::CodeBuild::Project provisioner

### DIFF
--- a/ministack/services/cloudformation/provisioners.py
+++ b/ministack/services/cloudformation/provisioners.py
@@ -2662,6 +2662,7 @@ _RESOURCE_HANDLERS = {
     "AWS::Cognito::IdentityPool": {"create": _cognito_identity_pool_create, "delete": _cognito_identity_pool_delete},
     "AWS::Cognito::UserPoolDomain": {"create": _cognito_user_pool_domain_create, "delete": _cognito_user_pool_domain_delete},
     "AWS::ECR::Repository": {"create": _ecr_repo_create, "delete": _ecr_repo_delete},
+    "AWS::CodeBuild::Project": {"create": _codebuild_project_create, "delete": _codebuild_project_delete},
     "AWS::IAM::ManagedPolicy": {"create": _iam_managed_policy_create, "delete": _iam_managed_policy_delete},
     "AWS::KMS::Key": {"create": _kms_key_create, "delete": _kms_key_delete},
     "AWS::KMS::Alias": {"create": _kms_alias_create, "delete": _kms_alias_delete},

--- a/ministack/services/cloudformation/provisioners.py
+++ b/ministack/services/cloudformation/provisioners.py
@@ -42,6 +42,7 @@ import ministack.services.waf as _waf
 import ministack.services.cloudfront as _cf
 import ministack.services.rds as _rds
 import ministack.services.autoscaling as _asg
+import ministack.services.codebuild as _codebuild
 
 
 logger = logging.getLogger("cloudformation")

--- a/ministack/services/cloudformation/provisioners.py
+++ b/ministack/services/cloudformation/provisioners.py
@@ -1351,6 +1351,35 @@ def _ecr_repo_delete(physical_id, props):
     _ecr._repositories.pop(physical_id, None)
 
 
+# --- CodeBuild Project provisioner ---
+
+def _codebuild_project_create(logical_id, props, stack_name):
+    name = props.get("Name") or _physical_name(stack_name, logical_id, max_len=255)
+    data = {
+        "name": name,
+        "description": props.get("Description", ""),
+        "source": props.get("Source", {"type": "NO_SOURCE"}),
+        "sourceVersion": props.get("SourceVersion", ""),
+        "artifacts": props.get("Artifacts", {"type": "NO_ARTIFACTS"}),
+        "environment": props.get("Environment", {
+            "type": "LINUX_CONTAINER",
+            "image": "aws/codebuild/standard:7.0",
+            "computeType": "BUILD_GENERAL1_SMALL",
+        }),
+        "serviceRole": props.get("ServiceRole", f"arn:aws:iam::{get_account_id()}:role/codebuild-role"),
+        "timeoutInMinutes": int(props.get("TimeoutInMinutes", 60)),
+        "tags": [{"key": t["Key"], "value": t["Value"]} for t in props.get("Tags", [])],
+        "encryptionKey": props.get("EncryptionKey", f"arn:aws:kms:{REGION}:{get_account_id()}:alias/aws/codebuild"),
+    }
+    _codebuild._create_project(data)
+    arn = _codebuild._project_arn(name)
+    return name, {"Arn": arn}
+
+
+def _codebuild_project_delete(physical_id, props):
+    _codebuild._projects.pop(physical_id, None)
+
+
 # --- IAM ManagedPolicy provisioner ---
 
 def _iam_managed_policy_create(logical_id, props, stack_name):

--- a/ministack/services/cloudformation/provisioners.py
+++ b/ministack/services/cloudformation/provisioners.py
@@ -1355,6 +1355,11 @@ def _ecr_repo_delete(physical_id, props):
 
 def _codebuild_project_create(logical_id, props, stack_name):
     name = props.get("Name") or _physical_name(stack_name, logical_id, max_len=255)
+    
+    # Pre-check for duplicates to raise exception (not just return error response)
+    if name in _codebuild._projects:
+        raise ValueError(f"CodeBuild project already exists: {name}")
+    
     data = {
         "name": name,
         "description": props.get("Description", ""),

--- a/tests/test_cfn.py
+++ b/tests/test_cfn.py
@@ -1343,6 +1343,7 @@ def test_cfn_lambda_nodejs_inline_zip(cfn, lam):
     cfn.delete_stack(StackName="cfn-nodejs-inline")
     _wait_stack(cfn, "cfn-nodejs-inline")
 
+<<<<<<< HEAD
 def test_cfn_dynamodb_stream_spec(cfn, ddb):
     """CloudFormation DynamoDB table with StreamViewType (no StreamEnabled) must
     have streams enabled: LatestStreamArn and StreamSpecification present on
@@ -1390,3 +1391,280 @@ def test_cfn_dynamodb_stream_spec(cfn, ddb):
 
     cfn.delete_stack(StackName=stack_name)
     _wait_stack(cfn, stack_name)
+
+
+# ===========================================================================
+# CodeBuild Project Tests
+# ===========================================================================
+
+def test_cfn_codebuild_project_basic(cfn, codebuild):
+    """CFN stack with a minimal CodeBuild project deploys successfully."""
+    template = {
+        "AWSTemplateFormatVersion": "2010-09-09",
+        "Resources": {
+            "Project": {
+                "Type": "AWS::CodeBuild::Project",
+                "Properties": {
+                    "Name": "cfn-cb-t01",
+                    "Source": {"Type": "NO_SOURCE"},
+                    "Artifacts": {"Type": "NO_ARTIFACTS"},
+                    "Environment": {
+                        "Type": "LINUX_CONTAINER",
+                        "Image": "aws/codebuild/standard:7.0",
+                        "ComputeType": "BUILD_GENERAL1_SMALL",
+                    },
+                    "ServiceRole": "arn:aws:iam::000000000000:role/codebuild-role",
+                },
+            }
+        },
+    }
+    cfn.create_stack(StackName="cfn-cb-t01", TemplateBody=json.dumps(template))
+    stack = _wait_stack(cfn, "cfn-cb-t01")
+    assert stack["StackStatus"] == "CREATE_COMPLETE"
+
+    # Verify project exists via CodeBuild API
+    result = codebuild.batch_get_projects(names=["cfn-cb-t01"])
+    assert len(result["projects"]) == 1
+    assert result["projects"][0]["name"] == "cfn-cb-t01"
+
+    # Delete stack and verify cleanup
+    cfn.delete_stack(StackName="cfn-cb-t01")
+    _wait_stack(cfn, "cfn-cb-t01")
+    result = codebuild.batch_get_projects(names=["cfn-cb-t01"])
+    assert len(result["projects"]) == 0
+
+
+def test_cfn_codebuild_project_auto_name(cfn, codebuild):
+    """When Name is omitted, _physical_name() generates one."""
+    template = {
+        "AWSTemplateFormatVersion": "2010-09-09",
+        "Resources": {
+            "Project": {
+                "Type": "AWS::CodeBuild::Project",
+                "Properties": {
+                    "Source": {"Type": "NO_SOURCE"},
+                    "Artifacts": {"Type": "NO_ARTIFACTS"},
+                    "Environment": {
+                        "Type": "LINUX_CONTAINER",
+                        "Image": "aws/codebuild/standard:7.0",
+                        "ComputeType": "BUILD_GENERAL1_SMALL",
+                    },
+                    "ServiceRole": "arn:aws:iam::000000000000:role/codebuild-role",
+                },
+            }
+        },
+    }
+    cfn.create_stack(StackName="cfn-cb-t02", TemplateBody=json.dumps(template))
+    stack = _wait_stack(cfn, "cfn-cb-t02")
+    assert stack["StackStatus"] == "CREATE_COMPLETE"
+
+    # Find the auto-generated project name via stack resources
+    resources = cfn.describe_stack_resources(StackName="cfn-cb-t02")["StackResources"]
+    project_name = next(r["PhysicalResourceId"] for r in resources if r["ResourceType"] == "AWS::CodeBuild::Project")
+    assert project_name.startswith("cfn-cb-t02-Project-")
+
+    # Verify it exists
+    result = codebuild.batch_get_projects(names=[project_name])
+    assert len(result["projects"]) == 1
+
+    cfn.delete_stack(StackName="cfn-cb-t02")
+    _wait_stack(cfn, "cfn-cb-t02")
+
+
+def test_cfn_codebuild_project_getatt_arn(cfn, codebuild):
+    """Fn::GetAtt on Arn attribute resolves correctly."""
+    template = {
+        "AWSTemplateFormatVersion": "2010-09-09",
+        "Resources": {
+            "Project": {
+                "Type": "AWS::CodeBuild::Project",
+                "Properties": {
+                    "Name": "cfn-cb-t03",
+                    "Source": {"Type": "NO_SOURCE"},
+                    "Artifacts": {"Type": "NO_ARTIFACTS"},
+                    "Environment": {
+                        "Type": "LINUX_CONTAINER",
+                        "Image": "aws/codebuild/standard:7.0",
+                        "ComputeType": "BUILD_GENERAL1_SMALL",
+                    },
+                    "ServiceRole": "arn:aws:iam::000000000000:role/codebuild-role",
+                },
+            }
+        },
+        "Outputs": {
+            "ProjectArn": {"Value": {"Fn::GetAtt": ["Project", "Arn"]}},
+        },
+    }
+    cfn.create_stack(StackName="cfn-cb-t03", TemplateBody=json.dumps(template))
+    stack = _wait_stack(cfn, "cfn-cb-t03")
+    assert stack["StackStatus"] == "CREATE_COMPLETE"
+
+    outputs = {o["OutputKey"]: o["OutputValue"] for o in stack.get("Outputs", [])}
+    assert outputs["ProjectArn"].startswith("arn:aws:codebuild:")
+    assert outputs["ProjectArn"].endswith(":project/cfn-cb-t03")
+
+    cfn.delete_stack(StackName="cfn-cb-t03")
+    _wait_stack(cfn, "cfn-cb-t03")
+
+
+def test_cfn_codebuild_project_tags(cfn, codebuild):
+    """CFN Tags (capitalised Key/Value) are translated correctly."""
+    template = {
+        "AWSTemplateFormatVersion": "2010-09-09",
+        "Resources": {
+            "Project": {
+                "Type": "AWS::CodeBuild::Project",
+                "Properties": {
+                    "Name": "cfn-cb-t04",
+                    "Source": {"Type": "NO_SOURCE"},
+                    "Artifacts": {"Type": "NO_ARTIFACTS"},
+                    "Environment": {
+                        "Type": "LINUX_CONTAINER",
+                        "Image": "aws/codebuild/standard:7.0",
+                        "ComputeType": "BUILD_GENERAL1_SMALL",
+                    },
+                    "ServiceRole": "arn:aws:iam::000000000000:role/codebuild-role",
+                    "Tags": [
+                        {"Key": "env", "Value": "test"},
+                        {"Key": "team", "Value": "platform"},
+                    ],
+                },
+            }
+        },
+    }
+    cfn.create_stack(StackName="cfn-cb-t04", TemplateBody=json.dumps(template))
+    stack = _wait_stack(cfn, "cfn-cb-t04")
+    assert stack["StackStatus"] == "CREATE_COMPLETE"
+
+    result = codebuild.batch_get_projects(names=["cfn-cb-t04"])
+    tags = {t["key"]: t["value"] for t in result["projects"][0]["tags"]}
+    assert tags["env"] == "test"
+    assert tags["team"] == "platform"
+
+    cfn.delete_stack(StackName="cfn-cb-t04")
+    _wait_stack(cfn, "cfn-cb-t04")
+
+
+def test_cfn_codebuild_project_with_iam_role(cfn, codebuild, iam):
+    """Project references IAM role via Fn::GetAtt."""
+    template = {
+        "AWSTemplateFormatVersion": "2010-09-09",
+        "Resources": {
+            "Role": {
+                "Type": "AWS::IAM::Role",
+                "Properties": {
+                    "RoleName": "cfn-cb-t05-role",
+                    "AssumeRolePolicyDocument": {
+                        "Version": "2012-10-17",
+                        "Statement": [{
+                            "Effect": "Allow",
+                            "Principal": {"Service": "codebuild.amazonaws.com"},
+                            "Action": "sts:AssumeRole",
+                        }],
+                    },
+                },
+            },
+            "Project": {
+                "Type": "AWS::CodeBuild::Project",
+                "Properties": {
+                    "Name": "cfn-cb-t05",
+                    "Source": {"Type": "NO_SOURCE"},
+                    "Artifacts": {"Type": "NO_ARTIFACTS"},
+                    "Environment": {
+                        "Type": "LINUX_CONTAINER",
+                        "Image": "aws/codebuild/standard:7.0",
+                        "ComputeType": "BUILD_GENERAL1_SMALL",
+                    },
+                    "ServiceRole": {"Fn::GetAtt": ["Role", "Arn"]},
+                },
+            },
+        },
+    }
+    cfn.create_stack(StackName="cfn-cb-t05", TemplateBody=json.dumps(template))
+    stack = _wait_stack(cfn, "cfn-cb-t05")
+    assert stack["StackStatus"] == "CREATE_COMPLETE"
+
+    role_arn = iam.get_role(RoleName="cfn-cb-t05-role")["Role"]["Arn"]
+    result = codebuild.batch_get_projects(names=["cfn-cb-t05"])
+    assert result["projects"][0]["serviceRole"] == role_arn
+
+    cfn.delete_stack(StackName="cfn-cb-t05")
+    _wait_stack(cfn, "cfn-cb-t05")
+
+
+def test_cfn_codebuild_project_duplicate_name_fails(cfn, codebuild):
+    """Duplicate project name causes CREATE_FAILED."""
+    # Pre-create the project directly via CodeBuild API
+    codebuild.create_project(
+        name="cfn-cb-t06-dup",
+        source={"type": "NO_SOURCE"},
+        artifacts={"type": "NO_ARTIFACTS"},
+        environment={
+            "type": "LINUX_CONTAINER",
+            "image": "aws/codebuild/standard:7.0",
+            "computeType": "BUILD_GENERAL1_SMALL",
+        },
+        serviceRole="arn:aws:iam::000000000000:role/codebuild-role",
+    )
+
+    template = {
+        "AWSTemplateFormatVersion": "2010-09-09",
+        "Resources": {
+            "Project": {
+                "Type": "AWS::CodeBuild::Project",
+                "Properties": {
+                    "Name": "cfn-cb-t06-dup",  # Same name — should fail
+                    "Source": {"Type": "NO_SOURCE"},
+                    "Artifacts": {"Type": "NO_ARTIFACTS"},
+                    "Environment": {
+                        "Type": "LINUX_CONTAINER",
+                        "Image": "aws/codebuild/standard:7.0",
+                        "ComputeType": "BUILD_GENERAL1_SMALL",
+                    },
+                    "ServiceRole": "arn:aws:iam::000000000000:role/codebuild-role",
+                },
+            }
+        },
+    }
+    cfn.create_stack(StackName="cfn-cb-t06", TemplateBody=json.dumps(template))
+    stack = _wait_stack(cfn, "cfn-cb-t06")
+    assert stack["StackStatus"] == "ROLLBACK_COMPLETE"
+
+    # Cleanup
+    cfn.delete_stack(StackName="cfn-cb-t06")
+    _wait_stack(cfn, "cfn-cb-t06")
+    codebuild.delete_project(name="cfn-cb-t06-dup")
+
+
+def test_cfn_codebuild_project_idempotent_delete(cfn, codebuild):
+    """Delete is idempotent — double delete does not crash."""
+    template = {
+        "AWSTemplateFormatVersion": "2010-09-09",
+        "Resources": {
+            "Project": {
+                "Type": "AWS::CodeBuild::Project",
+                "Properties": {
+                    "Name": "cfn-cb-t07",
+                    "Source": {"Type": "NO_SOURCE"},
+                    "Artifacts": {"Type": "NO_ARTIFACTS"},
+                    "Environment": {
+                        "Type": "LINUX_CONTAINER",
+                        "Image": "aws/codebuild/standard:7.0",
+                        "ComputeType": "BUILD_GENERAL1_SMALL",
+                    },
+                    "ServiceRole": "arn:aws:iam::000000000000:role/codebuild-role",
+                },
+            }
+        },
+    }
+    cfn.create_stack(StackName="cfn-cb-t07", TemplateBody=json.dumps(template))
+    _wait_stack(cfn, "cfn-cb-t07")
+
+    # First delete
+    cfn.delete_stack(StackName="cfn-cb-t07")
+    _wait_stack(cfn, "cfn-cb-t07")
+
+    # Second delete — must not raise
+    cfn.delete_stack(StackName="cfn-cb-t07")
+    stack = _wait_stack(cfn, "cfn-cb-t07")
+    assert stack["StackStatus"] in ("DELETE_COMPLETE", "DOES_NOT_EXIST")

--- a/tests/test_cfn.py
+++ b/tests/test_cfn.py
@@ -1343,7 +1343,6 @@ def test_cfn_lambda_nodejs_inline_zip(cfn, lam):
     cfn.delete_stack(StackName="cfn-nodejs-inline")
     _wait_stack(cfn, "cfn-nodejs-inline")
 
-<<<<<<< HEAD
 def test_cfn_dynamodb_stream_spec(cfn, ddb):
     """CloudFormation DynamoDB table with StreamViewType (no StreamEnabled) must
     have streams enabled: LatestStreamArn and StreamSpecification present on


### PR DESCRIPTION
Closes #348

## What
Adds a CloudFormation provisioner for AWS::CodeBuild::Project, wiring the existing codebuild.py service into the CFN engine so CDK/Terraform stacks that declare a CodeBuild project no longer fail with Unsupported resource type.

## Changes
- provisioners.py — import, _codebuild_project_create, _codebuild_project_delete, registry entry
- tests/test_cfn.py — 7 new tests covering happy path, auto-name, Fn::GetAtt, tags, IAM dependency, duplicate name rollback, and idempotent delete