### PR TITLE
feat(lambda): Add support for lambda layer from s3

### DIFF
--- a/ministack/services/lambda_svc.py
+++ b/ministack/services/lambda_svc.py
@@ -2209,6 +2209,8 @@ def _publish_layer_version(layer_name: str, data: dict):
     content = data.get("Content", {})
     if "ZipFile" in content:
         zip_data = base64.b64decode(content["ZipFile"])
+    elif "S3Bucket" in content and "S3Key" in content:
+        zip_data = _fetch_code_from_s3(content["S3Bucket"], content["S3Key"])
 
     ver_config: dict = {
         "LayerArn": _layer_arn(layer_name),


### PR DESCRIPTION
Hello,
This is a great tool, it works really smoothly. I just found an issue with Lambda layers — it seems that it does not support layer creation from a zip file on S3. So here is a PR for that.

Not gonna lie, I'm not a Python developer and this is AI-generated code. I read through the function and it seems okay, but I don't really know how to test it locally. So, as Ozzy Osbourne once sang, it's a shot in the dark.

Not the best pull request, I must admit