### PR TITLE
fix(glue): return null LocationUri when database has none

### DIFF
--- a/ministack/services/glue.py
+++ b/ministack/services/glue.py
@@ -192,7 +192,7 @@ def _create_database(data):
     _databases[name] = {
         "Name": name,
         "Description": db_input.get("Description", ""),
-        "LocationUri": db_input.get("LocationUri", ""),
+        "LocationUri": db_input.get("LocationUri"),
         "Parameters": db_input.get("Parameters", {}),
         "CreateTime": int(time.time()),
         "CatalogId": get_account_id(),

--- a/tests/test_glue.py
+++ b/tests/test_glue.py
@@ -59,6 +59,15 @@ def test_glue_crawler(glue):
     assert resp["Crawler"]["Name"] == "test-crawler"
     glue.start_crawler(Name="test-crawler")
 
+def test_glue_database_location_uri(glue):
+    glue.create_database(DatabaseInput={"Name": "db_no_location"})
+    resp = glue.get_database(Name="db_no_location")
+    assert resp["Database"].get("LocationUri") is None
+
+    glue.create_database(DatabaseInput={"Name": "db_with_location", "LocationUri": "s3://my-bucket/warehouse/"})
+    resp = glue.get_database(Name="db_with_location")
+    assert resp["Database"]["LocationUri"] == "s3://my-bucket/warehouse/"
+
 def test_glue_database_v2(glue):
     glue.create_database(DatabaseInput={"Name": "glue_db_v2", "Description": "v2 DB"})
     resp = glue.get_database(Name="glue_db_v2")


### PR DESCRIPTION
Glue's `CreateDatabase` was defaulting `LocationUri` to `""` when not provided. AWS and Localstack both return `null` in this case, and Iceberg relies on this — it checks `database.getLocationUri() == null` to detect a missing location ([GlueCatalog.java:299](https://github.com/apache/iceberg/blob/8ac703067a2adfae1928748712dc1d47dbc3c22b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java#L299)).

Fixes the default to `None` so it serialises as JSON `null`, and adds a test covering both the absent and present cases.