### PR TITLE
fix(sqs): honor MessageSystemAttributeNames in ReceiveMessage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- **SQS `ReceiveMessage` honors `MessageSystemAttributeNames`** — only the legacy `AttributeNames` / `SystemAttributeNames` request fields were read; the AWS Java SDK v2 (and any client using the modern, non-deprecated request shape) sends `MessageSystemAttributeNames`, so `Attributes` came back empty even when the client requested `All`. Broke `ApproximateReceiveCount`-based redelivery detection and DLQ logic for SDK v2 consumers.
+- **CFN `AWS::SNS::Subscription` honors `RawMessageDelivery`** — the CloudFormation provisioner read only `FilterPolicyScope` and `FilterPolicy` from the resource properties, silently defaulting subscriptions to `RawMessageDelivery=false` even when the template explicitly set it to `true`. Consumers received SNS-wrapped envelope JSON instead of the raw message, breaking attribute-based routing for any consumer that reads SQS-level `MessageAttributes`.
+
+---
+
 ## [1.3.28] — 2026-05-05
 
 ### Added

--- a/ministack/services/cloudformation/provisioners.py
+++ b/ministack/services/cloudformation/provisioners.py
@@ -316,6 +316,8 @@ def _sns_sub_create(logical_id, props, stack_name):
         return sub_arn, {"SubscriptionArn": sub_arn}
 
     sub_arn = f"{topic_arn}:{new_uuid()}"
+    raw = props.get("RawMessageDelivery", False)
+    raw_str = "true" if (raw is True or str(raw).lower() == "true") else "false"
     sub = {
         "arn": sub_arn,
         "topic_arn": topic_arn,
@@ -330,6 +332,7 @@ def _sns_sub_create(logical_id, props, stack_name):
                 if isinstance(props.get("FilterPolicy"), (dict, list))
                 else (props.get("FilterPolicy", "") or "")
             ),
+            "RawMessageDelivery": raw_str,
         },
     }
     topic["subscriptions"].append(sub)

--- a/ministack/services/sqs.py
+++ b/ministack/services/sqs.py
@@ -366,6 +366,7 @@ async def _act_receive_message(data: dict, qurl: str) -> dict:
                or q["attributes"].get("ReceiveMessageWaitTimeSeconds", "0"))
 
     attr_names = (data.get("AttributeNames")
+                  or data.get("MessageSystemAttributeNames")
                   or data.get("SystemAttributeNames") or [])
     msg_attr_names = data.get("MessageAttributeNames") or []
 

--- a/tests/test_cfn.py
+++ b/tests/test_cfn.py
@@ -1595,7 +1595,77 @@ def test_cfn_sns_topic_subscription_filter_policy_scope(cfn, sns, sqs):
 
     cfn.delete_stack(StackName=stack_name)
     _wait_stack(cfn, stack_name)
-    
+
+
+def test_cfn_sns_subscription_raw_message_delivery(cfn, sns, sqs):
+    """Regression: AWS::SNS::Subscription must honor RawMessageDelivery=true.
+    Without it, MessageAttributes are wrapped inside the SNS envelope JSON
+    instead of being delivered as SQS-level MessageAttributes — breaking
+    consumers that rely on attribute-based routing or read attrs directly."""
+    uid = _uuid_mod.uuid4().hex[:8]
+    stack_name = f"cfn-sns-raw-{uid}"
+    queue_name = f"cfn-sns-raw-q-{uid}"
+    topic_name = f"cfn-sns-raw-topic-{uid}"
+
+    template = {
+        "AWSTemplateFormatVersion": "2010-09-09",
+        "Resources": {
+            "RawQueue": {
+                "Type": "AWS::SQS::Queue",
+                "Properties": {"QueueName": queue_name},
+            },
+            "RawTopic": {
+                "Type": "AWS::SNS::Topic",
+                "Properties": {"TopicName": topic_name},
+            },
+            "RawSubscription": {
+                "Type": "AWS::SNS::Subscription",
+                "Properties": {
+                    "Protocol": "sqs",
+                    "TopicArn": {"Ref": "RawTopic"},
+                    "Endpoint": {"Fn::GetAtt": ["RawQueue", "Arn"]},
+                    "RawMessageDelivery": True,
+                },
+            },
+        },
+        "Outputs": {
+            "TopicArn": {"Value": {"Ref": "RawTopic"}},
+            "SubscriptionArn": {"Value": {"Ref": "RawSubscription"}},
+        },
+    }
+
+    cfn.create_stack(StackName=stack_name, TemplateBody=json.dumps(template))
+    stack = _wait_stack(cfn, stack_name)
+    assert stack["StackStatus"] == "CREATE_COMPLETE", stack.get("StackStatusReason")
+
+    outputs = {o["OutputKey"]: o["OutputValue"] for o in stack.get("Outputs", [])}
+    topic_arn = outputs["TopicArn"]
+    sub_arn = outputs["SubscriptionArn"]
+    queue_url = sqs.get_queue_url(QueueName=queue_name)["QueueUrl"]
+
+    sub_attrs = sns.get_subscription_attributes(SubscriptionArn=sub_arn)["Attributes"]
+    assert sub_attrs.get("RawMessageDelivery") == "true"
+
+    sns.publish(
+        TopicArn=topic_arn,
+        Message="raw-payload",
+        MessageAttributes={"ext_props": {"DataType": "String", "StringValue": "k=v"}},
+    )
+    msgs = sqs.receive_message(
+        QueueUrl=queue_url,
+        MaxNumberOfMessages=1,
+        WaitTimeSeconds=2,
+        MessageAttributeNames=["All"],
+    )
+    assert len(msgs.get("Messages", [])) == 1
+    m = msgs["Messages"][0]
+    assert m["Body"] == "raw-payload"
+    assert m.get("MessageAttributes", {}).get("ext_props", {}).get("StringValue") == "k=v"
+
+    cfn.delete_stack(StackName=stack_name)
+    _wait_stack(cfn, stack_name)
+
+
 # ===========================================================================
 # CodeBuild Project Tests
 # ===========================================================================

--- a/tests/test_sqs.py
+++ b/tests/test_sqs.py
@@ -344,6 +344,21 @@ def test_sqs_message_system_attributes(sqs):
     )
     assert msgs2["Messages"][0]["Attributes"]["ApproximateReceiveCount"] == "2"
 
+def test_sqs_message_system_attribute_names_modern_field(sqs):
+    """Regression: AWS SDK v2 / Java sends MessageSystemAttributeNames, not the
+    deprecated AttributeNames. Ministack must honor the modern field name."""
+    url = sqs.create_queue(QueueName="intg-sqs-msa-modern")["QueueUrl"]
+    sqs.send_message(QueueUrl=url, MessageBody="msa-modern")
+
+    msgs = sqs.receive_message(
+        QueueUrl=url,
+        MaxNumberOfMessages=1,
+        MessageSystemAttributeNames=["All"],
+    )
+    attrs = msgs["Messages"][0].get("Attributes", {})
+    assert attrs.get("ApproximateReceiveCount") == "1"
+    assert "SentTimestamp" in attrs
+
 def test_sqs_nonexistent_queue(sqs):
     with pytest.raises(ClientError) as exc:
         sqs.get_queue_url(QueueName="intg-sqs-does-not-exist")


### PR DESCRIPTION
## Summary

- Adds `MessageSystemAttributeNames` to the list of fields read by `ReceiveMessage`. AWS SDK v2 clients (Java/Kotlin/etc.) send the modern field name; ministack only read the deprecated `AttributeNames` / `SystemAttributeNames`.
- Adds a regression test that uses the modern field name.

Closes #577.

## Why

The AWS SQS service model marks `AttributeNames` as `"deprecated": true` with the doc string *"This parameter has been discontinued but will be supported for backward compatibility. To provide attribute names, you are encouraged to use `MessageSystemAttributeNames`."* The Java SDK v2 method `.messageSystemAttributeNames(...)` serializes to the new field only — it does not double-write. As a result, any Java/Kotlin consumer using SDK v2 received empty `Attributes`, which broke `ApproximateReceiveCount`-based logic (redelivery detection, DLQ, etc.).

Boto3 still uses the legacy parameter name by default, so this hadn't been caught by the existing test suite.

## Test plan

- [x] New test `test_sqs_message_system_attribute_names_modern_field` asserts that `receive_message(..., MessageSystemAttributeNames=["All"])` returns `ApproximateReceiveCount` and `SentTimestamp`.
- [x] Existing `test_sqs_message_system_attributes` (legacy `AttributeNames`) continues to pass.