### PR TITLE
Update log retrieval to filter by invoke time

### DIFF
--- a/ministack/services/lambda_svc.py
+++ b/ministack/services/lambda_svc.py
@@ -1896,6 +1896,7 @@ def _invoke_rie(container, event: dict, timeout: int) -> dict:
                 if not ports:
                     continue
                 rie_url = f"http://127.0.0.1:{ports[0]['HostPort']}/2015-03-31/functions/function/invocations"
+            invoke_time = time.time()
             req = urllib.request.Request(
                 rie_url, data=json.dumps(event).encode(),
                 headers={"Content-Type": "application/json"},
@@ -1906,7 +1907,7 @@ def _invoke_rie(container, event: dict, timeout: int) -> dict:
                 parsed = json.loads(body)
             except json.JSONDecodeError:
                 parsed = body
-            logs = container.logs(stdout=True, stderr=True).decode("utf-8", errors="replace").strip()
+            logs = container.logs(stdout=True, stderr=True, since=invoke_time).decode("utf-8", errors="replace").strip()
             # RIE sets 'Lambda-Runtime-Function-Error-Type' (or bare
             # 'X-Amz-Function-Error') when the handler raised an unhandled
             # exception. If it's set we surface the error flag + propagate the


### PR DESCRIPTION
This pull request introduces a targeted improvement to the Lambda service invocation logic. The main change ensures that when retrieving logs from the Lambda container, only logs generated after the invocation time are returned, making log output more relevant and easier to debug. Without it, all logs from any earlier invocations are retrieved and later embedded into the response, potentially ballooning the response well beyond the logs for the current invocation.

**Lambda invocation and logging improvements:**

* Track the invocation start time with `invoke_time` and use it to filter container logs, so only logs generated since the function was invoked are returned (`ministack/services/lambda_svc.py`). [[1]](diffhunk://#diff-8b61a2e187c34fe555ecb9d85ae1bb6926fc1be78923a2a264e520eb4c0fdfdcR1899) [[2]](diffhunk://#diff-8b61a2e187c34fe555ecb9d85ae1bb6926fc1be78923a2a264e520eb4c0fdfdcL1909-R1910)