### PR TITLE
Fix (sts): GetCallerIdentity retunrs assumed-role ARN instead of hard-coded root

### DIFF
--- a/ministack/services/sts.py
+++ b/ministack/services/sts.py
@@ -17,6 +17,13 @@ from ministack.services.iam import _p, _xml, _error, _future, \
     _gen_session_access_key, _gen_secret, _gen_session_token
 
 
+_sessions: dict[str, dict] = {}
+
+
+def reset():
+    _sessions.clear()
+
+
 async def handle_request(method, path, headers, body, query_params):
     params = dict(query_params)
     content_type = headers.get("content-type", "")
@@ -41,12 +48,23 @@ async def handle_request(method, path, headers, body, query_params):
     use_json = "amz-json" in content_type
 
     if action == "GetCallerIdentity":
+        auth = headers.get("authorization", "")
+        caller_arn = f"arn:aws:iam::{get_account_id()}:root"
+        caller_user_id = get_account_id()
+        if "Credential=" in auth:
+            try:
+                access_key = auth.split("Credential=")[1].split("/")[0]
+                if access_key in _sessions:
+                    caller_arn = _sessions[access_key]["Arn"]
+                    caller_user_id = _sessions[access_key]["UserId"]
+            except Exception:
+                pass
         if use_json:
-            return json_response({"Account": get_account_id(), "Arn": f"arn:aws:iam::{get_account_id()}:root", "UserId": get_account_id()})
+            return json_response({"Account": get_account_id(), "Arn": caller_arn, "UserId": caller_user_id})
         return _xml(200, "GetCallerIdentityResponse",
                     f"<GetCallerIdentityResult>"
-                    f"<Arn>arn:aws:iam::{get_account_id()}:root</Arn>"
-                    f"<UserId>{get_account_id()}</UserId>"
+                    f"<Arn>{caller_arn}</Arn>"
+                    f"<UserId>{caller_user_id}</UserId>"
                     f"<Account>{get_account_id()}</Account>"
                     f"</GetCallerIdentityResult>",
                     ns="sts")
@@ -65,6 +83,7 @@ async def handle_request(method, path, headers, body, query_params):
         assumed_arn = role_arn.replace(":iam:", ":sts:", 1).replace(":role/", ":assumed-role/", 1)
         if not assumed_arn.endswith(f"/{session_name}"):
             assumed_arn = f"{assumed_arn}/{session_name}"
+        _sessions[access_key] = {"Arn": assumed_arn, "UserId": f"{role_id}:{session_name}"}
         if use_json:
             return json_response({
                 "Credentials": {"AccessKeyId": access_key, "SecretAccessKey": secret_key, "SessionToken": session_token, "Expiration": time.time() + duration},
@@ -98,6 +117,7 @@ async def handle_request(method, path, headers, body, query_params):
         if not assumed_arn.endswith(f"/{session}"):
             assumed_arn = f"{assumed_arn}/{session}"
         role_id = "AROA" + new_uuid().replace("-", "")[:17].upper()
+        _sessions[access_key] = {"Arn": assumed_arn, "UserId": f"{role_id}:{session}"}
         provider = _p(params, "ProviderId") or "sts.amazonaws.com"
         if use_json:
             return json_response({

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -107,6 +107,21 @@ def ddb():
 def sts():
     return make_client("sts")
 
+@pytest.fixture
+def sts_as_role(sts):
+    def _make(role_arn, session_name="test-session"):
+        creds = sts.assume_role(RoleArn=role_arn, RoleSessionName=session_name)["Credentials"]
+        return boto3.client(
+            "sts",
+            endpoint_url=ENDPOINT,
+            aws_access_key_id=creds["AccessKeyId"],
+            aws_secret_access_key=creds["SecretAccessKey"],
+            aws_session_token=creds["SessionToken"],
+            region_name=REGION,
+            config=Config(retries={"mode": "standard"}),
+        )
+    return _make
+
 @pytest.fixture(scope="session")
 def sm():
     return make_client("secretsmanager")

--- a/tests/test_sts.py
+++ b/tests/test_sts.py
@@ -95,3 +95,29 @@ def test_sts_assume_role_with_web_identity(sts, iam):
     assert "SecretAccessKey" in creds
     assert "SessionToken" in creds
     assert "Expiration" in creds
+
+
+def test_get_caller_identity_reflects_assumed_role(sts_as_role):
+    """GetCallerIdentity called with assumed-role creds must return the role ARN, not root."""
+    identity = sts_as_role("arn:aws:iam::000000000000:role/MyTestRole", "caller-identity-session").get_caller_identity()
+
+    assert identity["Account"] == "000000000000"
+    assert "MyTestRole" in identity["Arn"]
+    assert "caller-identity-session" in identity["Arn"]
+    assert ":assumed-role/" in identity["Arn"]
+
+
+def test_get_caller_identity_without_assume_role_returns_root(sts):
+    """GetCallerIdentity with root/plain creds must still return root ARN."""
+    identity = sts.get_caller_identity()
+    assert identity["Arn"] == "arn:aws:iam::000000000000:root"
+
+
+def test_get_caller_identity_different_roles_return_different_arns(sts_as_role):
+    """Two distinct assumed roles must produce distinct caller identities."""
+    arn_a = sts_as_role("arn:aws:iam::000000000000:role/RoleA", "session-a").get_caller_identity()["Arn"]
+    arn_b = sts_as_role("arn:aws:iam::000000000000:role/RoleB", "session-b").get_caller_identity()["Arn"]
+
+    assert "RoleA" in arn_a
+    assert "RoleB" in arn_b
+    assert arn_a != arn_b


### PR DESCRIPTION
I suggest the following change because `GetCallerIdentity` always returns `arn:aws:iam::000000000000:root` regardless of the credentials used to make the request. On real AWS, when you call `GetCallerIdentity` using temporary credentials obtained via `AssumeRole`, the response reflects the assumed role, for instance:

```
arn:aws:sts::123456789012:assumed-role/MyRole/my-session
```

My main motivation is that I am using ministack (thank you so much for the fork and the tool!) for testing purposes and one of the tests I want to apply is: obtaining temporary credentials from STS and verifying that those credentials actually represent the intended role before using them to access other services (e.g. S3).

## Fix / Change

I've added a module-level `_sessions` dict in `ministack/services/sts.py` that maps `AccessKeyId → {Arn, UserId}` at `AssumeRole` (and `AssumeRoleWithWebIdentity`) time. `GetCallerIdentity` now extracts the `AccessKeyId` from the AWS Signature V4 `Authorization` header and looks it up in `_sessions`, falling back to the root ARN for non-assumed credentials. 

This gets reset by the `reset()` function clears the dict between test runs via the existing `/_ministack/reset` mechanism. And also already wired in the `_reset_all_state()` in `app.py`

## Tests

I've added the following tests and validated against the updated docker image running locally with the changes.

- `test_get_caller_identity_reflects_assumed_role` — verifies the ARN returned contains the role name and session name after `AssumeRole`
- `test_get_caller_identity_without_assume_role_returns_root` — verifies root credentials still return the root ARN
- `test_get_caller_identity_different_roles_return_different_arns` — verifies two distinct assumed roles produce distinct identities

## Notes

In the [CONTRIBUTING.md](https://github.com/ministackorg/ministack/blob/main/CONTRIBUTING.md) it is mentioned to run `ruff check ministack/` to validate that linting passes. Locally this raises hundreds of errors unrelated to my changes. Maybe some config I am missing?