### PR TITLE
Fix SFN REST-JSON aws-sdk output casing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 - **Step Functions `aws-sdk:s3` integration** — S3 was tagged as `rest`-protocol with no dispatcher; every call failed with `States.Runtime`. New REST-XML dispatcher covers `ListBuckets`, `CreateBucket`, `DeleteBucket`, `HeadBucket`, `GetBucketVersioning`, `ListObjectsV2`, `ListObjects`, `HeadObject`, `CopyObject`, `DeleteObject`, `GetObjectTagging`, `PutObjectTagging`. `GetObject`/`PutObject` deferred to Phase 2. Reported by @LeTrungNguyen1703.
 - **SQS `ReceiveMessage` honors `MessageSystemAttributeNames`** — only the deprecated `AttributeNames` was read, so AWS SDK v2 (Java/Kotlin) consumers got empty `Attributes` and broken `ApproximateReceiveCount`-based redelivery detection. Contributed by @joaomena.
 - **CFN `AWS::SNS::Subscription` honors `RawMessageDelivery`** — the provisioner silently defaulted to `false` even when templates set `true`, so consumers got SNS-wrapped envelopes instead of raw payloads. Contributed by @joaomena.
-
+- **Step Functions REST-JSON `aws-sdk` response casing** — successful REST-JSON integrations such as `aws-sdk:rdsdata:executeStatement` now expose SDK-shaped output keys (`Records`, `StringValue`, `NumberOfRecordsUpdated`) instead of raw wire keys (`records`, `stringValue`, `numberOfRecordsUpdated`), matching AWS Step Functions `ResultSelector` behavior.
 ---
 
 ## [1.3.28] — 2026-05-05

--- a/ministack/services/stepfunctions.py
+++ b/ministack/services/stepfunctions.py
@@ -3017,9 +3017,11 @@ def _dispatch_aws_sdk_rest_json(service_info, service_name, action, input_data):
             raise _ExecutionError(_prefix_sdk_error(service_name, "ServiceException"), decoded)
 
     try:
-        return json.loads(decoded) if decoded else {}
+        result = json.loads(decoded) if decoded else {}
     except (json.JSONDecodeError, TypeError):
         return decoded
+
+    return _convert_keys_to_sfn_convention(result)
 
 
 # ---------------------------------------------------------------------------
@@ -3220,7 +3222,7 @@ def _s3_normalize_lists(parsed, list_fields):
 def _dispatch_aws_sdk_rest_xml(service_info, service_name, action, input_data):
     """Dispatch an aws-sdk integration call to a REST-XML protocol service (S3)."""
     import xml.etree.ElementTree as ET
-    from urllib.parse import urlencode, quote
+    from urllib.parse import quote, urlencode
 
     from ministack import app
 

--- a/tests/test_stepfunctions.py
+++ b/tests/test_stepfunctions.py
@@ -2648,7 +2648,9 @@ def test_sfn_aws_sdk_rdsdata_execute_statement(sfn, sfn_sync, rds, sm):
     resp = sfn_sync.start_sync_execution(stateMachineArn=sm_arn, input=json.dumps({}))
     assert resp["status"] == "SUCCEEDED", f"Execution failed: {resp.get('error')} — {resp.get('cause')}"
     output = json.loads(resp["output"])
-    assert "numberOfRecordsUpdated" in output or "records" in output
+    assert "NumberOfRecordsUpdated" in output
+    assert "GeneratedFields" in output
+    assert "Records" in output
 
     sfn_sync.delete_state_machine(stateMachineArn=sm_arn)
 
@@ -2678,6 +2680,72 @@ def test_sfn_aws_sdk_rdsdata_unknown_action_fails(sfn, sfn_sync):
 
     resp = sfn_sync.start_sync_execution(stateMachineArn=sm_arn, input=json.dumps({}))
     assert resp["status"] == "FAILED"
+
+    sfn_sync.delete_state_machine(stateMachineArn=sm_arn)
+
+
+def test_sfn_aws_sdk_rdsdata_output_uses_sfn_key_convention(sfn, sfn_sync, rds, sm):
+    """REST-JSON aws-sdk output is exposed with AWS SFN SDK-shaped keys."""
+    import uuid as _uuid
+
+    cluster_id = f"rdsdata-sfn-output-{_uuid.uuid4().hex[:8]}"
+    sm_name = f"sdk-rdsdata-output-{_uuid.uuid4().hex[:8]}"
+
+    rds.create_db_cluster(
+        DBClusterIdentifier=cluster_id,
+        Engine="aurora-mysql",
+        MasterUsername="admin",
+        MasterUserPassword="testpass123",
+    )
+    secret_arn = sm.create_secret(
+        Name=f"rdsdata-output-secret-{_uuid.uuid4().hex[:8]}",
+        SecretString='{"username":"admin","password":"testpass123"}',
+    )["ARN"]
+    cluster_arn = f"arn:aws:rds:us-east-1:000000000000:cluster:{cluster_id}"
+
+    definition = json.dumps({
+        "StartAt": "CreateUser",
+        "States": {
+            "CreateUser": {
+                "Type": "Task",
+                "Resource": "arn:aws:states:::aws-sdk:rdsdata:executeStatement",
+                "Parameters": {
+                    "ResourceArn": cluster_arn,
+                    "SecretArn": secret_arn,
+                    "Sql": "CREATE USER IF NOT EXISTS 'alice'",
+                    "Database": "testdb",
+                },
+                "Next": "ObserveUser",
+            },
+            "ObserveUser": {
+                "Type": "Task",
+                "Resource": "arn:aws:states:::aws-sdk:rdsdata:executeStatement",
+                "Parameters": {
+                    "ResourceArn": cluster_arn,
+                    "SecretArn": secret_arn,
+                    "Sql": "SELECT User FROM mysql.user WHERE User = 'alice'",
+                    "Database": "testdb",
+                },
+                "ResultSelector": {
+                    "Records.$": "$.Records",
+                    "Updated.$": "$.NumberOfRecordsUpdated",
+                },
+                "End": True,
+            },
+        },
+    })
+
+    sm_arn = sfn_sync.create_state_machine(
+        name=sm_name,
+        definition=definition,
+        roleArn="arn:aws:iam::000000000000:role/sfn-role",
+    )["stateMachineArn"]
+
+    resp = sfn_sync.start_sync_execution(stateMachineArn=sm_arn, input=json.dumps({}))
+    assert resp["status"] == "SUCCEEDED", f"Execution failed: {resp.get('error')} — {resp.get('cause')}"
+    output = json.loads(resp["output"])
+    assert output["Records"] == [[{"StringValue": "alice"}]]
+    assert output["Updated"] == 0
 
     sfn_sync.delete_state_machine(stateMachineArn=sm_arn)
 
@@ -2943,7 +3011,9 @@ def test_sfn_rest_json_pascal_to_camel_conversion(sfn, sfn_sync, rds, sm):
     resp = sfn_sync.start_sync_execution(stateMachineArn=sm_arn, input=json.dumps({}))
     assert resp["status"] == "SUCCEEDED", f"Execution failed: {resp.get('error')} \u2014 {resp.get('cause')}"
     output = json.loads(resp["output"])
-    assert "numberOfRecordsUpdated" in output or "records" in output
+    assert "NumberOfRecordsUpdated" in output
+    assert "GeneratedFields" in output
+    assert "Records" in output
 
     sfn_sync.delete_state_machine(stateMachineArn=sm_arn)
 


### PR DESCRIPTION
🤖

## Why
Step Functions REST-JSON `aws-sdk` integrations were returning raw wire-shaped keys, so ASL selectors like `$.Records` resolved to null for `rdsdata:executeStatement`.

## What
- Normalize successful REST-JSON `aws-sdk` dispatcher responses to the SFN SDK key convention
- Update RDS Data Step Functions tests and add `ResultSelector` regression coverage
- Add changelog entry

## Risk Assessment
Low; this aligns REST-JSON output with existing query and REST-XML dispatcher behavior and currently only affects RDS Data `aws-sdk` integrations.

## References
- `MINISTACK_ENDPOINT=http://localhost:4567 .context/venv/bin/pytest -q tests/test_stepfunctions.py --tb=short`: 105 passed
- `.context/venv/bin/ruff check ministack/services/stepfunctions.py`: passed

Generated with Codex