### PR TITLE
fix(lambda): Sleep before retrying, not on first attempt

### DIFF
--- a/ministack/services/lambda_svc.py
+++ b/ministack/services/lambda_svc.py
@@ -1871,7 +1871,6 @@ def _invoke_rie(container, event: dict, timeout: int) -> dict:
     import urllib.request
     max_attempts = int(timeout * 10) + 20
     for _attempt in range(max_attempts):
-        time.sleep(0.1)
         container.reload()
         if container.status != "running":
             break
@@ -1921,6 +1920,7 @@ def _invoke_rie(container, event: dict, timeout: int) -> dict:
                 result["function_error"] = "Unhandled" if err_header else "Handled"
             return result
         except (urllib.error.URLError, ConnectionRefusedError, OSError):
+            time.sleep(0.1)
             continue
     # Timed out
     stdout = container.logs(stdout=True, stderr=True).decode("utf-8", errors="replace").strip()


### PR DESCRIPTION
This pull request makes a minor adjustment to the `_invoke_rie` function in `ministack/services/lambda_svc.py` to improve how retry delays are handled during Lambda function invocation.

Error handling improvements:

* Moved the `time.sleep(0.1)` call so that delays only occur after a failed attempt to connect to the container, rather than on every loop iteration. This makes retries more efficient and avoids unnecessary waiting when the container is available. [[1]](diffhunk://#diff-8b61a2e187c34fe555ecb9d85ae1bb6926fc1be78923a2a264e520eb4c0fdfdcL1874) [[2]](diffhunk://#diff-8b61a2e187c34fe555ecb9d85ae1bb6926fc1be78923a2a264e520eb4c0fdfdcR1923)