### PR TITLE
feat: add /_ministack/ready endpoint for ready.d script completion gating

### DIFF
--- a/ministack/app.py
+++ b/ministack/app.py
@@ -53,6 +53,15 @@ from ministack.core.router import detect_service, extract_access_key_id, extract
 # ---------------------------------------------------------------------------
 _loaded_modules: dict = {}
 
+# Execution state of ready.d scripts — surfaced via /_ministack/health and /_ministack/ready.
+# status: "pending" (not started) | "running" | "completed" (all scripts finished, errors included)
+_ready_scripts_state: dict = {
+    "status": "pending",
+    "total": 0,
+    "completed": 0,
+    "failed": 0,
+}
+
 
 class _ErrorModule:
     """Stub returned when a service module fails to import."""
@@ -339,6 +348,7 @@ async def app(scope, receive, send):
         await _send_response(send, 200, {"Content-Type": "application/json"},
                              json.dumps({"reset": "ok"}).encode())
         if run_init:
+            _ready_scripts_state.update({"status": "pending", "total": 0, "completed": 0, "failed": 0})
             asyncio.create_task(_run_ready_scripts())
         return
 
@@ -465,7 +475,19 @@ async def app(scope, receive, send):
             "services": {s: "available" for s in SERVICE_HANDLERS},
             "edition": "light",
             "version": _VERSION,
+            "ready_scripts": dict(_ready_scripts_state),
         }).encode())
+        return
+
+    # Readiness endpoint — returns 503 until all ready.d scripts finish, then 200.
+    # Point a compose healthcheck here to gate depends_on: service_healthy on script completion.
+    if path == "/_ministack/ready":
+        ready = _ready_scripts_state["status"] == "completed"
+        status = 200 if ready else 503
+        await _send_response(send, status, {
+            "Content-Type": "application/json",
+            "x-amzn-requestid": request_id,
+        }, json.dumps(dict(_ready_scripts_state)).encode())
         return
 
     if method == "OPTIONS":
@@ -733,7 +755,9 @@ async def _run_ready_scripts():
     """Execute .sh/.py scripts from ready.d directories after the server is ready."""
     scripts = _collect_scripts('/docker-entrypoint-initaws.d/ready.d', '/etc/localstack/init/ready.d')
     if not scripts:
+        _ready_scripts_state.update({"status": "completed", "total": 0, "completed": 0, "failed": 0})
         return
+    _ready_scripts_state.update({"status": "running", "total": len(scripts), "completed": 0, "failed": 0})
     port = int(_resolve_port())
     await _wait_for_port(port)
     logger.info('Found %d ready script(s)', len(scripts))
@@ -754,6 +778,7 @@ async def _run_ready_scripts():
     script_env.setdefault("AWS_ENDPOINT_URL", f"http://{_MINISTACK_HOST}:{port}")
     for script_path in scripts:
         logger.info('Running ready script: %s', script_path)
+        script_failed = False
         try:
             cmd = [sys.executable, script_path] if script_path.endswith('.py') else ['sh', script_path]
             proc = await asyncio.create_subprocess_exec(
@@ -766,15 +791,22 @@ async def _run_ready_scripts():
             if stdout:
                 logger.info('  stdout: %s', stdout.decode('utf-8', errors='replace').rstrip())
             if proc.returncode != 0:
+                script_failed = True
                 logger.error('Ready script %s failed (exit %d): %s', script_path, proc.returncode,
                              stderr.decode('utf-8', errors='replace'))
             else:
                 logger.info('Ready script %s completed successfully', script_path)
         except asyncio.TimeoutError:
+            script_failed = True
             logger.error('Ready script %s timed out after 300s', script_path)
             proc.kill()
         except Exception as e:
+            script_failed = True
             logger.error('Failed to execute ready script %s: %s', script_path, e)
+        _ready_scripts_state["completed"] += 1
+        if script_failed:
+            _ready_scripts_state["failed"] += 1
+    _ready_scripts_state["status"] = "completed"
 
 
 def _collect_scripts(*dirs):


### PR DESCRIPTION
## Summary

Adds a `/_ministack/ready` endpoint that exposes the completion state of ready.d scripts. Pointing a Compose healthcheck at this endpoint lets dependent services wait for script completion via `depends_on: condition: service_healthy`.

## Background

ready.d scripts run **asynchronously** (`asyncio.create_task`) after the server starts, so they may still be running by the time the container's healthcheck passes. There was no way for dependent services to wait until the init scripts had actually finished.

## Design

Following the Kubernetes liveness / readiness probe model, responsibilities are split across two endpoints:

| Endpoint | Role | Meaning |
|---|---|---|
| `/_ministack/health` | liveness-like  | Process is alive (always 200) |
| `/_ministack/ready`  | readiness-like | ready.d scripts have finished (503 until done) |

- Use `/_ministack/health` as before to check that the process is alive.
- Point healthchecks at `/_ministack/ready` when you need to wait for init scripts to finish.
- `/_ministack/health` now also includes a `ready_scripts` field so callers that just want the state can read it from there.

## Changes

- Track ready.d execution state in `_ready_scripts_state` (`pending` / `running` / `completed`, plus total / completed / failed counters).
- Add `/_ministack/ready`: returns 503 while scripts are pending/running, 200 once completed.
- Include `ready_scripts` in the `/_ministack/health` response.
- Reset state on `POST /_ministack/reset?init=1` so the lifecycle restarts cleanly.

## Usage (compose)

```yaml
services:
  ministack:
    image: ministackorg/ministack:latest
    healthcheck:
      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:4566/_ministack/ready')"]
  app:
    depends_on:
      ministack:
        condition: service_healthy  # waits until ready.d finishes
```