### PR TITLE
fix(sfn): return child execution ARNs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 ### Added
 - **`ministackorg/ministack:full` Docker variant** — Debian/glibc-based superset of the regular Alpine image, adding `duckdb` (Athena engine), `psycopg2-binary` (PostgreSQL driver), and `pymysql` (MySQL driver). DuckDB and psycopg2 ship `manylinux` wheels but no `musllinux` wheels, so on Alpine they either fall back to source-builds or silently disable themselves; the `:full` tag installs them cleanly. Published in lockstep with the regular image on every release: `:full` always points at the latest Debian build, alongside `:{version}-full` and `:{major}.{minor}-full`. The regular `:latest` / `:{version}` tags are unchanged. Full image reports `edition: full` on `/_ministack/health`; regular reports `edition: light`. Closes the long-standing Athena-on-Alpine gap raised by @arischow.
 
+### Fixed
+- **Step Functions child execution integrations now return child execution metadata** — `arn:aws:states:::states:startExecution` starts the nested execution and returns `ExecutionArn` / `StartDate` instead of echoing the request payload. `arn:aws:states:::aws-sdk:sfn:startExecution` now accepts AWS Step Functions' PascalCase integration parameters (`StateMachineArn`, `Input`, `Name`) by translating them to MiniStack's lower-camel Step Functions API shape.
+
 ---
 ## [1.3.16] — 2026-04-27
 

--- a/ministack/services/stepfunctions.py
+++ b/ministack/services/stepfunctions.py
@@ -39,12 +39,12 @@ from datetime import datetime, timezone
 from ministack.core.persistence import PERSIST_STATE, load_state
 from ministack.core.responses import (
     AccountScopedDict,
-    get_account_id,
     error_response_json,
+    get_account_id,
+    get_region,
     json_response,
     new_uuid,
     now_iso,
-    get_region,
 )
 
 logger = logging.getLogger("states")
@@ -1385,6 +1385,8 @@ def _invoke_resource(resource, input_data):
         return _invoke_activity(resource, input_data)
 
     if resource.startswith("arn:aws:states:::states:startExecution.sync"):
+        return _invoke_nested_start_execution_sync(resource, input_data)
+    if resource.startswith("arn:aws:states:::states:startExecution"):
         return _invoke_nested_start_execution(resource, input_data)
 
     # Service integration dispatch
@@ -2146,6 +2148,24 @@ def _parse_ts(v):
 
 
 def _invoke_nested_start_execution(resource, input_data):
+    """Start a nested Step Functions execution without waiting for completion."""
+    request = _nested_start_execution_request(input_data)
+    status, _, body = _start_execution(request)
+    payload = json.loads(body) if body else {}
+
+    if status >= 400:
+        raise _ExecutionError(
+            payload.get("__type", "States.Runtime"),
+            payload.get("message", "Nested execution failed to start"),
+        )
+
+    return {
+        "ExecutionArn": payload.get("executionArn"),
+        "StartDate": payload.get("startDate"),
+    }
+
+
+def _invoke_nested_start_execution_sync(resource, input_data):
     """Run a nested Step Functions execution and wait for the child result."""
     request = _nested_start_execution_request(input_data)
     status, _, body = _start_sync_execution(request)
@@ -2340,7 +2360,12 @@ _AWS_SDK_SERVICE_MAP = {
     # JSON-protocol services: use X-Amz-Target header
     "dynamodb": {"target_prefix": "DynamoDB_20120810", "protocol": "json"},
     "secretsmanager": {"target_prefix": "secretsmanager", "protocol": "json"},
-    "sfn": {"target_prefix": "AWSStepFunctions", "protocol": "json", "service_key": "states"},
+    "sfn": {
+        "target_prefix": "AWSStepFunctions",
+        "protocol": "json",
+        "service_key": "states",
+        "param_case": "lower-camel",
+    },
     "logs": {"target_prefix": "Logs_20140328", "protocol": "json"},
     "ssm": {"target_prefix": "AmazonSSM", "protocol": "json"},
     "eventbridge": {"target_prefix": "AWSEvents", "protocol": "json", "service_key": "events"},
@@ -2438,7 +2463,11 @@ def _dispatch_aws_sdk_json(service_info, service_name, action, input_data):
             f"Service '{service_key}' is not available in MiniStack",
         )
 
-    body = json.dumps(input_data)
+    if service_info.get("param_case") == "lower-camel":
+        wire_data = _convert_keys_to_camel(input_data or {})
+    else:
+        wire_data = input_data
+    body = json.dumps(wire_data)
     headers = {
         "x-amz-target": target,
         "content-type": "application/x-amz-json-1.0",
@@ -2706,6 +2735,7 @@ def _dispatch_aws_sdk_query(service_info, service_name, action, input_data):
     """Dispatch an aws-sdk integration call to a query-protocol MiniStack service."""
     import xml.etree.ElementTree as ET
     from urllib.parse import urlencode
+
     from ministack import app
 
     service_key = service_info.get("service_key", service_name)

--- a/tests/test_sfn.py
+++ b/tests/test_sfn.py
@@ -2,11 +2,13 @@ import io
 import json
 import os
 import time
+import uuid as _uuid_mod
 import zipfile
 from urllib.parse import urlparse
+
 import pytest
 from botocore.exceptions import ClientError
-import uuid as _uuid_mod
+
 
 def _make_zip(code: str) -> bytes:
     buf = io.BytesIO()
@@ -534,6 +536,99 @@ def test_sfn_aws_sdk_unknown_service_fails(sfn, sfn_sync):
     assert "neptune" in resp.get("cause", "").lower() or "neptune" in resp.get("error", "").lower()
 
     sfn_sync.delete_state_machine(stateMachineArn=sm_arn)
+
+
+def test_sfn_optimized_start_execution_returns_execution_arn(sfn, sfn_sync):
+    """Optimized states:startExecution returns the child ExecutionArn."""
+    suffix = _uuid_mod.uuid4().hex[:8]
+    child = sfn.create_state_machine(
+        name=f"sfn-child-opt-{suffix}",
+        definition=json.dumps({
+            "StartAt": "Done",
+            "States": {"Done": {"Type": "Pass", "End": True}},
+        }),
+        roleArn="arn:aws:iam::000000000000:role/R",
+    )
+    parent = sfn.create_state_machine(
+        name=f"sfn-parent-opt-{suffix}",
+        definition=json.dumps({
+            "StartAt": "Child",
+            "States": {
+                "Child": {
+                    "Type": "Task",
+                    "Resource": "arn:aws:states:::states:startExecution",
+                    "Parameters": {
+                        "StateMachineArn": child["stateMachineArn"],
+                        "Input": "{\"source\":\"optimized\"}",
+                    },
+                    "ResultPath": "$.child",
+                    "End": True,
+                },
+            },
+        }),
+        roleArn="arn:aws:iam::000000000000:role/R",
+    )
+
+    resp = sfn_sync.start_sync_execution(
+        stateMachineArn=parent["stateMachineArn"],
+        input="{}",
+    )
+    assert resp["status"] == "SUCCEEDED", f"Execution failed: {resp.get('error')} — {resp.get('cause')}"
+    output = json.loads(resp["output"])
+    child_arn = output["child"]["ExecutionArn"]
+    assert child_arn.startswith("arn:aws:states:us-east-1:000000000000:execution:sfn-child-opt-")
+    assert "StartDate" in output["child"]
+
+    sfn.describe_execution(executionArn=child_arn)
+    sfn_sync.delete_state_machine(stateMachineArn=parent["stateMachineArn"])
+    sfn_sync.delete_state_machine(stateMachineArn=child["stateMachineArn"])
+
+
+def test_sfn_aws_sdk_sfn_start_execution_accepts_pascal_case(sfn, sfn_sync):
+    """aws-sdk:sfn:startExecution accepts Step Functions PascalCase Parameters."""
+    suffix = _uuid_mod.uuid4().hex[:8]
+    child = sfn.create_state_machine(
+        name=f"sfn-child-sdk-{suffix}",
+        definition=json.dumps({
+            "StartAt": "Done",
+            "States": {"Done": {"Type": "Pass", "End": True}},
+        }),
+        roleArn="arn:aws:iam::000000000000:role/R",
+    )
+    parent = sfn.create_state_machine(
+        name=f"sfn-parent-sdk-{suffix}",
+        definition=json.dumps({
+            "StartAt": "Child",
+            "States": {
+                "Child": {
+                    "Type": "Task",
+                    "Resource": "arn:aws:states:::aws-sdk:sfn:startExecution",
+                    "Parameters": {
+                        "StateMachineArn": child["stateMachineArn"],
+                        "Input": "{\"source\":\"aws-sdk\"}",
+                    },
+                    "ResultPath": "$.child",
+                    "End": True,
+                },
+            },
+        }),
+        roleArn="arn:aws:iam::000000000000:role/R",
+    )
+
+    resp = sfn_sync.start_sync_execution(
+        stateMachineArn=parent["stateMachineArn"],
+        input="{}",
+    )
+    assert resp["status"] == "SUCCEEDED", f"Execution failed: {resp.get('error')} — {resp.get('cause')}"
+    output = json.loads(resp["output"])
+    child_arn = output["child"]["ExecutionArn"]
+    assert child_arn.startswith("arn:aws:states:us-east-1:000000000000:execution:sfn-child-sdk-")
+    assert "StartDate" in output["child"]
+
+    sfn.describe_execution(executionArn=child_arn)
+    sfn_sync.delete_state_machine(stateMachineArn=parent["stateMachineArn"])
+    sfn_sync.delete_state_machine(stateMachineArn=child["stateMachineArn"])
+
 
 def test_sfn_aws_sdk_rds_create_and_describe_cluster(sfn, sfn_sync):
     """aws-sdk:rds CreateDBCluster + DescribeDBClusters via query-protocol dispatch."""
@@ -2638,7 +2733,7 @@ def test_sfn_wait_scale_zero_does_not_timeout_lambda_tasks(sfn, lam):
         Handler="index.handler",
         Code={"ZipFile": _make_zip(code)},
     )
-    fn_arn = f"arn:aws:lambda:us-east-1:000000000000:function:sfn-timeout-test-fn"
+    fn_arn = "arn:aws:lambda:us-east-1:000000000000:function:sfn-timeout-test-fn"
 
     _set_wait_scale(0)
     try:


### PR DESCRIPTION
## Why
Step Functions child execution integrations should return child execution metadata, but MiniStack's optimized async `states:startExecution` path echoed the request payload and `aws-sdk:sfn:startExecution` rejected AWS-compatible PascalCase parameters.

## What
- Add async optimized `states:startExecution` dispatch that returns `ExecutionArn` and `StartDate`
- Convert `aws-sdk:sfn:*` PascalCase parameters to MiniStack's lower-camel Step Functions API shape
- Add regression coverage for both child execution integration paths
- Document the fix in the unreleased changelog

## Risk Assessment
Low to medium — this is scoped to Step Functions Task service integration dispatch. Existing `.sync` behavior is preserved by splitting it into a dedicated sync helper.

## References
- `MINISTACK_ENDPOINT=http://127.0.0.1:4666 .venv/bin/pytest tests/test_sfn.py -q` — 96 passed
- `.venv/bin/ruff check ministack/services/stepfunctions.py tests/test_sfn.py` — passed
- `git diff --check` — passed

Generated with Codex
