### PR TITLE
test: parametrized NameError-at-import regression for every persisted service

### DIFF
--- a/tests/test_state_dict_persistence.py
+++ b/tests/test_state_dict_persistence.py
@@ -212,3 +212,95 @@ def test_ecs_module_reload_with_persisted_attributes_does_not_namerror():
         "ECS _attributes lost after reload — same root cause."
     )
     mod.reset()
+
+
+# ── Generic NameError-at-import regression for ALL persisted services ─
+
+def _persisted_services():
+    """Yield (svc_key, mod_name) pairs for everything in _state_map.
+    Lazy-loaded so the test pulls fresh state on every run."""
+    from ministack.app import _state_map
+    return sorted(_state_map.items())
+
+
+@pytest.mark.parametrize("svc_key,mod_name", _persisted_services())
+def test_module_cold_import_with_typical_snapshot_does_not_log_restore_failure(
+    svc_key, mod_name, caplog,
+):
+    """Generic regression for the NameError-at-import pattern that hit
+    `ecs._attributes` (this PR) and `acm._synthetic_pem` (#494).
+
+    The bug shape: `restore_state(data)` references a module-level
+    symbol declared further down the file. The import-time `try:
+    load_state(...)` block calls `restore_state()` BEFORE Python
+    evaluates the later definition, so the lookup NameErrors. The
+    surrounding try/except logs `Failed to restore persisted state` and
+    swallows the exception, so the module appears to import cleanly
+    while ALL its persisted state silently disappears.
+
+    The test:
+      1. Captures the module's current `get_state()` snapshot (a
+         non-empty dict-of-empty-dicts — important so `restore_state`
+         doesn't early-return on truthy emptiness checks).
+      2. Persists that to disk via the production `save_state` path.
+      3. **Removes the module from `sys.modules` and re-imports it
+         fresh** — `importlib.reload()` would NOT catch the bug
+         because it merges new definitions into the existing
+         namespace, leaving any late-declared symbol bound from the
+         previous import.
+      4. Asserts no WARNING+ log record mentioning "restore" / "failed"
+         / "continuing fresh" was emitted during the cold import.
+
+    Catches: unconditional symbol references in restore_state
+    (ECS-style). Does NOT catch: conditional references inside loops
+    over restored data when the data is empty (ACM-style needs
+    populated state — see the per-service tests above).
+    """
+    import sys
+    import tempfile
+    monkeypatch_persistence = pytest.MonkeyPatch()
+    monkeypatch_persistence.setattr(persistence, "PERSIST_STATE", True)
+    with tempfile.TemporaryDirectory() as td:
+        monkeypatch_persistence.setattr(persistence, "STATE_DIR", td)
+
+        # Step 1+2: produce + persist a snapshot using the already-loaded
+        # module (so we get a valid get_state() shape).
+        mod = _module(mod_name)
+        if hasattr(mod, "reset"):
+            mod.reset()
+        persistence.save_state(svc_key, mod.get_state())
+
+        # Step 3: cold-import — wipe sys.modules and re-import.
+        # importlib.reload() won't work because it merges into the
+        # existing namespace; the late-declared symbol stays bound from
+        # the prior import.
+        full_name = f"ministack.services.{mod_name}"
+        sys.modules.pop(full_name, None)
+
+        caplog.clear()
+        with caplog.at_level("WARNING"):
+            mod = importlib.import_module(full_name)
+
+        bad = [
+            r for r in caplog.records
+            if r.levelno >= 30  # WARNING+
+            and any(needle in r.getMessage().lower()
+                    for needle in ("failed to restore", "restore failed",
+                                   "continuing fresh", "continuing with fresh"))
+        ]
+        if hasattr(mod, "reset"):
+            mod.reset()
+
+    monkeypatch_persistence.undo()
+    assert not bad, (
+        f"Cold import of `{mod_name}` (state-key `{svc_key}`) emitted "
+        f"a restore-failure log:\n  "
+        + "\n  ".join(r.getMessage() for r in bad)
+        + "\n\nThis usually means `restore_state` references a "
+        "module-level symbol that's declared further down the file. "
+        "The import-time `try: load_state()` block runs before the "
+        "later definition, so the symbol lookup NameErrors and the "
+        "surrounding try/except swallows it. Hoist the symbol above "
+        "the import-time `load_state` block (see ECS `_attributes` "
+        "or ACM `_synthetic_pem` for the canonical fix)."
+    )

--- a/tests/test_state_dict_persistence.py
+++ b/tests/test_state_dict_persistence.py
@@ -217,8 +217,13 @@ def test_ecs_module_reload_with_persisted_attributes_does_not_namerror():
 # ── Generic NameError-at-import regression for ALL persisted services ─
 
 def _persisted_services():
-    """Yield (svc_key, mod_name) pairs for everything in _state_map.
-    Lazy-loaded so the test pulls fresh state on every run."""
+    """Return a sorted list of ``(svc_key, mod_name)`` pairs from
+    ``ministack.app._state_map``.
+
+    Evaluated by ``@pytest.mark.parametrize(...)`` at test collection
+    time — `_state_map` is therefore imported when pytest collects this
+    module, NOT lazily per test case. (Calling it inside the parametrize
+    decorator means it runs once, at collection.)"""
     from ministack.app import _state_map
     return sorted(_state_map.items())
 
@@ -257,41 +262,38 @@ def test_module_cold_import_with_typical_snapshot_does_not_log_restore_failure(
     populated state — see the per-service tests above).
     """
     import sys
-    import tempfile
-    monkeypatch_persistence = pytest.MonkeyPatch()
-    monkeypatch_persistence.setattr(persistence, "PERSIST_STATE", True)
-    with tempfile.TemporaryDirectory() as td:
-        monkeypatch_persistence.setattr(persistence, "STATE_DIR", td)
 
-        # Step 1+2: produce + persist a snapshot using the already-loaded
-        # module (so we get a valid get_state() shape).
-        mod = _module(mod_name)
-        if hasattr(mod, "reset"):
-            mod.reset()
-        persistence.save_state(svc_key, mod.get_state())
+    # Persistence is already enabled and STATE_DIR is already pointed at
+    # a per-test tmp by the autouse `_enable_persistence` fixture.
 
-        # Step 3: cold-import — wipe sys.modules and re-import.
-        # importlib.reload() won't work because it merges into the
-        # existing namespace; the late-declared symbol stays bound from
-        # the prior import.
-        full_name = f"ministack.services.{mod_name}"
-        sys.modules.pop(full_name, None)
+    # Step 1+2: produce + persist a snapshot using the already-loaded
+    # module (so we get a valid get_state() shape).
+    mod = _module(mod_name)
+    if hasattr(mod, "reset"):
+        mod.reset()
+    persistence.save_state(svc_key, mod.get_state())
 
-        caplog.clear()
-        with caplog.at_level("WARNING"):
-            mod = importlib.import_module(full_name)
+    # Step 3: cold-import — wipe sys.modules and re-import.
+    # importlib.reload() won't work because it merges into the
+    # existing namespace; the late-declared symbol stays bound from
+    # the prior import.
+    full_name = f"ministack.services.{mod_name}"
+    sys.modules.pop(full_name, None)
 
-        bad = [
-            r for r in caplog.records
-            if r.levelno >= 30  # WARNING+
-            and any(needle in r.getMessage().lower()
-                    for needle in ("failed to restore", "restore failed",
-                                   "continuing fresh", "continuing with fresh"))
-        ]
-        if hasattr(mod, "reset"):
-            mod.reset()
+    caplog.clear()
+    with caplog.at_level("WARNING"):
+        mod = importlib.import_module(full_name)
 
-    monkeypatch_persistence.undo()
+    bad = [
+        r for r in caplog.records
+        if r.levelno >= 30  # WARNING+
+        and any(needle in r.getMessage().lower()
+                for needle in ("failed to restore", "restore failed",
+                               "continuing fresh", "continuing with fresh"))
+    ]
+    if hasattr(mod, "reset"):
+        mod.reset()
+
     assert not bad, (
         f"Cold import of `{mod_name}` (state-key `{svc_key}`) emitted "
         f"a restore-failure log:\n  "


### PR DESCRIPTION
## Summary

Follow-up to merged #492. The same NameError-at-import bug pattern surfaced during review on **two PRs in the persistence-fix series**:

- **#492 (merged)** — `ecs._attributes` was declared at line 1499 but referenced by `restore_state()` at line 124. The import-time `try: load_state(...)` block called `restore_state` BEFORE Python evaluated the later definition → `NameError` → caught by surrounding `try/except` → ALL ECS state silently lost on warm-boot.
- **#494 (open)** — same shape with `acm._synthetic_pem`.

Worth a structural guard that runs against every persisted service so the next instance of this bug fails at PR review time, not in production.

## What this PR adds

`test_module_cold_import_with_typical_snapshot_does_not_log_restore_failure` parametrizes over every entry in `_state_map` (45 services today). For each one:

1. Capture the module's current `get_state()` snapshot (a non-empty dict-of-empty-dicts so `restore_state` doesn't early-return on truthy-emptiness).
2. Persist it via `save_state` to a tmp `STATE_DIR`.
3. **Cold-import** the module by removing it from `sys.modules` and re-importing. `importlib.reload()` does NOT catch the bug — it merges new defs into the existing namespace, leaving any late-declared symbol bound from the prior import.
4. Capture log records during the cold import; assert no WARNING+ message about restore-failure was emitted.

## Verified

Temporarily reverted the ECS `_attributes` hoist (now on main from #492) and re-ran the test. It failed with the actual NameError traceback in the captured log:

```
ERROR ministack.services.ecs:ecs.py:156 Failed to restore persisted state
Traceback (most recent call last):
  File "ministack/services/ecs.py", line 153, in <module>
    restore_state(_restored)
  File "ministack/services/ecs.py", line 135, in restore_state
    _attributes.update(data.get("attributes", {}))
NameError: name '_attributes' is not defined
```

## What it catches / doesn't

- **Catches:** unconditional symbol references in `restore_state` (`_xxx.update(data.get(...))` where `_xxx` is declared too late). The ECS-style bug shape.
- **Doesn't catch:** conditional references inside loops over restored data when the data is empty (the ACM-style shape — that needs a populated snapshot per-service). For ACM specifically, `test_restore_state_backfills_pem_body_for_pre_upgrade_snapshots` in #494 covers it explicitly. The pattern is now established; future services that need it can copy.

## Test plan

- [x] `pytest tests/test_state_dict_persistence.py` — all 51 pass (45 new parametrized cases + 6 from #492).
- [x] Verified the test catches the bug by reverting the ECS hoist locally and observing the failure.

## Notes

Independent follow-up to #492 (already merged). No other production code changes — purely a structural test addition.