### PR TITLE
fix: 4 AWS wire-format compliance bugs

### DIFF
--- a/ministack/services/apigateway_v1.py
+++ b/ministack/services/apigateway_v1.py
@@ -1257,7 +1257,8 @@ def _put_integration(api_id, resource_id, http_method, data):
         "integrationResponses": {},
     }
     method_obj["methodIntegration"] = integration
-    return _v1_response(integration)
+    # Real AWS returns HTTP 201 Created for PutIntegration.
+    return _v1_response(integration, 201)
 
 
 def _get_integration(api_id, resource_id, http_method):

--- a/ministack/services/eventbridge.py
+++ b/ministack/services/eventbridge.py
@@ -1147,7 +1147,9 @@ def _start_replay(data):
     t = threading.Thread(target=_run, daemon=True)
     t.start()
 
-    return json_response({"ReplayArn": arn, "State": "RUNNING"})
+    # Real AWS StartReplay returns the initial state STARTING; the
+    # replay flips to RUNNING in the background dispatch thread above.
+    return json_response({"ReplayArn": arn, "State": "STARTING"})
 
 
 def _describe_replay(data):

--- a/ministack/services/sns.py
+++ b/ministack/services/sns.py
@@ -348,7 +348,9 @@ def _subscribe(params):
     if needs_confirmation:
         asyncio.ensure_future(_send_subscription_confirmation(topic_arn, sub))
 
-    result_arn = "PendingConfirmation" if needs_confirmation else sub_arn
+    # Real AWS returns the literal lowercase string "pending confirmation"
+    # (with a space) as the SubscriptionArn until the subscriber confirms.
+    result_arn = "pending confirmation" if needs_confirmation else sub_arn
     return _xml(200, "SubscribeResponse",
                 f"<SubscribeResult><SubscriptionArn>{result_arn}</SubscriptionArn></SubscribeResult>")
 

--- a/ministack/services/sts.py
+++ b/ministack/services/sts.py
@@ -60,7 +60,9 @@ async def handle_request(method, path, headers, body, query_params):
         secret_key = _gen_secret()
         session_token = _gen_session_token()
         role_id = "AROA" + new_uuid().replace("-", "")[:17].upper()
-        assumed_arn = role_arn.replace(":role/", ":assumed-role/", 1)
+        # Real AWS returns the assumed-role ARN under the `sts` service,
+        # not `iam` — e.g. arn:aws:sts::123456789012:assumed-role/demo/TestAR.
+        assumed_arn = role_arn.replace(":iam:", ":sts:", 1).replace(":role/", ":assumed-role/", 1)
         if not assumed_arn.endswith(f"/{session_name}"):
             assumed_arn = f"{assumed_arn}/{session_name}"
         if use_json:
@@ -92,7 +94,7 @@ async def handle_request(method, path, headers, body, query_params):
         access_key = _gen_session_access_key()
         secret_key = _gen_secret()
         session_token = _gen_session_token()
-        assumed_arn = role_arn.replace(":role/", ":assumed-role/", 1)
+        assumed_arn = role_arn.replace(":iam:", ":sts:", 1).replace(":role/", ":assumed-role/", 1)
         if not assumed_arn.endswith(f"/{session}"):
             assumed_arn = f"{assumed_arn}/{session}"
         role_id = "AROA" + new_uuid().replace("-", "")[:17].upper()

--- a/tests/test_apigatewayv1.py
+++ b/tests/test_apigatewayv1.py
@@ -184,6 +184,8 @@ def test_apigwv1_put_integration(apigw_v1):
         uri="arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:000000000000:function:myFunc/invocations",
     )
     assert resp["type"] == "AWS_PROXY"
+    # Real AWS returns HTTP 201 Created for PutIntegration.
+    assert resp["ResponseMetadata"]["HTTPStatusCode"] == 201
     apigw_v1.delete_rest_api(restApiId=api_id)
 
 def test_apigwv1_put_method_response(apigw_v1):

--- a/tests/test_eventbridge.py
+++ b/tests/test_eventbridge.py
@@ -444,10 +444,12 @@ def test_eventbridge_replay_lifecycle(eb):
         EventEndTime=t1,
         Destination={"Arn": bus_arn},
     )
-    assert start["State"] == "RUNNING"
+    # Real AWS returns STARTING as the immediate state; the background
+    # dispatch flips through RUNNING to COMPLETED.
+    assert start["State"] == "STARTING"
     desc = eb.describe_replay(ReplayName=rep_name)
     assert desc["ReplayName"] == rep_name
-    assert desc["State"] in ("RUNNING", "COMPLETED")
+    assert desc["State"] in ("STARTING", "RUNNING", "COMPLETED")
     listed = eb.list_replays(NamePrefix=rep_name)
     assert any(r["ReplayName"] == rep_name for r in listed["Replays"])
     from botocore.exceptions import ClientError as _CE
@@ -829,6 +831,27 @@ def test_eventbridge_archive_filters_by_pattern(eb):
     )
     desc = eb.describe_archive(ArchiveName=arch_name)
     assert desc["EventCount"] == 0
+    eb.delete_archive(ArchiveName=arch_name)
+
+
+def test_eventbridge_start_replay_initial_state_is_starting(eb):
+    """StartReplay's immediate response must return State=STARTING per the
+    AWS Replay state machine (STARTING → RUNNING → COMPLETED). The
+    background dispatch thread flips it to RUNNING then COMPLETED — but
+    callers reading the start_replay() return value must see STARTING."""
+    arch_name = f"replay-init-{_uuid_mod.uuid4().hex[:8]}"
+    bus_arn = "arn:aws:events:us-east-1:000000000000:event-bus/default"
+    eb.create_archive(ArchiveName=arch_name, EventSourceArn=bus_arn)
+    archive_arn = eb.describe_archive(ArchiveName=arch_name)["ArchiveArn"]
+    rep_name = f"rep-init-{_uuid_mod.uuid4().hex[:8]}"
+    resp = eb.start_replay(
+        ReplayName=rep_name,
+        EventSourceArn=archive_arn,
+        EventStartTime=0,
+        EventEndTime=time.time() + 3600,
+        Destination={"Arn": bus_arn},
+    )
+    assert resp["State"] == "STARTING", resp
     eb.delete_archive(ArchiveName=arch_name)
 
 

--- a/tests/test_sns.py
+++ b/tests/test_sns.py
@@ -64,6 +64,20 @@ def test_sns_subscribe_email(sns):
     )
     assert "SubscriptionArn" in resp
 
+
+def test_sns_subscribe_pending_arn_is_lowercase_with_space(sns):
+    """For protocols that require confirmation, AWS returns the literal
+    lowercase string 'pending confirmation' (with a space) as the
+    SubscriptionArn until the subscriber confirms — NOT PascalCase
+    'PendingConfirmation'."""
+    arn = sns.create_topic(Name="intg-sns-pending-arn")["TopicArn"]
+    resp = sns.subscribe(
+        TopicArn=arn,
+        Protocol="http",
+        Endpoint="http://example.com/sns-callback",
+    )
+    assert resp["SubscriptionArn"] == "pending confirmation", resp["SubscriptionArn"]
+
 def test_sns_unsubscribe(sns):
     arn = sns.create_topic(Name="intg-sns-unsub")["TopicArn"]
     sub = sns.subscribe(

--- a/tests/test_sts.py
+++ b/tests/test_sts.py
@@ -51,6 +51,26 @@ def test_sts_assume_role(sts):
     assert "test-session" in assumed["Arn"]
     assert "AssumedRoleId" in assumed
 
+
+def test_sts_assumed_role_arn_uses_sts_service(sts):
+    """Real AWS returns AssumeRole's AssumedRoleUser.Arn under the sts
+    service, not iam — e.g. arn:aws:sts::123456789012:assumed-role/demo/Sess.
+    Pinning this against future regressions."""
+    resp = sts.assume_role(
+        RoleArn="arn:aws:iam::000000000000:role/demo",
+        RoleSessionName="TestAR",
+    )
+    arn = resp["AssumedRoleUser"]["Arn"]
+    assert arn == "arn:aws:sts::000000000000:assumed-role/demo/TestAR", arn
+
+    resp_wi = sts.assume_role_with_web_identity(
+        RoleArn="arn:aws:iam::000000000000:role/demo",
+        RoleSessionName="WebSess",
+        WebIdentityToken="dummy.jwt.token",
+    )
+    arn_wi = resp_wi["AssumedRoleUser"]["Arn"]
+    assert arn_wi == "arn:aws:sts::000000000000:assumed-role/demo/WebSess", arn_wi
+
 def test_sts_get_session_token(sts):
     resp = sts.get_session_token(DurationSeconds=900)
     creds = resp["Credentials"]


### PR DESCRIPTION
- sts: AssumeRole/AssumeRoleWithWebIdentity ARN now uses sts service (was iam): arn:aws:sts::{acct}:assumed-role/{role}/{session}.
- apigateway_v1: PutIntegration returns HTTP 201 (was 200).
- eventbridge: StartReplay initial state is STARTING (was RUNNING); background thread still flips RUNNING then COMPLETED.
- sns: Subscribe returns 'pending confirmation' (lowercase, with space) as SubscriptionArn (was 'PendingConfirmation').