### PR TITLE
fix: persist CloudWatch Logs destinations / metric filters / queries

### DIFF
--- a/ministack/services/cloudwatch_logs.py
+++ b/ministack/services/cloudwatch_logs.py
@@ -70,6 +70,9 @@ _deliveries = AccountScopedDict()
 def get_state():
     return {
         "log_groups": copy.deepcopy(_log_groups),
+        "destinations": copy.deepcopy(_destinations),
+        "metric_filters": copy.deepcopy(_metric_filters),
+        "queries": copy.deepcopy(_queries),
         "delivery_sources": copy.deepcopy(_delivery_sources),
         "delivery_destinations": copy.deepcopy(_delivery_destinations),
         "deliveries": copy.deepcopy(_deliveries),
@@ -79,6 +82,9 @@ def get_state():
 def restore_state(data):
     if data:
         _log_groups.update(data.get("log_groups", {}))
+        _destinations.update(data.get("destinations", {}))
+        _metric_filters.update(data.get("metric_filters", {}))
+        _queries.update(data.get("queries", {}))
         _delivery_sources.update(data.get("delivery_sources", {}))
         _delivery_destinations.update(data.get("delivery_destinations", {}))
         _deliveries.update(data.get("deliveries", {}))

--- a/tests/test_cloudwatch_logs_persistence.py
+++ b/tests/test_cloudwatch_logs_persistence.py
@@ -16,20 +16,52 @@ Plus a follow-on consistency bug:
        still references a destination that no longer exists in
        _destinations.
 
-Each test exercises the public get_state / restore_state contract
-without going through the live HTTP server.
+Each test exercises the FULL warm-boot path:
+  1. populate the in-memory dict
+  2. `get_state()` snapshot
+  3. `persistence.save_state()` → JSON-encode to a tmp `STATE_DIR`
+  4. `mod.reset()` (simulate process restart)
+  5. `persistence.load_state()` → JSON-decode from disk
+  6. `restore_state(loaded)`
+
+Going through `save_state` / `load_state` (rather than just calling
+get_state / restore_state in-memory) is what catches encoder /
+decoder regressions — most notably the tuple-key path used by
+`_metric_filters`, which round-trips through repr → JSON string →
+ast.literal_eval in `core/persistence.py::_json_default` /
+`_json_object_hook`.
 """
 import importlib
+
+import pytest
+
+from ministack.core import persistence
 
 
 def _module():
     return importlib.import_module("ministack.services.cloudwatch_logs")
 
 
-def _round_trip(mod):
-    snapshot = mod.get_state()
+@pytest.fixture(autouse=True)
+def _enable_persistence(monkeypatch, tmp_path):
+    """Force PERSIST_STATE on and point STATE_DIR at a tmp dir for the
+    duration of each test so save_state / load_state actually write and
+    read JSON instead of short-circuiting."""
+    monkeypatch.setattr(persistence, "PERSIST_STATE", True)
+    monkeypatch.setattr(persistence, "STATE_DIR", str(tmp_path))
+
+
+def _round_trip(mod, svc_key="cloudwatch_logs"):
+    """Simulate a full warm-boot through the on-disk JSON path."""
+    persistence.save_state(svc_key, mod.get_state())
     mod.reset()
-    mod.restore_state(snapshot)
+    loaded = persistence.load_state(svc_key)
+    assert loaded is not None, (
+        f"persistence.load_state({svc_key!r}) returned None — state "
+        "file was not written by save_state(). Check get_state() "
+        "correctness and that PERSIST_STATE is True."
+    )
+    mod.restore_state(loaded)
 
 
 # ── H-2: _destinations ─────────────────────────────────────────────────

--- a/tests/test_cloudwatch_logs_persistence.py
+++ b/tests/test_cloudwatch_logs_persistence.py
@@ -1,0 +1,173 @@
+"""
+Regression tests for the CloudWatch Logs persistence drops.
+
+Three module-level AccountScopedDicts are mutated by public APIs but
+were missing from `get_state()` / `restore_state()`:
+
+  H-2  cloudwatch_logs._destinations      (PutDestination)
+  H-2  cloudwatch_logs._metric_filters    (PutMetricFilter)
+  H-2  cloudwatch_logs._queries           (StartQuery)
+
+Plus a follow-on consistency bug:
+
+  M-9  Subscription filters live inside _log_groups (persisted) but
+       reference destination ARNs in _destinations (not persisted).
+       After warm-boot you get split-brain: the filter on the log group
+       still references a destination that no longer exists in
+       _destinations.
+
+Each test exercises the public get_state / restore_state contract
+without going through the live HTTP server.
+"""
+import importlib
+
+
+def _module():
+    return importlib.import_module("ministack.services.cloudwatch_logs")
+
+
+def _round_trip(mod):
+    snapshot = mod.get_state()
+    mod.reset()
+    mod.restore_state(snapshot)
+
+
+# ── H-2: _destinations ─────────────────────────────────────────────────
+
+def test_destinations_survive_warm_boot():
+    mod = _module()
+    mod.reset()
+    mod._destinations["my-dest"] = {
+        "destinationName": "my-dest",
+        "targetArn": "arn:aws:kinesis:us-east-1:000000000000:stream/log-stream",
+        "roleArn": "arn:aws:iam::000000000000:role/CWLtoKinesis",
+        "accessPolicy": "",
+        "arn": "arn:aws:logs:us-east-1:000000000000:destination:my-dest",
+        "creationTime": 1700000000000,
+    }
+
+    _round_trip(mod)
+
+    assert "my-dest" in mod._destinations, (
+        "CloudWatch Logs destination lost across get_state → restore_state — "
+        "_destinations must be in both."
+    )
+    assert mod._destinations["my-dest"]["targetArn"].endswith(":stream/log-stream")
+    mod.reset()
+
+
+# ── H-2: _metric_filters ──────────────────────────────────────────────
+
+def test_metric_filters_survive_warm_boot():
+    mod = _module()
+    mod.reset()
+    # Create the parent log group first — _put_metric_filter would normally
+    # require it; we mirror that pre-condition for realism.
+    mod._log_groups["/aws/lambda/foo"] = {
+        "arn": "arn:aws:logs:us-east-1:000000000000:log-group:/aws/lambda/foo:*",
+        "creationTime": 1700000000000,
+        "retentionInDays": None,
+        "tags": {},
+        "subscriptionFilters": {},
+        "streams": {},
+    }
+    mod._metric_filters[("/aws/lambda/foo", "ErrorCount")] = {
+        "filterName": "ErrorCount",
+        "logGroupName": "/aws/lambda/foo",
+        "filterPattern": "ERROR",
+        "metricTransformations": [{
+            "metricName": "Errors",
+            "metricNamespace": "Lambda",
+            "metricValue": "1",
+        }],
+        "creationTime": 1700000000000,
+    }
+
+    _round_trip(mod)
+
+    assert ("/aws/lambda/foo", "ErrorCount") in mod._metric_filters, (
+        "Metric filter lost across get_state → restore_state — "
+        "_metric_filters must be in both. Tuple keys are round-tripped "
+        "by AccountScopedDict's JSON encoder hook."
+    )
+    mod.reset()
+
+
+# ── H-2: _queries ─────────────────────────────────────────────────────
+
+def test_queries_survive_warm_boot():
+    mod = _module()
+    mod.reset()
+    mod._queries["q-12345"] = {
+        "queryId": "q-12345",
+        "logGroupName": "/aws/lambda/foo",
+        "startTime": 1700000000,
+        "endTime": 1700001000,
+        "queryString": "fields @timestamp, @message | limit 20",
+        "status": "Complete",
+    }
+
+    _round_trip(mod)
+
+    assert "q-12345" in mod._queries, (
+        "CloudWatch Logs Insights query lost across get_state → "
+        "restore_state — _queries must be in both."
+    )
+    mod.reset()
+
+
+# ── M-9: subscription-filter ↔ destination consistency ────────────────
+
+def test_subscription_filter_destination_resolvable_after_warm_boot():
+    """A subscription filter on a log group references a destination ARN.
+    The filter lives inside _log_groups (persisted), the destination lives
+    in _destinations (was NOT persisted). After warm-boot the filter
+    pointed at a vanished destination — split-brain. With _destinations
+    persistence, the destination must still resolve."""
+    mod = _module()
+    mod.reset()
+
+    dest_arn = "arn:aws:logs:us-east-1:000000000000:destination:cross-account"
+    mod._destinations["cross-account"] = {
+        "destinationName": "cross-account",
+        "targetArn": "arn:aws:kinesis:us-east-1:222222222222:stream/audit",
+        "roleArn": "arn:aws:iam::000000000000:role/CWLtoKinesis",
+        "accessPolicy": "",
+        "arn": dest_arn,
+        "creationTime": 1700000000000,
+    }
+    mod._log_groups["/aws/lambda/audited"] = {
+        "arn": "arn:aws:logs:us-east-1:000000000000:log-group:/aws/lambda/audited:*",
+        "creationTime": 1700000000000,
+        "retentionInDays": None,
+        "tags": {},
+        "subscriptionFilters": {
+            "to-cross-account": {
+                "filterName": "to-cross-account",
+                "logGroupName": "/aws/lambda/audited",
+                "filterPattern": "",
+                "destinationArn": dest_arn,
+                "roleArn": "",
+                "distribution": "ByLogStream",
+                "creationTime": 1700000000000,
+            },
+        },
+        "streams": {},
+    }
+
+    _round_trip(mod)
+
+    # The log-group side already round-tripped on main; what was missing
+    # is the destination it references.
+    assert "/aws/lambda/audited" in mod._log_groups
+    sub_filter = mod._log_groups["/aws/lambda/audited"]["subscriptionFilters"]["to-cross-account"]
+    referenced_arn = sub_filter["destinationArn"]
+
+    # Find the destination that ought to back this ARN.
+    matching = [d for d in mod._destinations.values() if d.get("arn") == referenced_arn]
+    assert matching, (
+        "Subscription filter references a destination ARN that no "
+        "longer exists in _destinations after warm-boot — split-brain "
+        "state. _destinations must be persisted alongside _log_groups."
+    )
+    mod.reset()


### PR DESCRIPTION
## Summary

Three module-level `AccountScopedDict`s in `cloudwatch_logs.py` were mutated by public APIs but missing from `get_state()` / `restore_state()`. With `PERSIST_STATE=1`, every record stored via these APIs disappeared on restart — same bug family as #491 / #492 / #424 / #438.

| Dict | API that writes it | Real-world symptom |
|---|---|---|
| `_destinations` | `PutDestination` | Terraform `aws_cloudwatch_log_destination` vanishes |
| `_metric_filters` | `PutMetricFilter` | Terraform `aws_cloudwatch_log_metric_filter` vanishes |
| `_queries` | `StartQuery` | CloudWatch Logs Insights queries lose history |

## Plus a follow-on consistency bug

Subscription filters live inside `_log_groups[group]["subscriptionFilters"]` (already persisted) and reference `destinationArn` values that resolve through `_destinations` (was *not* persisted). After warm-boot you got split-brain: the subscription filter still pointed at a destination that no longer existed in `_destinations`. Persisting `_destinations` resolves this.

## What changed

| File | Change |
|---|---|
| `ministack/services/cloudwatch_logs.py` | +3 lines in `get_state()`, +3 in `restore_state()`. |
| `tests/test_cloudwatch_logs_persistence.py` *(new, 4 tests)* | One round-trip per dict + the subscription-filter ↔ destination consistency test. |

`reset()` already cleared all three dicts, confirming they hold real state — the omission was an oversight in the original wiring.

## Tuple-key note (`_metric_filters`)

`_metric_filters` is keyed by `(log_group_name, filter_name)` tuples. JSON cannot natively serialise non-string keys, but `AccountScopedDict`'s encoder hook in `core/persistence.py` repr-encodes the original key on save and `ast.literal_eval`-decodes on restore — so the tuple round-trips correctly. The new `test_metric_filters_survive_warm_boot` covers this path.

### Default behaviour unchanged

Restore is gated by `PERSIST_STATE` — `load_state()` returns `None` immediately when the env var is unset.

## Test plan

- [x] `pytest tests/test_cloudwatch_logs_persistence.py` — all 4 pass (all 4 fail without the fix).
- [x] `pytest tests/test_logs.py` — 33 pass; the 9 failures (`test_logs_*delivery*`) are pre-existing on `main` (`InvalidOperationException: Unknown action: PutDeliverySource`) and unrelated to this PR.
- [ ] Reviewer check: warm-boot a real ministack with `PERSIST_STATE=1`, create a destination / metric filter / query, restart, verify they survive.

## Notes

Independent of #491 (persistence architectural gap) and #492 (per-service state-dict drops). Can land in any order.