### PR TITLE
fix: eagerly import non-routable persisted services on startup

### DIFF
--- a/ministack/app.py
+++ b/ministack/app.py
@@ -1203,6 +1203,20 @@ def _load_persisted_state():
             _get_module(svc_key).load_persisted_state(data)
             logger.info("Loaded persisted state for %s", svc_key)
 
+    # Eagerly import services that participate in `_state_map` but are
+    # not directly in `SERVICE_REGISTRY` (or are reached only by a
+    # path-prefix shortcut, like `ses_v2` via `/v2/email/*` and `pipes`
+    # via CloudFormation). The lazy router won't import these on
+    # startup, so their module-level `load_state()` block never fires
+    # until something else triggers an import — silently dropping the
+    # persisted snapshot. Importing here triggers the restore (and, for
+    # pipes, also restarts the background poller for any RUNNING pipe).
+    # Keep this list narrow — every entry costs a cold-start import.
+    # Enforced by `tests/test_persistence_symmetry.py::test_state_map_
+    # services_without_endpoint_are_eagerly_imported`.
+    for svc_key in ("pipes", "ses_v2"):
+        _get_module(svc_key)
+
 
 async def _wait_for_port(port, timeout=30):
     """Wait until the server is accepting TCP connections."""

--- a/ministack/app.py
+++ b/ministack/app.py
@@ -1203,16 +1203,18 @@ def _load_persisted_state():
             _get_module(svc_key).load_persisted_state(data)
             logger.info("Loaded persisted state for %s", svc_key)
 
-    # Eagerly import services that participate in `_state_map` but are
-    # not directly in `SERVICE_REGISTRY` (or are reached only by a
-    # path-prefix shortcut, like `ses_v2` via `/v2/email/*` and `pipes`
-    # via CloudFormation). The lazy router won't import these on
-    # startup, so their module-level `load_state()` block never fires
-    # until something else triggers an import — silently dropping the
-    # persisted snapshot. Importing here triggers the restore (and, for
-    # pipes, also restarts the background poller for any RUNNING pipe).
-    # Keep this list narrow — every entry costs a cold-start import.
-    # Enforced by `tests/test_persistence_symmetry.py::test_state_map_
+    # Eagerly import persisted services whose restore path depends on
+    # a module-level `load_state()` side-effect, but which would not
+    # otherwise be imported during startup. These are NOT covered by
+    # the explicit central-restore loop above (no
+    # `load_persisted_state` method), and the lazy router will not
+    # pull them in early enough — for example, `ses_v2` is reached
+    # via the `/v2/email/*` path-prefix shortcut and `pipes` via
+    # CloudFormation, neither of which fires at lifespan startup.
+    # Importing here triggers the restore (and, for `pipes`, also
+    # restarts the background poller for any RUNNING pipe). Keep this
+    # list narrow — every entry costs a cold-start import. Enforced
+    # by `tests/test_persistence_symmetry.py::test_state_map_
     # services_without_endpoint_are_eagerly_imported`.
     for svc_key in ("pipes", "ses_v2"):
         _get_module(svc_key)

--- a/tests/test_persistence_symmetry.py
+++ b/tests/test_persistence_symmetry.py
@@ -82,6 +82,45 @@ def test_pipes_is_in_state_map():
     )
 
 
+def test_state_map_services_without_endpoint_are_eagerly_imported():
+    """Services in `_state_map` but NOT in `SERVICE_REGISTRY` have no
+    AWS endpoint, so the lazy router never imports them. Their
+    import-time `load_state()` block therefore never fires unless
+    `_load_persisted_state()` eagerly imports them at startup.
+
+    Without this, persisted RUNNING pipes don't resume their poller
+    after warm-boot until something else happens to import the
+    module (e.g. a new CFN pipe registration) — silently breaking
+    event forwarding for the entire window between restart and the
+    next pipe-related API call."""
+    from ministack.app import SERVICE_REGISTRY, _load_persisted_state
+    import inspect
+
+    # Find services that need eager import.
+    routable_modules = {cfg["module"] for cfg in SERVICE_REGISTRY.values()}
+    needs_eager_import = [
+        mod_name for _, mod_name in _state_map.items()
+        if mod_name not in routable_modules
+    ]
+    assert needs_eager_import, (
+        "Test premise broken: every persisted module is now also routable, "
+        "so this test would never catch the bug it's guarding against. "
+        "Update it or delete it."
+    )
+
+    # The eager-import section in _load_persisted_state must reference each
+    # such module by name, otherwise it stays unimported and its restore
+    # never runs.
+    src = inspect.getsource(_load_persisted_state)
+    for mod_name in needs_eager_import:
+        assert f'"{mod_name}"' in src or f"'{mod_name}'" in src, (
+            f"Service `{mod_name}` is in `_state_map` but not in "
+            f"`SERVICE_REGISTRY`, and `_load_persisted_state()` doesn't "
+            f"eagerly import it. With PERSIST_STATE=1, its persisted "
+            f"state will be silently ignored on warm-boot."
+        )
+
+
 # ── Functional round-trip tests ────────────────────────────────────────
 
 def _round_trip(mod_name, svc_key, populate_fn, observe_fn):


### PR DESCRIPTION
## Summary

Follow-up to #491 addressing a second-round Copilot review point that landed after the merge.

Services that participate in `_state_map` but are NOT in `SERVICE_REGISTRY` have no AWS endpoint, so the lazy router never imports them on process startup. Their module-level `load_state()` block therefore never fires until something else triggers an import — silently dropping the persisted snapshot until the first service-specific request arrives.

Two such services exist today:

| Module | How it's normally reached | Restore impact pre-fix |
|---|---|---|
| `pipes` | CloudFormation-internal, imported only when a CFN `AWS::Pipes::Pipe` resource is provisioned | RUNNING pipes silently stop forwarding events after warm-boot until a new pipe is registered |
| `ses_v2` | `/v2/email/*` path-prefix shortcut in `app.py` | v2 SES identities / templates / config-sets evaporate after warm-boot until the first v2 request arrives |

## What changed

| File | Change |
|---|---|
| `ministack/app.py` | `_load_persisted_state()` now eagerly imports both modules. Each entry is a tiny cold-start cost; comment explains the criterion (in `_state_map`, not in `SERVICE_REGISTRY`). |
| `tests/test_persistence_symmetry.py` | New `test_state_map_services_without_endpoint_are_eagerly_imported` derives the set `_state_map - SERVICE_REGISTRY` and asserts each entry is referenced by name in `_load_persisted_state()`'s source. The next time someone adds a non-routable service to `_state_map`, this test fails until they wire it up. |

For pipes this combines with the `restore_state()` poller-start that landed in #491, so persisted event forwarding actually resumes after warm-boot — not just the in-memory definition.

## Test plan

- [x] `pytest tests/test_persistence_symmetry.py` — all 58 pass.
- [x] The new structural test caught `ses_v2` as a second instance of the same bug class while writing the fix for `pipes` — exactly the regression behavior the test is designed to provide.
- [ ] Reviewer check: with `PERSIST_STATE=1`, persist a SES v2 identity, restart ministack, immediately call `list_email_identities` (without any prior `/v2/email/*` request) — should return the identity.

## Notes

This is a follow-up to merged #491. Original review thread on `pipes` was addressed before the merge; the broader generalization to all non-routable persisted services arrived afterwards.