### PR TITLE
fix(apigateway-v1): add GetUsagePlanKey handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- **API Gateway v1 `GetUsagePlanKey` per-key read handler** — `GET /usageplans/{planId}/keys/{keyId}` was missing from the route dispatcher; only list/create/delete were registered, so the per-key path fell through to a 404. Terraform's AWS provider invokes `GetUsagePlanKey` immediately after `CreateUsagePlanKey` to confirm the resource exists, and the missing handler caused `aws_api_gateway_usage_plan_key` applies to abort with `reading API Gateway Usage Plan Key (...): couldn't find resource`. Added `_get_usage_plan_key(plan_id, key_id)` returning the stored entry on hit and `NotFoundException` on miss for either the plan id or the key id. Contributed by @marcin-nowak-scl.
+
+---
+
 ## [1.3.26] — 2026-05-04
 
 ### Added

--- a/ministack/services/apigateway_v1.py
+++ b/ministack/services/apigateway_v1.py
@@ -652,6 +652,8 @@ async def handle_request(method, path, headers, body, query_params):
                 if method == "POST":
                     return _create_usage_plan_key(plan_id, data)
             else:
+                if method == "GET":
+                    return _get_usage_plan_key(plan_id, sub_id)
                 if method == "DELETE":
                     return _delete_usage_plan_key(plan_id, sub_id)
         else:
@@ -1760,6 +1762,15 @@ def _get_usage_plan_keys(plan_id, query_params):
     if plan_id not in _usage_plans:
         return _v1_error("NotFoundException", "Invalid Usage Plan identifier specified", 404)
     return _v1_paginated_response(list(_usage_plan_keys.get(plan_id, {}).values()), query_params)
+
+
+def _get_usage_plan_key(plan_id, key_id):
+    if plan_id not in _usage_plans:
+        return _v1_error("NotFoundException", "Invalid Usage Plan identifier specified", 404)
+    plan_key = _usage_plan_keys.get(plan_id, {}).get(key_id)
+    if not plan_key:
+        return _v1_error("NotFoundException", "Invalid Usage Plan Key identifier specified", 404)
+    return _v1_response(plan_key, 200)
 
 
 def _delete_usage_plan_key(plan_id, key_id):

--- a/tests/test_apigatewayv1.py
+++ b/tests/test_apigatewayv1.py
@@ -1225,6 +1225,34 @@ def test_apigwv1_usage_plan_key_crud(apigw_v1):
     keys2 = apigw_v1.get_usage_plan_keys(usagePlanId=plan_id)["items"]
     assert not any(k["id"] == key_id for k in keys2)
 
+def test_apigwv1_get_usage_plan_key(apigw_v1):
+    """GetUsagePlanKey returns the per-key entry. The Terraform AWS provider
+    issues this call immediately after CreateUsagePlanKey to verify the
+    resource exists; before the handler was added the request fell through
+    to a 404 and aws_api_gateway_usage_plan_key applies aborted with
+    'couldn't find resource'."""
+    api_key = apigw_v1.create_api_key(name="qa-v1-gupk-key", enabled=True)
+    key_id = api_key["id"]
+    plan_id = apigw_v1.create_usage_plan(
+        name="qa-v1-gupk-plan",
+        throttle={"rateLimit": 100, "burstLimit": 200},
+    )["id"]
+    apigw_v1.create_usage_plan_key(usagePlanId=plan_id, keyId=key_id, keyType="API_KEY")
+
+    got = apigw_v1.get_usage_plan_key(usagePlanId=plan_id, keyId=key_id)
+    assert got["id"] == key_id
+    assert got["type"] == "API_KEY"
+
+    with pytest.raises(ClientError) as exc:
+        apigw_v1.get_usage_plan_key(usagePlanId=plan_id, keyId="missing-key-id")
+    assert exc.value.response["Error"]["Code"] == "NotFoundException"
+
+    with pytest.raises(ClientError) as exc:
+        apigw_v1.get_usage_plan_key(usagePlanId="missing-plan-id", keyId=key_id)
+    assert exc.value.response["Error"]["Code"] == "NotFoundException"
+
+    apigw_v1.delete_usage_plan_key(usagePlanId=plan_id, keyId=key_id)
+
 def test_apigwv1_created_date_is_unix_timestamp(apigw_v1):
     resp = apigw_v1.create_rest_api(name="tf-date-test")
     created = resp["createdDate"]


### PR DESCRIPTION
## Summary

`GET /usageplans/{planId}/keys/{keyId}` (the `GetUsagePlanKey` operation) was missing from the v1 control-plane dispatcher; only
`GET /usageplans/{planId}/keys`, `POST /usageplans/{planId}/keys`, and `DELETE /usageplans/{planId}/keys/{keyId}` were registered. The per-key path fell through to the default 404, so the Terraform AWS provider - which calls `GetUsagePlanKey` immediately after `CreateUsagePlanKey` to confirm the resource exists - aborted every `aws_api_gateway_usage_plan_key` apply with:

```
reading API Gateway Usage Plan Key (<id>): couldn't find resource
```

even though the entry was correctly stored in `_usage_plan_keys[plan_id][key_id]`.

Closes #555.

## Changes
- New `_get_usage_plan_key(plan_id, key_id)` mirroring the existing `_get_usage_plan_keys` shape: `NotFoundException` (404) if the plan id is unknown, `NotFoundException` (404) if the key id is unknown within the plan, `200` with the stored `plan_key` dict on hit.
- New `test_apigwv1_get_usage_plan_key` exercising the happy path plus both 404 branches (unknown plan, unknown key). Uses the existing `apigw_v1` boto3 fixture; no new test infrastructure.

## Verification

```
python -m pytest tests/test_apigatewayv1.py::test_apigwv1_get_usage_plan_key -v
```

## References
- Issue #555 