### PR TITLE
fix: 3 verified MEDIUM/LOW correctness bugs (M-1, M-2, L-2)

### DIFF
--- a/ministack/services/acm.py
+++ b/ministack/services/acm.py
@@ -172,7 +172,13 @@ def _list_certificates(data):
             "DomainName": cert["DomainName"],
             "Status": cert["Status"],
         })
-    return json_response({"CertificateSummaryList": summaries, "NextToken": None})
+    # Real AWS omits NextToken when there's no next page. boto3 strips
+    # null fields client-side so it tolerates `"NextToken": null`, but
+    # other SDKs (Java, Go, raw HTTP) and pagination loops checking
+    # `if "NextToken" in response` see the literal null and loop
+    # forever. ACM emulator currently emits a single page, so always
+    # omit the key.
+    return json_response({"CertificateSummaryList": summaries})
 
 
 def _delete_certificate(data):

--- a/ministack/services/apigateway.py
+++ b/ministack/services/apigateway.py
@@ -119,17 +119,24 @@ def _extract_lambda_ref_from_integration_uri(uri: str) -> str:
 # ---- Persistence hooks ----
 
 def get_state() -> dict:
-    """Return full module state for persistence."""
+    """Return full module state for persistence.
+
+    Deep-copies each dict so a concurrent write during shutdown
+    serialisation can't corrupt the persisted JSON. Every other
+    persisted service in this codebase already does the same; the
+    apigateway pair was an outlier.
+    """
+    import copy
     return {
-        "apis": _apis,
-        "routes": _routes,
-        "integrations": _integrations,
-        "stages": _stages,
-        "deployments": _deployments,
-        "authorizers": _authorizers,
-        "api_tags": _api_tags,
-        "route_responses": _route_responses,
-        "integration_responses": _integration_responses,
+        "apis": copy.deepcopy(_apis),
+        "routes": copy.deepcopy(_routes),
+        "integrations": copy.deepcopy(_integrations),
+        "stages": copy.deepcopy(_stages),
+        "deployments": copy.deepcopy(_deployments),
+        "authorizers": copy.deepcopy(_authorizers),
+        "api_tags": copy.deepcopy(_api_tags),
+        "route_responses": copy.deepcopy(_route_responses),
+        "integration_responses": copy.deepcopy(_integration_responses),
     }
 
 

--- a/ministack/services/apigateway_v1.py
+++ b/ministack/services/apigateway_v1.py
@@ -460,21 +460,28 @@ async def _call_lambda(func_name, event, qualifier=None):
 # ---- Persistence hooks ----
 
 def get_state():
-    """Return full module state for persistence."""
+    """Return full module state for persistence.
+
+    Deep-copies each dict so a concurrent write during shutdown
+    serialisation can't corrupt the persisted JSON. Every other
+    persisted service in this codebase already does the same; the
+    apigateway pair was an outlier.
+    """
+    import copy
     return {
-        "rest_apis": _rest_apis,
-        "resources": _resources,
-        "stages_v1": _stages_v1,
-        "deployments_v1": _deployments_v1,
-        "authorizers_v1": _authorizers_v1,
-        "models": _models,
-        "api_keys": _api_keys,
-        "usage_plans": _usage_plans,
-        "usage_plan_keys": _usage_plan_keys,
-        "domain_names": _domain_names,
-        "base_path_mappings": _base_path_mappings,
-        "v1_tags": _v1_tags,
-        "account_settings": _account_settings,
+        "rest_apis": copy.deepcopy(_rest_apis),
+        "resources": copy.deepcopy(_resources),
+        "stages_v1": copy.deepcopy(_stages_v1),
+        "deployments_v1": copy.deepcopy(_deployments_v1),
+        "authorizers_v1": copy.deepcopy(_authorizers_v1),
+        "models": copy.deepcopy(_models),
+        "api_keys": copy.deepcopy(_api_keys),
+        "usage_plans": copy.deepcopy(_usage_plans),
+        "usage_plan_keys": copy.deepcopy(_usage_plan_keys),
+        "domain_names": copy.deepcopy(_domain_names),
+        "base_path_mappings": copy.deepcopy(_base_path_mappings),
+        "v1_tags": copy.deepcopy(_v1_tags),
+        "account_settings": copy.deepcopy(_account_settings),
     }
 
 

--- a/ministack/services/secretsmanager.py
+++ b/ministack/services/secretsmanager.py
@@ -418,6 +418,11 @@ def _delete_secret(data):
     if force:
         arn, sname = secret["ARN"], secret["Name"]
         del _secrets[key]
+        # Clean up any associated resource policy too — otherwise it
+        # lingers as an orphan keyed by the now-deleted ARN, invisible
+        # to the API but still consuming memory and surviving warm
+        # boot via the persistence path.
+        _resource_policies.pop(arn, None)
         return json_response({"ARN": arn, "Name": sname, "DeletionDate": deletion_date})
 
     secret["DeletedDate"] = deletion_date

--- a/tests/test_misc_medium_low_fixes.py
+++ b/tests/test_misc_medium_low_fixes.py
@@ -22,9 +22,15 @@ client-side null-stripping (L-2).
 """
 import importlib
 import json
+import os
 import urllib.request
 
 import pytest
+
+# Match the project convention from tests/conftest.py — honours
+# `MINISTACK_ENDPOINT` so tests run unchanged against a non-default
+# host / port (Docker networking, alternate CI bind, etc.).
+ENDPOINT = os.environ.get("MINISTACK_ENDPOINT", "http://localhost:4566")
 
 
 def _module(name):
@@ -139,7 +145,7 @@ def test_acm_list_certificates_omits_nexttoken_when_no_more_pages():
     Asserted at the wire level via raw HTTP to bypass boto3's null
     stripping."""
     req = urllib.request.Request(
-        "http://127.0.0.1:4566/",
+        ENDPOINT.rstrip("/") + "/",
         method="POST",
         headers={
             "x-amz-target": "CertificateManager.ListCertificates",

--- a/tests/test_misc_medium_low_fixes.py
+++ b/tests/test_misc_medium_low_fixes.py
@@ -1,0 +1,159 @@
+"""
+Regression tests for the §7.4 / §7.5 omnibus (MINISTACK_GAP_PLAN.md):
+
+  M-1  apigateway + apigateway_v1 get_state() returned live
+       AccountScopedDict references rather than deep copies. A
+       concurrent write during shutdown serialisation could corrupt
+       the persisted snapshot.
+
+  M-2  secretsmanager._delete_secret(force=True) deleted the secret
+       record but left orphan entries in `_resource_policies` (keyed
+       by ARN) — invisible to the API but accumulating in memory and
+       surviving warm-boot via the persistence path.
+
+  L-2  acm._list_certificates returned `{"NextToken": null}`
+       unconditionally. Real AWS omits the key when there is no next
+       page; SDK consumers that paginate via
+       `if "NextToken" in response` will loop forever.
+
+Each test bypasses boto3 to inspect a layer it would otherwise hide:
+in-process module state (M-1, M-2) or the wire-level JSON before
+client-side null-stripping (L-2).
+"""
+import importlib
+import json
+import urllib.request
+
+import pytest
+
+
+def _module(name):
+    return importlib.import_module(f"ministack.services.{name}")
+
+
+# ── M-1: apigateway / apigateway_v1 get_state must deep-copy ──────────
+
+@pytest.mark.parametrize("mod_name", ["apigateway", "apigateway_v1"])
+def test_apigateway_get_state_returns_independent_copy(mod_name):
+    """`get_state()` must return a snapshot decoupled from live module
+    state — i.e. a `copy.deepcopy()` of each dict, not the live
+    reference. If it returns the live ref, a concurrent write during
+    shutdown serialisation corrupts the persisted JSON.
+
+    Asserted by identity (`is not`) on every dict returned: each value
+    in the snapshot must be a different Python object than the
+    corresponding module-level state dict, so any subsequent mutation
+    on either side cannot affect the other."""
+    mod = _module(mod_name)
+    if hasattr(mod, "reset"):
+        mod.reset()
+
+    snapshot = mod.get_state()
+
+    leaks = []
+    for key, snap_value in snapshot.items():
+        live = getattr(mod, f"_{key}", None)
+        if live is None:
+            continue  # snapshot key without a matching `_key` attr
+        if snap_value is live:
+            leaks.append(key)
+
+    assert not leaks, (
+        f"{mod_name}.get_state() returned LIVE references for these keys: "
+        f"{leaks}. A concurrent write to one of these dicts during "
+        "shutdown serialisation would corrupt the persisted JSON. "
+        f"Wrap each value in `copy.deepcopy(...)`."
+    )
+
+    if hasattr(mod, "reset"):
+        mod.reset()
+
+
+# ── M-2: secretsmanager force-delete must clean up orphan policies ────
+
+def test_secretsmanager_force_delete_removes_resource_policy():
+    """ForceDeleteWithoutRecovery must remove not just the secret but
+    also its associated `_resource_policies[arn]` entry. Otherwise the
+    policy lingers as an orphan referenced by an ARN no longer in
+    `_secrets` — invisible to APIs but accumulating in memory.
+
+    Tests the in-process module directly (rather than via boto3
+    against the live server) so the assertion can observe both the
+    `_secrets` and `_resource_policies` dicts together."""
+    sm = _module("secretsmanager")
+    sm.reset()
+
+    # Stage 1: create a secret with a resource policy via the module's
+    # action handlers, mirroring what boto3 -> handle_request would do.
+    create_resp = json.loads(_invoke_action(
+        sm, "CreateSecret",
+        {"Name": "force-delete-canary", "SecretString": "x"},
+    ))
+    arn = create_resp["ARN"]
+    _invoke_action(sm, "PutResourcePolicy", {
+        "SecretId": arn,
+        "ResourcePolicy": '{"Version":"2012-10-17","Statement":[]}',
+    })
+    assert arn in sm._resource_policies, "Test setup failed — policy didn't register"
+
+    # Stage 2: force-delete.
+    _invoke_action(sm, "DeleteSecret", {
+        "SecretId": arn,
+        "ForceDeleteWithoutRecovery": True,
+    })
+
+    # Stage 3: assert the policy entry is also gone.
+    assert arn not in sm._resource_policies, (
+        "Force-deleting a secret left an orphan entry in "
+        "`_resource_policies` keyed by the now-deleted ARN. The "
+        "delete path must pop both `_secrets[name]` AND "
+        "`_resource_policies[arn]`."
+    )
+    sm.reset()
+
+
+def _invoke_action(mod, action, params):
+    """Mini-helper: run a service module's action handler synchronously
+    and return the raw JSON body. Bypasses boto3 + HTTP so tests can
+    observe in-process module state."""
+    import asyncio
+    headers = {"x-amz-target": f"secretsmanager.{action}"}
+    body = json.dumps(params).encode()
+    status, _resp_headers, resp_body = asyncio.run(
+        mod.handle_request("POST", "/", headers, body, {})
+    )
+    if status >= 300:
+        raise AssertionError(f"{action} failed: {status} {resp_body!r}")
+    return resp_body.decode() if isinstance(resp_body, bytes) else resp_body
+
+
+# ── L-2: ACM ListCertificates must omit NextToken when no more pages ──
+
+def test_acm_list_certificates_omits_nexttoken_when_no_more_pages():
+    """Returning `{"NextToken": null}` is non-standard AWS — real AWS
+    omits the key. boto3 strips null fields client-side so a boto3-
+    only test can't see this, but other SDKs (Java, Go, raw HTTP) and
+    pagination loops checking `if "NextToken" in response` see the
+    literal null and loop forever.
+
+    Asserted at the wire level via raw HTTP to bypass boto3's null
+    stripping."""
+    req = urllib.request.Request(
+        "http://127.0.0.1:4566/",
+        method="POST",
+        headers={
+            "x-amz-target": "CertificateManager.ListCertificates",
+            "Content-Type": "application/x-amz-json-1.1",
+            "Authorization": "AWS4-HMAC-SHA256 Credential=test/x/us-east-1/acm/aws4_request",
+        },
+        data=b"{}",
+    )
+    body = json.loads(urllib.request.urlopen(req, timeout=5).read())
+
+    assert "NextToken" not in body, (
+        f"ListCertificates wire response contains NextToken when "
+        f"there is no next page (got {body.get('NextToken')!r}). "
+        "Real AWS omits the key. SDK consumers checking "
+        "`if 'NextToken' in response` (Java, Go, raw HTTP — boto3 "
+        "strips nulls) loop forever against a literal null."
+    )


### PR DESCRIPTION
## Summary

Three independent correctness fixes from §7.4 / §7.5 of the gap audit, each verified against real AWS behaviour first (per the lesson from the rejected KMS audit claims).

| ID | File | Bug | Fix |
|---|---|---|---|
| **M-1** | `services/apigateway.py` + `apigateway_v1.py` | `get_state()` returned LIVE `AccountScopedDict` references rather than deep copies. A concurrent write during shutdown serialisation could corrupt the persisted JSON. The apigateway pair was the only outlier — all other persisted services already deep-copy. | Wrap each dict in `copy.deepcopy(...)`. |
| **M-2** | `services/secretsmanager.py` | `_delete_secret(force=True)` removed the secret but left the matching entry in `_resource_policies[arn]`. Invisible to APIs but accumulating in memory and surviving warm-boot via the persistence path. | Add `_resource_policies.pop(arn, None)` after `del _secrets[key]`. |
| **L-2** | `services/acm.py` | `_list_certificates` returned `{"NextToken": null}` unconditionally. boto3 strips null fields client-side, but other SDKs (Java, Go, raw HTTP) and pagination loops checking `if "NextToken" in response` see the literal null and loop forever. | Drop the `NextToken` key from the response (single-page emulator). |

## What changed

| File | Change |
|---|---|
| `ministack/services/apigateway.py` | `get_state()`: wrap 9 dicts in `copy.deepcopy(...)`. |
| `ministack/services/apigateway_v1.py` | Same shape: wrap 13 dicts. |
| `ministack/services/secretsmanager.py` | +1 `pop` line in force-delete path. |
| `ministack/services/acm.py` | Drop `NextToken` from response when no next page. |
| `tests/test_misc_medium_low_fixes.py` *(new, 4 tests)* | M-1 parametrised over both apigateway modules; M-2 in-process via the module's `handle_request`; L-2 wire-level via raw HTTP to bypass boto3's null-stripping. |

### Test design notes

- **L-2 test bypasses boto3** because boto3 strips null fields client-side, hiding the bug. Uses `urllib.request.urlopen` to assert the wire-level JSON response.
- **M-2 test bypasses boto3 + HTTP** because orphan resource policies are by definition invisible from the API surface. Uses an in-process helper that drives `mod.handle_request(...)` synchronously via `asyncio.run`, then inspects both `_secrets` and `_resource_policies` directly.

## Skipped from §7.4 / §7.5 with rationale

- **M-3** SNS `Signature: "FAKE"` — needs real RSA signing infrastructure; cosmetic for test usage. Track separately.
- **M-5** KMS `DescribeKey` shape — verified non-bug in the PR-6 follow-up: real AWS `DescribeKey` doesn't return `Tags` or `KeyRotationEnabled` either.
- **L-1** secretsmanager filter substring vs prefix — AWS docs don't clearly specify the matching semantics; defer until verifiable.
- **M-8 / M-11** Lambda alias migration — needs separate per-service backfill PR.

## Test plan

- [x] `pytest tests/test_misc_medium_low_fixes.py` — all 4 pass (all 4 fail without the fix).
- [x] `pytest tests/test_acm.py tests/test_secretsmanager.py tests/test_apigatewayv1.py tests/test_apigatewayv2.py` — 174 existing tests still pass.
- [ ] Reviewer check: SDK pagination test (e.g. Java SDK against ministack ACM `ListCertificates`) — should no longer loop forever.