### PR TITLE
[DRAFT] Enhance log forwarding for lambda

### DIFF
--- a/ministack/core/lambda_runtime.py
+++ b/ministack/core/lambda_runtime.py
@@ -332,6 +332,19 @@ class Worker:
         self._lock = threading.Lock()
         self._cold = True
         self._start_time = None
+        self._log_lines: list[str] = []
+        self._log_lock = threading.Lock()
+
+    def _read_stderr(self):
+        for line in self._proc.stderr:
+            with self._log_lock:
+                self._log_lines.append(line.rstrip("\n"))
+
+    def _flush_logs(self) -> str:
+        with self._log_lock:
+            logs = "\n".join(self._log_lines)
+            self._log_lines.clear()
+        return logs
 
     def _spawn(self):
         """Extract zip and start worker process."""
@@ -490,19 +503,10 @@ class Worker:
             raise RuntimeError(f"Worker init failed: {response.get('error')}")
 
         self._start_time = time.time()
+        self._stderr_thread = threading.Thread(target=self._read_stderr, daemon=True)
+        self._stderr_thread.start()
         logger.info("Lambda worker spawned for %s (%s, cold start)", self.func_name, runtime)
 
-    def _drain_stderr(self) -> str:
-        """Read any available stderr output without blocking."""
-        import select
-        lines = []
-        if self._proc and self._proc.stderr:
-            while select.select([self._proc.stderr], [], [], 0)[0]:
-                line = self._proc.stderr.readline()
-                if not line:
-                    break
-                lines.append(line.rstrip("\n"))
-        return "\n".join(lines)
 
     def invoke(self, event: dict, request_id: str) -> dict:
         with self._lock:
@@ -532,7 +536,7 @@ class Worker:
                         try:
                             response = json.loads(response_line)
                             response["cold_start"] = cold
-                            response["log"] = self._drain_stderr()
+                            response["log"] = self._flush_logs()
                             return response
                         except json.JSONDecodeError:
                             continue

--- a/ministack/core/lambda_runtime.py
+++ b/ministack/core/lambda_runtime.py
@@ -88,8 +88,12 @@ const http = require("http");
 const https = require("https");
 const url = require("url");
 
-// Redirect all console methods to stderr so stdout stays clean for JSON-line protocol
+// Redirect all stdout/console to stderr so stdout stays clean for JSON-line protocol
+const _realStdoutWrite = process.stdout.write.bind(process.stdout);
 const _stderrWrite = process.stderr.write.bind(process.stderr);
+process.stdout.write = function(chunk, encoding, callback) {
+  return _stderrWrite(chunk, encoding, callback);
+};
 console.log = (...a) => { _stderrWrite(require("util").format(...a) + "\n"); };
 console.warn = (...a) => { _stderrWrite(require("util").format(...a) + "\n"); };
 console.info = (...a) => { _stderrWrite(require("util").format(...a) + "\n"); };
@@ -227,15 +231,15 @@ rl.on("line", async (line) => {
         }
         handlerFn = mod[handlerName] || (mod.default && mod.default[handlerName]) || mod.default;
         if (typeof handlerFn !== "function") {
-          process.stdout.write(JSON.stringify({
+          _realStdoutWrite(JSON.stringify({
             status: "error",
             error: `Handler ${handlerName} is not a function in ${modPath}`
           }) + "\n");
           return;
         }
-        process.stdout.write(JSON.stringify({ status: "ready", cold: true }) + "\n");
+        _realStdoutWrite(JSON.stringify({ status: "ready", cold: true }) + "\n");
       } catch (e) {
-        process.stdout.write(JSON.stringify({
+        _realStdoutWrite(JSON.stringify({
           status: "error", error: e.message
         }) + "\n");
       }
@@ -265,11 +269,11 @@ rl.on("line", async (line) => {
         if (settled) return;
         settled = true;
         if (err) {
-          process.stdout.write(JSON.stringify({
+          _realStdoutWrite(JSON.stringify({
             status: "error", error: String(err.message || err), trace: err.stack || ""
           }) + "\n");
         } else {
-          process.stdout.write(JSON.stringify({ status: "ok", result: res }) + "\n");
+          _realStdoutWrite(JSON.stringify({ status: "ok", result: res }) + "\n");
         }
       };
       const callback = (err, res) => settle(err, res);
@@ -288,12 +292,12 @@ rl.on("line", async (line) => {
       // If handler accepts callback (arity >= 3) or returned undefined,
       // we wait for callback/context.done/context.succeed/context.fail
     } catch (e) {
-      process.stdout.write(JSON.stringify({
+      _realStdoutWrite(JSON.stringify({
         status: "error", error: e.message, trace: e.stack
       }) + "\n");
     }
   } catch (e) {
-    process.stdout.write(JSON.stringify({
+    _realStdoutWrite(JSON.stringify({
       status: "error", error: "JSON parse error: " + e.message
     }) + "\n");
   }

--- a/ministack/services/lambda_svc.py
+++ b/ministack/services/lambda_svc.py
@@ -971,11 +971,12 @@ async def _invoke(name: str, event: dict, headers: dict, path_qualifier: str | N
         return 204, {"X-Amz-Executed-Version": executed_version}, b""
 
     if invocation_type == "Event":
-        threading.Thread(
-            target=_execute_function,
-            args=(exec_record, event),
-            daemon=True,
-        ).start()
+        def _invoke_async():
+            result = _execute_function(exec_record, event)
+            log_output = result.get("log", "")
+            if log_output:
+                logger.info("Lambda %s output:\n%s", name, log_output)
+        threading.Thread(target=_invoke_async, daemon=True).start()
         return 202, {"X-Amz-Executed-Version": executed_version}, b""
 
     # RequestResponse — execute in worker thread so nested SDK calls
@@ -989,6 +990,7 @@ async def _invoke(name: str, event: dict, headers: dict, path_qualifier: str | N
 
     log_output = result.get("log", "")
     if log_output:
+        logger.info("Lambda %s output:\n%s", name, log_output)
         resp_headers["X-Amz-Log-Result"] = base64.b64encode(
             log_output.encode("utf-8"),
         ).decode()


### PR DESCRIPTION
Hello !

It's me, again. Log where not forwarded properly when invoking lambda (sync and async).
I found 3 issues

##### Missing log forwarding (5e85bdb)
For the `Event` invokation type, I wrapped the `_execute_function` in a function that log the return
For the classic path, I simply add a call to the logger

##### Winston Logger (a7f7fdb)
For the node run time, the console.log() was redirect to stderr and then process by the parent process. Classic production logger such as Winston use `process.stdout.write`

##### Log flushing (eed4a36)
The log where flush just after execution
