### PR TITLE
Fix EC2 DescribeInstances tag filters

### DIFF
--- a/ministack/services/ec2.py
+++ b/ministack/services/ec2.py
@@ -63,8 +63,8 @@ import time
 from urllib.parse import parse_qs
 from xml.sax.saxutils import escape as _esc
 
-from ministack.core.persistence import load_state, PERSIST_STATE
-from ministack.core.responses import AccountScopedDict, get_account_id, new_uuid, get_region
+from ministack.core.persistence import PERSIST_STATE, load_state
+from ministack.core.responses import AccountScopedDict, get_account_id, get_region, new_uuid
 
 logger = logging.getLogger("ec2")
 
@@ -2279,6 +2279,7 @@ def _parse_filters(params):
 
 
 def _matches_filters(inst, filters):
+    tag_list = _tags.get(inst["InstanceId"], [])
     for name, vals in filters.items():
         if name == "instance-state-name":
             if inst["State"]["Name"] not in vals:
@@ -2288,6 +2289,14 @@ def _matches_filters(inst, filters):
                 return False
         elif name == "image-id":
             if inst["ImageId"] not in vals:
+                return False
+        elif name.startswith("tag:"):
+            tag_key = name[4:]
+            tag_val = next((t["Value"] for t in tag_list if t["Key"] == tag_key), None)
+            if tag_val not in vals:
+                return False
+        elif name == "tag-key":
+            if not any(t["Key"] in vals for t in tag_list):
                 return False
     return True
 

--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -2,11 +2,13 @@ import io
 import json
 import os
 import time
+import uuid as _uuid_mod
 import zipfile
 from urllib.parse import urlparse
+
 import pytest
 from botocore.exceptions import ClientError
-import uuid as _uuid_mod
+
 
 def test_ec2_describe_vpcs_default(ec2):
     resp = ec2.describe_vpcs()
@@ -228,6 +230,33 @@ def test_ec2_tags_crud(ec2):
     assert not any(t["Key"] == "Name" for t in tags2)
 
     ec2.terminate_instances(InstanceIds=[iid])
+
+
+def test_ec2_describe_instances_tag_filter_excludes_untagged(ec2):
+    owner = f"devuser-{_uuid_mod.uuid4().hex}"
+    untagged_id = ec2.run_instances(ImageId="ami-untagged", MinCount=1, MaxCount=1)["Instances"][0]["InstanceId"]
+    tagged_id = ec2.run_instances(
+        ImageId="ami-tagged",
+        MinCount=1,
+        MaxCount=1,
+        TagSpecifications=[{
+            "ResourceType": "instance",
+            "Tags": [{"Key": "PopOpsOwner", "Value": owner}],
+        }],
+    )["Instances"][0]["InstanceId"]
+
+    resp = ec2.describe_instances(Filters=[{"Name": "tag:PopOpsOwner", "Values": [owner]}])
+    ids = [
+        inst["InstanceId"]
+        for reservation in resp["Reservations"]
+        for inst in reservation["Instances"]
+    ]
+
+    assert tagged_id in ids
+    assert untagged_id not in ids
+
+    ec2.terminate_instances(InstanceIds=[untagged_id, tagged_id])
+
 
 def test_ec2_modify_vpc_attribute(ec2):
     vpc_id = ec2.create_vpc(CidrBlock="10.10.0.0/16")["Vpc"]["VpcId"]


### PR DESCRIPTION
## Summary
- honor `tag:<key>` filters when matching EC2 instances in `DescribeInstances`
- support `tag-key` for instance filtering to align with the existing EC2 describe filter behavior
- add a regression test proving untagged instances are excluded from owner-tag queries

## Reproduction
1. Start MiniStack.
2. Create one instance tagged `PopOpsOwner=devuser` and another without that tag.
3. Call `DescribeInstances` with `tag:PopOpsOwner=devuser`.
4. Before this change, both instances were returned; after this change, only the tagged instance is returned.

Repro on main:

```bash
 curl -sf -X POST http://127.0.0.1:4579/_ministack/reset >/dev/null
 
 UNTAGGED=$(AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test \
   aws --region us-east-1 --endpoint-url=http://127.0.0.1:4579 \
   ec2 run-instances --image-id ami-untagged --count 1 \
   --query 'Instances[0].InstanceId' --output text)
 
 TAGGED=$(AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test \
   aws --region us-east-1 --endpoint-url=http://127.0.0.1:4579 \
   ec2 run-instances --image-id ami-tagged --count 1 \
   --query 'Instances[0].InstanceId' --output text)
 
 AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test \
   aws --region us-east-1 --endpoint-url=http://127.0.0.1:4579 \
   ec2 create-tags --resources "$TAGGED" \
   --tags Key=PopOpsOwner,Value=devuser >/dev/null
 
 AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test \
   aws --region us-east-1 --endpoint-url=http://127.0.0.1:4579 \
   ec2 describe-instances \
   --filters Name=tag:PopOpsOwner,Values=devuser \
   --query 'Reservations[].Instances[].InstanceId' --output text
```

Output:  i-8221dc65d301211a9    i-d84146693457919c2
Where:
*  untagged=`i-8221dc65d301211a9`
*  tagged=`i-d84146693457919c2`

**Branch with the fix:**

```bash
 curl -sf -X POST http://127.0.0.1:4580/_ministack/reset >/dev/null
 
 UNTAGGED=$(AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test \
   aws --region us-east-1 --endpoint-url=http://127.0.0.1:4580 \
   ec2 run-instances --image-id ami-untagged --count 1 \
   --query 'Instances[0].InstanceId' --output text)
 
 TAGGED=$(AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test \
   aws --region us-east-1 --endpoint-url=http://127.0.0.1:4580 \
   ec2 run-instances --image-id ami-tagged --count 1 \
   --query 'Instances[0].InstanceId' --output text)
 
 AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test \
   aws --region us-east-1 --endpoint-url=http://127.0.0.1:4580 \
   ec2 create-tags --resources "$TAGGED" \
   --tags Key=PopOpsOwner,Value=devuser >/dev/null
 
 AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test \
   aws --region us-east-1 --endpoint-url=http://127.0.0.1:4580 \
   ec2 describe-instances \
   --filters Name=tag:PopOpsOwner,Values=devuser \
   --query 'Reservations[].Instances[].InstanceId' --output text
```

Output: i-ca020119911e828ba

Where:
* untagged=i-0171676d30d79a16e
* tagged=i-ca020119911e828ba



This bug surfaced in when migrating from localstack to MiniStack  in an app that scopes resources by owner tag. Untagged instances were leaking into filtered results, which caused downstream rendering errors.