### PR TITLE
fix(s3): tighten virtual-hosted-bucket detection (post-#508 regression)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`_extract_s3_vhost_bucket` mis-classified non-S3 hostnames as S3 vhosts (regression from #508)** — the v1.3.18 rewrite accepted any `<word>.<rest>` host as a virtual-hosted bucket, which broke multi-service gateway setups: requests through sibling-Docker DNS names (`host.docker.internal`), mDNS (`service.local`), or any private CNAME got hijacked by the S3 handler and answered with 405 MethodNotAllowed. The canonical reproducer was an Aspire/Docker `terraform-apply` container hitting `STS:GetCallerIdentity` via `http://host.docker.internal:4566` (request fell into the S3 vhost path, S3 returned 405 for POST `/`). The function now requires the tail to look like an S3 endpoint: ends with `MINISTACK_HOST`, or first tail segment is `s3` / `s3-...` (covers AWS dot-region, dash-region, dualstack, FIPS, accelerate, website endpoints, plus the LocalStack-compat `bucket.localhost`). CNAME alias mode (AWS docs rule 3) and S3 Express One Zone remain unsupported — deliberate, the gateway shares port 4566 with all other services and the bug from #508 was that "any tail" hijacked them. 14 unit tests added covering both regression hosts and all positive S3 vhost shapes.
+
 ---
 
 ## [1.3.18] — 2026-04-28

--- a/ministack/app.py
+++ b/ministack/app.py
@@ -39,15 +39,27 @@ _EXECUTE_API_RE = re.compile(
 )
 # Virtual-hosted S3 bucket extraction. AWS-aligned per
 # docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html and
-# bucketnamingrules.html (HTTP vhost — ministack is HTTP). Works for any
-# endpoint hostname (localhost, ministack, custom Docker DNS, real AWS
-# domains) without hardcoding _MINISTACK_HOST.
+# bucketnamingrules.html (HTTP vhost — ministack is HTTP). The tail must
+# look like an S3 endpoint (s3 / s3-region segment) or end with the
+# configured _MINISTACK_HOST (LocalStack-compat: bucket.localhost). A bare
+# "<word>.<anything>" host is NOT treated as an S3 vhost — otherwise sibling
+# Docker DNS names like "host.docker.internal" or service names like
+# "service.local" would be mis-parsed as bucket="host" / "service" and
+# every non-S3 request reaching the gateway through such a hostname would
+# get hijacked by the S3 handler.
 _IPV4_RE = re.compile(r"^(?:\d{1,3}\.){3}\d{1,3}$")
 _BUCKET_LABEL_RE = re.compile(r"^[a-z0-9](?:[a-z0-9.\-]{1,61}[a-z0-9])$")
 
 
 def _extract_s3_vhost_bucket(host: str):
-    """Return the bucket if Host is virtual-hosted-style S3, else None."""
+    """Return the bucket if Host is virtual-hosted-style S3, else None.
+
+    Recognises:
+      - <bucket>.<MINISTACK_HOST>[:port]            (MiniStack-compat)
+      - <bucket>.s3.<anything>[:port]               (AWS standard vhost)
+      - <bucket>.s3-<region>.<anything>[:port]      (legacy AWS pattern)
+    Anything else falls through to generic routing.
+    """
     if not host:
         return None
     host = host.strip()
@@ -65,7 +77,12 @@ def _extract_s3_vhost_bucket(host: str):
         return None
     if ".." in candidate or _IPV4_RE.match(candidate):
         return None
-    return candidate
+    if tail == _MINISTACK_HOST or tail.endswith("." + _MINISTACK_HOST):
+        return candidate
+    first_tail_segment = tail.split(".", 1)[0]
+    if first_tail_segment == "s3" or first_tail_segment.startswith("s3-"):
+        return candidate
+    return None
 _S3_VHOST_EXCLUDE_RE = re.compile(r"\.(execute-api|alb|emr|efs|elasticache|s3-control)\.")
 _HEALTH_PATHS = ("/_ministack/health", "/_localstack/health", "/health")
 _BODY_METHODS = ("POST", "PUT", "PATCH")

--- a/tests/test_ministack.py
+++ b/tests/test_ministack.py
@@ -633,3 +633,86 @@ def test_persistence_s3_writes_state_after_ownership_and_public_access_block(tmp
     pers.save_state("roundtrip-bytes", state_with_bytes)
     loaded = pers.load_state("roundtrip-bytes")
     assert loaded["blob"] == b"\x00\x01\xff\xfe"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _extract_s3_vhost_bucket
+#
+# Regression coverage for the bug introduced in #508 where the function would
+# return the first dotted-host segment as a "bucket" for ANY hostname with a
+# dot. That caused sibling-container DNS names (host.docker.internal) and
+# private-net domains (foo.local, bar.example.com) to be hijacked by the S3
+# vhost handler, returning 405 MethodNotAllowed for legitimate non-S3 requests
+# (terraform-apply → STS:GetCallerIdentity is the canonical reproduction).
+# ---------------------------------------------------------------------------
+
+from ministack.app import _extract_s3_vhost_bucket
+
+
+class TestExtractS3VhostBucket:
+    """_extract_s3_vhost_bucket must accept real S3 vhost shapes only."""
+
+    # --- positives: real S3 vhost patterns ---
+
+    def test_bare_bucket_localhost(self):
+        assert _extract_s3_vhost_bucket("mybucket.localhost") == "mybucket"
+
+    def test_bare_bucket_localhost_with_port(self):
+        assert _extract_s3_vhost_bucket("mybucket.localhost:4566") == "mybucket"
+
+    def test_s3_segment_localhost(self):
+        assert _extract_s3_vhost_bucket("mybucket.s3.localhost") == "mybucket"
+
+    def test_s3_region_localhost(self):
+        assert _extract_s3_vhost_bucket("mybucket.s3.us-east-1.localhost") == "mybucket"
+
+    def test_s3_region_localhost_with_port(self):
+        assert _extract_s3_vhost_bucket("mybucket.s3.us-east-1.localhost:4566") == "mybucket"
+
+    def test_s3_aws_standard(self):
+        assert _extract_s3_vhost_bucket("mybucket.s3.amazonaws.com") == "mybucket"
+
+    def test_s3_aws_regional(self):
+        assert _extract_s3_vhost_bucket("mybucket.s3.us-west-2.amazonaws.com") == "mybucket"
+
+    def test_s3_aws_legacy_dash_region(self):
+        assert _extract_s3_vhost_bucket("mybucket.s3-us-east-1.amazonaws.com") == "mybucket"
+
+    def test_s3_dotted_bucket_name(self):
+        # Dotted bucket names: only the first label is captured (consistent
+        # with the existing behaviour codified in PR #504 tests).
+        assert _extract_s3_vhost_bucket("my-bucket.s3.amazonaws.com") == "my-bucket"
+
+    # --- negatives: not S3 vhosts, must NOT be claimed by the S3 handler ---
+
+    def test_host_docker_internal_not_vhost(self):
+        # Regression for the Aspire/Docker-Desktop case: terraform-apply
+        # container reaches the gateway via host.docker.internal:4566 and
+        # was getting 405 MethodNotAllowed because "host" was returned as
+        # bucket and S3 then refused POST / on a non-existent bucket.
+        assert _extract_s3_vhost_bucket("host.docker.internal") is None
+        assert _extract_s3_vhost_bucket("host.docker.internal:4566") is None
+
+    def test_service_local_not_vhost(self):
+        # mDNS / Bonjour-style hostnames common in dev environments.
+        assert _extract_s3_vhost_bucket("printer.local") is None
+        assert _extract_s3_vhost_bucket("api.local:4566") is None
+
+    def test_random_external_domain_not_vhost(self):
+        assert _extract_s3_vhost_bucket("api.example.com") is None
+        assert _extract_s3_vhost_bucket("internal.corp.example") is None
+
+    def test_bare_s3_host_not_vhost(self):
+        # Path-style S3 endpoints (no bucket label) must return None.
+        assert _extract_s3_vhost_bucket("s3.amazonaws.com") is None
+        assert _extract_s3_vhost_bucket("s3.us-east-1.amazonaws.com") is None
+        assert _extract_s3_vhost_bucket("s3.localhost") is None
+        assert _extract_s3_vhost_bucket("s3.us-east-1.localhost") is None
+
+    def test_empty_or_invalid_host(self):
+        assert _extract_s3_vhost_bucket("") is None
+        assert _extract_s3_vhost_bucket(None) is None
+        assert _extract_s3_vhost_bucket("localhost") is None  # no dot
+        assert _extract_s3_vhost_bucket("[::1]") is None  # IPv6 literal
+        assert _extract_s3_vhost_bucket("127.0.0.1") is None
+        assert _extract_s3_vhost_bucket("127.0.0.1:4566") is None


### PR DESCRIPTION
### Summary

After #508, `_extract_s3_vhost_bucket` treated too many `Host` values as S3 virtual-hosted buckets (`<label>.<anything>`). Requests that are **not** S3 — for example **STS** `GetCallerIdentity` when the client sends **`Host: host.docker.internal:<port>`** (common for Docker / Aspire hitting the gateway on the host) — were routed to the S3 handler and returned **`405 MethodNotAllowed`**.

This branch **requires the host tail to look like an S3 endpoint**: it ends with `MINISTACK_HOST`, or the first segment of the tail is `s3` / `s3-*` (covering regional, dualstack, FIPS, accelerate, website-style hostnames and `bucket.localhost` compatibility). Non-S3 hosts like `host.docker.internal`, `*.local`, and arbitrary domains are no longer misclassified.

### What changed

- `ministack/app.py` — `_extract_s3_vhost_bucket` logic
- `tests/test_ministack.py` — `TestExtractS3VhostBucket` (unit coverage for positive and negative cases)
- **CHANGELOG.md** — fixed / unreleased entry

### How to test

```powershell
$py = git diff main...HEAD --name-only -- ministack/ | Where-Object { $_ -match '\.py$' }
if ($py) { ruff check @py }

pytest tests/test_ministack.py::TestExtractS3VhostBucket -v --tb=short
# Optional integration: MiniStack must be listening (e.g. GATEWAY_PORT=4566). POST to loopback but set Host like Docker clients do:
# curl.exe ... "http://127.0.0.1:4566/" -H "Host: host.docker.internal:4566" ...  → expect 200, not 405
```

### Optional: reproduction for reviewers (`<details>`)

Place this block at the **bottom** of the PR body so the summary stays short.

<details>
<summary>Repro: STS via <code>host.docker.internal</code> returned 405 before fix</summary>

**Before:** With MiniStack on the gateway port, a client that used **`Host: host.docker.internal:4566`** (typical for Docker → host, or Aspire/terraform containers) could get S3’s **`405 MethodNotAllowed`** because that hostname was mis-parsed as a virtual-hosted bucket named `host`.

**After:** The same `Host` is **not** treated as S3 vhost; STS handles **`GetCallerIdentity`** and returns **`200`**.

**Why the old one-liner failed from PowerShell on the host:** `curl.exe http://host.docker.internal:4566/` tries to open a TCP connection *to* `host.docker.internal`. On the host that name may not reach your MiniStack process (nothing listening there, or name not wired like inside a container). The bug is about the **`Host` HTTP header**, not about using that name as the connect URL.

**Minimal check** (MiniStack running, default port `4566` — change both URL port and `Host:` if you use `GATEWAY_PORT` elsewhere):

```powershell
curl.exe -sS -w "`nHTTP %{http_code}`n" -X POST "http://127.0.0.1:4566/" `
  -H "Host: host.docker.internal:4566" `
  -H "Content-Type: application/x-www-form-urlencoded" `
  -H "X-Amz-Date: 20260428T120000Z" `
  -d "Action=GetCallerIdentity&Version=2011-06-15"
```

Expect **HTTP 200** and STS XML — not an S3 `MethodNotAllowed` error body.

**From inside a Linux container** (`--network=host` or similar), connecting to `http://host.docker.internal:4566/` can still be valid because there the hostname resolves to the host running MiniStack.

</details>

### PR checklist

- [ ] No new service file
- [x] Gateway / routing behaviour corrected in `ministack/app.py`
- [x] Unit tests added (`tests/test_ministack.py`)
- [x] Ruff: **no new** issues in `ministack/` `.py` files this PR changes (scoped check vs `main`; see **Ruff / lint** above)
- [ ] **README.md** — N/A
- [x] **CHANGELOG.md** updated