### PR TITLE
Enhance log forwarding for lambda

### DIFF
--- a/ministack/core/lambda_runtime.py
+++ b/ministack/core/lambda_runtime.py
@@ -90,13 +90,12 @@ const http = require("http");
 const https = require("https");
 const url = require("url");
 
-// Redirect all console methods to stderr so stdout stays clean for JSON-line protocol
+// Redirect stdout to stderr so stdout stays clean for JSON-line protocol
+const _realStdoutWrite = process.stdout.write.bind(process.stdout);
 const _stderrWrite = process.stderr.write.bind(process.stderr);
-console.log = (...a) => { _stderrWrite(require("util").format(...a) + "\n"); };
-console.warn = (...a) => { _stderrWrite(require("util").format(...a) + "\n"); };
-console.info = (...a) => { _stderrWrite(require("util").format(...a) + "\n"); };
-console.debug = (...a) => { _stderrWrite(require("util").format(...a) + "\n"); };
-console.error = (...a) => { _stderrWrite(require("util").format(...a) + "\n"); };
+process.stdout.write = function(chunk, encoding, callback) {
+  return _stderrWrite(chunk, encoding, callback);
+};
 
 function patchAwsSdk() {
   const endpoint = process.env.AWS_ENDPOINT_URL
@@ -229,15 +228,15 @@ rl.on("line", async (line) => {
         }
         handlerFn = mod[handlerName] || (mod.default && mod.default[handlerName]) || mod.default;
         if (typeof handlerFn !== "function") {
-          process.stdout.write(JSON.stringify({
+          _realStdoutWrite(JSON.stringify({
             status: "error",
             error: `Handler ${handlerName} is not a function in ${modPath}`
           }) + "\n");
           return;
         }
-        process.stdout.write(JSON.stringify({ status: "ready", cold: true }) + "\n");
+        _realStdoutWrite(JSON.stringify({ status: "ready", cold: true }) + "\n");
       } catch (e) {
-        process.stdout.write(JSON.stringify({
+        _realStdoutWrite(JSON.stringify({
           status: "error", error: e.message
         }) + "\n");
       }
@@ -267,11 +266,11 @@ rl.on("line", async (line) => {
         if (settled) return;
         settled = true;
         if (err) {
-          process.stdout.write(JSON.stringify({
+          _realStdoutWrite(JSON.stringify({
             status: "error", error: String(err.message || err), trace: err.stack || ""
           }) + "\n");
         } else {
-          process.stdout.write(JSON.stringify({ status: "ok", result: res }) + "\n");
+          _realStdoutWrite(JSON.stringify({ status: "ok", result: res }) + "\n");
         }
       };
       const callback = (err, res) => settle(err, res);
@@ -290,12 +289,12 @@ rl.on("line", async (line) => {
       // If handler accepts callback (arity >= 3) or returned undefined,
       // we wait for callback/context.done/context.succeed/context.fail
     } catch (e) {
-      process.stdout.write(JSON.stringify({
+      _realStdoutWrite(JSON.stringify({
         status: "error", error: e.message, trace: e.stack
       }) + "\n");
     }
   } catch (e) {
-    process.stdout.write(JSON.stringify({
+    _realStdoutWrite(JSON.stringify({
       status: "error", error: "JSON parse error: " + e.message
     }) + "\n");
   }

--- a/ministack/services/lambda_svc.py
+++ b/ministack/services/lambda_svc.py
@@ -1014,11 +1014,12 @@ async def _invoke(name: str, event: dict, headers: dict, path_qualifier: str | N
         return 204, {"X-Amz-Executed-Version": executed_version}, b""
 
     if invocation_type == "Event":
-        threading.Thread(
-            target=_execute_function,
-            args=(exec_record, event),
-            daemon=True,
-        ).start()
+        def _invoke_async():
+            result = _execute_function(exec_record, event)
+            log_output = result.get("log", "")
+            if log_output:
+                logger.info("Lambda %s output:\n%s", name, log_output)
+        threading.Thread(target=_invoke_async, daemon=True).start()
         return 202, {"X-Amz-Executed-Version": executed_version}, b""
 
     # RequestResponse — execute in worker thread so nested SDK calls
@@ -1032,6 +1033,7 @@ async def _invoke(name: str, event: dict, headers: dict, path_qualifier: str | N
 
     log_output = result.get("log", "")
     if log_output:
+        logger.info("Lambda %s output:\n%s", name, log_output)
         resp_headers["X-Amz-Log-Result"] = base64.b64encode(
             log_output.encode("utf-8"),
         ).decode()


### PR DESCRIPTION
Hello !

It's me, again. Log were not forwarded properly when invoking lambda (sync and async).
I found 2 issues

##### Missing log forwarding (18fdcd1)
For the `Event` invocation type, I wrapped the `_execute_function` in a function that logs the return
For the classic path, I simply added a call to the logger

##### Winston Logger (f2078b6)
For the node run time, the console.log() was redirected to stderr and then processed by the parent process. Classic production logger such as Winston use `process.stdout.write` so I put the redirection on this low level call. This way, I handle logger as well as `console.log()`
