### PR TITLE
fix: send s3:TestEvent to all destinations on PutBucketNotificationConfiguration

### DIFF
--- a/ministack/services/s3.py
+++ b/ministack/services/s3.py
@@ -1096,6 +1096,7 @@ def _put_bucket_notification(name: str, body: bytes):
     if name not in _buckets:
         return _no_such_bucket(name)
     _bucket_notifications[name] = body
+    _fire_s3_test_event_async(name)
     return 200, {}, b""
 
 
@@ -1547,6 +1548,42 @@ def _fire_s3_event_async(
         args=(bucket_name, key, event_name, size, etag),
         daemon=True,
     )
+    t.start()
+
+
+def _fire_s3_test_event(bucket_name: str) -> None:
+    """Deliver an s3:TestEvent to every destination in the bucket notification config."""
+    try:
+        configs = _parse_notification_config(bucket_name)
+        if not configs:
+            return
+        payload = {
+            "Service": "Amazon S3",
+            "Event": "s3:TestEvent",
+            "Time": _dt.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.000Z"),
+            "Bucket": bucket_name,
+            "RequestId": new_uuid(),
+            "HostId": new_uuid(),
+        }
+        for cfg in configs:
+            try:
+                if cfg["type"] == "sqs":
+                    _deliver_event_to_sqs(cfg["arn"], payload)
+                elif cfg["type"] == "sns":
+                    _deliver_event_to_sns(cfg["arn"], payload)
+                elif cfg["type"] == "lambda":
+                    _deliver_event_to_lambda(cfg["arn"], payload)
+            except Exception:
+                logger.exception(
+                    "S3 test-event delivery failed for config %s", cfg.get("id")
+                )
+    except Exception:
+        logger.exception("S3 test-event fire failed for %s", bucket_name)
+
+
+def _fire_s3_test_event_async(bucket_name: str) -> None:
+    """Fire s3:TestEvent in a background thread (non-blocking)."""
+    t = threading.Thread(target=_fire_s3_test_event, args=(bucket_name,), daemon=True)
     t.start()
 
 

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -777,8 +777,9 @@ def test_s3_event_notification_to_sqs(s3, sqs):
     s3.put_object(Bucket="s3-evt-bkt", Key="test-notify.txt", Body=b"hello")
     time.sleep(0.5)
     msgs = sqs.receive_message(QueueUrl=queue_url, MaxNumberOfMessages=10, WaitTimeSeconds=2)
-    assert "Messages" in msgs and len(msgs["Messages"]) > 0
-    body = json.loads(msgs["Messages"][0]["Body"])
+    s3_msgs = [m for m in msgs.get("Messages", []) if "Records" in json.loads(m["Body"])]
+    assert len(s3_msgs) > 0
+    body = json.loads(s3_msgs[0]["Body"])
     assert body["Records"][0]["eventSource"] == "aws:s3"
     assert body["Records"][0]["s3"]["object"]["key"] == "test-notify.txt"
 
@@ -805,7 +806,7 @@ def test_s3_event_notification_filter(s3, sqs):
     s3.put_object(Bucket="s3-evt-filter-bkt", Key="data.csv", Body=b"match")
     time.sleep(0.5)
     msgs = sqs.receive_message(QueueUrl=queue_url, MaxNumberOfMessages=10, WaitTimeSeconds=2)
-    keys = [json.loads(m["Body"])["Records"][0]["s3"]["object"]["key"] for m in msgs.get("Messages", [])]
+    keys = [json.loads(m["Body"])["Records"][0]["s3"]["object"]["key"] for m in msgs.get("Messages", []) if "Records" in json.loads(m["Body"])]
     assert "data.csv" in keys
     assert "data.txt" not in keys
 
@@ -826,9 +827,52 @@ def test_s3_event_notification_delete(s3, sqs):
     s3.delete_object(Bucket="s3-evt-del-bkt", Key="to-del.txt")
     time.sleep(0.5)
     msgs = sqs.receive_message(QueueUrl=queue_url, MaxNumberOfMessages=10, WaitTimeSeconds=2)
-    assert "Messages" in msgs and len(msgs["Messages"]) > 0
-    body = json.loads(msgs["Messages"][0]["Body"])
+    s3_msgs = [m for m in msgs.get("Messages", []) if "Records" in json.loads(m["Body"])]
+    assert len(s3_msgs) > 0
+    body = json.loads(s3_msgs[0]["Body"])
     assert "ObjectRemoved" in body["Records"][0]["eventName"]
+
+def test_s3_put_notification_sends_test_event(s3, sqs):
+    bkt = "s3-test-evt-bkt"
+    s3.create_bucket(Bucket=bkt)
+    queue_url = sqs.create_queue(QueueName="s3-test-evt-q")["QueueUrl"]
+    queue_arn = sqs.get_queue_attributes(
+        QueueUrl=queue_url,
+        AttributeNames=["QueueArn"],
+    )["Attributes"]["QueueArn"]
+    s3.put_bucket_notification_configuration(
+        Bucket=bkt,
+        NotificationConfiguration={
+            "QueueConfigurations": [{"QueueArn": queue_arn, "Events": ["s3:ObjectCreated:*"]}],
+        },
+    )
+    time.sleep(0.5)
+    msgs = sqs.receive_message(QueueUrl=queue_url, MaxNumberOfMessages=10, WaitTimeSeconds=2)
+    assert "Messages" in msgs and len(msgs["Messages"]) == 1
+    body = json.loads(msgs["Messages"][0]["Body"])
+    assert body["Event"] == "s3:TestEvent"
+    assert body["Bucket"] == bkt
+    assert "Records" not in body
+
+
+def test_s3_put_notification_no_test_event_for_missing_bucket(s3, sqs):
+    queue_url = sqs.create_queue(QueueName="s3-test-evt-missing-q")["QueueUrl"]
+    queue_arn = sqs.get_queue_attributes(
+        QueueUrl=queue_url,
+        AttributeNames=["QueueArn"],
+    )["Attributes"]["QueueArn"]
+    with pytest.raises(ClientError) as exc:
+        s3.put_bucket_notification_configuration(
+            Bucket="no-such-bucket-xyz",
+            NotificationConfiguration={
+                "QueueConfigurations": [{"QueueArn": queue_arn, "Events": ["s3:ObjectCreated:*"]}],
+            },
+        )
+    assert exc.value.response["Error"]["Code"] == "NoSuchBucket"
+    time.sleep(0.5)
+    msgs = sqs.receive_message(QueueUrl=queue_url, MaxNumberOfMessages=10, WaitTimeSeconds=1)
+    assert "Messages" not in msgs
+
 
 def test_s3_eventbridge_notification(s3, sqs, eb):
     """S3 EventBridgeConfiguration sends events to EventBridge, routed to SQS via rule."""
@@ -1346,23 +1390,25 @@ def test_s3_event_to_sqs(s3, sqs):
     s3.put_object(Bucket=bucket, Key="hello.txt", Body=b"world")
     time.sleep(1)
     msgs = sqs.receive_message(QueueUrl=queue_url, MaxNumberOfMessages=10, WaitTimeSeconds=2)
-    assert "Messages" in msgs and len(msgs["Messages"]) >= 1
-    body = json.loads(msgs["Messages"][0]["Body"])
+    s3_msgs = [m for m in msgs.get("Messages", []) if "Records" in json.loads(m["Body"])]
+    assert len(s3_msgs) >= 1
+    body = json.loads(s3_msgs[0]["Body"])
     assert body["Records"][0]["eventSource"] == "aws:s3"
     assert body["Records"][0]["eventName"].startswith("ObjectCreated:")
     assert body["Records"][0]["s3"]["bucket"]["name"] == bucket
     assert body["Records"][0]["s3"]["object"]["key"] == "hello.txt"
 
     # Delete receipts so queue is clean
-    for m in msgs["Messages"]:
+    for m in msgs.get("Messages", []):
         sqs.delete_message(QueueUrl=queue_url, ReceiptHandle=m["ReceiptHandle"])
 
     # Delete the object — should fire ObjectRemoved event
     s3.delete_object(Bucket=bucket, Key="hello.txt")
     time.sleep(1)
     msgs = sqs.receive_message(QueueUrl=queue_url, MaxNumberOfMessages=10, WaitTimeSeconds=2)
-    assert "Messages" in msgs and len(msgs["Messages"]) >= 1
-    del_body = json.loads(msgs["Messages"][0]["Body"])
+    s3_msgs = [m for m in msgs.get("Messages", []) if "Records" in json.loads(m["Body"])]
+    assert len(s3_msgs) >= 1
+    del_body = json.loads(s3_msgs[0]["Body"])
     assert del_body["Records"][0]["eventName"].startswith("ObjectRemoved:")
 
 


### PR DESCRIPTION
From the [PutBucketNotificationConfiguration API reference](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketNotificationConfiguration.html):

> After Amazon S3 receives this request, it first verifies that any Amazon SNS or SQS destination exists, and that the bucket owner has permission to publish to it by sending a test notification.

Attempts to match the real AWS S3 behavior (and LocalStack) where configuring bucket notifications immediately delivers a flat s3:TestEvent payload (no Records wrapper) to every SQS, SNS, and Lambda destination in the config.