### PR TITLE
fix(secretsmanager): honor IncludePlannedDeletion in ListSecrets

### DIFF
--- a/ministack/services/secretsmanager.py
+++ b/ministack/services/secretsmanager.py
@@ -323,8 +323,12 @@ def _list_secrets(data):
     max_results = min(data.get("MaxResults", 100), 100)
     next_token = data.get("NextToken")
     filters = data.get("Filters", [])
+    include_planned_deletion = bool(data.get("IncludePlannedDeletion", False))
 
-    names = sorted(n for n, s in _secrets.items() if not s.get("DeletedDate"))
+    names = sorted(
+        n for n, s in _secrets.items()
+        if include_planned_deletion or not s.get("DeletedDate")
+    )
 
     for f in filters:
         key = f.get("Key", "")
@@ -352,7 +356,7 @@ def _list_secrets(data):
     secret_list = []
     for n in page:
         s = _secrets[n]
-        secret_list.append({
+        entry = {
             "ARN": s["ARN"],
             "Name": s["Name"],
             "Description": s.get("Description", ""),
@@ -362,7 +366,10 @@ def _list_secrets(data):
             "Tags": s.get("Tags", []),
             "SecretVersionsToStages": _vid_to_stages(s),
             "RotationEnabled": s.get("RotationEnabled", False),
-        })
+        }
+        if s.get("DeletedDate"):
+            entry["DeletedDate"] = s["DeletedDate"]
+        secret_list.append(entry)
 
     resp: dict = {"SecretList": secret_list}
     end = start + max_results

--- a/tests/test_secretsmanager.py
+++ b/tests/test_secretsmanager.py
@@ -337,3 +337,26 @@ def test_secretsmanager_get_by_partial_arn(sm):
     assert partial_arn != full_arn
     assert sm.get_secret_value(SecretId=partial_arn)["SecretString"] == "partial-arn-value"
 
+
+def test_secretsmanager_list_include_planned_deletion(sm):
+    """ListSecrets honors IncludePlannedDeletion per the AWS SecretListEntry spec.
+
+    When a secret is soft-deleted (scheduled for deletion with a recovery
+    window), it must:
+      - be hidden from ListSecrets by default, and
+      - be returned by ListSecrets(IncludePlannedDeletion=True) with its
+        DeletedDate populated so clients can distinguish it.
+    """
+    sm.create_secret(Name="sm-list-pd", SecretString="soft")
+    sm.delete_secret(SecretId="sm-list-pd", RecoveryWindowInDays=7)
+
+    # Default: soft-deleted secret is hidden.
+    names = [s["Name"] for s in sm.list_secrets()["SecretList"]]
+    assert "sm-list-pd" not in names
+
+    # IncludePlannedDeletion=True: soft-deleted secret is visible with DeletedDate.
+    resp = sm.list_secrets(IncludePlannedDeletion=True)
+    entry = next((s for s in resp["SecretList"] if s["Name"] == "sm-list-pd"), None)
+    assert entry is not None
+    assert "DeletedDate" in entry
+


### PR DESCRIPTION
`ListSecrets` unconditionally filtered out any secret with a non-null `DeletedDate`, so soft-deleted secrets were invisible even when a client explicitly asked for them via `IncludePlannedDeletion=true`. The parameter itself was also never read from the request payload.

Two small changes in `_list_secrets`:

- Parse `IncludePlannedDeletion` (default `False`) and gate the `DeletedDate` filter on it, so soft-deleted secrets come through when requested.
- Include `DeletedDate` on each returned `SecretListEntry` when it's set, mirroring what `DescribeSecret` already does and matching the [AWS `SecretListEntry` spec](https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_SecretListEntry.html). Without it clients can't distinguish scheduled-for-deletion entries from active ones.

Added `test_secretsmanager_list_include_planned_deletion` covering the default-hidden path, the flag-visible path, and the presence of `DeletedDate` on the returned entry. All existing secretsmanager tests still pass.

Ran into this while using ministack as the AWS endpoint for a local service that polls `list-secrets --include-planned-deletion` after a `delete-secret` to confirm the soft-delete landed — the empty list surfaced as a "not found" error even though `DescribeSecret`/`GetSecretValue` still resolved the secret correctly.

Fixes #455.