### PR TITLE
fix: Raise `ReceiptHandleIsInvalid` on singular `DeleteMessage` and `ChangeMessageVisibility`

### DIFF
--- a/ministack/services/sqs.py
+++ b/ministack/services/sqs.py
@@ -398,9 +398,11 @@ def _act_delete_message(data: dict, qurl: str) -> dict:
     # Only remove messages whose receipt_handle is set and matches.
     # Messages that have never been received (receipt_handle is None) are never
     # accidentally removed by an empty or unrelated receipt handle.
+    found = False
     kept = []
     for m in q["messages"]:
         if m["receipt_handle"] is not None and m["receipt_handle"] == rh:
+            found = True
             # Clear the FIFO dedup cache entry so the same dedup ID can be
             # reused immediately after deletion.  Real AWS keeps a strict
             # 5-minute window, but clearing on delete is more practical for
@@ -412,6 +414,8 @@ def _act_delete_message(data: dict, qurl: str) -> dict:
                 q["dedup_cache"].pop(cache_key, None)
         else:
             kept.append(m)
+    if not found:
+        raise _Err("ReceiptHandleIsInvalid", "The input receipt handle is invalid.")
     q["messages"] = kept
     return {}
 
@@ -423,10 +427,14 @@ def _act_change_visibility(data: dict, qurl: str) -> dict:
     q = _get_q(url)
     rh = data.get("ReceiptHandle", "")
     vt = int(data.get("VisibilityTimeout", 30))
+    found = False
     for m in q["messages"]:
         if m["receipt_handle"] is not None and m["receipt_handle"] == rh:
             m["visible_at"] = time.time() + vt
+            found = True
             break
+    if not found:
+        raise _Err("ReceiptHandleIsInvalid", "The input receipt handle is invalid.")
     return {}
 
 

--- a/tests/test_sqs.py
+++ b/tests/test_sqs.py
@@ -376,6 +376,24 @@ def test_sqs_batch_delete_invalid_receipt_handle(sqs):
     assert "bad" in failed_ids
     assert resp["Failed"][0]["Code"] == "ReceiptHandleIsInvalid"
 
+def test_sqs_delete_message_invalid_receipt_handle(sqs):
+    """DeleteMessage with an invalid ReceiptHandle must raise ReceiptHandleIsInvalid."""
+    url = sqs.create_queue(QueueName="intg-sqs-del-invalid")["QueueUrl"]
+    with pytest.raises(ClientError) as exc_info:
+        sqs.delete_message(QueueUrl=url, ReceiptHandle="INVALID-HANDLE-XYZ")
+    assert exc_info.value.response["Error"]["Code"] == "ReceiptHandleIsInvalid"
+    assert exc_info.value.response["ResponseMetadata"]["HTTPStatusCode"] == 400
+
+
+def test_sqs_change_message_visibility_invalid_receipt_handle(sqs):
+    """ChangeMessageVisibility with an invalid ReceiptHandle must raise ReceiptHandleIsInvalid."""
+    url = sqs.create_queue(QueueName="intg-sqs-vis-invalid")["QueueUrl"]
+    with pytest.raises(ClientError) as exc_info:
+        sqs.change_message_visibility(QueueUrl=url, ReceiptHandle="INVALID-HANDLE-XYZ", VisibilityTimeout=60)
+    assert exc_info.value.response["Error"]["Code"] == "ReceiptHandleIsInvalid"
+    assert exc_info.value.response["ResponseMetadata"]["HTTPStatusCode"] == 400
+
+
 def test_sqs_receive_max_10(sqs):
     """ReceiveMessage with MaxNumberOfMessages > 10 is capped at 10."""
     url = sqs.create_queue(QueueName="qa-sqs-max10")["QueueUrl"]


### PR DESCRIPTION
`DeleteMessage` and `ChangeMessageVisibility` silently succeeded when given an unrecognised receipt handle. This is inconsistent with:

- **Real AWS SQS**, which returns HTTP 400 `ReceiptHandleIsInvalid` — documented in the [DeleteMessage API reference](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_DeleteMessage.html) and [troubleshooting guide](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/troubleshooting-api-errors.html)
- **The existing batch equivalents** (`DeleteMessageBatch`, `ChangeMessageVisibilityBatch`) in the same file, which already return `ReceiptHandleIsInvalid` per-entry correctly