### PR TITLE
fix(apigateway-v1): substitute path params and forward query string in HTTP_PROXY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- **API Gateway v1 HTTP_PROXY path-parameter substitution and query-string forwarding** — `_invoke_http_proxy_v1` ignored `integration.requestParameters` mappings (so `{paramName}` placeholders in the integration `uri` were forwarded literally), appended the inbound execute path to the integration URI, and dropped the request query string. Real AWS HTTP_PROXY substitutes `{paramName}` from `integration.request.path.X = method.request.path.X` mappings (and `{proxy}` for greedy `{proxy+}` resources), uses the substituted URI as the complete upstream URL, and forwards the query string. Terraform `aws_api_gateway_integration` configurations of the form `uri = ".../resource/{id}"` + `integration.request.path.id = method.request.path.id` now reach the upstream with the correct URL.
+
+---
+
 ## [1.3.26] — 2026-05-04
 
 ### Added

--- a/ministack/services/apigateway_v1.py
+++ b/ministack/services/apigateway_v1.py
@@ -76,6 +76,7 @@ import os
 import re
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 
 from ministack.core.responses import AccountScopedDict, get_account_id, get_region, new_uuid
@@ -889,7 +890,9 @@ async def handle_execute(api_id, stage_name, method, path, headers, body, query_
             headers, body, query_params, path_params
         )
     elif int_type in ("HTTP_PROXY", "HTTP"):
-        return await _invoke_http_proxy_v1(integration, path, method, headers, body, query_params)
+        return await _invoke_http_proxy_v1(
+            integration, path, method, headers, body, query_params, path_params
+        )
     elif int_type == "MOCK":
         return _invoke_mock_v1(integration)
     else:
@@ -974,12 +977,41 @@ async def _invoke_lambda_proxy_v1(integration, api_id, stage_name, stage, resour
     return status, resp_headers, resp_body
 
 
-async def _invoke_http_proxy_v1(integration, path, method, headers, body, query_params):
+async def _invoke_http_proxy_v1(integration, path, method, headers, body, query_params, path_params=None):
     """Forward a request to an HTTP backend."""
     uri = integration.get("uri", "")
-    url = uri.rstrip("/") + path
+    req_params = integration.get("requestParameters", {})
+    path_params = path_params or {}
 
-    req = urllib.request.Request(url, data=body or None, method=method)
+    for dest, src in req_params.items():
+        if not dest.startswith("integration.request.path."):
+            continue
+
+        placeholder = "{" + dest[len("integration.request.path."):] + "}"
+        value = ""
+        if isinstance(src, str):
+            if src.startswith("'") and src.endswith("'"):
+                value = src[1:-1]
+            elif src.startswith("method.request.path."):
+                value = path_params.get(src[len("method.request.path."):], "")
+
+        uri = uri.replace(placeholder, value)
+
+    if "{proxy}" in uri:
+        uri = uri.replace("{proxy}", path_params.get("proxy", ""))
+
+    if query_params:
+        flat_query = []
+        for key, value in query_params.items():
+            values = value if isinstance(value, list) else [value]
+            for item in values:
+                flat_query.append((key, item))
+
+        query_string = urllib.parse.urlencode(flat_query)
+        if query_string:
+            uri = uri + ("&" if "?" in uri else "?") + query_string
+
+    req = urllib.request.Request(uri, data=body or None, method=method)
     for k, v in headers.items():
         if k.lower() not in ("host", "content-length"):
             req.add_header(k, v)

--- a/tests/test_apigatewayv1.py
+++ b/tests/test_apigatewayv1.py
@@ -724,6 +724,92 @@ def test_apigwv1_http_proxy_does_not_block_parallel_ddb(monkeypatch):
     assert elapsed < 0.2, f"Parallel DDB request was delayed for {elapsed:.2f}s"
 
 
+def test_apigwv1_http_proxy_substitutes_path_params_and_forwards_query(monkeypatch):
+    """HTTP_PROXY uses the substituted integration URI as the upstream URL."""
+    import asyncio
+
+    from ministack.services import apigateway as apigw_mod
+    from ministack.services import apigateway_v1 as apigw_v1_mod
+
+    captured = {}
+
+    def _capture(req, _timeout_seconds):
+        captured["url"] = req.full_url
+        return 200, {"Content-Type": "application/json"}, b'{"ok": true}'
+
+    monkeypatch.setattr(apigw_mod, "_urlopen_sync", _capture)
+
+    status, _headers, body = apigw_v1_mod._create_rest_api({"name": "qa-v1-httpproxy-subst"})
+    assert status == 201
+    api_id = json.loads(body)["id"]
+
+    try:
+        status, _headers, body = apigw_v1_mod._get_resources(api_id, {})
+        assert status == 200
+        root = next(r for r in json.loads(body)["item"] if r["path"] == "/")
+
+        status, _headers, body = apigw_v1_mod._create_resource(
+            api_id,
+            root["id"],
+            {"pathPart": "things"},
+        )
+        assert status == 201
+        things = json.loads(body)
+
+        status, _headers, body = apigw_v1_mod._create_resource(
+            api_id,
+            things["id"],
+            {"pathPart": "{thingId}"},
+        )
+        assert status == 201
+        thing = json.loads(body)
+
+        status, _headers, _body = apigw_v1_mod._put_method(
+            api_id,
+            thing["id"],
+            "GET",
+            {
+                "authorizationType": "NONE",
+                "requestParameters": {"method.request.path.thingId": True},
+            },
+        )
+        assert status == 201
+
+        status, _headers, _body = apigw_v1_mod._put_integration(
+            api_id,
+            thing["id"],
+            "GET",
+            {
+                "type": "HTTP_PROXY",
+                "httpMethod": "GET",
+                "uri": "http://upstream.test/items/{thingId}",
+                "requestParameters": {"integration.request.path.thingId": "method.request.path.thingId"},
+            },
+        )
+        assert status == 201
+
+        status, _headers, _body = apigw_v1_mod._create_deployment(api_id, {"stageName": "test"})
+        assert status == 201
+
+        status, _headers, _body = asyncio.run(
+            apigw_v1_mod.handle_execute(
+                api_id,
+                "test",
+                "GET",
+                "/things/abc-123",
+                {"host": "test"},
+                b"",
+                {"limit": ["10"]},
+            )
+        )
+
+        assert status == 200
+        assert captured["url"] == "http://upstream.test/items/abc-123?limit=10"
+
+    finally:
+        apigw_v1_mod._delete_rest_api(api_id)
+
+
 def test_apigwv1_http_proxy_timeout_is_configurable(monkeypatch):
     """`_timeout_from_env` honours the env var and falls back on bad input.
     Tested directly instead of via importlib.reload so the suite-wide


### PR DESCRIPTION
## Summary

Fixes API Gateway v1 `HTTP_PROXY` integration URL construction. Ministack do not currently match AWS behavior when the integration `uri` contains path placeholders such as `{thingId}`. The request is routed to the configured integration, but the upstream URL is built incorrectly in three ways:

- `{paramName}` placeholders in the integration `uri` are not substituted from
  `integration.requestParameters` mappings such as
  `integration.request.path.thingId = method.request.path.thingId`.
- The inbound execute-api path is appended to the integration `uri`, even though AWS uses the substituted integration `uri` as the complete upstream URL for `HTTP_PROXY`.
- The query string is dropped instead of being forwarded.

The result is that a request like:

```text
GET /test/things/abc-123?limit=10
```

reaches the upstream as a malformed URL similar to:

```text
http://upstream.test/items/{thingId}/things/abc-123
```

instead of:

```text
http://upstream.test/items/abc-123?limit=10
```

#### Minimal Terraform Repro

<details>
<summary>Details</summary>

```hcl
provider "aws" {
  region                      = "eu-west-2"
  access_key                  = "test"
  secret_key                  = "test"
  skip_credentials_validation = true
  skip_metadata_api_check     = true
  skip_requesting_account_id  = true

  endpoints {
    apigateway = "http://localhost:4566"
  }
}

resource "aws_api_gateway_rest_api" "example" {
  name = "example-api"
}

resource "aws_api_gateway_resource" "things" {
  rest_api_id = aws_api_gateway_rest_api.example.id
  parent_id   = aws_api_gateway_rest_api.example.root_resource_id
  path_part   = "things"
}

resource "aws_api_gateway_resource" "thing" {
  rest_api_id = aws_api_gateway_rest_api.example.id
  parent_id   = aws_api_gateway_resource.things.id
  path_part   = "{thingId}"
}

resource "aws_api_gateway_method" "thing_get" {
  rest_api_id   = aws_api_gateway_rest_api.example.id
  resource_id   = aws_api_gateway_resource.thing.id
  http_method   = "GET"
  authorization = "NONE"

  request_parameters = {
    "method.request.path.thingId" = true
  }
}

resource "aws_api_gateway_integration" "thing_get" {
  rest_api_id             = aws_api_gateway_rest_api.example.id
  resource_id             = aws_api_gateway_resource.thing.id
  http_method             = aws_api_gateway_method.thing_get.http_method
  type                    = "HTTP_PROXY"
  integration_http_method = "GET"
  uri                     = "http://upstream.test/items/{thingId}"

  request_parameters = {
    "integration.request.path.thingId" = "method.request.path.thingId"
  }
}

resource "aws_api_gateway_deployment" "example" {
  rest_api_id = aws_api_gateway_rest_api.example.id

  depends_on = [aws_api_gateway_integration.thing_get]

  lifecycle {
    create_before_destroy = true
  }
}

resource "aws_api_gateway_stage" "example" {
  rest_api_id   = aws_api_gateway_rest_api.example.id
  deployment_id = aws_api_gateway_deployment.example.id
  stage_name    = "test"
}
```

</details>

## Changes

- Pass matched REST API path parameters into the v1 HTTP proxy invocation path.
- Substitute `{paramName}` placeholders from `integration.request.path.X = method.request.path.X` mappings.
- Support greedy resources by substituting `{proxy}` from the path parameter captured by REST API resources declared as `{proxy+}`.
- Stop appending the inbound execute-api path to the integration URI.
- Forward query string parameters to the upstream URL.
- Add a regression test for path substitution plus query-string forwarding.

## Verification

```bash
python -m pytest tests/test_apigatewayv1.py::test_apigwv1_http_proxy_substitutes_path_params_and_forwards_query -v
```

Result: `1 passed`

```bash
python -m pytest tests/test_apigatewayv1.py -v
```

Result: `65 passed`