### PR TITLE
Allow user pool client secrets to be created by Cloudformation

### DIFF
--- a/ministack/services/cloudformation/provisioners.py
+++ b/ministack/services/cloudformation/provisioners.py
@@ -1425,7 +1425,7 @@ def _cognito_user_pool_client_create(logical_id, props, stack_name):
         "UserPoolId": pid,
         "ClientName": props.get("ClientName", ""),
         "ClientId": cid,
-        "ClientSecret": None,
+        "ClientSecret": props.get("GenerateSecret", False) and _cognito._client_secret() or None,
         "CreationDate": now,
         "LastModifiedDate": now,
         "ExplicitAuthFlows": props.get("ExplicitAuthFlows", []),


### PR DESCRIPTION
See
https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-resource-cognito-userpoolclient.html#aws-resource-cognito-userpoolclient-properties for docs on this.

I did not see any existing testing for Cognito CloudFormation flows, which is why I did not add any new tests to this, but I did verify it works locally via a CDK based stack deployment.