### PR TITLE
Fix(rds): handle MasterUserPassword in ModifyDBInstance

### DIFF
--- a/ministack/services/rds.py
+++ b/ministack/services/rds.py
@@ -427,6 +427,7 @@ def _create_db_instance(p):
         "_docker_container_id": docker_container_id,
         "_internal_address": internal_host,
         "_internal_port": internal_port,
+        "_MasterUserPassword": master_pass,
     }
     _instances[db_id] = instance
 
@@ -488,6 +489,52 @@ def _describe_db_instances(p):
         f"<DescribeDBInstancesResult><DBInstances>{members}</DBInstances></DescribeDBInstancesResult>")
 
 
+def _rotate_instance_password(instance, old_pass, new_pass):
+    """Alter the root password on the real DB container for a standalone instance."""
+    db_id = instance.get("DBInstanceIdentifier", "")
+    engine = instance.get("Engine", "")
+    host = instance.get("_internal_address")
+    port = instance.get("_internal_port")
+    if not host or not port:
+        endpoint = instance.get("Endpoint", {})
+        if not isinstance(endpoint, dict) or not endpoint.get("Port"):
+            return
+        host = endpoint.get("Address", "localhost")
+        port = int(endpoint.get("Port", 3306))
+    if any(e in engine for e in ("mysql", "aurora-mysql", "mariadb")):
+        try:
+            import pymysql
+            conn = pymysql.connect(
+                host=host, port=port, user="root",
+                password=old_pass, autocommit=True)
+            cur = conn.cursor()
+            cur.execute(
+                "ALTER USER 'root'@'%%' IDENTIFIED BY %s", (new_pass,))
+            cur.close()
+            conn.close()
+            logger.info("RDS: rotated root password on instance %s", db_id)
+        except Exception as e:
+            logger.warning("RDS: password rotation failed on instance %s: %s",
+                           db_id, e)
+    elif any(e in engine for e in ("postgres", "aurora-postgresql")):
+        try:
+            import psycopg2
+            conn = psycopg2.connect(
+                host=host, port=port, user=instance.get("MasterUsername", "admin"),
+                password=old_pass, dbname=instance.get("DBName", "postgres"))
+            conn.autocommit = True
+            cur = conn.cursor()
+            cur.execute(
+                "ALTER USER %s WITH PASSWORD %s",
+                (psycopg2.extensions.AsIs(instance.get("MasterUsername", "admin")), new_pass))
+            cur.close()
+            conn.close()
+            logger.info("RDS: rotated password on instance %s", db_id)
+        except Exception as e:
+            logger.warning("RDS: password rotation failed on instance %s: %s",
+                           db_id, e)
+
+
 def _modify_db_instance(p):
     db_id = _p(p, "DBInstanceIdentifier")
     instance = _resolve_instance(db_id)
@@ -535,6 +582,12 @@ def _modify_db_instance(p):
             instance[instance_key] = val
         else:
             pending[instance_key] = val
+
+    new_pass = _p(p, "MasterUserPassword")
+    if new_pass:
+        old_pass = instance.get("_MasterUserPassword", "password")
+        instance["_MasterUserPassword"] = new_pass
+        _rotate_instance_password(instance, old_pass, new_pass)
 
     if _p(p, "DBParameterGroupName"):
         instance["DBParameterGroups"] = [{

--- a/tests/test_rds.py
+++ b/tests/test_rds.py
@@ -717,6 +717,31 @@ def test_rds_modify_cluster_password(rds):
     assert cluster["DBClusterIdentifier"] == "pw-mod-cluster"
 
 
+def test_rds_modify_instance_password(rds):
+    """ModifyDBInstance with MasterUserPassword updates the stored password."""
+    rds.create_db_instance(
+        DBInstanceIdentifier="pw-mod-inst",
+        DBInstanceClass="db.t3.micro",
+        Engine="postgres",
+        MasterUsername="admin",
+        MasterUserPassword="old_pass",
+        AllocatedStorage=20,
+    )
+    # Password change should succeed without error
+    rds.modify_db_instance(
+        DBInstanceIdentifier="pw-mod-inst",
+        MasterUserPassword="new_pass",
+        ApplyImmediately=True,
+    )
+    resp = rds.describe_db_instances(DBInstanceIdentifier="pw-mod-inst")
+    inst = resp["DBInstances"][0]
+    assert inst["DBInstanceIdentifier"] == "pw-mod-inst"
+    # Other fields should remain unchanged
+    assert inst["MasterUsername"] == "admin"
+    assert inst["Engine"] == "postgres"
+    assert inst["DBInstanceStatus"] == "available"
+
+
 # ---------------------------------------------------------------------------
 # Tests for the 8 previously-untested operations
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `ModifyDBInstance` now correctly handles `MasterUserPassword` changes — previously the password was silently ignored
- Standalone DB instances now store `_MasterUserPassword` internally (matching how clusters already do), enabling password tracking and rotation
- New `_rotate_instance_password` helper rotates the password on real Docker-backed Postgres and MySQL containers

## Problem

Applications calling `ModifyDBInstance` with `MasterUserPassword` expected the password to be updated (matching real AWS behavior), but MiniStack silently discarded the value. The `field_map` mapped `"MasterUserPassword": None`, and the loop skipped all `None`-mapped entries. Unlike `DBParameterGroupName` (also `None`-mapped but with dedicated handling below), there was no special code path for password changes. Additionally, instances never stored `_MasterUserPassword` at creation time, so there was no way to track the old password for rotation.

## Changes

| File | Change |
|------|--------|
| `ministack/services/rds.py` | Store `_MasterUserPassword` on instances at creation; add `_rotate_instance_password` helper (supports both MySQL/MariaDB and PostgreSQL); handle `MasterUserPassword` in `_modify_db_instance` |
| `tests/test_rds.py` | New `test_rds_modify_instance_password` — creates instance, modifies password, asserts operation succeeds and other fields remain unchanged |

## Test plan

- [x] New `test_rds_modify_instance_password` passes
- [x] Existing `test_rds_modify_cluster_password` still passes
- [x] All 46 RDS tests pass (45 existing + 1 new)
- [x] Backward-compatible — `_MasterUserPassword` defaults to `"password"` for existing instances without the field