### PR TITLE
Replace uvicorn with hypercorn for HTTP/2 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Start MiniStack
         run: |
-          REDIS_HOST=localhost python -m uvicorn ministack.app:app --host 0.0.0.0 --port 4566 &
+          REDIS_HOST=localhost python -m hypercorn ministack.app:app --bind 0.0.0.0:4566 --keep-alive 75 &
           sleep 3
           curl -sf http://localhost:4566/_ministack/health
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.12-alpine AS builder
 
 RUN pip install --no-cache-dir --no-compile \
-        uvicorn==0.30.6 \
+        hypercorn==0.18.0 \
         "cbor2>=5.4.0" \
         "defusedxml>=0.7" \
         "docker>=7.0.0" \
@@ -33,7 +33,7 @@ WORKDIR /opt/ministack
 COPY --from=builder /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
 COPY --from=builder /usr/local/bin/aws /usr/local/bin/aws
 COPY --from=builder /usr/local/bin/aws_completer /usr/local/bin/aws_completer
-COPY --from=builder /usr/local/bin/uvicorn /usr/local/bin/uvicorn
+COPY --from=builder /usr/local/bin/hypercorn /usr/local/bin/hypercorn
 
 COPY bin/awslocal /usr/local/bin/awslocal
 RUN chmod +x /usr/local/bin/awslocal
@@ -67,4 +67,4 @@ EXPOSE 4566
 HEALTHCHECK --interval=10s --timeout=3s --start-period=5s --retries=3 \
     CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:4566/_ministack/health')" || exit 1
 
-ENTRYPOINT ["python", "-m", "uvicorn", "ministack.app:app", "--host", "0.0.0.0", "--port", "4566"]
+ENTRYPOINT ["python", "-m", "hypercorn", "ministack.app:app", "--bind", "0.0.0.0:4566", "--keep-alive", "75"]

--- a/README.md
+++ b/README.md
@@ -739,7 +739,7 @@ services:
   ministack:
     image: ministackorg/ministack:latest
     container_name: infra_ministack
-    entrypoint: ["python", "-m", "uvicorn", "ministack.app:app", "--host", "0.0.0.0", "--port", "4566"]
+    entrypoint: ["python", "-m", "hypercorn", "ministack.app:app", "--bind", "0.0.0.0:4566", "--keep-alive", "75"]
     networks:
       infra-network:
     healthcheck:

--- a/ministack/app.py
+++ b/ministack/app.py
@@ -904,7 +904,8 @@ def _pid_file(port: int) -> str:
 
 
 def main():
-    import uvicorn
+    from hypercorn.config import Config as HypercornConfig
+    from hypercorn.asyncio import serve as hypercorn_serve
 
     parser = argparse.ArgumentParser(description="MiniStack — Local AWS Service Emulator")
     parser.add_argument("-d", "--detach", action="store_true", help="Run in the background (detached mode)")
@@ -943,10 +944,10 @@ def main():
         # process; the OS reclaims it when the parent exits.
         log_fh = open(log_file, "w")
         proc = subprocess.Popen(
-            [sys.executable, "-m", "uvicorn", "ministack.app:app",
-             "--host", "0.0.0.0", "--port", str(port),
-             "--log-level", LOG_LEVEL.lower(),
-             "--timeout-keep-alive", "75"],
+            [sys.executable, "-m", "hypercorn", "ministack.app:app",
+             "--bind", f"0.0.0.0:{port}",
+             "--log-level", LOG_LEVEL.upper(),
+             "--keep-alive", "75"],
             stdout=log_fh,
             stderr=subprocess.STDOUT,
             start_new_session=True,
@@ -980,18 +981,16 @@ def main():
             def filter(self, record):
                 if LOG_LEVEL == "DEBUG":
                     return True
-                msg = record.getMessage()
-                return not any(p in msg for p in _HEALTH_PATHS)
+                return not any(p in record.getMessage() for p in _HEALTH_PATHS)
 
-        log_config = uvicorn.config.LOGGING_CONFIG.copy()
-        log_config["loggers"] = log_config.get("loggers", {}).copy()
-        log_config["filters"] = {"health_filter": {"()": lambda: _HealthLogFilter()}}
-        access_logger = log_config["loggers"].get("uvicorn.access", {}).copy()
-        access_logger["filters"] = ["health_filter"]
-        log_config["loggers"]["uvicorn.access"] = access_logger
+        logging.getLogger("hypercorn.access").addFilter(_HealthLogFilter())
 
-        uvicorn.run("ministack.app:app", host="0.0.0.0", port=port, log_level=LOG_LEVEL.lower(),
-                    timeout_keep_alive=75, log_config=log_config)
+        config = HypercornConfig()
+        config.bind = [f"0.0.0.0:{port}"]
+        config.keep_alive_timeout = 75
+        config.loglevel = LOG_LEVEL.upper()
+
+        asyncio.run(hypercorn_serve(app, config))
     finally:
         _cleanup()
 

--- a/ministack/services/stepfunctions.py
+++ b/ministack/services/stepfunctions.py
@@ -2318,7 +2318,7 @@ def _dispatch_aws_sdk_json(service_info, service_name, action, input_data):
 
     # Service handlers are async def but perform no real I/O, so we can
     # drive the coroutine synchronously — this avoids conflicts with the
-    # already-running uvicorn event loop.
+    # already-running asyncio event loop.
     coro = handler("POST", "/", headers, body, {})
     try:
         coro.send(None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,7 @@ classifiers = [
     "Topic :: Internet",
 ]
 dependencies = [
-    "uvicorn[standard]>=0.30.6",
-    "httptools>=0.6.1",
+    "hypercorn>=0.18.0",
     "pyyaml>=6.0",
     "defusedxml>=0.7",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-uvicorn[standard]==0.30.6
-httptools==0.6.1
+hypercorn==0.18.0
 docker>=7.0.0
 cbor2>=5.4.0


### PR DESCRIPTION
## Summary

- Replaces `uvicorn` with `hypercorn==0.18.0` as the ASGI server across all run paths (foreground, detach, Docker, CI)
- Enables HTTP/2 (h2c cleartext) natively — unblocks the AWS Kinesis Client Library which requires HTTP/2
- Migrates the `_HealthLogFilter` from uvicorn's internal logger to `hypercorn.access` via Python's standard logging API
- Fixes a pre-existing bug where `--keep-alive 75` was missing from the Dockerfile ENTRYPOINT and CI workflow

## Changes

| File | What changed |
|---|---|
| `requirements.txt` | `uvicorn[standard]==0.30.6` + `httptools` → `hypercorn==0.18.0` |
| `pyproject.toml` | Same dependency swap at package declaration level |
| `ministack/app.py` | Replace `uvicorn.run()` with `asyncio.run(hypercorn_serve(app, config))`, update detach Popen CLI args, migrate health log filter |
| `Dockerfile` | Install hypercorn, update ENTRYPOINT to use `--bind` and `--keep-alive 75` |
| `.github/workflows/ci.yml` | Update CLI invocation to hypercorn, add missing `--keep-alive 75` |
| `README.md` | Update docker-compose example entrypoint |
| `ministack/services/stepfunctions.py` | Update stale comment referencing uvicorn event loop |

## Test plan

- [ ] `curl http://localhost:4566/_ministack/health` returns 200
- [ ] `curl --http2-prior-knowledge http://localhost:4566/_ministack/health` returns HTTP/2 200
- [ ] Health endpoint requests do NOT appear in access logs at INFO level
- [ ] `ministack --detach` starts successfully, `ministack --stop` stops it cleanly
- [ ] CI passes — all existing tests green
