### PR TITLE
release v1.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [1.3.2] — 2026-04-18
+
+### Added
+- **Resource Groups Tagging API — Phase 1** — new service at credential scope `tagging` / target prefix `ResourceGroupsTaggingAPI_20170126`. `GetResources` with `TagFilters` (AND across keys, OR across values) and `ResourceTypeFilters` across S3, Lambda, SQS, SNS, DynamoDB, EventBridge. Contributed by @AdigaAkhil (#372). Fixes #371
+- **Resource Groups Tagging API — Phase 2** — `GetTagKeys` and `GetTagValues` operations, plus GetResources expanded to KMS, ECR, ECS, Glue, Cognito (User Pools + Identity Pools), AppSync, Scheduler, CloudFront, EFS (file systems + access points). 15 services total, 18 new tests. Contributed by @AdigaAkhil (#380). Fixes #379
+- **CloudFormation `AWS::Pipes::Pipe` provisioner** — minimal EventBridge Pipes runtime covering DynamoDB Streams → SNS with background polling; `CreationTime`, `CurrentState`, and ARN exposed via `Fn::GetAtt`. Also adds `FilterPolicy` / `FilterPolicyScope` support to the `AWS::SNS::Subscription` provisioner. Contributed by @davidtme (#354)
+- **RDS `ModifyDBInstance` MasterUserPassword rotation** — password changes are now propagated to the real Postgres/MySQL Docker container via `ALTER USER`, so follow-up connections from application code authenticate with the new password. Contributed by @ptanlam (#376)
+- **Preview Docker image on every PR (including forks)** — `docker-publish-on-pr.yml` switched to `pull_request_target` and now publishes `ministackorg/ministack-preview-build:pr-N-<shortsha>` for any contributor's PR. Reviewers can `docker pull` the exact build without waiting for merge. Workflow runs against main's copy of the file, so a PR's own edits to `.github/workflows/*` cannot redirect the publish. Contributed by @jgrumboe (#377)
+
+### Fixed
+- **Resource Groups Tagging — `ResourceTypeFilters` with no matching collector** — previously fell through to every collector (asking for EC2 returned S3/SQS/SNS/etc.). Now correctly returns an empty list, matching AWS.
+- **Resource Groups Tagging — CloudFormation-provisioned DynamoDB tables** — tags set via `AWS::DynamoDB::Table { Tags: [...] }` are stored on the table record, not in the central `_tags` dict, so they were invisible to `GetResources`. The DynamoDB collector now unions both sources.
+- **EventBridge Pipes `CreationTime`** — stored as `int(time.time())` instead of `time.time()`, matching the project-wide int-epoch convention for JSON responses (Java SDK v2 compatibility).
+- **RDS `_rotate_instance_password` — SQL injection via unquoted username** — the Postgres path used `psycopg2.extensions.AsIs` to splice `MasterUsername` into an `ALTER USER` statement, bypassing quoting. Replaced with `psycopg2.sql.Identifier` for safe identifier quoting.
+- **RDS `_rotate_instance_password` — silent failure visibility** — rotation failures (unreachable container, stale old password) now log at `ERROR` rather than `WARNING` so operators notice when the stored master password diverges from the real DB.
+
+---
+
 ## [1.3.1] — 2026-04-18
 
 ### Added

--- a/ministack/services/pipes.py
+++ b/ministack/services/pipes.py
@@ -64,7 +64,7 @@ def register_pipe(
         "CurrentState": state,
         "StartingPosition": start,
         "Tags": tags or {},
-        "CreationTime": time.time(),
+        "CreationTime": int(time.time()),
     }
     _positions[arn] = _initial_position(_pipes[name])
 

--- a/ministack/services/rds.py
+++ b/ministack/services/rds.py
@@ -514,25 +514,33 @@ def _rotate_instance_password(instance, old_pass, new_pass):
             conn.close()
             logger.info("RDS: rotated root password on instance %s", db_id)
         except Exception as e:
-            logger.warning("RDS: password rotation failed on instance %s: %s",
-                           db_id, e)
+            # Error (not warning) — the stored master password no longer matches
+            # the real DB container, so follow-up connections will fail.
+            logger.error("RDS: password rotation failed on instance %s: %s",
+                         db_id, e)
     elif any(e in engine for e in ("postgres", "aurora-postgresql")):
         try:
             import psycopg2
+            from psycopg2 import sql as _pgsql
+            master_user = instance.get("MasterUsername", "admin")
             conn = psycopg2.connect(
-                host=host, port=port, user=instance.get("MasterUsername", "admin"),
+                host=host, port=port, user=master_user,
                 password=old_pass, dbname=instance.get("DBName", "postgres"))
             conn.autocommit = True
             cur = conn.cursor()
+            # Use psycopg2.sql.Identifier to quote the role name safely — AsIs
+            # skips quoting entirely and is a SQL-injection hazard when
+            # MasterUsername comes from user input.
             cur.execute(
-                "ALTER USER %s WITH PASSWORD %s",
-                (psycopg2.extensions.AsIs(instance.get("MasterUsername", "admin")), new_pass))
+                _pgsql.SQL("ALTER USER {role} WITH PASSWORD %s").format(
+                    role=_pgsql.Identifier(master_user)),
+                (new_pass,))
             cur.close()
             conn.close()
             logger.info("RDS: rotated password on instance %s", db_id)
         except Exception as e:
-            logger.warning("RDS: password rotation failed on instance %s: %s",
-                           db_id, e)
+            logger.error("RDS: password rotation failed on instance %s: %s",
+                         db_id, e)
 
 
 def _modify_db_instance(p):

--- a/ministack/services/tagging.py
+++ b/ministack/services/tagging.py
@@ -64,8 +64,20 @@ def _collect_sns():
 
 def _collect_dynamodb():
     import ministack.services.dynamodb as svc
+    seen = set()
+    # Tags set via TagResource are stored centrally, arn -> [{"Key":, "Value":}, ...]
     for arn, tags in svc._tags.items():
+        seen.add(arn)
         yield arn, _normalise_list(tags)
+    # CloudFormation-provisioned tables store tags on the table record as {k: v}.
+    # Surface those too so CDK / Terraform-via-CFN resources show up.
+    for _name, table in svc._tables.items():
+        arn = table.get("TableArn")
+        if not arn or arn in seen:
+            continue
+        cfn_tags = table.get("tags")
+        if cfn_tags:
+            yield arn, _normalise_flat(cfn_tags)
 
 
 def _collect_eventbridge():
@@ -202,8 +214,9 @@ def _get_resources(data):
     if type_filters:
         type_prefixes = {tf.split(":")[0] for tf in type_filters}
         active = {k: v for k, v in _COLLECTORS.items() if k in type_prefixes}
-        if not active:
-            active = _COLLECTORS
+        # If none of the requested prefixes match a supported collector, return
+        # an empty result — matching AWS (filter narrows the universe, it
+        # never broadens it back to "everything").
     else:
         active = _COLLECTORS
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ministack"
-version = "1.3.1"
+version = "1.3.2"
 description = "Free, open-source local AWS emulator — drop-in LocalStack replacement"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
 Fixes:                                                                                          
  - ministack/services/tagging.py — two fixes: unknown ResourceTypeFilter now returns empty (was  
  all-fallthrough); DynamoDB collector unions _tags + _tables[*]["tags"] so CFN-tagged tables     
  appear.                                                                                    
  - ministack/services/pipes.py:67 — CreationTime is int(time.time()).                            
  - ministack/services/rds.py:492-540 — SQL injection fixed (psycopg2.sql.Identifier);
  rotation-failure logs bumped warning → error.                                                   
  - .github/workflows/docker-publish-on-pr.yml — pull_request_target, ref: head.sha on checkout,  
  head.sha for tag SHA (applied earlier).                                                         
                                                                                                  
  Release metadata:                                         
  - pyproject.toml:7 — 1.3.1 → 1.3.2.                                                             
  - CHANGELOG.md — 1.3.2 — 2026-04-18 block inserted above 1.3.1, format matches prior entries    
  (bold title — description, Contributed by @user (#N), Fixes #N trailers).                       
                                                                                                  
  Dropped from plan after verification:                     
  - app.py:726 — save_all invokes the callable (persistence.py:92), not a bug.                    
  - Cognito _identity_tags — exists at cognito.py:200, Phase 2 collector works.                   
  - Tagging PaginationToken: "" — real AWS also returns empty string for this API; not a drift    
  bug.               