### PR TITLE
fix: return JSON 404 for unknown /_localstack/* paths (#386)

### DIFF
--- a/ministack/app.py
+++ b/ministack/app.py
@@ -379,6 +379,27 @@ def _handle_ready_request(path: str, request_id: str):
     }, json.dumps(dict(_ready_scripts_state)).encode()
 
 
+def _handle_unknown_localstack_request(path: str, request_id: str):
+    """Return a clear 404 JSON for unrecognised /_localstack/* paths.
+
+    /_localstack/health is already matched by _handle_health_request (included in
+    _HEALTH_PATHS), so only unknown paths reach here. This prevents them from
+    falling through to the S3 handler and returning confusing NoSuchBucket XML.
+    """
+    if not path.startswith("/_localstack/"):
+        return None
+    return 404, {
+        "Content-Type": "application/json",
+        "x-amzn-requestid": request_id,
+    }, json.dumps({
+        "error": (
+            f"Unknown LocalStack endpoint: {path}. "
+            "Ministack exposes /_ministack/health, /_ministack/ready, and /_ministack/reset. "
+            "See https://github.com/ministackorg/ministack for the full API."
+        )
+    }).encode()
+
+
 def _handle_lambda_download_request(path: str, method: str):
     """Serve MiniStack's Lambda layer and function-code download endpoints."""
     if path.startswith("/_ministack/lambda-layers/") and method == "GET":
@@ -442,6 +463,7 @@ async def _handle_pre_body_request(method: str, path: str, headers: dict, query_
         None if is_execute_api else _handle_options_request(method, request_id),
         _handle_health_request(path, request_id),
         _handle_ready_request(path, request_id),
+        _handle_unknown_localstack_request(path, request_id),
         _handle_lambda_download_request(path, method),
     ):
         if response is not None:

--- a/tests/test_ministack.py
+++ b/tests/test_ministack.py
@@ -71,6 +71,40 @@ def test_ministack_health_endpoints():
     data_localstack = json.loads(resp_localstack.read())
     assert data_health == data_localstack
 
+def test_localstack_unknown_paths_return_json_404():
+    """Unknown /_localstack/* paths must return 404 JSON, not S3 XML NoSuchBucket."""
+    import urllib.error
+    import urllib.request
+
+    endpoint = os.environ.get("MINISTACK_ENDPOINT", "http://localhost:4566")
+    for subpath in ("info", "plugins", "init"):
+        url = f"{endpoint}/_localstack/{subpath}"
+        try:
+            urllib.request.urlopen(url, timeout=5)
+            raise AssertionError(f"Expected 404 for {url}, got 200")
+        except urllib.error.HTTPError as exc:
+            assert exc.code == 404, f"Expected 404, got {exc.code} for {url}"
+            body = json.loads(exc.read())
+            assert "error" in body, f"Response body missing 'error' key for {url}"
+            assert "LocalStack" in body["error"], f"Error message should mention LocalStack: {body['error']}"
+            assert "ministack" in body["error"].lower(), f"Error message should mention ministack: {body['error']}"
+            assert exc.headers.get("Content-Type") == "application/json", (
+                f"Expected application/json Content-Type for {url}"
+            )
+
+
+def test_localstack_health_still_returns_200():
+    """/_localstack/health must still return 200 after the interceptor is wired in."""
+    import urllib.request
+
+    endpoint = os.environ.get("MINISTACK_ENDPOINT", "http://localhost:4566")
+    resp = urllib.request.urlopen(f"{endpoint}/_localstack/health", timeout=5)
+    assert resp.status == 200
+    data = json.loads(resp.read())
+    assert "services" in data
+    assert "edition" in data
+
+
 @_requires_package
 def test_ministack_package_core_importable():
     """ministack.core modules must all be importable."""


### PR DESCRIPTION
## Problem

Teams migrating from LocalStack to Ministack use tooling that probes
`/_localstack/info`, `/_localstack/plugins`, and `/_localstack/init`.
These paths fall through to the S3 handler and return confusing XML:

```xml
HTTP 404
Content-Type: application/xml

<Error>
  <Code>NoSuchBucket</Code>
  <Message>The specified bucket does not exist</Message>
  <Resource>/_localstack</Resource>
</Error>
```

## Solution

Add `_handle_unknown_localstack_request` in `app.py`, wired into the
`_handle_pre_body_request` chain after `_handle_health_request`. Any
`/_localstack/*` path not already matched returns a JSON 404 pointing
users to the Ministack equivalent endpoints.

`/_localstack/health` is already in `_HEALTH_PATHS` and is unaffected.

## Changes

- `ministack/app.py`: new handler + wired into pre-body chain (22 lines)
- `tests/test_ministack.py`: 2 new tests covering the 404 response and health regression

Closes #386
