### PR TITLE
fix(opensearch): emit AWS-compatible VPC endpoint shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- **OpenSearch non-VPC domains omit empty `VPCOptions`** — `CreateDomain` / `DescribeDomain` previously returned `VPCOptions: {}` alongside `Endpoint`, causing Terraform AWS provider reads to classify the domain as VPC-backed and fail with `OpenSearch Domain in VPC expected to have null Endpoint value`. Non-VPC domains now omit `VPCOptions`; VPC-shaped domains return `Endpoints["vpc"]` instead of `Endpoint`.
+
+---
+
 ## [1.3.25] — 2026-05-03
 
 ### Added

--- a/ministack/services/opensearch.py
+++ b/ministack/services/opensearch.py
@@ -150,7 +150,10 @@ def _engine_type(version: str) -> str:
 
 def _public(d: dict) -> dict:
     """Strip internal _-prefixed bookkeeping fields before serialising."""
-    return {k: v for k, v in d.items() if not k.startswith("_")}
+    out = {k: v for k, v in d.items() if not k.startswith("_")}
+    if not out.get("VPCOptions"):
+        out.pop("VPCOptions", None)
+    return out
 
 
 def _now() -> int:
@@ -324,6 +327,47 @@ def _default_ebs_options(override=None):
     return base
 
 
+def _normalise_vpc_options(options):
+    if not isinstance(options, dict):
+        return None
+
+    subnet_ids = list(options.get("SubnetIds") or [])
+    security_group_ids = list(options.get("SecurityGroupIds") or [])
+    if not subnet_ids and not security_group_ids:
+        return None
+
+    out = dict(options)
+    out["SubnetIds"] = subnet_ids
+    out["SecurityGroupIds"] = security_group_ids
+    out.setdefault("VPCId", "vpc-ministack")
+    out.setdefault(
+        "AvailabilityZones",
+        [f"{get_region()}{chr(ord('a') + idx)}" for idx, _ in enumerate(subnet_ids or ["default"])],
+    )
+    return out
+
+
+def _set_vpc_options(rec: dict, options) -> None:
+    vpc_options = _normalise_vpc_options(options)
+    endpoint = rec.get("_Endpoint") or rec.get("Endpoint")
+    endpoints = rec.get("Endpoints") or {}
+    endpoint = endpoint or endpoints.get("vpc")
+
+    if vpc_options:
+        rec["VPCOptions"] = vpc_options
+        if endpoint:
+            rec["_Endpoint"] = endpoint
+            rec["Endpoints"] = {"vpc": endpoint}
+        rec.pop("Endpoint", None)
+        return
+
+    rec.pop("VPCOptions", None)
+    rec.pop("Endpoints", None)
+    if endpoint:
+        rec["_Endpoint"] = endpoint
+        rec["Endpoint"] = endpoint
+
+
 def _new_domain_record(name, payload):
     engine_version = payload.get("EngineVersion", _DEFAULT_VERSION)
     cluster_cfg = _default_cluster_config(payload.get("ClusterConfig"))
@@ -347,7 +391,6 @@ def _new_domain_record(name, payload):
         "EBSOptions": ebs_opts,
         "AccessPolicies": access_policies,
         "SnapshotOptions": {"AutomatedSnapshotStartHour": 0},
-        "VPCOptions": payload.get("VPCOptions", {}),
         "CognitoOptions": payload.get("CognitoOptions", {"Enabled": False}),
         "EncryptionAtRestOptions": payload.get(
             "EncryptionAtRestOptions", {"Enabled": False}
@@ -378,11 +421,13 @@ def _new_domain_record(name, payload):
         "ChangeProgressDetails": {},
         "OffPeakWindowOptions": {"Enabled": False},
         "SoftwareUpdateOptions": {"AutoSoftwareUpdateEnabled": False},
+        "_Endpoint": endpoint,
         "_CreatedTime": _now(),
         "_UpdatedTime": _now(),
         "_ContainerId": cid,
         "_DashboardsContainerId": dash_cid,
     }
+    _set_vpc_options(rec, payload.get("VPCOptions"))
     if dash_endpoint:
         rec["DashboardEndpoint"] = dash_endpoint
     return rec
@@ -407,13 +452,12 @@ def _domain_config(rec: dict) -> dict:
     def wrap(value):
         return {"Options": value, "Status": dict(status)}
 
-    return {
+    config = {
         "EngineVersion": wrap(rec["EngineVersion"]),
         "ClusterConfig": wrap(rec["ClusterConfig"]),
         "EBSOptions": wrap(rec["EBSOptions"]),
         "AccessPolicies": wrap(rec["AccessPolicies"]),
         "SnapshotOptions": wrap(rec["SnapshotOptions"]),
-        "VPCOptions": wrap(rec["VPCOptions"]),
         "CognitoOptions": wrap(rec["CognitoOptions"]),
         "EncryptionAtRestOptions": wrap(rec["EncryptionAtRestOptions"]),
         "NodeToNodeEncryptionOptions": wrap(rec["NodeToNodeEncryptionOptions"]),
@@ -425,6 +469,9 @@ def _domain_config(rec: dict) -> dict:
         "OffPeakWindowOptions": wrap(rec["OffPeakWindowOptions"]),
         "SoftwareUpdateOptions": wrap(rec["SoftwareUpdateOptions"]),
     }
+    if rec.get("VPCOptions"):
+        config["VPCOptions"] = wrap(rec["VPCOptions"])
+    return config
 
 
 # ---------------------------------------------------------------------------
@@ -526,7 +573,10 @@ def _update_domain_config(name, payload):
     }
     for k, v in payload.items():
         if k in updatable:
-            rec[k] = v
+            if k == "VPCOptions":
+                _set_vpc_options(rec, v)
+            else:
+                rec[k] = v
     rec["_UpdatedTime"] = _now()
 
     # Real AWS marks the domain Processing while config rollout happens; we

--- a/tests/test_opensearch.py
+++ b/tests/test_opensearch.py
@@ -133,6 +133,75 @@ def test_opensearch_describe_domain_config_wraps_options_status(os_client):
         os_client.delete_domain(DomainName=name)
 
 
+def test_opensearch_describe_omits_empty_vpc_options(os_client):
+    name = f"novpc-{_uid()}"
+    os_client.create_domain(DomainName=name)
+    try:
+        desc = os_client.describe_domain(DomainName=name)["DomainStatus"]
+        assert "VPCOptions" not in desc
+        assert desc["Endpoint"]
+        assert "Endpoints" not in desc
+
+        cfg = os_client.describe_domain_config(DomainName=name)["DomainConfig"]
+        assert "VPCOptions" not in cfg
+    finally:
+        os_client.delete_domain(DomainName=name)
+
+
+def test_opensearch_describe_domain_config_skips_unset_vpc_options(os_client):
+    name = f"dcfg-{_uid()}"
+    os_client.create_domain(DomainName=name)
+    try:
+        cfg = os_client.describe_domain_config(DomainName=name)["DomainConfig"]
+        assert "VPCOptions" not in cfg
+    finally:
+        os_client.delete_domain(DomainName=name)
+
+
+def test_opensearch_describe_with_vpc_returns_endpoints_map(os_client):
+    name = f"vpc-{_uid()}"
+    vpc_options = {
+        "SubnetIds": ["subnet-aaa", "subnet-bbb"],
+        "SecurityGroupIds": ["sg-1"],
+    }
+    rec = os_client.create_domain(DomainName=name, VPCOptions=vpc_options)["DomainStatus"]
+    try:
+        assert "Endpoint" not in rec
+        assert rec["Endpoints"]["vpc"]
+        assert rec["VPCOptions"]["SubnetIds"] == vpc_options["SubnetIds"]
+        assert rec["VPCOptions"]["SecurityGroupIds"] == vpc_options["SecurityGroupIds"]
+        assert rec["VPCOptions"]["VPCId"].startswith("vpc-")
+        assert rec["VPCOptions"]["AvailabilityZones"]
+
+        desc = os_client.describe_domain(DomainName=name)["DomainStatus"]
+        assert "Endpoint" not in desc
+        assert desc["Endpoints"]["vpc"] == rec["Endpoints"]["vpc"]
+    finally:
+        os_client.delete_domain(DomainName=name)
+
+
+def test_opensearch_update_domain_to_vpc_swaps_endpoint_shape(os_client):
+    name = f"uvpc-{_uid()}"
+    os_client.create_domain(DomainName=name)
+    try:
+        before = os_client.describe_domain(DomainName=name)["DomainStatus"]
+        assert before["Endpoint"]
+        assert "Endpoints" not in before
+
+        vpc_options = {
+            "SubnetIds": ["subnet-upd"],
+            "SecurityGroupIds": ["sg-upd"],
+        }
+        os_client.update_domain_config(DomainName=name, VPCOptions=vpc_options)
+
+        after = os_client.describe_domain(DomainName=name)["DomainStatus"]
+        assert "Endpoint" not in after
+        assert after["Endpoints"]["vpc"] == before["Endpoint"]
+        assert after["VPCOptions"]["SubnetIds"] == vpc_options["SubnetIds"]
+    finally:
+        os_client.delete_domain(DomainName=name)
+
+
 def test_opensearch_update_domain_config_persists(os_client):
     name = f"upd-{_uid()}"
     os_client.create_domain(DomainName=name)


### PR DESCRIPTION
## Summary

Fix OpenSearch domain response shape so non-VPC domains no longer emit an empty `VPCOptions` object. Terraform AWS provider treated `VPCOptions: {}` as a VPC-backed domain and failed because `Endpoint` was still populated.

For VPC-configured domains, the emulator now returns the AWS-compatible `Endpoints["vpc"]` shape instead of `Endpoint`.

## Changes

- Omit unset/empty `VPCOptions` from `CreateDomain`, `DescribeDomain`, and `DescribeDomainConfig`.
- Normalize configured VPC options and return `Endpoints["vpc"]` for VPC-shaped domains.
- Add regression coverage for non-VPC omission, VPC endpoint map, update-to-VPC behavior, and DomainConfig shape.

## Test Plan

- `pytest tests/test_opensearch.py -q`
  - `19 passed, 1 skipped`

## References
- Issue #548 