### PR TITLE
fix(lambda): accept slash-form Python handler paths

### DIFF
--- a/ministack/core/lambda_runtime.py
+++ b/ministack/core/lambda_runtime.py
@@ -414,6 +414,12 @@ class Worker:
 
         handler = self.config.get("Handler", "index.handler")
         module_name, handler_name = handler.rsplit(".", 1)
+        # AWS Python Lambda accepts both dot (``pkg.mod.fn``) and slash
+        # (``pkg/mod.fn``) in nested handler paths; ``__import__`` only
+        # takes dot. Other runtimes (Node.js, etc.) keep the raw string
+        # because they don't use Python module resolution.
+        if runtime.startswith("python"):
+            module_name = module_name.replace("/", ".")
         env_vars = self.config.get("Environment", {}).get("Variables", {})
         spawn_env = {**os.environ, **env_vars}
         # Restore the internal endpoint URL so Lambda SDK calls reach

--- a/ministack/services/lambda_svc.py
+++ b/ministack/services/lambda_svc.py
@@ -2665,6 +2665,12 @@ def _execute_function_local(func: dict, event: dict) -> dict:
             if "." not in handler:
                 return {"body": {"errorMessage": f"Invalid handler format: {handler}", "errorType": "Runtime.InvalidEntrypoint"}, "error": True}
             module_name, func_name = handler.rsplit(".", 1)
+            # AWS Python Lambda accepts both dot (``pkg.mod.fn``) and slash
+            # (``pkg/mod.fn``) in nested handler paths; ``__import__`` only
+            # takes dot. Other runtimes (Node.js, etc.) keep the raw string
+            # because they don't use Python module resolution.
+            if runtime.startswith("python"):
+                module_name = module_name.replace("/", ".")
 
             if is_node:
                 wrapper_path = os.path.join(tmpdir, "_wrapper.js")

--- a/tests/test_lambda.py
+++ b/tests/test_lambda.py
@@ -59,6 +59,34 @@ def test_lambda_create_invoke(lam):
     payload = json.loads(resp["Payload"].read())
     assert payload["statusCode"] == 200
 
+
+def test_lambda_python_nested_handler_slash_form(lam):
+    """AWS Python Lambda accepts both dot and slash separators in nested
+    handler paths (``pkg/sub/mod.fn`` equivalent to ``pkg.sub.mod.fn``);
+    real AWS resolves either form via the underlying file path. MiniStack
+    previously imported the pre-rsplit string literally, so slash form
+    failed with ``ModuleNotFoundError: No module named 'pkg/sub/mod'``.
+    """
+    code = b"def hello(event, context):\n    return {\"ok\": True, \"event\": event}\n"
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("pkg/sub/mod.py", code)
+    lam.create_function(
+        FunctionName="slash-handler-fn",
+        Runtime="python3.12",
+        Role="arn:aws:iam::000000000000:role/test-role",
+        Handler="pkg/sub/mod.hello",
+        Code={"ZipFile": buf.getvalue()},
+    )
+    resp = lam.invoke(
+        FunctionName="slash-handler-fn",
+        Payload=json.dumps({"k": "v"}),
+    )
+    assert "FunctionError" not in resp, resp
+    payload = json.loads(resp["Payload"].read())
+    assert payload.get("ok") is True
+
+
 def test_create_function_missing_runtime_raises(lam):
     """Zip deployment without a Runtime should return InvalidParameterValueException."""
     buf = io.BytesIO()


### PR DESCRIPTION
## Summary

AWS Python Lambda accepts both dot (`pkg.sub.mod.fn`) and slash (`pkg/sub/mod.fn`) as separators in nested handler paths. Real Lambda resolves handlers via the underlying file path, so the two forms route to the same module. MiniStack's Python path does `__import__(module_name)` against the pre-rsplit literal, which rejects slashes.

Repros with any nested handler + slash form:

```python
lam.create_function(
    FunctionName="demo",
    Runtime="python3.12",
    Role="arn:aws:iam::000000000000:role/test",
    Handler="pkg/sub/mod.hello",
    Code={"ZipFile": zip_bytes},   # zip contains pkg/sub/mod.py
)
lam.invoke(FunctionName="demo", Payload="{}")
# FunctionError: Unhandled
# {"errorMessage": "Worker init failed: No module named 'pkg/sub/mod'", ...}
```

## Fix

Normalize `/` → `.` in `module_name` for **Python** runtimes only. Two call sites:

1. `ministack/services/lambda_svc.py:2672` — `_execute_function_local` (subprocess path used when Docker isn't available for this invoke style)
2. `ministack/core/lambda_runtime.py:419` — `Worker._spawn` (persistent warm worker pool, the default Python invoke path)

Node.js is intentionally untouched — the Node wrapper uses `path.resolve(codeDir, modPath)`, a filesystem path resolution, so `subdir/file.handler` is the natural form there.

## Test

Added `tests/test_lambda.py::test_lambda_python_nested_handler_slash_form`:

- Zips `pkg/sub/mod.py` with `def hello(event, context): return {"ok": True, ...}`
- Registers with `Handler="pkg/sub/mod.hello"`
- Invokes with `{"k": "v"}`
- Asserts no `FunctionError` and `payload["ok"] is True`

Passes locally against v1.3.12 with the fix:
```
tests/test_lambda.py::test_lambda_python_nested_handler_slash_form PASSED [100%]
============================== 1 passed in 0.27s ===============================
```

Fails without the fix (exact same error shown in "Summary").

## Why this matters

Many production Terraform codebases use slash form for nested handlers — it matches the filesystem layout and works unchanged on real AWS. Running those codebases against MiniStack previously failed at `Invoke` time with an opaque `No module named '<path>'` error that gave no hint the separator was the issue. After this fix, both forms work identically across MiniStack Python runtimes.

