### PR TITLE
fix: persist Cognito hosted-UI / federation _auth_codes across warm-boot

### DIFF
--- a/ministack/services/cognito.py
+++ b/ministack/services/cognito.py
@@ -200,8 +200,17 @@ _identity_pools = AccountScopedDict()
 _identity_tags = AccountScopedDict()   # identity_pool_id -> {key: value}
 
 # ---------------------------------------------------------------------------
-# In-memory state — OAuth2 authorization codes (ephemeral, not persisted)
+# In-memory state — OAuth2 hosted-UI / federation codes
 # ---------------------------------------------------------------------------
+# `_auth_codes` and `_authorization_codes` are intentionally plain dicts
+# (NOT AccountScopedDict). The OAuth2 token endpoint is a public callback
+# with no AWS authentication context — it identifies the caller via the
+# random code + client_id + client_secret, not via a SigV4 access key.
+# Wrapping these in AccountScopedDict would make the callback lookup
+# happen under a default account, invisible to codes issued under any
+# other tenant. Effective tenant isolation is provided by the random
+# unguessable token namespace. See
+# tests/test_cognito_auth_codes_persistence.py for a regression pin.
 
 _auth_codes = {}   # code -> {pool_id, client_id, username, redirect_uri, scopes, state, created_at}
 _AUTH_CODE_TTL = 300  # 5 minutes
@@ -217,6 +226,7 @@ def get_state():
         "identity_tags": copy.deepcopy(_identity_tags),
         "authorization_codes": copy.deepcopy(_authorization_codes),
         "refresh_tokens": copy.deepcopy(_refresh_tokens),
+        "auth_codes": copy.deepcopy(_auth_codes),
     }
 
 
@@ -228,6 +238,7 @@ def restore_state(data):
         _identity_tags.update(data.get("identity_tags", {}))
         _authorization_codes.update(data.get("authorization_codes", {}))
         _refresh_tokens.update(data.get("refresh_tokens", {}))
+        _auth_codes.update(data.get("auth_codes", {}))
 
 
 try:

--- a/tests/test_cognito_auth_codes_persistence.py
+++ b/tests/test_cognito_auth_codes_persistence.py
@@ -1,0 +1,106 @@
+"""
+Regression test for cognito hosted-UI / federation `_auth_codes`
+persistence.
+
+Background
+----------
+Two distinct OAuth2 code stores exist in `services/cognito.py`:
+
+  - `_authorization_codes` — managed-login PKCE flow. Was already
+    persisted in get_state/restore_state.
+  - `_auth_codes` — hosted-UI / SAML-OIDC federation relay flow. Was
+    declared with the comment "ephemeral, not persisted" but the codes
+    have a 5-minute TTL and any in-flight Cognito hosted-UI sign-in
+    that straddles a warm-boot becomes invalid for no good reason
+    (the user has to re-auth even though the code itself is still
+    well within its TTL).
+
+Why these dicts are intentionally PLAIN dicts (not AccountScopedDict):
+the OAuth2 token endpoint (`cognito.py:_oauth2_token`) is a public
+endpoint with no AWS authentication context — it identifies the
+caller via the OAuth2 `code` + `client_id` + `client_secret` (HTTP
+Basic), NOT via a SigV4 access key. If these dicts were AccountScopedDict,
+the code lookup would happen under whatever default account the
+callback runs in, and codes issued under one tenant would be invisible
+to other tenants, breaking the OAuth2 flow entirely. Effective tenant
+isolation is provided by the random unguessable token namespace.
+"""
+import importlib
+
+import pytest
+
+from ministack.core import persistence
+
+
+def _module():
+    return importlib.import_module("ministack.services.cognito")
+
+
+@pytest.fixture(autouse=True)
+def _enable_persistence(monkeypatch, tmp_path):
+    """Force PERSIST_STATE on and point STATE_DIR at a tmp dir so
+    save_state / load_state actually write and read JSON files."""
+    monkeypatch.setattr(persistence, "PERSIST_STATE", True)
+    monkeypatch.setattr(persistence, "STATE_DIR", str(tmp_path))
+
+
+def _round_trip(mod, svc_key="cognito"):
+    """Simulate a full warm-boot via the on-disk JSON path."""
+    persistence.save_state(svc_key, mod.get_state())
+    mod.reset()
+    loaded = persistence.load_state(svc_key)
+    assert loaded is not None, "load_state returned None — get_state may be wrong"
+    mod.restore_state(loaded)
+
+
+def test_auth_codes_survive_warm_boot():
+    """`_auth_codes` populated by the hosted-UI / federation flow must
+    survive a warm-boot through the on-disk JSON path. Without the fix
+    `_auth_codes` was missing from get_state/restore_state, so any
+    in-flight hosted-UI sign-in within the 5-minute code TTL was
+    silently invalidated by a restart."""
+    mod = _module()
+    mod.reset()
+
+    relay_state = "test-relay-12345"
+    mod._auth_codes[relay_state] = {
+        "type": "code",
+        "pool_id": "us-east-1_TestPool",
+        "client_id": "client-id-abc",
+        "username": "user@example.com",
+        "redirect_uri": "https://app.example.com/callback",
+        "scopes": ["openid", "email"],
+        "state": "client-state-xyz",
+        "created_at": 1700000000.0,
+    }
+
+    _round_trip(mod)
+
+    assert relay_state in mod._auth_codes, (
+        "Hosted-UI relay code lost across warm-boot — _auth_codes must "
+        "be in both get_state() and restore_state()."
+    )
+    assert mod._auth_codes[relay_state]["pool_id"] == "us-east-1_TestPool"
+    assert mod._auth_codes[relay_state]["client_id"] == "client-id-abc"
+    mod.reset()
+
+
+def test_auth_codes_dict_types_not_account_scoped():
+    """Belt-and-braces: assert that `_auth_codes` and
+    `_authorization_codes` remain plain dicts (NOT AccountScopedDict).
+
+    These dicts are looked up by random unguessable token from a public
+    OAuth2 callback with no AWS auth context. Wrapping them in
+    AccountScopedDict would make the callback lookup happen under a
+    default account, invisible to codes issued under any other tenant —
+    breaking the entire OAuth2 flow. This test pins the type so a
+    well-meaning future refactor doesn't silently break OAuth2."""
+    mod = _module()
+    from ministack.core.responses import AccountScopedDict
+
+    assert not isinstance(mod._auth_codes, AccountScopedDict), (
+        "_auth_codes must remain a plain dict — see the docstring for why."
+    )
+    assert not isinstance(mod._authorization_codes, AccountScopedDict), (
+        "_authorization_codes must remain a plain dict — same reason."
+    )

--- a/tests/test_cognito_auth_codes_persistence.py
+++ b/tests/test_cognito_auth_codes_persistence.py
@@ -62,15 +62,20 @@ def test_auth_codes_survive_warm_boot():
     mod = _module()
     mod.reset()
 
+    # Match the actual production payload shape written by the SAML/OIDC
+    # callback handler in `cognito.py` — `type: "code"` entries store
+    # `scopes` as a space-separated string (copied from `relay["scope"]`)
+    # and have no `state` field (state lives on the sibling `type: "relay"`
+    # entry that this code-type one is created from).
     relay_state = "test-relay-12345"
     mod._auth_codes[relay_state] = {
         "type": "code",
         "pool_id": "us-east-1_TestPool",
         "client_id": "client-id-abc",
         "username": "user@example.com",
+        "sub": "user-sub-12345",
         "redirect_uri": "https://app.example.com/callback",
-        "scopes": ["openid", "email"],
-        "state": "client-state-xyz",
+        "scopes": "openid email",
         "created_at": 1700000000.0,
     }
 
@@ -85,22 +90,28 @@ def test_auth_codes_survive_warm_boot():
     mod.reset()
 
 
-def test_auth_codes_dict_types_not_account_scoped():
+def test_auth_codes_dict_types_are_plain_builtin_dict():
     """Belt-and-braces: assert that `_auth_codes` and
-    `_authorization_codes` remain plain dicts (NOT AccountScopedDict).
+    `_authorization_codes` remain plain built-in `dict` instances —
+    not AccountScopedDict, not any other dict-like wrapper.
 
     These dicts are looked up by random unguessable token from a public
     OAuth2 callback with no AWS auth context. Wrapping them in
-    AccountScopedDict would make the callback lookup happen under a
-    default account, invisible to codes issued under any other tenant —
+    AccountScopedDict (or anything else with request-scoped lookup
+    semantics) would make the callback lookup happen under a default
+    account, invisible to codes issued under any other tenant —
     breaking the entire OAuth2 flow. This test pins the type so a
-    well-meaning future refactor doesn't silently break OAuth2."""
-    mod = _module()
-    from ministack.core.responses import AccountScopedDict
+    well-meaning future refactor doesn't silently break OAuth2.
 
-    assert not isinstance(mod._auth_codes, AccountScopedDict), (
-        "_auth_codes must remain a plain dict — see the docstring for why."
+    `type(x) is dict` (strict identity) catches not just AccountScopedDict
+    but also any other Mapping subclass that might quietly slip in."""
+    mod = _module()
+
+    assert type(mod._auth_codes) is dict, (
+        "_auth_codes must remain a plain built-in dict — see the "
+        "docstring for why."
     )
-    assert not isinstance(mod._authorization_codes, AccountScopedDict), (
-        "_authorization_codes must remain a plain dict — same reason."
+    assert type(mod._authorization_codes) is dict, (
+        "_authorization_codes must remain a plain built-in dict — same "
+        "reason."
     )


### PR DESCRIPTION
## Summary

`_auth_codes` (hosted-UI / SAML-OIDC federation relay flow) was declared with the comment "ephemeral, not persisted" but in fact has a 5-minute TTL. Any in-flight Cognito hosted-UI sign-in that straddled a warm-boot was silently invalidated even though the code itself was still well within its TTL — forcing a needless re-auth.

| Symbol | Pre-fix | Post-fix |
|---|---|---|
| `_auth_codes` (hosted-UI / federation) | Plain dict, NOT in `get_state` / `restore_state` | Plain dict, IN both |
| `_authorization_codes` (managed-login PKCE) | Plain dict, already IN both | Unchanged (regression-locked by new test) |

## Why these dicts are intentionally PLAIN dicts (not AccountScopedDict)

The OAuth2 token endpoint (`cognito.py:_oauth2_token`) is a public callback authenticated via HTTP Basic (`client_id` / `client_secret`), with **no SigV4 access key**. Wrapping these dicts in `AccountScopedDict` would make every callback lookup happen under the default account (`MINISTACK_ACCOUNT_ID` / `"000000000000"`), invisible to codes minted under any other tenant — breaking the entire OAuth2 flow.

Effective tenant isolation is provided by the `secrets.token_urlsafe(32)` (256-bit unguessable) token namespace. The new code adds a multi-line section comment explaining this and a `test_auth_codes_dict_types_not_account_scoped` regression test pins the choice so a future "well-meaning" `AccountScopedDict` refactor can't silently break OAuth2.

## What changed

| File | Change |
|---|---|
| `ministack/services/cognito.py` | +1 line in `get_state()`, +1 in `restore_state()`, plus a 9-line section-header comment block replacing the misleading "ephemeral, not persisted" one-liner. |
| `tests/test_cognito_auth_codes_persistence.py` *(new, 2 tests)* | Warm-boot persistence round-trip (fails before the fix) + a type-pin regression guard. |

### Default behaviour unchanged

Restore is gated by `PERSIST_STATE` — `load_state()` returns `None` when the env var is unset.

## Stale-code safety

`_cleanup_expired_relay_codes()` (line 493) runs from the OAuth2 token endpoint before any code lookup. Past-TTL codes restored from disk are evicted on the next token-exchange attempt; they cannot be successfully redeemed. No replay-risk surface.

## Test plan

- [x] `pytest tests/test_cognito_auth_codes_persistence.py` — both pass after the fix (the persistence test fails without it).
- [x] `pytest tests/test_cognito.py` — all 94 existing cognito tests still pass.
- [ ] Reviewer check: end-to-end with `PERSIST_STATE=1`: initiate hosted-UI flow → restart ministack within 5 min → completing the flow with the same code should succeed.

## Notes

Independent of #491 / #492 / #493 / #494 / #495.