### PR TITLE
[BUGFIX] : fix zero-byte S3 put checksum mismatch via aws chunked encoding (#461)

### DIFF
--- a/ministack/app.py
+++ b/ministack/app.py
@@ -278,8 +278,7 @@ def _decode_aws_chunked_body(body: bytes, headers: dict) -> bytes:
         decoded += remaining[data_start:data_start + chunk_size]
         remaining = remaining[data_start + chunk_size + 2:]  # skip trailing \r\n
 
-    if decoded or not body:
-        body = decoded
+    body = decoded
     if "aws-chunked" in content_encoding:
         encodings = [p.strip() for p in content_encoding.split(",") if p.strip() != "aws-chunked"]
         if encodings:

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -98,6 +98,28 @@ def test_s3_put_get_json_chunked(s3):
     body = resp["Body"].read().decode()
     assert _json.loads(body) == {"hello": "world", "number": 42}
 
+def test_s3_put_zero_byte_chunked(s3):
+    """Zero-byte PutObject via AWS chunked encoding must store empty body and return correct ETag."""
+    import urllib.request, hashlib
+    bucket = "intg-s3-zero-byte"
+    s3.create_bucket(Bucket=bucket)
+
+    fake_sig = b"abc123"
+    chunked = b"0;chunk-signature=" + fake_sig + b"\r\n\r\n"
+    endpoint = "http://localhost:4566/" + bucket + "/empty.bin"
+    req = urllib.request.Request(endpoint, data=chunked, method="PUT", headers={
+        "x-amz-content-sha256": "STREAMING-AWS4-HMAC-SHA256-PAYLOAD",
+        "Authorization": "AWS4-HMAC-SHA256 Credential=test/20240101/us-east-1/s3/aws4_request, SignedHeaders=host, Signature=fake",
+    })
+    with urllib.request.urlopen(req) as r:
+        assert r.status == 200
+        etag = r.headers.get("ETag", "").strip('"')
+    assert etag == hashlib.md5(b"").hexdigest()
+
+    resp = s3.get_object(Bucket=bucket, Key="empty.bin")
+    assert resp["Body"].read() == b""
+    assert resp["ContentLength"] == 0
+
 def test_s3_head_object(s3):
     s3.create_bucket(Bucket="intg-s3-headobj")
     s3.put_object(


### PR DESCRIPTION
Fixes #461

## What

Zero-byte PutObject requests sent with AWS SigV4 chunked transfer encoding
(`x-amz-content-sha256: STREAMING-AWS4-HMAC-SHA256-PAYLOAD`) were returning
the wrong ETag. The raw chunked bytes were being stored as the object body
instead of an empty body, causing the Java SDK v2 to throw a
RetryableException on checksum validation.

## Root Cause

In `_decode_aws_chunked_body` (app.py), the final chunk of a zero-byte upload
has `chunk_size == 0`, which breaks out of the decode loop immediately leaving
`decoded = b""`. The guard condition on the next line:

    if decoded or not body:
        body = decoded

evaluates to False when `decoded` is empty but `body` contains raw chunked
bytes, so the body is never updated. The raw bytes get stored and their MD5
becomes the ETag instead of the MD5 of empty string.

## Fix

Remove the guard. Once the chunked encoding path is confirmed by the header
check above, `decoded` always holds the correct result, including `b""` for
zero-byte uploads.

## Test

Added `test_s3_put_zero_byte_chunked` which sends a raw AWS-chunked zero-byte
PUT, asserts a 200 response, verifies the ETag matches MD5 of empty string,
and confirms the stored object body is empty.