### PR TITLE
fix(lambda): include EventSourceMappingArn in ESM responses

### DIFF
--- a/ministack/services/lambda_svc.py
+++ b/ministack/services/lambda_svc.py
@@ -383,6 +383,10 @@ def _layer_arn(name: str) -> str:
     return f"arn:aws:lambda:{get_region()}:{get_account_id()}:layer:{name}"
 
 
+def _esm_arn(uuid: str) -> str:
+    return f"arn:aws:lambda:{get_region()}:{get_account_id()}:event-source-mapping:{uuid}"
+
+
 def _now_iso() -> str:
     now = datetime.now(timezone.utc)
     ms = now.microsecond // 1000
@@ -3775,7 +3779,12 @@ def _delete_provisioned_concurrency(func_name: str, qualifier: str):
 
 def _esm_response(esm: dict) -> dict:
     """Return ESM dict without internal-only fields."""
-    return {k: v for k, v in esm.items() if k not in ("FunctionName", "Enabled")}
+    out = {k: v for k, v in esm.items() if k not in ("FunctionName", "Enabled")}
+    # Backfill EventSourceMappingArn for ESMs persisted before this field was
+    # added (warm boots from older state). New ESMs get it set at create time.
+    if "EventSourceMappingArn" not in out and "UUID" in out:
+        out["EventSourceMappingArn"] = _esm_arn(out["UUID"])
+    return out
 
 
 def _create_esm(data: dict):
@@ -3790,6 +3799,11 @@ def _create_esm(data: dict):
         enabled = enabled.lower() != "false"
     esm = {
         "UUID": esm_id,
+        # EventSourceMappingArn is the ESM's own ARN. terraform-provider-aws's
+        # tag interceptor uses this (via @Tags(identifierAttribute="arn")) to
+        # call ListTagsForResource during refresh; without it, state.tags is
+        # always empty and any provider-default tags drift on every plan.
+        "EventSourceMappingArn": _esm_arn(esm_id),
         "EventSourceArn": event_source_arn,
         "FunctionArn": _func_arn(func_name) + (f":{qualifier}" if qualifier else ""),
         "FunctionName": func_name,

--- a/tests/test_lambda.py
+++ b/tests/test_lambda.py
@@ -1093,6 +1093,58 @@ def test_lambda_event_source_mapping_tags(lam, sqs):
     sqs.delete_queue(QueueUrl=q["QueueUrl"])
 
 
+def test_lambda_event_source_mapping_arn_field(lam, sqs):
+    """The ESM's own ARN must be returned as ``EventSourceMappingArn`` in
+    Create/Get/List responses. terraform-provider-aws's tag interceptor uses
+    this (via ``@Tags(identifierAttribute="arn")``) to call ListTagsForResource
+    during refresh; without it, ``state.tags`` is always empty and any
+    provider-default tags drift on every plan.
+
+    Asserted against the raw HTTP response because older botocore lambda
+    service models drop fields they don't recognize, but the AWS Go SDK
+    that terraform-provider-aws uses does parse it.
+    """
+    import json as _json
+    import urllib.request as _ur
+    from tests.conftest import ENDPOINT  # noqa: PLC0415
+
+    code = _zip_lambda("def handler(e,c): return 'ok'")
+    fn = "qa-esm-arn-fn"
+    lam.create_function(
+        FunctionName=fn,
+        Runtime="python3.12",
+        Role="arn:aws:iam::000000000000:role/r",
+        Handler="index.handler",
+        Code={"ZipFile": code},
+    )
+    q = sqs.create_queue(QueueName="qa-esm-arn-queue")
+    q_arn = sqs.get_queue_attributes(QueueUrl=q["QueueUrl"], AttributeNames=["QueueArn"])["Attributes"]["QueueArn"]
+
+    created = lam.create_event_source_mapping(FunctionName=fn, EventSourceArn=q_arn)
+    uuid = created["UUID"]
+    expected_arn = f"arn:aws:lambda:us-east-1:000000000000:event-source-mapping:{uuid}"
+
+    def _http_json(path: str) -> dict:
+        # The signing details are unchecked; only the service segment is read by
+        # the request router so it knows to dispatch to lambda instead of s3.
+        req = _ur.Request(
+            f"{ENDPOINT}{path}",
+            headers={"Authorization": "AWS4-HMAC-SHA256 Credential=test/x/us-east-1/lambda/aws4_request"},
+        )
+        return _json.loads(_ur.urlopen(req).read().decode())
+
+    got = _http_json(f"/2015-03-31/event-source-mappings/{uuid}")
+    assert got.get("EventSourceMappingArn") == expected_arn
+
+    listed = _http_json(f"/2015-03-31/event-source-mappings/?FunctionName={fn}")
+    match = next(e for e in listed["EventSourceMappings"] if e["UUID"] == uuid)
+    assert match.get("EventSourceMappingArn") == expected_arn
+
+    lam.delete_event_source_mapping(UUID=uuid)
+    lam.delete_function(FunctionName=fn)
+    sqs.delete_queue(QueueUrl=q["QueueUrl"])
+
+
 def test_lambda_publish_version_snapshot(lam):
     """PublishVersion creates a numbered version snapshot."""
     code = _zip_lambda("def handler(e,c): return 'v1'")


### PR DESCRIPTION
## Summary

Add `EventSourceMappingArn` to ESM API responses so terraform-provider-aws can read tags on `aws_lambda_event_source_mapping` resources. Without it, every `terraform plan` against an ESM with provider `default_tags` reports drift forever, and `apply` churns dependent resources on every run.

## The bug

`terraform-provider-aws` (≥6.x) annotates `aws_lambda_event_source_mapping` with `@Tags(identifierAttribute="arn")`. During refresh, the tag interceptor reads the resource's `arn` attribute and calls `ListTagsForResource(arn)` to populate `tags_all`. The provider gets that `arn` value from the `EventSourceMappingArn` field in the `GetEventSourceMapping` response (the AWS Go SDK v2 lambda module exposes it on `EventSourceMappingConfiguration`).

MiniStack didn't include `EventSourceMappingArn` in its ESM response. Result:

1. SDK parses the response → `arn = ""` in terraform state.
2. Tag interceptor sees an empty ARN → silently skips `ListTagsForResource`.
3. `tags_all` stays `{}` in state, even when tags exist on the ESM (set via `TagResource`, e.g. provider-default tags).
4. Every `terraform plan` shows the same drift forever:
   ```
   ~ resource "aws_lambda_event_source_mapping" "example" {
         tags     = {}
       ~ tags_all = {
           + "team" = "platform"
       }
   }
   ```
5. `terraform apply` calls `TagResource`, which MiniStack accepts, but the underlying record still has no ARN — drift returns on the next plan.

## Why this matters

Anyone using MiniStack as a local stand-in for AWS while authoring or running terraform configs that include `aws_lambda_event_source_mapping` resources is affected — especially when `default_tags` is set on the AWS provider (a common HashiCorp-recommended pattern for ownership / cost-allocation / environment tagging).

The drift is silent in the sense that nothing breaks — but it has real costs:

- **Plans are never clean.** `terraform plan` always reports changes, defeating the "should be a no-op when nothing changed" contract that local dev loops rely on. Engineers learn to ignore the drift, which trains them to ignore real drift too.
- **Apply churn on every run.** Bootstrap workflows that run `terraform apply` on container start (CI, dev-up scripts, ephemeral environments) re-issue `TagResource` calls every time, and dependent data sources (`data.aws_iam_policy_document`, IAM role policies, S3 bucket policies that reference the ESM's role) get marked "will be read during apply" and replanned downstream — turning a small bug into 5–10× the visible churn.
- **CI signal degradation.** Pipelines that gate on "terraform plan shows no changes" can't be used as a guardrail when the baseline is always-noisy.
- **Lost confidence in the local emulator.** Drift that doesn't reproduce against real AWS makes MiniStack feel less trustworthy for terraform workflows specifically — which is one of its primary use cases.

The fix is one field in the response and unlocks a clean `terraform plan` for any config that uses ESMs with provider tags.

## Fix

- New helper `_esm_arn(uuid)` — same shape as `_func_arn` / `_layer_arn`.
- `_create_esm`: set `EventSourceMappingArn` on the new ESM dict.
- `_esm_response`: backfill `EventSourceMappingArn` on read for ESMs persisted before this change. This makes the upgrade transparent — no state wipe needed for warm boots from older `lambda.json`. The check is a no-op once the record has been read once and re-persisted.

## Reproducer

Requires Docker, terraform ≥1.5, and AWS CLI.

**Setup:**

```bash
docker run -d --name ministack -p 4566:4566 ministackorg/ministack:1.3.14
```

**`main.tf`:**

```hcl
terraform {
  required_providers {
    aws = { source = "hashicorp/aws", version = "~> 6.0" }
  }
}

provider "aws" {
  region                      = "us-east-1"
  access_key                  = "test"
  secret_key                  = "test"
  skip_credentials_validation = true
  skip_metadata_api_check     = true
  skip_requesting_account_id  = true

  endpoints {
    lambda = "http://localhost:4566"
    sqs    = "http://localhost:4566"
    iam    = "http://localhost:4566"
  }

  default_tags {
    tags = { team = "platform" }
  }
}

data "archive_file" "code" {
  type        = "zip"
  output_path = "${path.module}/lambda.zip"
  source {
    filename = "index.js"
    content  = "exports.handler = async () => ({});"
  }
}

resource "aws_iam_role" "fn" {
  name               = "esm-repro-role"
  assume_role_policy = jsonencode({
    Version = "2012-10-17",
    Statement = [{
      Effect = "Allow", Action = "sts:AssumeRole",
      Principal = { Service = "lambda.amazonaws.com" }
    }]
  })
}

resource "aws_lambda_function" "fn" {
  function_name    = "esm-repro-fn"
  role             = aws_iam_role.fn.arn
  handler          = "index.handler"
  runtime          = "nodejs20.x"
  filename         = data.archive_file.code.output_path
  source_code_hash = data.archive_file.code.output_base64sha256
}

resource "aws_sqs_queue" "src" {
  name = "esm-repro-queue"
}

resource "aws_lambda_event_source_mapping" "esm" {
  event_source_arn = aws_sqs_queue.src.arn
  function_name    = aws_lambda_function.fn.arn
}
```

**Reproduce the drift:**

```bash
terraform init
terraform apply -auto-approve
terraform plan        # <- shows ESM tags_all drift
terraform plan        # <- still shows it
```

Each plan reports the same diff:
```
# aws_lambda_event_source_mapping.esm will be updated in-place
~ resource "aws_lambda_event_source_mapping" "esm" {
      tags     = {}
    ~ tags_all = {
        + "team" = "platform"
    }
}

Plan: 0 to add, 1 to change, 0 to destroy.
```

`apply` "fixes" it via `TagResource`, but the next `plan` shows the same drift again.

**With the fix (build this branch):**

```bash
docker stop ministack && docker rm ministack
docker build -t ministack-fix .
docker run -d --name ministack -p 4566:4566 ministack-fix
# (re-apply terraform; subsequent plans are clean)
terraform plan        # No changes. Your infrastructure matches the configuration.
```

You can also verify directly:

```bash
UUID=\$(aws --endpoint-url=http://localhost:4566 lambda list-event-source-mappings \
  --query 'EventSourceMappings[0].UUID' --output text)
curl -s "http://localhost:4566/2015-03-31/event-source-mappings/\$UUID" \
  -H "Authorization: AWS4-HMAC-SHA256 Credential=test/x/us-east-1/lambda/aws4_request" \
  | jq .EventSourceMappingArn
# Before fix: null
# After fix:  "arn:aws:lambda:us-east-1:000000000000:event-source-mapping:<uuid>"
```

## Test plan

- [x] New `tests/test_lambda.py::test_lambda_event_source_mapping_arn_field` — asserts the field on Get and List responses, against the raw HTTP body (boto3 1.34's lambda model doesn't expose the field, but the Go SDK that terraform-provider-aws uses does).
- [x] Existing `test_lambda_event_source_mapping_tags` still passes — no regression to `TagResource`/`ListTagsForResource` round-trip.
- [x] Full `tests/test_lambda.py` suite passes (121 tests, excluding Docker-runtime tests not in scope).
- [ ] End-to-end: terraform plan against ESM with `default_tags` — drift goes away.