### PR TITLE
Add AWS::EventBridge::Pipes provisioner

### DIFF
--- a/ministack/app.py
+++ b/ministack/app.py
@@ -47,6 +47,7 @@ from ministack.services import (
     autoscaling,
     apigateway_v1,
     appconfig,
+    pipes,
     appsync,
     athena,
     cloudformation,
@@ -846,6 +847,7 @@ def _reset_all_state():
         (rds_data, rds_data.reset),
         (s3files, s3files.reset),
         (appconfig, appconfig.reset),
+        (pipes, pipes.reset),
     ]:
         try:
             fn()

--- a/ministack/app.py
+++ b/ministack/app.py
@@ -830,6 +830,7 @@ def _reset_all_state():
         "emr", "alb", "acm", "ses_v2", "waf", "efs", "cloudformation", "kms",
         "cloudfront", "codebuild", "ecr", "appsync", "servicediscovery",
         "rds_data", "s3files", "appconfig", "transfer", "scheduler", "autoscaling", "eks", "iam",
+        "pipes"
     ]
     for mod_name in _ALL_SERVICE_MODULES:
         if mod_name in _loaded_modules:

--- a/ministack/app.py
+++ b/ministack/app.py
@@ -24,6 +24,12 @@ from urllib.parse import parse_qs, urlparse
 _MINISTACK_HOST = os.environ.get("MINISTACK_HOST", "localhost")
 _MINISTACK_PORT = os.environ.get("GATEWAY_PORT", "4566")
 
+try:
+    from importlib.metadata import version as _pkg_version
+    _VERSION = _pkg_version("ministack")
+except Exception:
+    _VERSION = "dev"
+
 # Matches host headers like "{apiId}.execute-api.<host>" or "{apiId}.execute-api.<host>:4566"
 _EXECUTE_API_RE = re.compile(
     r"^([a-f0-9]{8})\.execute-api\." + re.escape(_MINISTACK_HOST) + r"(?::\d+)?$"
@@ -40,52 +46,57 @@ _S3_VHOST_EXCLUDE_RE = re.compile(r"\.(execute-api|alb|emr|efs|elasticache|s3-co
 from ministack.core.persistence import PERSIST_STATE, load_state, save_all
 from ministack.core.responses import set_request_account_id
 from ministack.core.router import detect_service, extract_access_key_id, extract_account_id, extract_region
-from ministack.services import (
-    acm,
-    alb,
-    apigateway,
-    autoscaling,
-    apigateway_v1,
-    appconfig,
-    appsync,
-    athena,
-    cloudformation,
-    cloudwatch,
-    cloudwatch_logs,
-    cognito,
-    dynamodb,
-    ec2,
-    ecr,
-    ecs,
-    efs,
-    elasticache,
-    emr,
-    eventbridge,
-    firehose,
-    glue,
-    kinesis,
-    kms,
-    lambda_svc,
-    rds,
-    rds_data,
-    route53,
-    s3,
-    secretsmanager,
-    ses,
-    ses_v2,
-    sns,
-    sqs,
-    ssm,
-    stepfunctions,
-    waf,
-    cloudfront,
-    servicediscovery,
-    s3files,
-    codebuild,
-    transfer,
-)
-from ministack.services import iam_sts
-from ministack.services.iam_sts import handle_iam_request, handle_sts_request
+
+# ---------------------------------------------------------------------------
+# Lazy service loader — modules are imported on first request, not at startup.
+# This saves ~20 MB of idle RAM and speeds up boot.
+# ---------------------------------------------------------------------------
+_loaded_modules: dict = {}
+
+
+class _ErrorModule:
+    """Stub returned when a service module fails to import."""
+    def __init__(self, name: str, error: str):
+        self._name = name
+        self._error = error
+
+    async def handle_request(self, method, path, headers, body, query_params):
+        return 500, {"Content-Type": "application/json"}, \
+            json.dumps({"__type": "ServiceUnavailable",
+                        "message": f"Service module '{self._name}' failed to load: {self._error}"}).encode()
+
+    def get_state(self):
+        return {}
+
+    def restore_state(self, data):
+        pass
+
+    def load_persisted_state(self, data):
+        pass
+
+    def reset(self):
+        pass
+
+
+def _get_module(name: str):
+    """Import and cache a service module by short name (e.g. 's3', 'lambda_svc')."""
+    mod = _loaded_modules.get(name)
+    if mod is None:
+        try:
+            mod = __import__(f"ministack.services.{name}", fromlist=["handle_request"])
+        except (ModuleNotFoundError, ImportError) as e:
+            logger.warning("Service module failed to load: %s - %s", name, e)
+            mod = _ErrorModule(name, str(e))
+        _loaded_modules[name] = mod
+    return mod
+
+
+def _lazy_handler(module_name: str):
+    """Return a callable that lazily imports module_name and delegates to handle_request."""
+    async def _handler(method, path, headers, body, query_params):
+        mod = _get_module(module_name)
+        return await mod.handle_request(method, path, headers, body, query_params)
+    return _handler
 
 LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO").upper()
 logging.basicConfig(
@@ -96,50 +107,52 @@ logging.basicConfig(
 logger = logging.getLogger("ministack")
 
 SERVICE_HANDLERS = {
-    "s3": s3.handle_request,
-    "sqs": sqs.handle_request,
-    "cloudformation": cloudformation.handle_request,
-    "sns": sns.handle_request,
-    "dynamodb": dynamodb.handle_request,
-    "lambda": lambda_svc.handle_request,
-    "iam": handle_iam_request,
-    "sts": handle_sts_request,
-    "secretsmanager": secretsmanager.handle_request,
-    "logs": cloudwatch_logs.handle_request,
-    "ssm": ssm.handle_request,
-    "events": eventbridge.handle_request,
-    "kinesis": kinesis.handle_request,
-    "monitoring": cloudwatch.handle_request,
-    "ses": ses.handle_request,
-    "acm": acm.handle_request,
-    "wafv2": waf.handle_request,
-    "states": stepfunctions.handle_request,
-    "ecr": ecr.handle_request,
-    "ecs": ecs.handle_request,
-    "rds": rds.handle_request,
-    "elasticache": elasticache.handle_request,
-    "glue": glue.handle_request,
-    "athena": athena.handle_request,
-    "apigateway": apigateway.handle_request,
-    "firehose": firehose.handle_request,
-    "route53": route53.handle_request,
-    "cognito-idp": cognito.handle_request,
-    "cognito-identity": cognito.handle_request,
-    "ec2": ec2.handle_request,
-    "elasticmapreduce": emr.handle_request,
-    "elasticloadbalancing": alb.handle_request,
-    "elasticfilesystem": efs.handle_request,
-    "kms": kms.handle_request,
-    "cloudfront": cloudfront.handle_request,
-    "codebuild": codebuild.handle_request,
-    "transfer": transfer.handle_request,
-    "appsync": appsync.handle_request,
-    "servicediscovery": servicediscovery.handle_request,
-    "s3files": s3files.handle_request,
-    "rds-data": rds_data.handle_request,
-    "autoscaling": autoscaling.handle_request,
-    "appconfig": appconfig.handle_request,
-    "appconfigdata": appconfig.handle_request,
+    "s3": _lazy_handler("s3"),
+    "sqs": _lazy_handler("sqs"),
+    "cloudformation": _lazy_handler("cloudformation"),
+    "sns": _lazy_handler("sns"),
+    "dynamodb": _lazy_handler("dynamodb"),
+    "lambda": _lazy_handler("lambda_svc"),
+    "iam": _lazy_handler("iam"),
+    "sts": _lazy_handler("sts"),
+    "secretsmanager": _lazy_handler("secretsmanager"),
+    "logs": _lazy_handler("cloudwatch_logs"),
+    "ssm": _lazy_handler("ssm"),
+    "events": _lazy_handler("eventbridge"),
+    "kinesis": _lazy_handler("kinesis"),
+    "monitoring": _lazy_handler("cloudwatch"),
+    "ses": _lazy_handler("ses"),
+    "acm": _lazy_handler("acm"),
+    "wafv2": _lazy_handler("waf"),
+    "states": _lazy_handler("stepfunctions"),
+    "ecr": _lazy_handler("ecr"),
+    "ecs": _lazy_handler("ecs"),
+    "rds": _lazy_handler("rds"),
+    "elasticache": _lazy_handler("elasticache"),
+    "glue": _lazy_handler("glue"),
+    "athena": _lazy_handler("athena"),
+    "apigateway": _lazy_handler("apigateway"),
+    "firehose": _lazy_handler("firehose"),
+    "route53": _lazy_handler("route53"),
+    "cognito-idp": _lazy_handler("cognito"),
+    "cognito-identity": _lazy_handler("cognito"),
+    "ec2": _lazy_handler("ec2"),
+    "elasticmapreduce": _lazy_handler("emr"),
+    "elasticloadbalancing": _lazy_handler("alb"),
+    "elasticfilesystem": _lazy_handler("efs"),
+    "kms": _lazy_handler("kms"),
+    "cloudfront": _lazy_handler("cloudfront"),
+    "codebuild": _lazy_handler("codebuild"),
+    "transfer": _lazy_handler("transfer"),
+    "appsync": _lazy_handler("appsync"),
+    "servicediscovery": _lazy_handler("servicediscovery"),
+    "s3files": _lazy_handler("s3files"),
+    "rds-data": _lazy_handler("rds_data"),
+    "autoscaling": _lazy_handler("autoscaling"),
+    "appconfig": _lazy_handler("appconfig"),
+    "appconfigdata": _lazy_handler("appconfig"),
+    "scheduler": _lazy_handler("scheduler"),
+    "eks": _lazy_handler("eks"),
 }
 
 SERVICE_NAME_ALIASES = {
@@ -195,7 +208,7 @@ BANNER = r"""
           SSM, EventBridge, Kinesis, CloudWatch, SES, SES v2, ACM, WAF v2, Step Functions,
           ECS, RDS, ElastiCache, Glue, Athena, API Gateway, Firehose, Route53,
           Cognito, EC2, EMR, EBS, EFS, ALB/ELBv2, CloudFormation, KMS, ECR, CloudFront,
-          AppSync, Cloud Map, S3 Files, RDS Data API, CodeBuild, AppConfig, Transfer
+          AppSync, Cloud Map, S3 Files, RDS Data API, CodeBuild, AppConfig, Transfer, EKS
 """
 
 
@@ -274,8 +287,7 @@ async def app(scope, receive, send):
     if path.startswith("/_ministack/lambda-layers/") and method == "GET":
         lp = path.split("/")  # ['', '_ministack', 'lambda-layers', name, ver, 'content']
         if len(lp) >= 6 and lp[5] == "content" and lp[4].isdigit():
-            from ministack.services import lambda_svc
-            status, resp_headers, resp_body = lambda_svc.serve_layer_content(lp[3], int(lp[4]))
+            status, resp_headers, resp_body = _get_module("lambda_svc").serve_layer_content(lp[3], int(lp[4]))
             await _send_response(send, status, resp_headers, resp_body)
             return
 
@@ -286,16 +298,38 @@ async def app(scope, receive, send):
             _pool_id = path.rsplit("/.well-known/jwks.json", 1)[0].lstrip("/")
             if _pool_id:
                 _region = extract_region(headers) or "us-east-1"
-                status, resp_headers, resp_body = cognito.well_known_jwks(_pool_id)
+                status, resp_headers, resp_body = _get_module("cognito").well_known_jwks(_pool_id)
                 await _send_response(send, status, resp_headers, resp_body)
                 return
         elif path.endswith("/.well-known/openid-configuration"):
             _pool_id = path.rsplit("/.well-known/openid-configuration", 1)[0].lstrip("/")
             if _pool_id:
                 _region = extract_region(headers) or "us-east-1"
-                status, resp_headers, resp_body = cognito.well_known_openid_configuration(_pool_id, _region)
+                status, resp_headers, resp_body = _get_module("cognito").well_known_openid_configuration(_pool_id, _region)
                 await _send_response(send, status, resp_headers, resp_body)
                 return
+
+    # Cognito OAuth2 / Managed Login UI endpoints
+    if path == "/oauth2/authorize" and method == "GET":
+        status, resp_headers, resp_body = _get_module("cognito").handle_oauth2_authorize(method, path, headers, query_params)
+        await _send_response(send, status, resp_headers, resp_body)
+        return
+    if path in ("/oauth2/login", "/login") and method == "POST":
+        status, resp_headers, resp_body = _get_module("cognito").handle_login_submit(method, path, headers, body, query_params)
+        await _send_response(send, status, resp_headers, resp_body)
+        return
+    if path == "/oauth2/token" and method == "POST":
+        status, resp_headers, resp_body = _get_module("cognito").handle_oauth2_token(method, path, headers, body, query_params)
+        await _send_response(send, status, resp_headers, resp_body)
+        return
+    if path in ("/oauth2/userInfo", "/oauth2/userinfo") and method in ("GET", "POST"):
+        status, resp_headers, resp_body = _get_module("cognito").handle_oauth2_userinfo(method, path, headers, body, query_params)
+        await _send_response(send, status, resp_headers, resp_body)
+        return
+    if path == "/logout" and method == "GET":
+        status, resp_headers, resp_body = _get_module("cognito").handle_logout(method, path, headers, query_params)
+        await _send_response(send, status, resp_headers, resp_body)
+        return
 
     # Admin endpoints — no wildcard CORS headers (return early, before CORS block)
     if path == "/_ministack/reset" and method == "POST":
@@ -358,8 +392,8 @@ async def app(scope, receive, send):
             bucket_name = arn.split(":::")[-1].split("/")[0] if ":::" in arn else arn.split("/")[0]
 
             if method == "GET":
-                # ListTagsForResource — return real tags from s3._bucket_tags
-                tags = s3._bucket_tags.get(bucket_name, {})
+                # ListTagsForResource — return real tags from _get_module("s3")._bucket_tags
+                tags = _get_module("s3")._bucket_tags.get(bucket_name, {})
                 tag_members = "".join(
                     f"<member><Key>{k}</Key><Value>{v}</Value></member>"
                     for k, v in tags.items()
@@ -375,13 +409,13 @@ async def app(scope, receive, send):
                     "x-amzn-requestid": request_id,
                 }, xml_body)
             elif method == "PUT":
-                # TagResource — merge tags into s3._bucket_tags
+                # TagResource — merge tags into _get_module("s3")._bucket_tags
                 try:
                     payload = json.loads(body) if body else {}
                     new_tags = {t["Key"]: t["Value"] for t in payload.get("Tags", [])}
-                    existing = s3._bucket_tags.get(bucket_name, {})
+                    existing = _get_module("s3")._bucket_tags.get(bucket_name, {})
                     existing.update(new_tags)
-                    s3._bucket_tags[bucket_name] = existing
+                    _get_module("s3")._bucket_tags[bucket_name] = existing
                 except Exception as e:
                     logger.warning("S3 Control TagResource parse error: %s", e)
                 await _send_response(send, 204, {
@@ -392,10 +426,10 @@ async def app(scope, receive, send):
                 keys_to_remove = query_params.get("tagKeys", [])
                 if isinstance(keys_to_remove, str):
                     keys_to_remove = [keys_to_remove]
-                tags = s3._bucket_tags.get(bucket_name, {})
+                tags = _get_module("s3")._bucket_tags.get(bucket_name, {})
                 for k in keys_to_remove:
                     tags.pop(k, None)
-                s3._bucket_tags[bucket_name] = tags
+                _get_module("s3")._bucket_tags[bucket_name] = tags
                 await _send_response(send, 204, {
                     "x-amzn-requestid": request_id,
                 }, b"")
@@ -414,13 +448,13 @@ async def app(scope, receive, send):
 
     # RDS Data API — /Execute, /BeginTransaction, /CommitTransaction, /RollbackTransaction, /BatchExecute
     if path in ("/Execute", "/BeginTransaction", "/CommitTransaction", "/RollbackTransaction", "/BatchExecute"):
-        status, resp_headers, resp_body = await rds_data.handle_request(method, path, headers, body, query_params)
+        status, resp_headers, resp_body = await _get_module("rds_data").handle_request(method, path, headers, body, query_params)
         await _send_response(send, status, resp_headers, resp_body)
         return
 
     # SES v2 REST API — /v2/email/...
     if path.startswith("/v2/email"):
-        status, resp_headers, resp_body = await ses_v2.handle_request(method, path, headers, body, query_params)
+        status, resp_headers, resp_body = await _get_module("ses_v2").handle_request(method, path, headers, body, query_params)
         await _send_response(send, status, resp_headers, resp_body)
         return
 
@@ -431,7 +465,7 @@ async def app(scope, receive, send):
         }, json.dumps({
             "services": {s: "available" for s in SERVICE_HANDLERS},
             "edition": "light",
-            "version": "3.0.0.dev",
+            "version": _VERSION,
         }).encode())
         return
 
@@ -457,12 +491,12 @@ async def app(scope, receive, send):
         stage = path_parts[0] if path_parts else "$default"
         execute_path = "/" + path_parts[1] if len(path_parts) > 1 else "/"
         try:
-            if api_id in apigateway_v1._rest_apis:
-                status, resp_headers, resp_body = await apigateway_v1.handle_execute(
+            if api_id in _get_module("apigateway_v1")._rest_apis:
+                status, resp_headers, resp_body = await _get_module("apigateway_v1").handle_execute(
                     api_id, stage, method, execute_path, headers, body, query_params
                 )
             else:
-                status, resp_headers, resp_body = await apigateway.handle_execute(
+                status, resp_headers, resp_body = await _get_module("apigateway").handle_execute(
                     api_id, stage, execute_path, method, headers, body, query_params
                 )
         except Exception as e:
@@ -479,10 +513,10 @@ async def app(scope, receive, send):
     # ALB data-plane — two addressing modes:
     #   1. Host header matches a configured ALB DNS name or {lb-name}.alb.localhost
     #   2. Path prefix /_alb/{lb-name}/...  (no DNS config needed for local testing)
-    _alb_lb = alb.find_lb_for_host(host)
+    _alb_lb = _get_module("alb").find_lb_for_host(host)
     if _alb_lb is None and path.startswith("/_alb/"):
         _alb_path_parts = path[6:].split("/", 1)
-        _alb_lb = alb._find_lb_by_name(_alb_path_parts[0])
+        _alb_lb = _get_module("alb")._find_lb_by_name(_alb_path_parts[0])
         if _alb_lb:
             path = "/" + _alb_path_parts[1] if len(_alb_path_parts) > 1 else "/"
 
@@ -494,7 +528,7 @@ async def app(scope, receive, send):
             except ValueError:
                 pass
         try:
-            status, resp_headers, resp_body = await alb.dispatch_request(
+            status, resp_headers, resp_body = await _get_module("alb").dispatch_request(
                 _alb_lb, method, path, headers, body, query_params, _alb_port
             )
         except Exception as e:
@@ -522,7 +556,7 @@ async def app(scope, receive, send):
         if bucket not in _non_s3_hosts:
             vhost_path = "/" + bucket + path if path != "/" else "/" + bucket + "/"
             try:
-                status, resp_headers, resp_body = await s3.handle_request(
+                status, resp_headers, resp_body = await _get_module("s3").handle_request(
                     method, vhost_path, headers, body, query_params
                 )
             except Exception as e:
@@ -622,48 +656,32 @@ async def _handle_lifespan(scope, receive, send):
         elif message["type"] == "lifespan.shutdown":
             logger.info("MiniStack shutting down...")
             if PERSIST_STATE:
-                save_all({
-                    "apigateway": apigateway.get_state,
-                    "apigateway_v1": apigateway_v1.get_state,
-                    "sqs": sqs.get_state,
-                    "sns": sns.get_state,
-                    "ssm": ssm.get_state,
-                    "secretsmanager": secretsmanager.get_state,
-                    "iam": iam_sts.get_state,
-                    "dynamodb": dynamodb.get_state,
-                    "kms": kms.get_state,
-                    "eventbridge": eventbridge.get_state,
-                    "cloudwatch_logs": cloudwatch_logs.get_state,
-                    "kinesis": kinesis.get_state,
-                    "ec2": ec2.get_state,
-                    "route53": route53.get_state,
-                    "cognito": cognito.get_state,
-                    "ecr": ecr.get_state,
-                    "cloudwatch": cloudwatch.get_state,
-                    "s3": s3.get_state,
-                    "lambda": lambda_svc.get_state,
-                    "rds": rds.get_state,
-                    "ecs": ecs.get_state,
-                    "elasticache": elasticache.get_state,
-                    "appsync": appsync.get_state,
-                    "stepfunctions": stepfunctions.get_state,
-                    "alb": alb.get_state,
-                    "glue": glue.get_state,
-                    "efs": efs.get_state,
-                    "waf": waf.get_state,
-                    "athena": athena.get_state,
-                    "emr": emr.get_state,
-                    "cloudfront": cloudfront.get_state,
-                    "codebuild": codebuild.get_state,
-                    "transfer": transfer.get_state,
-                    "acm": acm.get_state,
-                    "firehose": firehose.get_state,
-                    "ses": ses.get_state,
-                    "ses_v2": ses_v2.get_state,
-                    "servicediscovery": servicediscovery.get_state,
-                    "s3files": s3files.get_state,
-                    "appconfig": appconfig.get_state,
-                })
+                # Only save state for modules that were actually loaded
+                _state_map = {
+                    "apigateway": "apigateway", "apigateway_v1": "apigateway_v1",
+                    "sqs": "sqs", "sns": "sns", "ssm": "ssm",
+                    "secretsmanager": "secretsmanager", "iam": "iam",
+                    "dynamodb": "dynamodb", "kms": "kms", "eventbridge": "eventbridge",
+                    "cloudwatch_logs": "cloudwatch_logs", "kinesis": "kinesis",
+                    "ec2": "ec2", "route53": "route53", "cognito": "cognito",
+                    "ecr": "ecr", "cloudwatch": "cloudwatch", "s3": "s3",
+                    "lambda": "lambda_svc", "rds": "rds", "ecs": "ecs",
+                    "elasticache": "elasticache", "appsync": "appsync",
+                    "stepfunctions": "stepfunctions", "alb": "alb",
+                    "glue": "glue", "efs": "efs", "waf": "waf",
+                    "athena": "athena", "emr": "emr", "cloudfront": "cloudfront",
+                    "codebuild": "codebuild", "acm": "acm", "firehose": "firehose",
+                    "ses": "ses", "ses_v2": "ses_v2",
+                    "servicediscovery": "servicediscovery", "s3files": "s3files",
+                    "appconfig": "appconfig", "transfer": "transfer",
+                    "scheduler": "scheduler", "autoscaling": "autoscaling",
+                    "eks": "eks",
+                }
+                save_dict = {}
+                for key, mod_name in _state_map.items():
+                    if mod_name in _loaded_modules:
+                        save_dict[key] = _loaded_modules[mod_name].get_state
+                save_all(save_dict)
             _stop_docker_containers()
             await send({"type": "lifespan.shutdown.complete"})
             return
@@ -677,7 +695,7 @@ def _stop_docker_containers():
         client = docker.from_env()
     except Exception:
         return
-    for label in ("ministack=rds", "ministack=ecs", "ministack=elasticache"):
+    for label in ("ministack=rds", "ministack=ecs", "ministack=elasticache", "ministack=eks", "ministack=lambda"):
         try:
             for c in client.containers.list(filters={"label": label}):
                 try:
@@ -691,18 +709,11 @@ def _stop_docker_containers():
 
 def _load_persisted_state():
     """Load persisted state for services that support it."""
-    data = load_state("apigateway")
-    if data:
-        apigateway.load_persisted_state(data)
-        logger.info("Loaded persisted state for apigateway")
-    data_v1 = load_state("apigateway_v1")
-    if data_v1:
-        apigateway_v1.load_persisted_state(data_v1)
-        logger.info("Loaded persisted state for apigateway_v1")
-    data_sd = load_state("servicediscovery")
-    if data_sd:
-        servicediscovery.load_persisted_state(data_sd)
-        logger.info("Loaded persisted state for servicediscovery")
+    for svc_key in ("apigateway", "apigateway_v1", "servicediscovery"):
+        data = load_state(svc_key)
+        if data:
+            _get_module(svc_key).load_persisted_state(data)
+            logger.info("Loaded persisted state for %s", svc_key)
 
 
 async def _wait_for_port(port, timeout=30):
@@ -810,51 +821,26 @@ def _reset_all_state():
     """Wipe all in-memory state across every service module, and persisted files if enabled."""
 
     from ministack.core.persistence import PERSIST_STATE, STATE_DIR
-    from ministack.services.iam_sts import reset as _iam_reset
-    from ministack.services.s3 import DATA_DIR as S3_DATA_DIR
-    from ministack.services.s3 import PERSIST as S3_PERSIST
 
-    for mod, fn in [
-        (s3, s3.reset), (sqs, sqs.reset), (sns, sns.reset),
-        (dynamodb, dynamodb.reset), (lambda_svc, lambda_svc.reset),
-        (secretsmanager, secretsmanager.reset), (cloudwatch_logs, cloudwatch_logs.reset),
-        (ssm, ssm.reset), (eventbridge, eventbridge.reset), (kinesis, kinesis.reset),
-        (cloudwatch, cloudwatch.reset), (ses, ses.reset),
-        (stepfunctions, stepfunctions.reset), (ecs, ecs.reset),
-        (rds, rds.reset), (elasticache, elasticache.reset),
-        (glue, glue.reset), (athena, athena.reset),
-        (apigateway, apigateway.reset),
-        (apigateway_v1, apigateway_v1.reset),
-        (firehose, firehose.reset),
-        (route53, route53.reset),
-        (cognito, cognito.reset),
-        (ec2, ec2.reset),
-        (emr, emr.reset),
-        (alb, alb.reset),
-        (acm, acm.reset),
-        (ses_v2, ses_v2.reset),
-        (waf, waf.reset),
-        (efs, efs.reset),
-        (cloudformation, cloudformation.reset),
-        (kms, kms.reset),
-        (cloudfront, cloudfront.reset),
-        (codebuild, codebuild.reset),
-        (transfer, transfer.reset),
-        (ecr, ecr.reset),
-        (appsync, appsync.reset),
-        (servicediscovery, servicediscovery.reset),
-        (rds_data, rds_data.reset),
-        (s3files, s3files.reset),
-        (appconfig, appconfig.reset),
-    ]:
-        try:
-            fn()
-        except Exception as e:
-            logger.warning("reset() failed for %s: %s", mod.__name__, e)
-    try:
-        _iam_reset()
-    except Exception as e:
-        logger.warning("reset() failed for iam_sts: %s", e)
+    _ALL_SERVICE_MODULES = [
+        "s3", "sqs", "sns", "dynamodb", "lambda_svc", "secretsmanager",
+        "cloudwatch_logs", "ssm", "eventbridge", "kinesis", "cloudwatch",
+        "ses", "stepfunctions", "ecs", "rds", "elasticache", "glue", "athena",
+        "apigateway", "apigateway_v1", "firehose", "route53", "cognito", "ec2",
+        "emr", "alb", "acm", "ses_v2", "waf", "efs", "cloudformation", "kms",
+        "cloudfront", "codebuild", "ecr", "appsync", "servicediscovery",
+        "rds_data", "s3files", "appconfig", "transfer", "scheduler", "autoscaling", "eks", "iam",
+    ]
+    for mod_name in _ALL_SERVICE_MODULES:
+        if mod_name in _loaded_modules:
+            mod = _loaded_modules[mod_name]
+            try:
+                mod.reset()
+            except Exception as e:
+                logger.warning("reset() failed for %s: %s", mod_name, e)
+
+    S3_DATA_DIR = os.environ.get("S3_DATA_DIR", "/tmp/ministack-data/s3")
+    S3_PERSIST = os.environ.get("S3_PERSIST", "0") == "1"
 
     # Wipe persisted files so a subsequent restart doesn't reload old state
     if PERSIST_STATE and os.path.isdir(STATE_DIR):

--- a/ministack/app.py
+++ b/ministack/app.py
@@ -24,12 +24,6 @@ from urllib.parse import parse_qs, urlparse
 _MINISTACK_HOST = os.environ.get("MINISTACK_HOST", "localhost")
 _MINISTACK_PORT = os.environ.get("GATEWAY_PORT", "4566")
 
-try:
-    from importlib.metadata import version as _pkg_version
-    _VERSION = _pkg_version("ministack")
-except Exception:
-    _VERSION = "dev"
-
 # Matches host headers like "{apiId}.execute-api.<host>" or "{apiId}.execute-api.<host>:4566"
 _EXECUTE_API_RE = re.compile(
     r"^([a-f0-9]{8})\.execute-api\." + re.escape(_MINISTACK_HOST) + r"(?::\d+)?$"
@@ -46,7 +40,6 @@ _S3_VHOST_EXCLUDE_RE = re.compile(r"\.(execute-api|alb|emr|efs|elasticache|s3-co
 from ministack.core.persistence import PERSIST_STATE, load_state, save_all
 from ministack.core.responses import set_request_account_id
 from ministack.core.router import detect_service, extract_access_key_id, extract_account_id, extract_region
-<<<<<<< cf-pipes
 from ministack.services import (
     acm,
     alb,
@@ -54,7 +47,6 @@ from ministack.services import (
     autoscaling,
     apigateway_v1,
     appconfig,
-    pipes,
     appsync,
     athena,
     cloudformation,
@@ -94,59 +86,6 @@ from ministack.services import (
 )
 from ministack.services import iam_sts
 from ministack.services.iam_sts import handle_iam_request, handle_sts_request
-=======
-
-# ---------------------------------------------------------------------------
-# Lazy service loader — modules are imported on first request, not at startup.
-# This saves ~20 MB of idle RAM and speeds up boot.
-# ---------------------------------------------------------------------------
-_loaded_modules: dict = {}
-
-
-class _ErrorModule:
-    """Stub returned when a service module fails to import."""
-    def __init__(self, name: str, error: str):
-        self._name = name
-        self._error = error
-
-    async def handle_request(self, method, path, headers, body, query_params):
-        return 500, {"Content-Type": "application/json"}, \
-            json.dumps({"__type": "ServiceUnavailable",
-                        "message": f"Service module '{self._name}' failed to load: {self._error}"}).encode()
-
-    def get_state(self):
-        return {}
-
-    def restore_state(self, data):
-        pass
-
-    def load_persisted_state(self, data):
-        pass
-
-    def reset(self):
-        pass
-
-
-def _get_module(name: str):
-    """Import and cache a service module by short name (e.g. 's3', 'lambda_svc')."""
-    mod = _loaded_modules.get(name)
-    if mod is None:
-        try:
-            mod = __import__(f"ministack.services.{name}", fromlist=["handle_request"])
-        except (ModuleNotFoundError, ImportError) as e:
-            logger.warning("Service module failed to load: %s - %s", name, e)
-            mod = _ErrorModule(name, str(e))
-        _loaded_modules[name] = mod
-    return mod
-
-
-def _lazy_handler(module_name: str):
-    """Return a callable that lazily imports module_name and delegates to handle_request."""
-    async def _handler(method, path, headers, body, query_params):
-        mod = _get_module(module_name)
-        return await mod.handle_request(method, path, headers, body, query_params)
-    return _handler
->>>>>>> main
 
 LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO").upper()
 logging.basicConfig(
@@ -157,52 +96,50 @@ logging.basicConfig(
 logger = logging.getLogger("ministack")
 
 SERVICE_HANDLERS = {
-    "s3": _lazy_handler("s3"),
-    "sqs": _lazy_handler("sqs"),
-    "cloudformation": _lazy_handler("cloudformation"),
-    "sns": _lazy_handler("sns"),
-    "dynamodb": _lazy_handler("dynamodb"),
-    "lambda": _lazy_handler("lambda_svc"),
-    "iam": _lazy_handler("iam"),
-    "sts": _lazy_handler("sts"),
-    "secretsmanager": _lazy_handler("secretsmanager"),
-    "logs": _lazy_handler("cloudwatch_logs"),
-    "ssm": _lazy_handler("ssm"),
-    "events": _lazy_handler("eventbridge"),
-    "kinesis": _lazy_handler("kinesis"),
-    "monitoring": _lazy_handler("cloudwatch"),
-    "ses": _lazy_handler("ses"),
-    "acm": _lazy_handler("acm"),
-    "wafv2": _lazy_handler("waf"),
-    "states": _lazy_handler("stepfunctions"),
-    "ecr": _lazy_handler("ecr"),
-    "ecs": _lazy_handler("ecs"),
-    "rds": _lazy_handler("rds"),
-    "elasticache": _lazy_handler("elasticache"),
-    "glue": _lazy_handler("glue"),
-    "athena": _lazy_handler("athena"),
-    "apigateway": _lazy_handler("apigateway"),
-    "firehose": _lazy_handler("firehose"),
-    "route53": _lazy_handler("route53"),
-    "cognito-idp": _lazy_handler("cognito"),
-    "cognito-identity": _lazy_handler("cognito"),
-    "ec2": _lazy_handler("ec2"),
-    "elasticmapreduce": _lazy_handler("emr"),
-    "elasticloadbalancing": _lazy_handler("alb"),
-    "elasticfilesystem": _lazy_handler("efs"),
-    "kms": _lazy_handler("kms"),
-    "cloudfront": _lazy_handler("cloudfront"),
-    "codebuild": _lazy_handler("codebuild"),
-    "transfer": _lazy_handler("transfer"),
-    "appsync": _lazy_handler("appsync"),
-    "servicediscovery": _lazy_handler("servicediscovery"),
-    "s3files": _lazy_handler("s3files"),
-    "rds-data": _lazy_handler("rds_data"),
-    "autoscaling": _lazy_handler("autoscaling"),
-    "appconfig": _lazy_handler("appconfig"),
-    "appconfigdata": _lazy_handler("appconfig"),
-    "scheduler": _lazy_handler("scheduler"),
-    "eks": _lazy_handler("eks"),
+    "s3": s3.handle_request,
+    "sqs": sqs.handle_request,
+    "cloudformation": cloudformation.handle_request,
+    "sns": sns.handle_request,
+    "dynamodb": dynamodb.handle_request,
+    "lambda": lambda_svc.handle_request,
+    "iam": handle_iam_request,
+    "sts": handle_sts_request,
+    "secretsmanager": secretsmanager.handle_request,
+    "logs": cloudwatch_logs.handle_request,
+    "ssm": ssm.handle_request,
+    "events": eventbridge.handle_request,
+    "kinesis": kinesis.handle_request,
+    "monitoring": cloudwatch.handle_request,
+    "ses": ses.handle_request,
+    "acm": acm.handle_request,
+    "wafv2": waf.handle_request,
+    "states": stepfunctions.handle_request,
+    "ecr": ecr.handle_request,
+    "ecs": ecs.handle_request,
+    "rds": rds.handle_request,
+    "elasticache": elasticache.handle_request,
+    "glue": glue.handle_request,
+    "athena": athena.handle_request,
+    "apigateway": apigateway.handle_request,
+    "firehose": firehose.handle_request,
+    "route53": route53.handle_request,
+    "cognito-idp": cognito.handle_request,
+    "cognito-identity": cognito.handle_request,
+    "ec2": ec2.handle_request,
+    "elasticmapreduce": emr.handle_request,
+    "elasticloadbalancing": alb.handle_request,
+    "elasticfilesystem": efs.handle_request,
+    "kms": kms.handle_request,
+    "cloudfront": cloudfront.handle_request,
+    "codebuild": codebuild.handle_request,
+    "transfer": transfer.handle_request,
+    "appsync": appsync.handle_request,
+    "servicediscovery": servicediscovery.handle_request,
+    "s3files": s3files.handle_request,
+    "rds-data": rds_data.handle_request,
+    "autoscaling": autoscaling.handle_request,
+    "appconfig": appconfig.handle_request,
+    "appconfigdata": appconfig.handle_request,
 }
 
 SERVICE_NAME_ALIASES = {
@@ -258,7 +195,7 @@ BANNER = r"""
           SSM, EventBridge, Kinesis, CloudWatch, SES, SES v2, ACM, WAF v2, Step Functions,
           ECS, RDS, ElastiCache, Glue, Athena, API Gateway, Firehose, Route53,
           Cognito, EC2, EMR, EBS, EFS, ALB/ELBv2, CloudFormation, KMS, ECR, CloudFront,
-          AppSync, Cloud Map, S3 Files, RDS Data API, CodeBuild, AppConfig, Transfer, EKS
+          AppSync, Cloud Map, S3 Files, RDS Data API, CodeBuild, AppConfig, Transfer
 """
 
 
@@ -337,7 +274,8 @@ async def app(scope, receive, send):
     if path.startswith("/_ministack/lambda-layers/") and method == "GET":
         lp = path.split("/")  # ['', '_ministack', 'lambda-layers', name, ver, 'content']
         if len(lp) >= 6 and lp[5] == "content" and lp[4].isdigit():
-            status, resp_headers, resp_body = _get_module("lambda_svc").serve_layer_content(lp[3], int(lp[4]))
+            from ministack.services import lambda_svc
+            status, resp_headers, resp_body = lambda_svc.serve_layer_content(lp[3], int(lp[4]))
             await _send_response(send, status, resp_headers, resp_body)
             return
 
@@ -348,38 +286,16 @@ async def app(scope, receive, send):
             _pool_id = path.rsplit("/.well-known/jwks.json", 1)[0].lstrip("/")
             if _pool_id:
                 _region = extract_region(headers) or "us-east-1"
-                status, resp_headers, resp_body = _get_module("cognito").well_known_jwks(_pool_id)
+                status, resp_headers, resp_body = cognito.well_known_jwks(_pool_id)
                 await _send_response(send, status, resp_headers, resp_body)
                 return
         elif path.endswith("/.well-known/openid-configuration"):
             _pool_id = path.rsplit("/.well-known/openid-configuration", 1)[0].lstrip("/")
             if _pool_id:
                 _region = extract_region(headers) or "us-east-1"
-                status, resp_headers, resp_body = _get_module("cognito").well_known_openid_configuration(_pool_id, _region)
+                status, resp_headers, resp_body = cognito.well_known_openid_configuration(_pool_id, _region)
                 await _send_response(send, status, resp_headers, resp_body)
                 return
-
-    # Cognito OAuth2 / Managed Login UI endpoints
-    if path == "/oauth2/authorize" and method == "GET":
-        status, resp_headers, resp_body = _get_module("cognito").handle_oauth2_authorize(method, path, headers, query_params)
-        await _send_response(send, status, resp_headers, resp_body)
-        return
-    if path in ("/oauth2/login", "/login") and method == "POST":
-        status, resp_headers, resp_body = _get_module("cognito").handle_login_submit(method, path, headers, body, query_params)
-        await _send_response(send, status, resp_headers, resp_body)
-        return
-    if path == "/oauth2/token" and method == "POST":
-        status, resp_headers, resp_body = _get_module("cognito").handle_oauth2_token(method, path, headers, body, query_params)
-        await _send_response(send, status, resp_headers, resp_body)
-        return
-    if path in ("/oauth2/userInfo", "/oauth2/userinfo") and method in ("GET", "POST"):
-        status, resp_headers, resp_body = _get_module("cognito").handle_oauth2_userinfo(method, path, headers, body, query_params)
-        await _send_response(send, status, resp_headers, resp_body)
-        return
-    if path == "/logout" and method == "GET":
-        status, resp_headers, resp_body = _get_module("cognito").handle_logout(method, path, headers, query_params)
-        await _send_response(send, status, resp_headers, resp_body)
-        return
 
     # Admin endpoints — no wildcard CORS headers (return early, before CORS block)
     if path == "/_ministack/reset" and method == "POST":
@@ -442,8 +358,8 @@ async def app(scope, receive, send):
             bucket_name = arn.split(":::")[-1].split("/")[0] if ":::" in arn else arn.split("/")[0]
 
             if method == "GET":
-                # ListTagsForResource — return real tags from _get_module("s3")._bucket_tags
-                tags = _get_module("s3")._bucket_tags.get(bucket_name, {})
+                # ListTagsForResource — return real tags from s3._bucket_tags
+                tags = s3._bucket_tags.get(bucket_name, {})
                 tag_members = "".join(
                     f"<member><Key>{k}</Key><Value>{v}</Value></member>"
                     for k, v in tags.items()
@@ -459,13 +375,13 @@ async def app(scope, receive, send):
                     "x-amzn-requestid": request_id,
                 }, xml_body)
             elif method == "PUT":
-                # TagResource — merge tags into _get_module("s3")._bucket_tags
+                # TagResource — merge tags into s3._bucket_tags
                 try:
                     payload = json.loads(body) if body else {}
                     new_tags = {t["Key"]: t["Value"] for t in payload.get("Tags", [])}
-                    existing = _get_module("s3")._bucket_tags.get(bucket_name, {})
+                    existing = s3._bucket_tags.get(bucket_name, {})
                     existing.update(new_tags)
-                    _get_module("s3")._bucket_tags[bucket_name] = existing
+                    s3._bucket_tags[bucket_name] = existing
                 except Exception as e:
                     logger.warning("S3 Control TagResource parse error: %s", e)
                 await _send_response(send, 204, {
@@ -476,10 +392,10 @@ async def app(scope, receive, send):
                 keys_to_remove = query_params.get("tagKeys", [])
                 if isinstance(keys_to_remove, str):
                     keys_to_remove = [keys_to_remove]
-                tags = _get_module("s3")._bucket_tags.get(bucket_name, {})
+                tags = s3._bucket_tags.get(bucket_name, {})
                 for k in keys_to_remove:
                     tags.pop(k, None)
-                _get_module("s3")._bucket_tags[bucket_name] = tags
+                s3._bucket_tags[bucket_name] = tags
                 await _send_response(send, 204, {
                     "x-amzn-requestid": request_id,
                 }, b"")
@@ -498,13 +414,13 @@ async def app(scope, receive, send):
 
     # RDS Data API — /Execute, /BeginTransaction, /CommitTransaction, /RollbackTransaction, /BatchExecute
     if path in ("/Execute", "/BeginTransaction", "/CommitTransaction", "/RollbackTransaction", "/BatchExecute"):
-        status, resp_headers, resp_body = await _get_module("rds_data").handle_request(method, path, headers, body, query_params)
+        status, resp_headers, resp_body = await rds_data.handle_request(method, path, headers, body, query_params)
         await _send_response(send, status, resp_headers, resp_body)
         return
 
     # SES v2 REST API — /v2/email/...
     if path.startswith("/v2/email"):
-        status, resp_headers, resp_body = await _get_module("ses_v2").handle_request(method, path, headers, body, query_params)
+        status, resp_headers, resp_body = await ses_v2.handle_request(method, path, headers, body, query_params)
         await _send_response(send, status, resp_headers, resp_body)
         return
 
@@ -515,7 +431,7 @@ async def app(scope, receive, send):
         }, json.dumps({
             "services": {s: "available" for s in SERVICE_HANDLERS},
             "edition": "light",
-            "version": _VERSION,
+            "version": "3.0.0.dev",
         }).encode())
         return
 
@@ -541,12 +457,12 @@ async def app(scope, receive, send):
         stage = path_parts[0] if path_parts else "$default"
         execute_path = "/" + path_parts[1] if len(path_parts) > 1 else "/"
         try:
-            if api_id in _get_module("apigateway_v1")._rest_apis:
-                status, resp_headers, resp_body = await _get_module("apigateway_v1").handle_execute(
+            if api_id in apigateway_v1._rest_apis:
+                status, resp_headers, resp_body = await apigateway_v1.handle_execute(
                     api_id, stage, method, execute_path, headers, body, query_params
                 )
             else:
-                status, resp_headers, resp_body = await _get_module("apigateway").handle_execute(
+                status, resp_headers, resp_body = await apigateway.handle_execute(
                     api_id, stage, execute_path, method, headers, body, query_params
                 )
         except Exception as e:
@@ -563,10 +479,10 @@ async def app(scope, receive, send):
     # ALB data-plane — two addressing modes:
     #   1. Host header matches a configured ALB DNS name or {lb-name}.alb.localhost
     #   2. Path prefix /_alb/{lb-name}/...  (no DNS config needed for local testing)
-    _alb_lb = _get_module("alb").find_lb_for_host(host)
+    _alb_lb = alb.find_lb_for_host(host)
     if _alb_lb is None and path.startswith("/_alb/"):
         _alb_path_parts = path[6:].split("/", 1)
-        _alb_lb = _get_module("alb")._find_lb_by_name(_alb_path_parts[0])
+        _alb_lb = alb._find_lb_by_name(_alb_path_parts[0])
         if _alb_lb:
             path = "/" + _alb_path_parts[1] if len(_alb_path_parts) > 1 else "/"
 
@@ -578,7 +494,7 @@ async def app(scope, receive, send):
             except ValueError:
                 pass
         try:
-            status, resp_headers, resp_body = await _get_module("alb").dispatch_request(
+            status, resp_headers, resp_body = await alb.dispatch_request(
                 _alb_lb, method, path, headers, body, query_params, _alb_port
             )
         except Exception as e:
@@ -606,7 +522,7 @@ async def app(scope, receive, send):
         if bucket not in _non_s3_hosts:
             vhost_path = "/" + bucket + path if path != "/" else "/" + bucket + "/"
             try:
-                status, resp_headers, resp_body = await _get_module("s3").handle_request(
+                status, resp_headers, resp_body = await s3.handle_request(
                     method, vhost_path, headers, body, query_params
                 )
             except Exception as e:
@@ -706,32 +622,48 @@ async def _handle_lifespan(scope, receive, send):
         elif message["type"] == "lifespan.shutdown":
             logger.info("MiniStack shutting down...")
             if PERSIST_STATE:
-                # Only save state for modules that were actually loaded
-                _state_map = {
-                    "apigateway": "apigateway", "apigateway_v1": "apigateway_v1",
-                    "sqs": "sqs", "sns": "sns", "ssm": "ssm",
-                    "secretsmanager": "secretsmanager", "iam": "iam",
-                    "dynamodb": "dynamodb", "kms": "kms", "eventbridge": "eventbridge",
-                    "cloudwatch_logs": "cloudwatch_logs", "kinesis": "kinesis",
-                    "ec2": "ec2", "route53": "route53", "cognito": "cognito",
-                    "ecr": "ecr", "cloudwatch": "cloudwatch", "s3": "s3",
-                    "lambda": "lambda_svc", "rds": "rds", "ecs": "ecs",
-                    "elasticache": "elasticache", "appsync": "appsync",
-                    "stepfunctions": "stepfunctions", "alb": "alb",
-                    "glue": "glue", "efs": "efs", "waf": "waf",
-                    "athena": "athena", "emr": "emr", "cloudfront": "cloudfront",
-                    "codebuild": "codebuild", "acm": "acm", "firehose": "firehose",
-                    "ses": "ses", "ses_v2": "ses_v2",
-                    "servicediscovery": "servicediscovery", "s3files": "s3files",
-                    "appconfig": "appconfig", "transfer": "transfer",
-                    "scheduler": "scheduler", "autoscaling": "autoscaling",
-                    "eks": "eks",
-                }
-                save_dict = {}
-                for key, mod_name in _state_map.items():
-                    if mod_name in _loaded_modules:
-                        save_dict[key] = _loaded_modules[mod_name].get_state
-                save_all(save_dict)
+                save_all({
+                    "apigateway": apigateway.get_state,
+                    "apigateway_v1": apigateway_v1.get_state,
+                    "sqs": sqs.get_state,
+                    "sns": sns.get_state,
+                    "ssm": ssm.get_state,
+                    "secretsmanager": secretsmanager.get_state,
+                    "iam": iam_sts.get_state,
+                    "dynamodb": dynamodb.get_state,
+                    "kms": kms.get_state,
+                    "eventbridge": eventbridge.get_state,
+                    "cloudwatch_logs": cloudwatch_logs.get_state,
+                    "kinesis": kinesis.get_state,
+                    "ec2": ec2.get_state,
+                    "route53": route53.get_state,
+                    "cognito": cognito.get_state,
+                    "ecr": ecr.get_state,
+                    "cloudwatch": cloudwatch.get_state,
+                    "s3": s3.get_state,
+                    "lambda": lambda_svc.get_state,
+                    "rds": rds.get_state,
+                    "ecs": ecs.get_state,
+                    "elasticache": elasticache.get_state,
+                    "appsync": appsync.get_state,
+                    "stepfunctions": stepfunctions.get_state,
+                    "alb": alb.get_state,
+                    "glue": glue.get_state,
+                    "efs": efs.get_state,
+                    "waf": waf.get_state,
+                    "athena": athena.get_state,
+                    "emr": emr.get_state,
+                    "cloudfront": cloudfront.get_state,
+                    "codebuild": codebuild.get_state,
+                    "transfer": transfer.get_state,
+                    "acm": acm.get_state,
+                    "firehose": firehose.get_state,
+                    "ses": ses.get_state,
+                    "ses_v2": ses_v2.get_state,
+                    "servicediscovery": servicediscovery.get_state,
+                    "s3files": s3files.get_state,
+                    "appconfig": appconfig.get_state,
+                })
             _stop_docker_containers()
             await send({"type": "lifespan.shutdown.complete"})
             return
@@ -745,7 +677,7 @@ def _stop_docker_containers():
         client = docker.from_env()
     except Exception:
         return
-    for label in ("ministack=rds", "ministack=ecs", "ministack=elasticache", "ministack=eks", "ministack=lambda"):
+    for label in ("ministack=rds", "ministack=ecs", "ministack=elasticache"):
         try:
             for c in client.containers.list(filters={"label": label}):
                 try:
@@ -759,11 +691,18 @@ def _stop_docker_containers():
 
 def _load_persisted_state():
     """Load persisted state for services that support it."""
-    for svc_key in ("apigateway", "apigateway_v1", "servicediscovery"):
-        data = load_state(svc_key)
-        if data:
-            _get_module(svc_key).load_persisted_state(data)
-            logger.info("Loaded persisted state for %s", svc_key)
+    data = load_state("apigateway")
+    if data:
+        apigateway.load_persisted_state(data)
+        logger.info("Loaded persisted state for apigateway")
+    data_v1 = load_state("apigateway_v1")
+    if data_v1:
+        apigateway_v1.load_persisted_state(data_v1)
+        logger.info("Loaded persisted state for apigateway_v1")
+    data_sd = load_state("servicediscovery")
+    if data_sd:
+        servicediscovery.load_persisted_state(data_sd)
+        logger.info("Loaded persisted state for servicediscovery")
 
 
 async def _wait_for_port(port, timeout=30):
@@ -871,7 +810,6 @@ def _reset_all_state():
     """Wipe all in-memory state across every service module, and persisted files if enabled."""
 
     from ministack.core.persistence import PERSIST_STATE, STATE_DIR
-<<<<<<< cf-pipes
     from ministack.services.iam_sts import reset as _iam_reset
     from ministack.services.s3 import DATA_DIR as S3_DATA_DIR
     from ministack.services.s3 import PERSIST as S3_PERSIST
@@ -908,7 +846,6 @@ def _reset_all_state():
         (rds_data, rds_data.reset),
         (s3files, s3files.reset),
         (appconfig, appconfig.reset),
-        (pipes, pipes.reset),
     ]:
         try:
             fn()
@@ -918,28 +855,6 @@ def _reset_all_state():
         _iam_reset()
     except Exception as e:
         logger.warning("reset() failed for iam_sts: %s", e)
-=======
-
-    _ALL_SERVICE_MODULES = [
-        "s3", "sqs", "sns", "dynamodb", "lambda_svc", "secretsmanager",
-        "cloudwatch_logs", "ssm", "eventbridge", "kinesis", "cloudwatch",
-        "ses", "stepfunctions", "ecs", "rds", "elasticache", "glue", "athena",
-        "apigateway", "apigateway_v1", "firehose", "route53", "cognito", "ec2",
-        "emr", "alb", "acm", "ses_v2", "waf", "efs", "cloudformation", "kms",
-        "cloudfront", "codebuild", "ecr", "appsync", "servicediscovery",
-        "rds_data", "s3files", "appconfig", "transfer", "scheduler", "autoscaling", "eks", "iam",
-    ]
-    for mod_name in _ALL_SERVICE_MODULES:
-        if mod_name in _loaded_modules:
-            mod = _loaded_modules[mod_name]
-            try:
-                mod.reset()
-            except Exception as e:
-                logger.warning("reset() failed for %s: %s", mod_name, e)
-
-    S3_DATA_DIR = os.environ.get("S3_DATA_DIR", "/tmp/ministack-data/s3")
-    S3_PERSIST = os.environ.get("S3_PERSIST", "0") == "1"
->>>>>>> main
 
     # Wipe persisted files so a subsequent restart doesn't reload old state
     if PERSIST_STATE and os.path.isdir(STATE_DIR):

--- a/ministack/services/cloudformation/provisioners.py
+++ b/ministack/services/cloudformation/provisioners.py
@@ -286,7 +286,14 @@ def _sns_sub_create(logical_id, props, stack_name):
         "endpoint": endpoint,
         "confirmed": protocol not in ("http", "https"),
         "owner": get_account_id(),
-        "attributes": {},
+        "attributes": {
+            "FilterPolicyScope": props.get("FilterPolicyScope", "MessageAttributes"),
+            "FilterPolicy": (
+                json.dumps(props.get("FilterPolicy"))
+                if isinstance(props.get("FilterPolicy"), (dict, list))
+                else (props.get("FilterPolicy", "") or "")
+            ),
+        },
     }
     topic["subscriptions"].append(sub)
     _sns._sub_arn_to_topic[sub_arn] = topic_arn

--- a/ministack/services/cloudformation/provisioners.py
+++ b/ministack/services/cloudformation/provisioners.py
@@ -245,7 +245,14 @@ def _sns_create(logical_id, props, stack_name):
             "endpoint": endpoint,
             "confirmed": protocol not in ("http", "https"),
             "owner": get_account_id(),
-            "attributes": {},
+            "attributes": {
+                "FilterPolicyScope": sub_def.get("FilterPolicyScope", "MessageAttributes"),
+                "FilterPolicy": (
+                    json.dumps(sub_def.get("FilterPolicy"))
+                    if isinstance(sub_def.get("FilterPolicy"), (dict, list))
+                    else (sub_def.get("FilterPolicy", "") or "")
+                )
+            }
         }
         _sns._topics[arn]["subscriptions"].append(sub)
         _sns._sub_arn_to_topic[sub_arn] = arn

--- a/ministack/services/cloudformation/provisioners.py
+++ b/ministack/services/cloudformation/provisioners.py
@@ -34,6 +34,7 @@ import ministack.services.ec2 as _ec2
 import ministack.services.ecs as _ecs
 import ministack.services.alb as _alb
 import ministack.services.kinesis as _kinesis
+import ministack.services.pipes as _pipes
 import ministack.services.stepfunctions as _sfn
 import ministack.services.route53 as _r53
 import ministack.services.apigateway as _apigw_v2
@@ -944,6 +945,34 @@ def _lambda_esm_create(logical_id, props, stack_name):
 
 def _lambda_esm_delete(physical_id, props):
     _lambda_svc._esms.pop(physical_id, None)
+
+
+# --- EventBridge Pipes (minimal: DynamoDB Streams -> SNS) ---
+
+def _pipes_pipe_create(logical_id, props, stack_name):
+    name = props.get("Name") or _physical_name(stack_name, logical_id, max_len=64)
+    source = props.get("Source", "")
+    target = props.get("Target", "")
+    role_arn = props.get("RoleArn", "")
+    desired_state = props.get("DesiredState", "RUNNING")
+
+    source_params = props.get("SourceParameters", {})
+    ddb_params = source_params.get("DynamoDBStreamParameters", {}) if isinstance(source_params, dict) else {}
+    starting_position = ddb_params.get("StartingPosition", "LATEST")
+
+    pipe = _pipes.register_pipe(
+        name=name,
+        source=source,
+        target=target,
+        role_arn=role_arn,
+        desired_state=desired_state,
+        starting_position=starting_position,
+    )
+    return name, {"Arn": pipe["Arn"], "Name": name}
+
+
+def _pipes_pipe_delete(physical_id, props):
+    _pipes.delete_pipe(physical_id)
 
 
 # --- Lambda Alias ---
@@ -2618,6 +2647,7 @@ _RESOURCE_HANDLERS = {
     "AWS::ApiGateway::Deployment": {"create": _apigw_deployment_create, "delete": _apigw_deployment_delete},
     "AWS::ApiGateway::Stage": {"create": _apigw_stage_create, "delete": _apigw_stage_delete},
     "AWS::Lambda::EventSourceMapping": {"create": _lambda_esm_create, "delete": _lambda_esm_delete},
+    "AWS::Pipes::Pipe": {"create": _pipes_pipe_create, "delete": _pipes_pipe_delete},
     "AWS::Lambda::Alias": {"create": _lambda_alias_create, "delete": _lambda_alias_delete},
     "AWS::SQS::QueuePolicy": {"create": _sqs_queue_policy_create, "delete": _sqs_queue_policy_delete},
     "AWS::SNS::TopicPolicy": {"create": _sns_topic_policy_create, "delete": _sns_topic_policy_delete},

--- a/ministack/services/cloudformation/provisioners.py
+++ b/ministack/services/cloudformation/provisioners.py
@@ -245,14 +245,7 @@ def _sns_create(logical_id, props, stack_name):
             "endpoint": endpoint,
             "confirmed": protocol not in ("http", "https"),
             "owner": get_account_id(),
-            "attributes": {
-                "FilterPolicyScope": sub_def.get("FilterPolicyScope", "MessageAttributes"),
-                "FilterPolicy": (
-                    json.dumps(sub_def.get("FilterPolicy"))
-                    if isinstance(sub_def.get("FilterPolicy"), (dict, list))
-                    else (sub_def.get("FilterPolicy", "") or "")
-                )
-            }
+            "attributes": {}
         }
         _sns._topics[arn]["subscriptions"].append(sub)
         _sns._sub_arn_to_topic[sub_arn] = arn

--- a/ministack/services/pipes.py
+++ b/ministack/services/pipes.py
@@ -1,0 +1,173 @@
+"""
+Minimal EventBridge Pipes runtime for local CloudFormation use.
+
+Scope intentionally limited to:
+- Source: DynamoDB Streams
+- Target: SNS
+- Lifecycle: create/delete (via CloudFormation handlers)
+"""
+
+import copy
+import json
+import logging
+import os
+import threading
+import time
+
+from ministack.core.responses import AccountScopedDict, get_account_id, new_uuid
+
+logger = logging.getLogger("pipes")
+
+REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
+
+_pipes = AccountScopedDict()       # pipe_name -> pipe record
+_positions = AccountScopedDict()   # pipe_arn -> next stream record index
+_poller_started = False
+_poller_lock = threading.Lock()
+
+
+def get_state():
+    return {
+        "pipes": copy.deepcopy(_pipes),
+        "positions": copy.deepcopy(_positions),
+    }
+
+
+def reset():
+    _pipes.clear()
+    _positions.clear()
+
+
+def register_pipe(
+    *,
+    name: str,
+    source: str,
+    target: str,
+    role_arn: str = "",
+    desired_state: str = "RUNNING",
+    starting_position: str = "LATEST",
+    tags: dict | None = None,
+):
+    arn = f"arn:aws:pipes:{REGION}:{get_account_id()}:pipe/{name}"
+    state = "STOPPED" if str(desired_state).upper() == "STOPPED" else "RUNNING"
+    start = str(starting_position or "LATEST").upper()
+    if start not in ("LATEST", "TRIM_HORIZON"):
+        start = "LATEST"
+
+    _pipes[name] = {
+        "Name": name,
+        "Arn": arn,
+        "RoleArn": role_arn,
+        "Source": source,
+        "Target": target,
+        "DesiredState": state,
+        "CurrentState": state,
+        "StartingPosition": start,
+        "Tags": tags or {},
+        "CreationTime": time.time(),
+    }
+    _positions[arn] = _initial_position(_pipes[name])
+
+    _ensure_poller()
+    return _pipes[name]
+
+
+def delete_pipe(name: str):
+    pipe = _pipes.pop(name, None)
+    if pipe:
+        _positions.pop(pipe["Arn"], None)
+
+
+def _ensure_poller():
+    global _poller_started
+    with _poller_lock:
+        if not _poller_started:
+            t = threading.Thread(target=_poll_loop, daemon=True)
+            t.start()
+            _poller_started = True
+
+
+def _poll_loop():
+    while True:
+        try:
+            _poll_once()
+        except Exception as e:
+            logger.error("Pipes poller error: %s", e)
+        time.sleep(1 if _pipes else 5)
+
+
+def _poll_once():
+    from ministack.services import dynamodb as _ddb
+
+    stream_records = getattr(_ddb, "_stream_records", None)
+    if stream_records is None:
+        return
+
+    for pipe in list(_pipes.values()):
+        if pipe.get("CurrentState") != "RUNNING":
+            continue
+
+        source_arn = pipe.get("Source", "")
+        target_arn = pipe.get("Target", "")
+        if ":dynamodb:" not in source_arn or "/stream/" not in source_arn:
+            continue
+        if ":sns:" not in target_arn:
+            continue
+
+        table_name = _table_name_from_stream_arn(source_arn)
+        if not table_name:
+            continue
+
+        records = stream_records.get(table_name, [])
+        pos = int(_positions.get(pipe["Arn"], 0))
+        if pos < 0:
+            pos = 0
+        if pos >= len(records):
+            continue
+
+        batch = records[pos:]
+        for rec in batch:
+            _publish_record_to_sns(target_arn, pipe, rec)
+        _positions[pipe["Arn"]] = pos + len(batch)
+
+
+def _publish_record_to_sns(topic_arn: str, pipe: dict, record: dict):
+    from ministack.services import sns as _sns
+
+    topic = _sns._topics.get(topic_arn)
+    if not topic:
+        logger.warning("Pipes %s: SNS topic not found %s", pipe.get("Name"), topic_arn)
+        return
+
+    msg_id = new_uuid()
+    message = json.dumps(record)
+    subject = f"Pipes {pipe.get('Name', '')}"
+
+    topic["messages"].append({
+        "id": msg_id,
+        "message": message,
+        "subject": subject,
+        "message_structure": "",
+        "message_attributes": {},
+        "timestamp": int(time.time()),
+    })
+    _sns._fanout(topic_arn, msg_id, message, subject, "", {})
+
+
+def _table_name_from_stream_arn(stream_arn: str) -> str:
+    if "/stream/" not in stream_arn:
+        return ""
+    return stream_arn.split("/stream/", 1)[0].rsplit("/", 1)[-1]
+
+
+def _initial_position(pipe: dict) -> int:
+    from ministack.services import dynamodb as _ddb
+
+    table_name = _table_name_from_stream_arn(pipe.get("Source", ""))
+    if not table_name:
+        return 0
+
+    records = getattr(_ddb, "_stream_records", {}).get(table_name, [])
+    if pipe.get("StartingPosition") == "TRIM_HORIZON":
+        return 0
+    return len(records)

--- a/tests/test_cfn.py
+++ b/tests/test_cfn.py
@@ -1472,7 +1472,10 @@ def test_cfn_pipes_dynamodb_stream_to_sns(cfn, ddb, sqs):
     rec = json.loads(envelope["Message"])
     assert rec.get("eventSource") == "aws:dynamodb"
     assert rec.get("eventName") in ("INSERT", "MODIFY", "REMOVE")
-    assert rec.get("dynamodb", {}).get("Keys", {}).get("pk", {}).get("S") == "1"
+
+    dynamodb  = rec.get("dynamodb", {})
+    assert dynamodb.get("Keys", {}).get("pk", {}).get("S") == "1"
+    assert dynamodb.get("NewImage", {}).get("pk", {}).get("S") == "1"
 
     cfn.delete_stack(StackName=stack_name)
     _wait_stack(cfn, stack_name)

--- a/tests/test_cfn.py
+++ b/tests/test_cfn.py
@@ -1479,6 +1479,70 @@ def test_cfn_pipes_dynamodb_stream_to_sns(cfn, ddb, sqs):
 
     cfn.delete_stack(StackName=stack_name)
     _wait_stack(cfn, stack_name)
+
+
+def test_cfn_sns_topic_subscription_filter_policy_scope(cfn, sns, sqs):
+    uid = _uuid_mod.uuid4().hex[:8]
+    stack_name = f"cfn-sns-filter-{uid}"
+    queue_name = f"cfn-sns-filter-q-{uid}"
+    topic_name = f"cfn-sns-filter-topic-{uid}"
+
+    template = {
+        "AWSTemplateFormatVersion": "2010-09-09",
+        "Resources": {
+            "FilterQueue": {
+                "Type": "AWS::SQS::Queue",
+                "Properties": {"QueueName": queue_name},
+            },
+            "FilterTopic": {
+                "Type": "AWS::SNS::Topic",
+                "Properties": {
+                    "TopicName": topic_name,
+                },  
+            },
+            "FilterSubscription": {
+                "Type": "AWS::SNS::Subscription",
+                "Properties": {
+                    "Protocol": "sqs",
+                    "TopicArn": {"Ref": "FilterTopic"},
+                    "Endpoint": {"Fn::GetAtt": ["FilterQueue", "Arn"]},
+                    "FilterPolicy": {"color": ["blue"]},
+                },
+            },
+        },
+        "Outputs": {
+            "TopicArn": {"Value": {"Ref": "FilterTopic"}},
+        },
+    }
+
+    cfn.create_stack(StackName=stack_name, TemplateBody=json.dumps(template))
+    stack = _wait_stack(cfn, stack_name)
+    assert stack["StackStatus"] == "CREATE_COMPLETE", stack.get("StackStatusReason")
+
+    outputs = {o["OutputKey"]: o["OutputValue"] for o in stack.get("Outputs", [])}
+    topic_arn = outputs["TopicArn"]
+    queue_url = sqs.get_queue_url(QueueName=queue_name)["QueueUrl"]
+
+    sns.publish(
+        TopicArn=topic_arn,
+        Message="red message",
+        MessageAttributes={"color": {"DataType": "String", "StringValue": "red"}},
+    )
+    msgs = sqs.receive_message(QueueUrl=queue_url, MaxNumberOfMessages=1, WaitTimeSeconds=0)
+    assert len(msgs.get("Messages", [])) == 0
+
+    sns.publish(
+        TopicArn=topic_arn,
+        Message="blue message",
+        MessageAttributes={"color": {"DataType": "String", "StringValue": "blue"}},
+    )
+    msgs = sqs.receive_message(QueueUrl=queue_url, MaxNumberOfMessages=1, WaitTimeSeconds=1)
+    assert len(msgs.get("Messages", [])) == 1
+    body = json.loads(msgs["Messages"][0]["Body"])
+    assert body["Message"] == "blue message"
+
+    cfn.delete_stack(StackName=stack_name)
+    _wait_stack(cfn, stack_name)
     
 # ===========================================================================
 # CodeBuild Project Tests

--- a/tests/test_cfn.py
+++ b/tests/test_cfn.py
@@ -1390,3 +1390,89 @@ def test_cfn_dynamodb_stream_spec(cfn, ddb):
 
     cfn.delete_stack(StackName=stack_name)
     _wait_stack(cfn, stack_name)
+
+
+def test_cfn_pipes_dynamodb_stream_to_sns(cfn, ddb, sqs):
+    uid = _uuid_mod.uuid4().hex[:8]
+    stack_name = f"cfn-pipe-{uid}"
+    table_name = f"cfn-pipe-table-{uid}"
+    queue_name = f"cfn-pipe-q-{uid}"
+    topic_name = f"cfn-pipe-topic-{uid}"
+
+    template = {
+        "AWSTemplateFormatVersion": "2010-09-09",
+        "Resources": {
+            "PipeTable": {
+                "Type": "AWS::DynamoDB::Table",
+                "Properties": {
+                    "TableName": table_name,
+                    "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
+                    "AttributeDefinitions": [{"AttributeName": "pk", "AttributeType": "S"}],
+                    "BillingMode": "PAY_PER_REQUEST",
+                    "StreamSpecification": {"StreamViewType": "NEW_AND_OLD_IMAGES"},
+                },
+            },
+            "PipeTopic": {
+                "Type": "AWS::SNS::Topic",
+                "Properties": {"TopicName": topic_name},
+            },
+            "PipeQueue": {
+                "Type": "AWS::SQS::Queue",
+                "Properties": {"QueueName": queue_name},
+            },
+            "PipeSubscription": {
+                "Type": "AWS::SNS::Subscription",
+                "Properties": {
+                    "Protocol": "sqs",
+                    "TopicArn": {"Ref": "PipeTopic"},
+                    "Endpoint": {"Fn::GetAtt": ["PipeQueue", "Arn"]},
+                },
+            },
+            "DdbToSnsPipe": {
+                "Type": "AWS::Pipes::Pipe",
+                "Properties": {
+                    "Name": f"{stack_name}-pipe",
+                    "RoleArn": "arn:aws:iam::000000000000:role/test-pipe-role",
+                    "Source": {"Fn::GetAtt": ["PipeTable", "StreamArn"]},
+                    "Target": {"Ref": "PipeTopic"},
+                    "SourceParameters": {
+                        "DynamoDBStreamParameters": {"StartingPosition": "TRIM_HORIZON"}
+                    },
+                },
+            },
+        },
+    }
+
+    cfn.create_stack(StackName=stack_name, TemplateBody=json.dumps(template))
+    stack = _wait_stack(cfn, stack_name)
+    assert stack["StackStatus"] == "CREATE_COMPLETE", stack.get("StackStatusReason")
+
+    queue_url = sqs.get_queue_url(QueueName=queue_name)["QueueUrl"]
+
+    ddb.put_item(
+        TableName=table_name,
+        Item={
+            "pk": {"S": "1"},
+            "val": {"S": "hello"},
+        },
+    )
+
+    msg = None
+    deadline = time.time() + 8
+    while time.time() < deadline:
+        out = sqs.receive_message(QueueUrl=queue_url, MaxNumberOfMessages=1, WaitTimeSeconds=1)
+        msgs = out.get("Messages", [])
+        if msgs:
+            msg = msgs[0]
+            break
+
+    assert msg is not None, "Expected DynamoDB stream record to reach SNS/SQS via Pipe"
+
+    envelope = json.loads(msg["Body"])
+    rec = json.loads(envelope["Message"])
+    assert rec.get("eventSource") == "aws:dynamodb"
+    assert rec.get("eventName") in ("INSERT", "MODIFY", "REMOVE")
+    assert rec.get("dynamodb", {}).get("Keys", {}).get("pk", {}).get("S") == "1"
+
+    cfn.delete_stack(StackName=stack_name)
+    _wait_stack(cfn, stack_name)


### PR DESCRIPTION
This pull request introduces initial support for AWS EventBridge Pipes in the ministack project, specifically enabling DynamoDB Streams to SNS integration via CloudFormation. The implementation includes a minimal runtime for Pipes, CloudFormation resource handlers

**EventBridge Pipes support:**

- Added a minimal `pipes` service (`ministack/services/pipes.py`) that supports creating and deleting EventBridge Pipes connecting DynamoDB Streams to SNS topics, including a background poller to forward stream records to SNS.

**CloudFormation integration:**

- Implemented CloudFormation resource handlers for `AWS::Pipes::Pipe` in `provisioners.py`