### PR TITLE
feat(cli): add `BIND_HOST` env var to configure listen interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
+
+## [Unreleased]
+
+### Added
+- **`BIND_HOST` env var to configure the listen interface** — the bind interface was previously hard-coded to `0.0.0.0` (no env var, no CLI flag). Setting `BIND_HOST=127.0.0.1 ministack` now restricts MiniStack to loopback (useful on shared dev machines or when a `pip install` user wants tighter network exposure). Defaults to `0.0.0.0`, so existing setups behave identically. Distinct from `MINISTACK_HOST` (the *virtual* hostname used for S3 virtual-host / execute-api URL matching) — `BIND_HOST` is the TCP listen interface only. Docker users can keep using `docker run -p 127.0.0.1:4566:4566 …` as before; this is for the `pip install ministack` path.
+
+---
 ## [1.3.15] — 2026-04-26
 
 ### Added

--- a/ministack/app.py
+++ b/ministack/app.py
@@ -1372,6 +1372,10 @@ def main():
     args = parser.parse_args()
 
     port = int(_resolve_port())
+    # BIND_HOST controls the bind interface; defaults to 0.0.0.0 (existing
+    # behaviour). Distinct from MINISTACK_HOST, which is the virtual hostname
+    # used for S3 virtual-host / execute-api URL matching.
+    bind_host = os.environ.get("BIND_HOST", "0.0.0.0")
 
     if args.stop:
         pf = _pid_file(port)
@@ -1388,9 +1392,12 @@ def main():
         os.remove(pf)
         return
 
+    # 0.0.0.0 binds every interface so 127.0.0.1 always works as a probe;
+    # for an explicit BIND_HOST, probe that host directly.
+    probe_host = "127.0.0.1" if bind_host == "0.0.0.0" else bind_host
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        if s.connect_ex(("127.0.0.1", port)) == 0:
-            print(f"ERROR: Port {port} is already in use. Is MiniStack already running?\n"
+        if s.connect_ex((probe_host, port)) == 0:
+            print(f"ERROR: {probe_host}:{port} is already in use. Is MiniStack already running?\n"
                   f"  Stop it with: ministack --stop\n"
                   f"  Or use a different port: GATEWAY_PORT=4567 ministack")
             raise SystemExit(1)
@@ -1404,7 +1411,7 @@ def main():
         log_fh = open(log_file, "w")
         proc = subprocess.Popen(
             [sys.executable, "-m", "hypercorn", "ministack.app:app",
-             "--bind", f"0.0.0.0:{port}",
+             "--bind", f"{bind_host}:{port}",
              "--log-level", LOG_LEVEL.upper(),
              "--keep-alive", "75"],
             stdout=log_fh,
@@ -1443,7 +1450,7 @@ def main():
         logging.getLogger("hypercorn.access").addFilter(_HealthLogFilter())
 
         config = HypercornConfig()
-        config.bind = [f"0.0.0.0:{port}"]
+        config.bind = [f"{bind_host}:{port}"]
         config.keep_alive_timeout = 75
         config.loglevel = LOG_LEVEL.upper()
 


### PR DESCRIPTION
## Summary

Replaces #477 per @Nahuel990's review feedback there. Instead of adding `--host` / `--port` CLI flags, this PR adds a single `BIND_HOST` env var, staying consistent with the existing `GATEWAY_PORT` / `MINISTACK_HOST` env-var convention.

The bind interface was previously hard-coded to `0.0.0.0` with no env or CLI knob. Setting `BIND_HOST=127.0.0.1 ministack` now restricts MiniStack to loopback (useful on shared dev machines, or when a `pip install` user wants tighter network exposure). Defaults to `0.0.0.0`, so existing setups behave identically.

## Why this isn't already covered

Docker users are covered today by:

```
docker run -p 127.0.0.1:4566:4566 ministackorg/ministack
```

…and that's the right pattern there. This PR closes the same case for the `pip install ministack` path, where Docker port mapping doesn't apply.

## `BIND_HOST` vs `MINISTACK_HOST`

These are two different things and the source comment + CHANGELOG entry call out the distinction so they don't get confused:

| | What it controls | Default |
|---|---|---|
| **`BIND_HOST`** (new) | The TCP listen interface (e.g. `127.0.0.1` for loopback-only) | `0.0.0.0` |
| **`MINISTACK_HOST`** (existing) | The virtual hostname used for S3 virtual-host-style URLs (`<bucket>.s3.<MINISTACK_HOST>`) and execute-api routing (`<api-id>.execute-api.<MINISTACK_HOST>`) | `localhost` |

A user wanting MiniStack to listen only on loopback should set `BIND_HOST`, not touch `MINISTACK_HOST`.

## What changed

- `main()` reads `os.environ.get("BIND_HOST", "0.0.0.0")` once into `bind_host`.
- Three hard-coded `0.0.0.0:{port}` strings now use `{bind_host}:{port}` — the hypercorn `--bind` arg in the detached subprocess, the `HypercornConfig.bind` in foreground mode, and the in-use socket probe.
- The in-use socket probe targets the actual bind interface (probes `127.0.0.1` when `BIND_HOST=0.0.0.0`; probes the explicit host otherwise), so the friendly "port already in use" warning still fires when `BIND_HOST` is set to a specific NIC address. Without this, a second `ministack` startup would fail with hypercorn's raw "address already in use" instead.

Total diff: **+18 / -4** across `ministack/app.py` and `CHANGELOG.md`.

## Verified

| Scenario | Result |
|---|---|
| `ministack -d` (no env, no flags) | ✅ binds `0.0.0.0:4566` (existing behavior unchanged) |
| `BIND_HOST=127.0.0.1 GATEWAY_PORT=4598 ministack -d` | ✅ reachable via `127.0.0.1:4598`; **not** reachable via the LAN IP — confirms loopback-only |

## Checklist

- [x] Verified end-to-end on macOS host (Python 3.12)
- [x] CHANGELOG entry under `[Unreleased]` → `Added`
- [x] Defaults unchanged → no impact on existing setups
- [N/A] New service file — extends existing `main()` in `ministack/app.py`
- [N/A] SERVICE_REGISTRY / router patterns — unrelated