### PR TITLE
Add command arg to call to docker client run

### DIFF
--- a/ministack/services/ecs.py
+++ b/ministack/services/ecs.py
@@ -907,6 +907,7 @@ def _run_task(data):
                         name=f"ministack-ecs-{task_id[:8]}-{cdef['name']}",
                         labels={"ministack": "ecs", "task_arn": task_arn},
                         network=ecs_network,
+                        command=cdef["command"]
                     )
                     task["_docker_ids"].append(container.id)
                     if i < len(task["containers"]):


### PR DESCRIPTION
If a task definition has a command section within the containerDefinitions section which overrides that in the image being used, currently this command is not passed to the run function of the docker client in ecs.py so it is ignored and the default image's command is used. This PR adds the command 'field' to run()'s arguments.