### PR TITLE
fix(rds): support SigV4 JSON DescribeDBInstances and Aurora cluster membership

### DIFF
--- a/ministack/services/rds.py
+++ b/ministack/services/rds.py
@@ -22,10 +22,16 @@ Supports: CreateDBInstance, DeleteDBInstance, DescribeDBInstances, ModifyDBInsta
 
 When Docker is available, CreateDBInstance spins up a real Postgres/MySQL container
 and returns the actual host:port as the endpoint.
+
+JSON request bodies (``application/x-amz-json-1.*``, SigV4 JSON) are accepted for the
+same actions as the legacy Query API form body, so Terraform / current botocore
+clients can call DescribeDBInstances and other operations without ``Action=`` query
+parameters.
 """
 
 import copy
 import datetime
+import json
 import logging
 import os
 import socket
@@ -182,13 +188,49 @@ def _next_port():
 # Request routing
 # ---------------------------------------------------------------------------
 
+def _flatten_json_request_params(params, data):
+    """Merge SigV4 JSON (``application/x-amz-json-1.*``) bodies into query-style params.
+
+    Botocore's JSON protocol sends a JSON object; our handlers expect the same
+    keys as the Query API with list-shaped values (``_p`` reads ``[0]``).
+    """
+    if not isinstance(data, dict):
+        return
+    for key, val in data.items():
+        if val is None:
+            continue
+        if isinstance(val, bool):
+            params[key] = ["true" if val else "false"]
+        elif isinstance(val, (int, float)):
+            params[key] = [str(val)]
+        elif isinstance(val, str):
+            params[key] = [val]
+        elif isinstance(val, list) and key == "Filters":
+            for i, f in enumerate(val, 1):
+                if not isinstance(f, dict):
+                    continue
+                name = f.get("Name")
+                if not name:
+                    continue
+                params[f"Filters.member.{i}.Name"] = [name]
+                for j, v in enumerate(f.get("Values") or [], 1):
+                    params[f"Filters.member.{i}.Values.member.{j}"] = [str(v)]
+
+
 async def handle_request(method, path, headers, body, query_params):
     params = dict(query_params)
     if method == "POST" and body:
         raw = body if isinstance(body, str) else body.decode("utf-8", errors="replace")
-        form_params = parse_qs(raw)
-        for k, v in form_params.items():
-            params[k] = v
+        stripped = raw.lstrip()
+        if stripped.startswith("{"):
+            try:
+                _flatten_json_request_params(params, json.loads(raw))
+            except json.JSONDecodeError:
+                pass
+        else:
+            form_params = parse_qs(raw)
+            for k, v in form_params.items():
+                params[k] = v
 
     target = headers.get("x-amz-target", "") or headers.get("X-Amz-Target", "")
     if target:
@@ -220,6 +262,33 @@ def _resolve_instance(db_id):
             if inst.get("DbiResourceId") == db_id:
                 return inst
     return None
+
+
+def _register_instance_in_cluster(instance):
+    """Append instance to parent cluster ``DBClusterMembers`` (Aurora parity)."""
+    cid = instance.get("DBClusterIdentifier")
+    if not cid:
+        return
+    cluster = _clusters.get(cid)
+    if not cluster:
+        return
+    members = cluster.setdefault("DBClusterMembers", [])
+    db_id = instance["DBInstanceIdentifier"]
+    members[:] = [m for m in members if m.get("DBInstanceIdentifier") != db_id]
+    any_writer = any(m.get("IsClusterWriter") for m in members)
+    is_writer = not any_writer
+    members.append({
+        "DBInstanceIdentifier": db_id,
+        "IsClusterWriter": is_writer,
+        "PromotionTier": int(instance.get("PromotionTier", 1)),
+    })
+
+
+def _unregister_instance_from_clusters(db_id):
+    """Remove instance from any cluster member list."""
+    for cl in _clusters.values():
+        mem = cl.get("DBClusterMembers") or []
+        cl["DBClusterMembers"] = [m for m in mem if m.get("DBInstanceIdentifier") != db_id]
 
 
 # ---------------------------------------------------------------------------
@@ -436,6 +505,7 @@ def _create_db_instance(p):
         "_MasterUserPassword": master_pass,
     }
     _instances[db_id] = instance
+    _register_instance_in_cluster(instance)
 
     req_tags = _parse_tags(p)
     if req_tags:
@@ -450,6 +520,8 @@ def _delete_db_instance(p):
     instance = _resolve_instance(db_id)
     if not instance:
         return _error("DBInstanceNotFoundFault", f"DBInstance {db_id} not found.", 404)
+
+    _unregister_instance_from_clusters(db_id)
 
     if instance.get("DeletionProtection"):
         return _error("InvalidParameterCombination",

--- a/ministack/services/rds.py
+++ b/ministack/services/rds.py
@@ -188,6 +188,16 @@ def _next_port():
 # Request routing
 # ---------------------------------------------------------------------------
 
+def _json_key_to_query_param_name(key: str) -> str:
+    """Map JSON / Smithy body keys to Query-API parameter names."""
+    lk = key.lower()
+    if lk == "dbinstanceidentifier":
+        return "DBInstanceIdentifier"
+    if lk == "filters":
+        return "Filters"
+    return key
+
+
 def _flatten_json_request_params(params, data):
     """Merge SigV4 JSON (``application/x-amz-json-1.*``) bodies into query-style params.
 
@@ -199,35 +209,43 @@ def _flatten_json_request_params(params, data):
     for key, val in data.items():
         if val is None:
             continue
+        qkey = _json_key_to_query_param_name(key)
         if isinstance(val, bool):
-            params[key] = ["true" if val else "false"]
+            params[qkey] = ["true" if val else "false"]
         elif isinstance(val, (int, float)):
-            params[key] = [str(val)]
+            params[qkey] = [str(val)]
         elif isinstance(val, str):
-            params[key] = [val]
-        elif isinstance(val, list) and key == "Filters":
+            params[qkey] = [val]
+        elif isinstance(val, list) and qkey == "Filters":
             for i, f in enumerate(val, 1):
                 if not isinstance(f, dict):
                     continue
-                name = f.get("Name")
+                name = f.get("Name") or f.get("name")
                 if not name:
                     continue
                 params[f"Filters.member.{i}.Name"] = [name]
-                for j, v in enumerate(f.get("Values") or [], 1):
+                values = f.get("Values") or f.get("values") or []
+                for j, v in enumerate(values, 1):
                     params[f"Filters.member.{i}.Values.member.{j}"] = [str(v)]
 
 
 async def handle_request(method, path, headers, body, query_params):
     params = dict(query_params)
     if method == "POST" and body:
-        raw = body if isinstance(body, str) else body.decode("utf-8", errors="replace")
+        raw = body if isinstance(body, str) else body.decode("utf-8-sig", errors="replace")
         stripped = raw.lstrip()
-        if stripped.startswith("{"):
+        ct = (headers.get("content-type") or headers.get("Content-Type") or "").lower()
+        merged_json = False
+        # Prefer JSON when it looks like JSON, or when the client declares AWS/JSON.
+        if stripped.startswith("{") or ("json" in ct and stripped):
             try:
-                _flatten_json_request_params(params, json.loads(raw))
+                payload = json.loads(stripped)
+                if isinstance(payload, dict):
+                    _flatten_json_request_params(params, payload)
+                    merged_json = True
             except json.JSONDecodeError:
                 pass
-        else:
+        if not merged_json:
             form_params = parse_qs(raw)
             for k, v in form_params.items():
                 params[k] = v

--- a/tests/test_rds.py
+++ b/tests/test_rds.py
@@ -1,3 +1,4 @@
+import asyncio
 import io
 import json
 import os
@@ -698,6 +699,80 @@ def test_rds_instance_inherits_cluster_username(rds):
     inst = resp["DBInstances"][0]
     assert inst["MasterUsername"] == "myadmin"
     assert inst["DBClusterIdentifier"] == "inherit-cluster"
+
+
+def test_rds_handle_request_describe_with_json_body():
+    """DescribeDBInstances works when the request body is JSON (not form-encoded)."""
+    from ministack.core.responses import set_request_account_id
+    from ministack.services import rds as m
+
+    set_request_account_id("111111111111")
+    iid = f"inproc-json-{_uuid_mod.uuid4().hex[:12]}"
+    m._create_db_instance({
+        "DBInstanceIdentifier": [iid],
+        "DBInstanceClass": ["db.t3.micro"],
+        "Engine": ["postgres"],
+        "MasterUsername": ["admin"],
+        "MasterUserPassword": ["pw"],
+        "AllocatedStorage": ["20"],
+    })
+
+    async def desc():
+        body = json.dumps({"DBInstanceIdentifier": iid}).encode()
+        hdrs = {
+            "x-amz-target": "AmazonRDSv19.DescribeDBInstances",
+            "content-type": "application/x-amz-json-1.1",
+        }
+        return await m.handle_request("POST", "/", hdrs, body, {})
+
+    status, _, xml = asyncio.run(desc())
+    assert status == 200
+    assert iid.encode() in xml
+
+
+def test_rds_flatten_json_request_params():
+    """JSON protocol bodies are merged into query-style params for existing handlers."""
+    from ministack.services import rds as m
+
+    params = {}
+    m._flatten_json_request_params(
+        params,
+        {
+            "DBInstanceIdentifier": "my-writer",
+            "ApplyImmediately": True,
+            "BackupRetentionPeriod": 7,
+            "Filters": [
+                {"Name": "db-instance-id", "Values": ["a", "b"]},
+            ],
+        },
+    )
+    assert params["DBInstanceIdentifier"] == ["my-writer"]
+    assert params["ApplyImmediately"] == ["true"]
+    assert params["BackupRetentionPeriod"] == ["7"]
+    assert params["Filters.member.1.Name"] == ["db-instance-id"]
+    assert params["Filters.member.1.Values.member.1"] == ["a"]
+    assert params["Filters.member.1.Values.member.2"] == ["b"]
+
+
+def test_rds_aurora_cluster_lists_instance_member(rds):
+    """CreateDBInstance for a cluster updates DescribeDBClusters DBClusterMembers."""
+    cid = f"memclus-{_uuid_mod.uuid4().hex[:10]}"
+    iid = f"{cid}-writer"
+    rds.create_db_cluster(
+        DBClusterIdentifier=cid,
+        Engine="aurora-postgresql",
+        MasterUsername="admin",
+        MasterUserPassword="pw",
+    )
+    rds.create_db_instance(
+        DBInstanceIdentifier=iid,
+        DBClusterIdentifier=cid,
+        DBInstanceClass="db.r6g.large",
+        Engine="aurora-postgresql",
+    )
+    out = rds.describe_db_clusters(DBClusterIdentifier=cid)
+    members = out["DBClusters"][0].get("DBClusterMembers") or []
+    assert any(m["DBInstanceIdentifier"] == iid for m in members)
 
 
 def test_rds_modify_cluster_password(rds):

--- a/tests/test_rds.py
+++ b/tests/test_rds.py
@@ -753,6 +753,13 @@ def test_rds_flatten_json_request_params():
     assert params["Filters.member.1.Values.member.1"] == ["a"]
     assert params["Filters.member.1.Values.member.2"] == ["b"]
 
+    params2 = {}
+    m._flatten_json_request_params(
+        params2,
+        {"dbInstanceIdentifier": "smithy-style-id", "filters": []},
+    )
+    assert params2["DBInstanceIdentifier"] == ["smithy-style-id"]
+
 
 def test_rds_aurora_cluster_lists_instance_member(rds):
     """CreateDBInstance for a cluster updates DescribeDBClusters DBClusterMembers."""


### PR DESCRIPTION
## Summary
MiniStack’s RDS handler assumed query-style / form-encoded POST bodies. Modern **botocore** and **Terraform** often call RDS with **SigV4 JSON** (`application/x-amz-json-1.*`). Parameters such as `DBInstanceIdentifier` never reached the handler, so **`DescribeDBInstances` returned `DBInstanceNotFoundFault`** even when the instance existed or should be discoverable.
This PR merges JSON bodies into the same parameter space as the query API and aligns Aurora cluster metadata with AWS.
## Changes
- **JSON POST bodies**: flatten JSON into query-style params used by existing RDS logic.
- **Key / casing**: map Smithy-style keys (e.g. `dbInstanceIdentifier`) to query names (`DBInstanceIdentifier`); accept `Filters` member shapes with mixed-case `Name` / `Values`.
- **Decoding / detection**: decode with **`utf-8-sig`**; treat declared **JSON** `Content-Type` as JSON; only fall back to form parsing when JSON was not merged (avoids mis-handling JSON payloads).
- **Aurora**: on **create/delete** of a cluster instance, **update the parent cluster’s `DBClusterMembers`** so **`DescribeDBClusters`** stays consistent with AWS.
## Motivation
Unblocks **`aws_rds_cluster_instance`** (and related Terraform refresh) against MiniStack when the provider uses the JSON protocol for `DescribeDBInstances`.
## Testing
- Unit tests for JSON flattening (including Smithy-style keys and filters) and Aurora cluster member listing.
