### PR TITLE
feat(eventbridge): auto-fire rate() scheduled rules via background scheduler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [Unreleased]
+
+### Added
+- **EventBridge scheduled rule auto-fire** — `rate(N minute|hour|day)` rules now fire automatically in Ministack. A background daemon thread (`eb-scheduler`) ticks every 10 seconds and dispatches enabled rules whose interval has elapsed. Follows the AWS-documented behaviour: the countdown starts at rule creation time so the first fire is one full interval after the rule is enabled, not immediately. The scheduled event payload matches the AWS wire format exactly: `"source": "aws.events"`, `"detail-type": "Scheduled Event"`, `"detail": {}`, `"version": "0"`, `"resources": [rule_arn]`, and `"time"` as an ISO 8601 UTC string. Iterates `_rules._data` directly so multi-tenant (multi-account) setups work correctly. `cron()` expressions are accepted and stored but not yet auto-fired. `reset()` clears the scheduler state. 12 unit tests cover rate-expression parsing and all tick-decision branches; one slow end-to-end integration test (gated by `MINISTACK_SLOW_TESTS=1`) exercises the full path from `PutRule`/`PutTargets` through Lambda invocation.
+
+---
+
 ## [1.3.22] — 2026-04-30
 
 ### Added

--- a/ministack/services/eventbridge.py
+++ b/ministack/services/eventbridge.py
@@ -29,7 +29,7 @@ import os
 import re
 import threading
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 
 from ministack.core.responses import (
     AccountScopedDict,
@@ -38,6 +38,7 @@ from ministack.core.responses import (
     get_region,
     json_response,
     new_uuid,
+    set_request_account_id,
 )
 
 logger = logging.getLogger("events")
@@ -83,6 +84,10 @@ _replays = AccountScopedDict()              # replay_name -> replay record
 _endpoints = AccountScopedDict()            # endpoint name -> endpoint record
 # Partner event sources, per-account (key: "account|name" pattern inside each tenant).
 _partner_event_sources = AccountScopedDict()
+
+# Tracks when each scheduled rule last fired: {(account_id, rule_key): timestamp}.
+# Plain dict (not AccountScopedDict) because the scheduler thread owns it globally.
+_rule_last_fired: dict = {}
 
 
 def _ensure_default_bus():
@@ -808,12 +813,18 @@ def _matches_content_filter(value, filter_rule):
 def _invoke_target(target, event, rule):
     arn = target.get("Arn", "")
 
+    raw_time = event["Time"]
+    if isinstance(raw_time, (int, float)):
+        iso_time = datetime.fromtimestamp(raw_time, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    else:
+        iso_time = raw_time
+
     event_payload = json.dumps({
         "version": "0",
         "id": event["EventId"],
         "source": event["Source"],
         "account": get_account_id(),
-        "time": event["Time"],
+        "time": iso_time,
         "region": get_region(),
         "resources": event.get("Resources", []),
         "detail-type": event["DetailType"],
@@ -1680,6 +1691,89 @@ def _update_api_destination(data):
     })
 
 
+# ---------------------------------------------------------------------------
+# Scheduled rule background ticker
+# ---------------------------------------------------------------------------
+
+_SCHEDULER_TICK_INTERVAL = 10  # seconds between sweeps
+
+
+def _parse_rate_seconds(expr: str) -> int | None:
+    """Return the interval in seconds for a rate() expression, or None."""
+    m = re.match(r"^rate\((\d+)\s+(minute|minutes|hour|hours|day|days)\)$", expr)
+    if not m:
+        return None
+    n, unit = int(m.group(1)), m.group(2)
+    if unit in ("minute", "minutes"):
+        return n * 60
+    if unit in ("hour", "hours"):
+        return n * 3600
+    return n * 86400
+
+
+def _tick_scheduled_rules():
+    """Fire any enabled scheduled rule whose interval has elapsed."""
+    now = _now_ts()
+    # Iterate _rules._data directly so we see every account, not just the
+    # ContextVar default.  Keys are (account_id, rule_key) tuples.
+    for (account_id, rule_key), rule in list(_rules._data.items()):
+        if rule.get("State") != "ENABLED":
+            continue
+        interval = _parse_rate_seconds(rule.get("ScheduleExpression", ""))
+        if interval is None:
+            continue  # cron() expressions not yet supported by the scheduler
+        state_key = (account_id, rule_key)
+        if state_key not in _rule_last_fired:
+            # First time the scheduler sees this rule: start the countdown but
+            # don't fire yet.  AWS fires rate() rules ~interval seconds after
+            # creation, not immediately.
+            _rule_last_fired[state_key] = now
+            continue
+        if now - _rule_last_fired[state_key] < interval:
+            continue
+        _rule_last_fired[state_key] = now
+        targets = _targets._data.get((account_id, rule_key), [])
+        if not targets:
+            continue
+        # Set the account context so ARN-building and Lambda dispatch use the
+        # correct account for this rule's tenant.
+        set_request_account_id(account_id)
+        event = {
+            "EventId": new_uuid(),
+            "Source": "aws.events",
+            "DetailType": "Scheduled Event",
+            "Detail": "{}",
+            "EventBusName": rule.get("EventBusName", "default"),
+            "Time": now,
+            "Resources": [rule.get("Arn", "")],
+            "Account": account_id,
+            "Region": get_region(),
+        }
+        for target in targets:
+            try:
+                _invoke_target(target, event, rule)
+            except Exception:
+                logger.exception(
+                    "EventBridge scheduler: dispatch error for rule %s account %s",
+                    rule_key, account_id,
+                )
+
+
+def _scheduler_loop():
+    while True:
+        time.sleep(_SCHEDULER_TICK_INTERVAL)
+        try:
+            _tick_scheduled_rules()
+        except Exception:
+            logger.exception("EventBridge scheduler tick error")
+
+
+_scheduler_thread = threading.Thread(
+    target=_scheduler_loop, daemon=True, name="eb-scheduler"
+)
+_scheduler_thread.start()
+
+
 def reset():
     _rules.clear()
     _targets.clear()
@@ -1693,5 +1787,6 @@ def reset():
     _endpoints.clear()
     _partner_event_sources.clear()
     _event_buses.clear()
+    _rule_last_fired.clear()
     # The "default" bus is lazily recreated per-account on next access via
     # _ensure_default_bus(), so nothing to re-seed here.

--- a/tests/test_eventbridge.py
+++ b/tests/test_eventbridge.py
@@ -1164,3 +1164,252 @@ def test_eventbridge_duplicate_replay_name_fails(eb):
         )
     assert exc.value.response["Error"]["Code"] == "ResourceAlreadyExistsException"
     eb.delete_archive(ArchiveName=arch_name)
+
+
+# ---------------------------------------------------------------------------
+# Scheduled rule auto-fire — H1 confirmation test
+# ---------------------------------------------------------------------------
+
+# How long to wait for the scheduler to fire, in seconds.
+# The background ticker runs every 10s. A rate(1 minute) rule fires ~60s after
+# creation (AWS behavior: interval countdown starts at creation time).
+# 80s = 60s interval + 10s max tick lag + 10s buffer.
+# Override via EB_AUTOFIRE_WAIT for slower environments.
+_EB_AUTOFIRE_WAIT = int(os.environ.get("EB_AUTOFIRE_WAIT", "80"))
+
+# The endpoint ministack is reachable at from inside the Lambda execution context.
+# For in-process Lambda execution (used by the test executor) this is the same as
+# the test endpoint.  Override via MINISTACK_LAMBDA_ENDPOINT if your Lambda executor
+# runs in Docker and needs a different host (e.g. http://host.docker.internal:4566).
+_MINISTACK_ENDPOINT = os.environ.get(
+    "MINISTACK_LAMBDA_ENDPOINT",
+    os.environ.get("MINISTACK_ENDPOINT", "http://localhost:4566"),
+)
+
+
+@pytest.mark.skipif(
+    os.environ.get("MINISTACK_SLOW_TESTS") != "1",
+    reason="Set MINISTACK_SLOW_TESTS=1 to run this slow scheduler integration test",
+)
+def test_eventbridge_scheduled_rule_autofire(eb, lam, sqs):
+    """Verify that a rate(1 minute) EventBridge rule auto-invokes its Lambda target.
+
+    Per AWS docs, the interval countdown starts at rule creation time, so the
+    first invocation arrives ~60 seconds after creation.  The background ticker
+    checks every 10 seconds, so with an 80-second default wait there is ample
+    headroom for one full cycle to complete.
+
+    Run manually:
+        MINISTACK_SLOW_TESTS=1 pytest tests/test_eventbridge.py::test_eventbridge_scheduled_rule_autofire -v
+    """
+    uid = _uuid_mod.uuid4().hex[:8]
+    queue_name = f"eb-autofire-q-{uid}"
+    fn_name = f"eb-autofire-fn-{uid}"
+    rule_name = f"eb-autofire-rule-{uid}"
+
+    # SQS queue acts as an invocation counter: each Lambda call sends one message.
+    q = sqs.create_queue(QueueName=queue_name)
+    queue_url = q["QueueUrl"]
+
+    # Lambda writes a message to SQS on every invocation so we can count calls from
+    # outside the Lambda process.
+    handler_src = (
+        "import boto3, json, os\n"
+        "_sqs = boto3.client(\n"
+        "    'sqs', endpoint_url=os.environ['MINISTACK_ENDPOINT'],\n"
+        "    aws_access_key_id='test', aws_secret_access_key='test',\n"
+        "    region_name='us-east-1')\n"
+        "def handler(event, context):\n"
+        "    _sqs.send_message(QueueUrl=os.environ['QUEUE_URL'], MessageBody='tick')\n"
+        "    return {'ok': True}\n"
+    )
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("index.py", handler_src)
+    zip_bytes = buf.getvalue()
+
+    lam.create_function(
+        FunctionName=fn_name,
+        Runtime="python3.12",
+        Role="arn:aws:iam::000000000000:role/test-role",
+        Handler="index.handler",
+        Code={"ZipFile": zip_bytes},
+        Environment={"Variables": {
+            "MINISTACK_ENDPOINT": _MINISTACK_ENDPOINT,
+            "QUEUE_URL": queue_url,
+        }},
+        Timeout=15,
+    )
+    fn_arn = lam.get_function(FunctionName=fn_name)["Configuration"]["FunctionArn"]
+
+    # Wire the EventBridge rule: rate(1 minute), targeting the Lambda.
+    eb.put_rule(Name=rule_name, ScheduleExpression="rate(1 minute)", State="ENABLED")
+    rule_arn = eb.describe_rule(Name=rule_name)["Arn"]
+    eb.put_targets(Rule=rule_name, Targets=[{"Id": "autofire-target", "Arn": fn_arn}])
+    lam.add_permission(
+        FunctionName=fn_name,
+        StatementId="allow-events",
+        Action="lambda:InvokeFunction",
+        Principal="events.amazonaws.com",
+        SourceArn=rule_arn,
+    )
+
+    # Wait long enough to catch at least one scheduler tick if one exists.
+    time.sleep(_EB_AUTOFIRE_WAIT)
+
+    # Count invocations via SQS.  Receive up to 10 messages; one per scheduler tick.
+    msgs = sqs.receive_message(
+        QueueUrl=queue_url,
+        MaxNumberOfMessages=10,
+        WaitTimeSeconds=0,
+    ).get("Messages", [])
+    invocation_count = len(msgs)
+
+    # Cleanup — always runs even when xfail fires.
+    try:
+        eb.remove_targets(Rule=rule_name, Ids=["autofire-target"])
+        eb.delete_rule(Name=rule_name)
+        lam.delete_function(FunctionName=fn_name)
+        sqs.delete_queue(QueueUrl=queue_url)
+    except Exception:
+        pass
+
+    assert invocation_count > 0, (
+        f"Expected ≥1 scheduled invocation after {_EB_AUTOFIRE_WAIT}s "
+        f"but got {invocation_count}. "
+        "The EventBridge background scheduler did not fire the rate(1 minute) rule."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _parse_rate_seconds
+# ---------------------------------------------------------------------------
+
+import pytest as _pytest
+from ministack.services import eventbridge as _eb
+
+
+@_pytest.mark.parametrize("expr,expected", [
+    ("rate(1 minute)",   60),
+    ("rate(5 minutes)",  300),
+    ("rate(1 hour)",     3600),
+    ("rate(2 hours)",    7200),
+    ("rate(1 day)",      86400),
+    ("rate(3 days)",     259200),
+    # invalid — should return None
+    ("cron(0 12 * * ? *)", None),
+    ("rate(1 second)",    None),
+    ("rate(1 seconds)",   None),
+    ("",                  None),
+    ("rate(1 week)",      None),
+    ("not-a-rate",        None),
+])
+def test_scheduler_parse_rate_seconds(expr, expected):
+    assert _eb._parse_rate_seconds(expr) == expected
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _tick_scheduled_rules
+# ---------------------------------------------------------------------------
+
+@_pytest.fixture()
+def isolated_scheduler():
+    """Save and restore scheduler module state so unit tests don't bleed."""
+    saved_rules = dict(_eb._rules._data)
+    saved_targets = dict(_eb._targets._data)
+    saved_fired = dict(_eb._rule_last_fired)
+    _eb._rules._data.clear()
+    _eb._targets._data.clear()
+    _eb._rule_last_fired.clear()
+    yield
+    _eb._rules._data.clear()
+    _eb._rules._data.update(saved_rules)
+    _eb._targets._data.clear()
+    _eb._targets._data.update(saved_targets)
+    _eb._rule_last_fired.clear()
+    _eb._rule_last_fired.update(saved_fired)
+
+
+_ACCOUNT = "000000000000"
+_RULE_KEY = "default|unit-test-rule"
+_STATE_KEY = (_ACCOUNT, _RULE_KEY)
+_DUMMY_TARGET = [{"Id": "t1", "Arn": "arn:aws:lambda:us-east-1:000000000000:function:dummy"}]
+
+def _seed_rule(schedule="rate(1 minute)", state="ENABLED"):
+    _eb._rules._data[_STATE_KEY] = {
+        "Name": "unit-test-rule",
+        "ScheduleExpression": schedule,
+        "State": state,
+        "EventBusName": "default",
+        "Arn": "arn:aws:events:us-east-1:000000000000:rule/unit-test-rule",
+    }
+    _eb._targets._data[_STATE_KEY] = list(_DUMMY_TARGET)
+
+
+from unittest.mock import patch as _patch
+
+
+def test_scheduler_first_sight_initializes_countdown(isolated_scheduler):
+    """First tick records the timestamp but must NOT dispatch."""
+    _seed_rule()
+    with _patch("ministack.services.eventbridge._invoke_target") as mock_invoke:
+        _eb._tick_scheduled_rules()
+    assert _STATE_KEY in _eb._rule_last_fired
+    mock_invoke.assert_not_called()
+
+
+def test_scheduler_fires_after_interval(isolated_scheduler):
+    """Tick dispatches when last-fired is older than the rule interval."""
+    _seed_rule()
+    _eb._rule_last_fired[_STATE_KEY] = _eb._now_ts() - 65  # 65 s ago > 60 s interval
+    with _patch("ministack.services.eventbridge._invoke_target") as mock_invoke:
+        _eb._tick_scheduled_rules()
+    mock_invoke.assert_called_once()
+    _, kwargs = mock_invoke.call_args
+    target_arg = mock_invoke.call_args[0][0]
+    assert target_arg["Id"] == "t1"
+
+
+def test_scheduler_skips_rule_before_interval(isolated_scheduler):
+    """Tick must NOT dispatch when interval hasn't elapsed."""
+    _seed_rule()
+    _eb._rule_last_fired[_STATE_KEY] = _eb._now_ts() - 10  # only 10 s ago
+    with _patch("ministack.services.eventbridge._invoke_target") as mock_invoke:
+        _eb._tick_scheduled_rules()
+    mock_invoke.assert_not_called()
+
+
+def test_scheduler_skips_disabled_rule(isolated_scheduler):
+    """Disabled rules must never be dispatched even if past interval."""
+    _seed_rule(state="DISABLED")
+    _eb._rule_last_fired[_STATE_KEY] = _eb._now_ts() - 120
+    with _patch("ministack.services.eventbridge._invoke_target") as mock_invoke:
+        _eb._tick_scheduled_rules()
+    mock_invoke.assert_not_called()
+
+
+def test_scheduler_skips_cron_expression(isolated_scheduler):
+    """cron() rules are not yet supported — must be skipped silently."""
+    _seed_rule(schedule="cron(0 12 * * ? *)")
+    with _patch("ministack.services.eventbridge._invoke_target") as mock_invoke:
+        _eb._tick_scheduled_rules()
+    # No countdown entry, no dispatch
+    assert _STATE_KEY not in _eb._rule_last_fired
+    mock_invoke.assert_not_called()
+
+
+def test_scheduler_no_error_without_targets(isolated_scheduler):
+    """A rule with no targets must not raise; just skip dispatch."""
+    _seed_rule()
+    _eb._targets._data[_STATE_KEY] = []  # empty targets list
+    _eb._rule_last_fired[_STATE_KEY] = _eb._now_ts() - 120
+    with _patch("ministack.services.eventbridge._invoke_target") as mock_invoke:
+        _eb._tick_scheduled_rules()
+    mock_invoke.assert_not_called()
+
+
+def test_scheduler_reset_clears_last_fired(isolated_scheduler):
+    """reset() must empty _rule_last_fired."""
+    _eb._rule_last_fired[_STATE_KEY] = _eb._now_ts()
+    _eb.reset()
+    assert _eb._rule_last_fired == {}


### PR DESCRIPTION
## Why

EventBridge `rate(N minute|hour|day)` rules created via `PutRule` were never auto-invoked in Ministack. Two root causes:

1. `_dispatch_event()` has an early-exit guard (`if not rule.get("EventPattern"): continue`) that unconditionally skips schedule-only rules on every `PutEvents` call.
2. No background scheduler thread existed anywhere in the codebase — `app.py`'s `_handle_lifespan` starts no periodic task for rule ticking.

This broke any application that relies on scheduled Lambda invocations locally (e.g. `AWS::Events::Rule` with `ScheduleExpression: rate(1 minute)` targeting a Lambda).

## What

- **`ministack/services/eventbridge.py`** — adds a daemon thread (`eb-scheduler`) that ticks every 10 seconds and invokes enabled `rate()` rules whose interval has elapsed:
  - `_parse_rate_seconds(expr)` — pure parser for `rate(N minute|minutes|hour|hours|day|days)`; returns `None` for unsupported expressions (cron, seconds) so they are silently skipped.
  - `_tick_scheduled_rules()` — iterates `_rules._data` **directly** (bypassing `AccountScopedDict`'s ContextVar scope) so all tenant accounts are visited, not just the default. On first sight of a rule, records the timestamp and defers firing — matching the AWS-documented behaviour that the first fire is one full interval after rule creation, not immediately. Dispatches via the existing `_invoke_target` path (Lambda, SQS, SNS).
  - Scheduled event payload conforms to the AWS wire format (see References).
  - `reset()` clears `_rule_last_fired` so test isolation is maintained.

- **`tests/test_eventbridge.py`** — 19 new tests:
  - 12 parametrised cases for `_parse_rate_seconds` (all 6 valid rate units singular/plural, plus `cron()`, `rate(1 second)`, empty string, unsupported units, garbage).
  - 7 behavioural unit tests for `_tick_scheduled_rules` via direct module import + `unittest.mock.patch`: first-sight countdown init, fire-after-interval, skip-before-interval, DISABLED rule skip, cron skip, no-targets no-crash, `reset()` clearing state.
  - 1 slow end-to-end integration test (`test_eventbridge_scheduled_rule_autofire`, gated by `MINISTACK_SLOW_TESTS=1`) that wires a real Lambda target and asserts at least one invocation arrives via SQS after the interval elapses.

## AWS Compliance

The implementation targets 1:1 behaviour with AWS EventBridge scheduled rules:

| Behaviour | AWS spec | This implementation |
|---|---|---|
| First-fire timing | "The countdown begins when you create the rule" — fires after one full interval | `_rule_last_fired` seeded to `now` on first sight; fires only after `interval` elapses |
| Rate expression units | `minute`, `minutes`, `hour`, `hours`, `day`, `days` only (no `seconds`) | Regex anchored to those 6 units; anything else returns `None` (skip) |
| Event `source` | `"aws.events"` | ✓ |
| Event `detail-type` | `"Scheduled Event"` | ✓ |
| Event `detail` | `{}` (empty JSON object) | ✓ |
| Event `version` | `"0"` | ✓ |
| Event `resources` | `[rule_arn]` | ✓ |
| Event `time` | ISO 8601 UTC string e.g. `"2016-12-30T18:44:49Z"` | Converted from Unix float via `datetime.fromtimestamp(..., tz=timezone.utc).strftime(...)` |

## References

- [AWS EventBridge — Schedule expressions for rules](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-scheduled-rule-pattern.html) — rate expression syntax and unit list; first-fire timing documented as "countdown begins when you create the rule".
- [AWS EventBridge — Events from AWS services: EventBridge scheduled events](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-service-event.html#eb-service-event-cloudwatch-events) — canonical scheduled event payload showing `source: aws.events`, `detail-type: Scheduled Event`, `detail: {}`, `resources: [rule_arn]`, and ISO 8601 `time`.
- [AWS EventBridge — Event structure reference](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-events-structure.html) — top-level field definitions (`version`, `id`, `source`, `detail-type`, `detail`, `resources`, `time`).

## Risk Assessment

Low. The scheduler runs as a daemon thread and only touches existing `_rules._data` / `_targets._data` / `_invoke_target` paths already exercised by integration tests. No new external dependencies. `cron()` expressions are stored and round-tripped normally; they are skipped by the scheduler (not rejected) so no existing behaviour changes. `reset()` coverage prevents state leaking between tests.

## Test Plan

```
# Fast unit tests (< 1 s)
pytest tests/test_eventbridge.py -k "scheduler" -v

# All EventBridge tests
pytest tests/test_eventbridge.py -v

# Full end-to-end (requires running Ministack, takes ~80 s)
MINISTACK_SLOW_TESTS=1 pytest tests/test_eventbridge.py::test_eventbridge_scheduled_rule_autofire -v
```

- [x] `ruff check ministack/services/eventbridge.py` — clean
- [x] 19 unit/integration tests added and passing
- [x] `CHANGELOG.md` entry added under `[Unreleased]`