### PR TITLE
fix(cfn): preserve S3 bucket physical resource ID on stack update

### DIFF
--- a/ministack/services/cloudformation/provisioners.py
+++ b/ministack/services/cloudformation/provisioners.py
@@ -118,14 +118,40 @@ def _update_resource(resource_type: str, physical_id: str, old_props: dict,
 
 def _s3_create(logical_id, props, stack_name):
     name = props.get("BucketName") or _physical_name(stack_name, logical_id, lowercase=True, max_len=63)
-    _s3._buckets[name] = {
+    _s3._buckets.setdefault(name, {
         "created": now_iso(),
         "objects": {},
         "region": get_region(),
-    }
+    })
     versioning = props.get("VersioningConfiguration", {})
     if versioning.get("Status") == "Enabled":
         _s3._bucket_versioning[name] = "Enabled"
+    attrs = {
+        "Arn": f"arn:aws:s3:::{name}",
+        "DomainName": f"{name}.s3.amazonaws.com",
+        "RegionalDomainName": f"{name}.s3.{get_region()}.amazonaws.com",
+        "WebsiteURL": f"http://{name}.s3-website-{get_region()}.amazonaws.com",
+    }
+    return name, attrs
+
+
+def _s3_update(physical_id, old_props, new_props, stack_name):
+    """Update an S3 bucket in place. Real AWS CloudFormation preserves the
+    physical bucket (and its name) when only mutable properties change.
+    Auto-named buckets (no explicit ``BucketName``) must keep their existing
+    physical resource id so that ``Ref`` keeps resolving to the same bucket
+    where artifacts were uploaded."""
+    old_name = old_props.get("BucketName")
+    new_name = new_props.get("BucketName")
+    if new_name and new_name != physical_id:
+        return _s3_create(new_name, new_props, stack_name)
+    name = physical_id
+    if name in _s3._buckets:
+        versioning = new_props.get("VersioningConfiguration", {})
+        if versioning.get("Status") == "Enabled":
+            _s3._bucket_versioning[name] = "Enabled"
+    else:
+        return _s3_create(name, new_props, stack_name)
     attrs = {
         "Arn": f"arn:aws:s3:::{name}",
         "DomainName": f"{name}.s3.amazonaws.com",
@@ -2981,7 +3007,7 @@ def _backup_plan_delete(physical_id, props):
 
 
 _RESOURCE_HANDLERS = {
-    "AWS::S3::Bucket": {"create": _s3_create, "delete": _s3_delete},
+    "AWS::S3::Bucket": {"create": _s3_create, "update": _s3_update, "delete": _s3_delete},
     "AWS::S3::BucketPolicy": {"create": _s3_bucket_policy_create, "delete": _s3_bucket_policy_delete},
     "AWS::SQS::Queue": {"create": _sqs_create, "delete": _sqs_delete},
     "AWS::SNS::Topic": {"create": _sns_create, "delete": _sns_delete},

--- a/ministack/services/cloudformation/provisioners.py
+++ b/ministack/services/cloudformation/provisioners.py
@@ -2,6 +2,8 @@
 CloudFormation provisioners — resource create/delete handlers for each AWS resource type.
 """
 
+import base64
+import hashlib
 import io
 import json
 import logging
@@ -452,6 +454,12 @@ def _lambda_create(logical_id, props, stack_name):
             version_id=code.get("S3ObjectVersion"),
         )
 
+    code_size = len(code_zip) if code_zip else 0
+    code_sha = (
+        base64.b64encode(hashlib.sha256(code_zip).digest()).decode()
+        if code_zip else "cfn-deployed"
+    )
+
     func = {
         "config": {
             "FunctionName": name,
@@ -459,11 +467,12 @@ def _lambda_create(logical_id, props, stack_name):
             "Runtime": runtime,
             "Role": role,
             "Handler": handler,
+            "CodeSize": code_size,
             "Description": description,
             "Timeout": timeout,
             "MemorySize": memory,
             "LastModified": now_iso(),
-            "CodeSha256": "cfn-deployed",
+            "CodeSha256": code_sha,
             "Version": "$LATEST",
             "Environment": {"Variables": env_vars},
             "Layers": [{"Arn": l} if isinstance(l, str) else l for l in layers],

--- a/tests/test_cfn.py
+++ b/tests/test_cfn.py
@@ -7,7 +7,10 @@ import zipfile
 from urllib.parse import urlparse
 
 import pytest
+import urllib.request
 from botocore.exceptions import ClientError
+
+from conftest import ENDPOINT
 
 
 def _wait_stack(cfn, name, timeout=30):
@@ -2727,3 +2730,131 @@ def test_cfn_cloudfront_keyvaluestore_create_update_delete(cfn, cloudfront):
     with pytest.raises(ClientError) as exc:
         cloudfront.describe_key_value_store(Name=kvs_name)
     assert exc.value.response["Error"]["Code"] == "EntityNotFound"
+
+
+def test_cfn_auto_named_s3_bucket_stable_across_updates(cfn, s3):
+    """Regression: auto-named S3 buckets (no explicit BucketName) must keep
+    the same physical resource ID across stack updates.  Before the fix,
+    _update_resource fell through to _s3_create which generated a new random
+    name on every update, orphaning the original bucket and all its objects."""
+    stack_name = f"cfn-s3-stable-{_uuid_mod.uuid4().hex[:8]}"
+    template_v1 = json.dumps({
+        "AWSTemplateFormatVersion": "2010-09-09",
+        "Resources": {
+            "DeployBucket": {
+                "Type": "AWS::S3::Bucket",
+            },
+        },
+        "Outputs": {
+            "BucketName": {"Value": {"Ref": "DeployBucket"}},
+        },
+    })
+    cfn.create_stack(StackName=stack_name, TemplateBody=template_v1)
+    stack = _wait_stack(cfn, stack_name)
+    assert stack["StackStatus"] == "CREATE_COMPLETE"
+    bucket_v1 = {o["OutputKey"]: o["OutputValue"] for o in stack["Outputs"]}["BucketName"]
+
+    s3.put_object(Bucket=bucket_v1, Key="artifact.zip", Body=b"zipdata")
+
+    template_v2 = json.dumps({
+        "AWSTemplateFormatVersion": "2010-09-09",
+        "Resources": {
+            "DeployBucket": {
+                "Type": "AWS::S3::Bucket",
+            },
+            "LogGroup": {
+                "Type": "AWS::Logs::LogGroup",
+                "Properties": {"LogGroupName": f"/test/{stack_name}"},
+            },
+        },
+        "Outputs": {
+            "BucketName": {"Value": {"Ref": "DeployBucket"}},
+        },
+    })
+    cfn.update_stack(StackName=stack_name, TemplateBody=template_v2)
+    stack = _wait_stack(cfn, stack_name)
+    assert stack["StackStatus"] == "UPDATE_COMPLETE"
+    bucket_v2 = {o["OutputKey"]: o["OutputValue"] for o in stack["Outputs"]}["BucketName"]
+
+    assert bucket_v1 == bucket_v2, (
+        f"Auto-named bucket changed from {bucket_v1!r} to {bucket_v2!r} on update"
+    )
+
+    obj = s3.get_object(Bucket=bucket_v2, Key="artifact.zip")
+    assert obj["Body"].read() == b"zipdata"
+
+    cfn.delete_stack(StackName=stack_name)
+    _wait_stack(cfn, stack_name)
+
+
+def test_cfn_lambda_s3_ref_bucket_has_code_size(cfn, lam, s3):
+    """Regression: Lambda deployed via CFN with Code.S3Bucket using
+    {Ref: DeployBucket} must report correct CodeSize and CodeSha256
+    (not NaN / 'cfn-deployed'), and the code must be downloadable."""
+    uid = _uuid_mod.uuid4().hex[:8]
+    stack_name = f"cfn-lam-s3ref-{uid}"
+    fn_name = f"cfn-lam-s3ref-fn-{uid}"
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("index.mjs",
+            'export async function handler(event) '
+            '{ return { statusCode: 200, body: "ok" }; }')
+    zip_bytes = buf.getvalue()
+
+    template_create = json.dumps({
+        "AWSTemplateFormatVersion": "2010-09-09",
+        "Resources": {
+            "DeployBucket": {"Type": "AWS::S3::Bucket"},
+        },
+        "Outputs": {
+            "BucketName": {"Value": {"Ref": "DeployBucket"}},
+        },
+    })
+    cfn.create_stack(StackName=stack_name, TemplateBody=template_create)
+    stack = _wait_stack(cfn, stack_name)
+    assert stack["StackStatus"] == "CREATE_COMPLETE"
+    bucket = {o["OutputKey"]: o["OutputValue"] for o in stack["Outputs"]}["BucketName"]
+
+    s3_key = f"deploy/{uid}/code.zip"
+    s3.put_object(Bucket=bucket, Key=s3_key, Body=zip_bytes)
+
+    template_update = json.dumps({
+        "AWSTemplateFormatVersion": "2010-09-09",
+        "Resources": {
+            "DeployBucket": {"Type": "AWS::S3::Bucket"},
+            "Fn": {
+                "Type": "AWS::Lambda::Function",
+                "Properties": {
+                    "FunctionName": fn_name,
+                    "Runtime": "nodejs20.x",
+                    "Handler": "index.handler",
+                    "Role": "arn:aws:iam::000000000000:role/r",
+                    "Code": {"S3Bucket": {"Ref": "DeployBucket"}, "S3Key": s3_key},
+                },
+            },
+        },
+        "Outputs": {
+            "BucketName": {"Value": {"Ref": "DeployBucket"}},
+        },
+    })
+    cfn.update_stack(StackName=stack_name, TemplateBody=template_update)
+    stack = _wait_stack(cfn, stack_name)
+    assert stack["StackStatus"] == "UPDATE_COMPLETE"
+
+    fn = lam.get_function(FunctionName=fn_name)
+    config = fn["Configuration"]
+    assert config["CodeSize"] == len(zip_bytes), (
+        f"CodeSize mismatch: expected {len(zip_bytes)}, got {config.get('CodeSize')}"
+    )
+    assert config["CodeSha256"] != "cfn-deployed", "CodeSha256 still hardcoded"
+
+    code_url = fn["Code"]["Location"]
+    local_url = code_url.replace("localhost", "127.0.0.1")
+    resp = urllib.request.urlopen(local_url, timeout=5)
+    downloaded = resp.read()
+    assert len(downloaded) == len(zip_bytes)
+    assert downloaded == zip_bytes
+
+    cfn.delete_stack(StackName=stack_name)
+    _wait_stack(cfn, stack_name)


### PR DESCRIPTION
## Summary

Fixes two bugs in the CloudFormation provisioner that broke Serverless Framework deployments.

### Bug 1: Auto-named S3 bucket gets a new name on every stack update

When a CloudFormation stack is **updated**, `AWS::S3::Bucket` resources without an explicit `BucketName` (such as the `ServerlessDeploymentBucket` created by Serverless Framework) were incorrectly getting a **new random bucket name** on every update instead of preserving the existing one.

This caused Lambda functions referencing the bucket via `{"Ref": "ServerlessDeploymentBucket"}` to resolve to the **new empty bucket** instead of the one where the deployment zip was actually uploaded, resulting in Lambda functions created with **no code**.

**Root cause:** `_RESOURCE_HANDLERS` had no `"update"` entry for `AWS::S3::Bucket`. On stack update, `_update_resource` fell back to `_provision_resource(type, physical_id, props, stack_name)`, passing the old physical resource ID where `_s3_create` expected a logical ID. `_s3_create` called `_physical_name()` which always generates a new random suffix, creating a brand new empty bucket.

**Fix:** Add `_s3_update` handler that preserves the existing physical resource ID (bucket name) when the bucket is updated in place (matching real AWS CloudFormation behavior). Also make `_s3_create` use `setdefault` to avoid wiping existing bucket data.

### Bug 2: Lambda functions deployed via CFN missing `CodeSize` and proper `CodeSha256`

The CF provisioner `_lambda_create` never set `CodeSize` in the config dict and hardcoded `CodeSha256` to `"cfn-deployed"`. This caused UIs (like StackPort) to display **"NaN undefined"** for code size, even when the code was correctly loaded from S3.

**Fix:** Compute `CodeSize` and `CodeSha256` from the actual zip bytes when available.

## Reproduction

1. Deploy a Serverless Framework service to ministack using `serverless-localstack`
2. Deploy again (update)
3. Observe: Lambda functions have no code, "NaN undefined" code size, and a new empty S3 bucket is created on each update
4. S3 bucket list shows multiple deployment buckets, only the oldest has data

## Test plan

- [x] `test_cfn_auto_named_s3_bucket_stable_across_updates` — auto-named bucket keeps same name and objects across stack updates
- [x] `test_cfn_lambda_s3_ref_bucket_has_code_size` — Lambda with `Code.S3Bucket: {Ref: Bucket}` reports correct `CodeSize`, real `CodeSha256`, and code is downloadable
- [x] Existing CFN tests with explicit `BucketName` still pass (no regression)
- [x] Full Serverless Framework deploy + redeploy validated end-to-end locally