### PR TITLE
fix(sns): Forward SNS attributes for raw SQS subscriptions

### DIFF
--- a/ministack/services/sns.py
+++ b/ministack/services/sns.py
@@ -813,7 +813,8 @@ def _fanout(topic_arn: str, msg_id: str, message: str, subject: str,
 
         if protocol == "sqs":
             _deliver_to_sqs(endpoint, envelope, raw, effective_message,
-                           message_group_id=message_group_id, message_dedup_id=message_dedup_id)
+                           message_group_id=message_group_id, message_dedup_id=message_dedup_id,
+                           message_attributes=message_attributes or {})
         elif protocol in ("http", "https"):
             _threading.Thread(
                 target=asyncio.run,
@@ -831,7 +832,8 @@ def _fanout(topic_arn: str, msg_id: str, message: str, subject: str,
 
 
 def _deliver_to_sqs(endpoint: str, envelope: str, raw: bool, raw_message: str,
-                    message_group_id: str = "", message_dedup_id: str = ""):
+                    message_group_id: str = "", message_dedup_id: str = "",
+                    message_attributes: dict | None = None):
     queue_name = endpoint.split(":")[-1]
     queue_url = _sqs._queue_url(queue_name)
     queue = _sqs._queues.get(queue_url)
@@ -840,11 +842,13 @@ def _deliver_to_sqs(endpoint: str, envelope: str, raw: bool, raw_message: str,
         return
 
     body = raw_message if raw else envelope
+    sqs_attrs = dict(message_attributes) if raw and message_attributes else {}
     now = time.time()
     msg = {
         "id": new_uuid(),
         "body": body,
         "md5": hashlib.md5(body.encode()).hexdigest(),
+        "message_attributes": sqs_attrs,
         "receipt_handle": None,
         "sent_at": now,
         "visible_at": now,

--- a/tests/test_sns.py
+++ b/tests/test_sns.py
@@ -211,15 +211,26 @@ def test_sns_sqs_fanout_raw_message_delivery(sns, sqs):
         Endpoint=q_arn,
         Attributes={"RawMessageDelivery": "true"},
     )
-    sns.publish(TopicArn=topic_arn, Message="raw fanout msg")
+    message_attrs = {
+        "type": {"DataType": "String", "StringValue": "user.created"},
+    }
+    sns.publish(
+        TopicArn=topic_arn,
+        Message='{"user_id": "123"}',
+        MessageAttributes=message_attrs,
+    )
 
     msgs = sqs.receive_message(
         QueueUrl=q_url,
         MaxNumberOfMessages=1,
         WaitTimeSeconds=1,
+        MessageAttributeNames=["All"],
     )
     assert len(msgs.get("Messages", [])) == 1
-    assert msgs["Messages"][0]["Body"] == "raw fanout msg"
+    msg = msgs["Messages"][0]
+    assert msg["Body"] == '{"user_id": "123"}'
+    assert msg["MessageAttributes"] == message_attrs
+    assert msg["MessageAttributes"]["type"]["StringValue"] == "user.created"
 
 def test_sns_publish_batch(sns):
     arn = sns.create_topic(Name="intg-sns-batch")["TopicArn"]


### PR DESCRIPTION
## Summary

Fix raw SNS-to-SQS fanout so SNS publish `MessageAttributes` are preserved as top-level SQS `MessageAttributes`.

When an SQS subscription has `RawMessageDelivery` set to `"true"`, MiniStack now forwards SNS publish message attributes into the queued SQS message. This matches the behavior expected by SQS consumers that call `receive_message` with `MessageAttributeNames`, and prevents consumers from missing the `MessageAttributes` field on raw SNS-to-SQS messages.

Non-raw SNS-to-SQS delivery remains unchanged.