### PR TITLE
feat: ministack full Docker variant for DuckDB-backed Athena

### DIFF
--- a/.github/workflows/docker-publish-on-pr.yml
+++ b/.github/workflows/docker-publish-on-pr.yml
@@ -2,6 +2,7 @@ name: Docker Publish on PR
 
 on:
   pull_request_target:
+    types: [opened, synchronize, reopened, labeled]
 
 env:
   DOCKERHUB_IMAGE_ORG: ministackorg/ministack-preview-build
@@ -37,7 +38,8 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Extract metadata
+      # ── Regular (Alpine) image ──
+      - name: Extract metadata (regular)
         id: meta
         uses: docker/metadata-action@v6
         with:
@@ -46,18 +48,48 @@ jobs:
           tags: |
             type=ref,event=pr,suffix=-${{ steps.short_sha.outputs.short_sha }}
 
-      - name: Build and push
+      - name: Build and push (regular)
         uses: docker/build-push-action@v7
         with:
           context: .
+          file: Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             MINISTACK_VERSION=pr-${{ github.event.pull_request.number }}-${{ steps.short_sha.outputs.short_sha }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=regular-pr
+          cache-to: type=gha,mode=max,scope=regular-pr
+
+      # ── Full (Debian/glibc) image — DuckDB-backed Athena, psycopg2, pymysql.
+      # Only built when the PR carries the `full-preview` label (opt-in to keep
+      # default PR cost down). Add the label to any PR that touches the full
+      # variant or needs DuckDB/Postgres/MySQL paths verified end-to-end.
+      - name: Extract metadata (full)
+        id: meta_full
+        if: contains(github.event.pull_request.labels.*.name, 'full-preview')
+        uses: docker/metadata-action@v6
+        with:
+          images: |
+            ${{ env.DOCKERHUB_IMAGE_ORG }}
+          tags: |
+            type=ref,event=pr,suffix=-${{ steps.short_sha.outputs.short_sha }}-full
+
+      - name: Build and push (full)
+        if: contains(github.event.pull_request.labels.*.name, 'full-preview')
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Dockerfile.full
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta_full.outputs.tags }}
+          labels: ${{ steps.meta_full.outputs.labels }}
+          build-args: |
+            MINISTACK_VERSION=pr-${{ github.event.pull_request.number }}-${{ steps.short_sha.outputs.short_sha }}
+          cache-from: type=gha,scope=full-pr
+          cache-to: type=gha,mode=max,scope=full-pr
 
       - name: Comment on PR with Docker image info
         uses: peter-evans/create-or-update-comment@v4
@@ -66,3 +98,4 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             Docker image for this PR has been published: `${{ steps.meta.outputs.tags }}`
+            ${{ steps.meta_full.outputs.tags && format('Full variant: `{0}`', steps.meta_full.outputs.tags) || '' }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -28,7 +28,8 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Extract metadata
+      # ── Regular (Alpine) image — :latest, :{version}, :{major}.{minor} ──
+      - name: Extract metadata (regular)
         id: meta
         uses: docker/metadata-action@v5
         with:
@@ -40,15 +41,47 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest
 
-      - name: Build and push
+      - name: Build and push (regular)
         uses: docker/build-push-action@v5
         with:
           context: .
+          file: Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             MINISTACK_VERSION=${{ steps.meta.outputs.version }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=regular
+          cache-to: type=gha,mode=max,scope=regular
+
+      # ── Full (Debian/glibc) image — :full, :{version}-full, :{major}.{minor}-full ──
+      # Adds DuckDB (Athena engine), psycopg2-binary, pymysql. Larger
+      # image (~360 MB vs ~110 MB) but all manylinux wheels install
+      # cleanly. Tracks the same release cadence as regular until
+      # issue #411 has a longer-term answer.
+      - name: Extract metadata (full)
+        id: meta_full
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.DOCKERHUB_IMAGE }}
+            ${{ env.DOCKERHUB_IMAGE_ORG }}
+          tags: |
+            type=semver,pattern={{version}},suffix=-full
+            type=semver,pattern={{major}}.{{minor}},suffix=-full
+            type=raw,value=full
+
+      - name: Build and push (full)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.full
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta_full.outputs.tags }}
+          labels: ${{ steps.meta_full.outputs.labels }}
+          build-args: |
+            MINISTACK_VERSION=${{ steps.meta_full.outputs.version }}
+          cache-from: type=gha,scope=full
+          cache-to: type=gha,mode=max,scope=full

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to MiniStack will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Versioning follows [Semantic Versioning](https://semver.org/).
 
+---
+
+## [Unreleased]
+
+### Added
+- **`ministackorg/ministack:full` Docker variant** — Debian/glibc-based superset of the regular Alpine image, adding `duckdb` (Athena engine), `psycopg2-binary` (PostgreSQL driver), and `pymysql` (MySQL driver). DuckDB and psycopg2 ship `manylinux` wheels but no `musllinux` wheels, so on Alpine they either fall back to source-builds or silently disable themselves; the `:full` tag installs them cleanly. Published in lockstep with the regular image on every release: `:full` always points at the latest Debian build, alongside `:{version}-full` and `:{major}.{minor}-full`. The regular `:latest` / `:{version}` tags are unchanged. Full image reports `edition: full` on `/_ministack/health`; regular reports `edition: light`. Closes the long-standing Athena-on-Alpine gap raised by @arischow.
 
 ---
 ## [1.3.16] — 2026-04-27

--- a/Dockerfile.full
+++ b/Dockerfile.full
@@ -1,0 +1,88 @@
+FROM python:3.12-slim AS builder
+
+# Full variant — Debian/glibc base so DuckDB and psycopg2 install from
+# published manylinux wheels instead of building from source against musl.
+# See issue #411: DuckDB has no musllinux wheels and runs ~30% slower
+# on musl per upstream docs; psycopg2-binary likewise has no musl wheels.
+RUN pip install --no-cache-dir --no-compile \
+        hypercorn==0.18.0 \
+        "cbor2>=5.4.0" \
+        "defusedxml>=0.7" \
+        "docker>=7.0.0" \
+        "pyyaml>=6.0" \
+        "cryptography>=41.0" \
+        "pymysql>=1.1" \
+        "psycopg2-binary>=2.9" \
+        "duckdb>=0.10.0" \
+        "asyncssh>=2.14" \
+        "boto3>=1.34" \
+        "awscli"
+
+# Strip awscli help examples (~25 MB), Python cache files (~15 MB),
+# pip metadata, and DuckDB stub / ADBC artefacts that aren't used at runtime.
+RUN rm -rf /usr/local/lib/python3.12/site-packages/awscli/examples \
+    && find /usr/local/lib/python3.12/site-packages -type d -name '__pycache__' -exec rm -rf {} + 2>/dev/null \
+    && rm -rf /usr/local/lib/python3.12/site-packages/pip*.dist-info \
+    && rm -rf /usr/local/lib/python3.12/site-packages/pip* \
+    && rm -rf /usr/local/lib/python3.12/site-packages/_duckdb-stubs \
+    && rm -rf /usr/local/lib/python3.12/site-packages/adbc_driver_duckdb
+
+FROM python:3.12-slim
+
+LABEL maintainer="MiniStack" \
+      description="Local AWS Service Emulator — full variant with DuckDB (Athena), PostgreSQL, MySQL drivers, and SFTP"
+
+# Upgrade base packages, install runtime essentials (nodejs/bash for
+# Lambda Node.js + init scripts), then strip pip and locale/doc payload
+# we never use at runtime.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends nodejs bash \
+    && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
+    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* /tmp/* \
+    && rm -rf /usr/local/lib/python3.12/site-packages/pip* /usr/local/bin/pip* \
+    && rm -rf /usr/share/doc /usr/share/man /usr/share/info /usr/share/locale
+
+WORKDIR /opt/ministack
+
+# Copy cleaned Python packages and CLI entrypoints from builder.
+COPY --from=builder /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
+COPY --from=builder /usr/local/bin/aws /usr/local/bin/aws
+COPY --from=builder /usr/local/bin/aws_completer /usr/local/bin/aws_completer
+COPY --from=builder /usr/local/bin/hypercorn /usr/local/bin/hypercorn
+
+COPY bin/awslocal /usr/local/bin/awslocal
+RUN chmod +x /usr/local/bin/awslocal
+
+COPY ministack/ ministack/
+
+RUN groupadd -r ministack && useradd -r -g ministack ministack
+RUN mkdir -p /tmp/ministack-data/s3 && chown -R ministack:ministack /tmp/ministack-data
+RUN mkdir -p /docker-entrypoint-initaws.d/ready.d \
+             /etc/localstack/init/boot.d \
+             /etc/localstack/init/ready.d && \
+    chown -R ministack:ministack /docker-entrypoint-initaws.d /etc/localstack
+VOLUME /docker-entrypoint-initaws.d
+VOLUME /etc/localstack/init
+
+ARG MINISTACK_VERSION=dev
+ENV MINISTACK_VERSION=${MINISTACK_VERSION} \
+    MINISTACK_EDITION=full \
+    GATEWAY_PORT=4566 \
+    LOG_LEVEL=INFO \
+    S3_PERSIST=0 \
+    S3_DATA_DIR=/tmp/ministack-data/s3 \
+    REDIS_HOST=redis \
+    REDIS_PORT=6379 \
+    RDS_BASE_PORT=15432 \
+    RDS_PERSIST=0 \
+    ELASTICACHE_BASE_PORT=16379 \
+    LAMBDA_EXECUTOR=local \
+    PYTHONUNBUFFERED=1
+
+EXPOSE 4566 2222
+
+# Pure Python healthcheck — no curl dependency
+HEALTHCHECK --interval=10s --timeout=3s --start-period=5s --retries=3 \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:4566/_ministack/health')" || exit 1
+
+ENTRYPOINT ["python", "-m", "hypercorn", "ministack.app:app", "--bind", "0.0.0.0:4566", "--keep-alive", "75"]

--- a/ministack/app.py
+++ b/ministack/app.py
@@ -390,7 +390,7 @@ def _handle_health_request(path: str, request_id: str):
         "x-amzn-requestid": request_id,
     }, json.dumps({
         "services": {s: "available" for s in SERVICE_HANDLERS},
-        "edition": "light",
+        "edition": os.environ.get("MINISTACK_EDITION", "light"),
         "version": _VERSION,
         "ready_scripts": dict(_ready_scripts_state),
     }).encode()


### PR DESCRIPTION
Debian/glibc-based superset of the Alpine image. Adds duckdb, psycopg2-binary, and pymysql, which rely on manylinux wheels and do not work reliably on musl. Fixes Athena support in Alpine-based setups.

- Dockerfile.full: strict superset of Dockerfile (keeps asyncssh, SFTP port, MINISTACK_VERSION arg, healthcheck, env vars).
- docker-publish.yml: builds and pushes regular and full variants in parallel, with separate GHA cache scopes. Full image tagged as :full, :{version}-full, and :{major}.{minor}-full.