### PR TITLE
fix: security group description parameter in EC2 service and update related test assertion

### DIFF
--- a/ministack/services/ec2.py
+++ b/ministack/services/ec2.py
@@ -541,7 +541,7 @@ def _describe_images(p):
 
 def _create_security_group(p):
     name = _p(p, "GroupName")
-    desc = _p(p, "Description") or name
+    desc = _p(p, "GroupDescription") or name
     vpc_id = _p(p, "VpcId") or _DEFAULT_VPC_ID
     if not name:
         return _error("MissingParameter", "GroupName is required", 400)

--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -92,6 +92,7 @@ def test_ec2_security_group_crud(ec2):
 
     desc = ec2.describe_security_groups(GroupIds=[sg_id])
     assert desc["SecurityGroups"][0]["GroupName"] == "qa-ec2-sg"
+    assert desc["SecurityGroups"][0]["Description"] == "test sg"
 
     ec2.delete_security_group(GroupId=sg_id)
     desc2 = ec2.describe_security_groups()


### PR DESCRIPTION
AWS API reads and writes "GroupDescription" while boto3 stores it as "Description".

Fixes #393