### PR TITLE
fix: Endpoint in Docker returns "dev"

### DIFF
--- a/.github/workflows/docker-publish-on-pr.yml
+++ b/.github/workflows/docker-publish-on-pr.yml
@@ -54,6 +54,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            MINISTACK_VERSION=pr-${{ github.event.pull_request.number }}-${{ steps.short_sha.outputs.short_sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -48,5 +48,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            MINISTACK_VERSION=${{ steps.meta.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,9 @@ RUN mkdir -p /docker-entrypoint-initaws.d/ready.d \
 VOLUME /docker-entrypoint-initaws.d
 VOLUME /etc/localstack/init
 
-ENV GATEWAY_PORT=4566 \
+ARG MINISTACK_VERSION=dev
+ENV MINISTACK_VERSION=${MINISTACK_VERSION} \
+    GATEWAY_PORT=4566 \
     LOG_LEVEL=INFO \
     S3_PERSIST=0 \
     S3_DATA_DIR=/tmp/ministack-data/s3 \

--- a/ministack/app.py
+++ b/ministack/app.py
@@ -25,11 +25,13 @@ from urllib.parse import parse_qs, unquote
 _MINISTACK_HOST = os.environ.get("MINISTACK_HOST", "localhost")
 _MINISTACK_PORT = os.environ.get("GATEWAY_PORT", "4566")
 
-try:
-    from importlib.metadata import version as _pkg_version
-    _VERSION = _pkg_version("ministack")
-except Exception:
-    _VERSION = "dev"
+_VERSION = os.environ.get("MINISTACK_VERSION") or "dev"
+if _VERSION == "dev":
+    try:
+        from importlib.metadata import version as _pkg_version
+        _VERSION = _pkg_version("ministack")
+    except Exception:
+        pass
 
 # Matches host headers like "{apiId}.execute-api.<host>" or "{apiId}.execute-api.<host>:4566"
 _EXECUTE_API_RE = re.compile(


### PR DESCRIPTION
currently health endpoint in Docker returns dev as PIP is striped from the image, it works correctly in pip install as it falls in the importlib meta