### PR TITLE
Add CORS headers to Cognito OAuth2 / OIDC endpoints

### DIFF
--- a/ministack/app.py
+++ b/ministack/app.py
@@ -662,7 +662,11 @@ async def _handle_pre_body_request(method: str, path: str, headers: dict, query_
 
     response = await _handle_cognito_get_request(method, path, headers, query_params)
     if response is not None:
-        return response
+        # Cognito's OAuth2/OIDC endpoints (Hosted UI, /oauth2/*, /.well-known/*)
+        # are typically called by browser-based OIDC clients and must therefore
+        # carry the same `Access-Control-Allow-Origin: *` that every other data
+        # plane response gets via _with_data_plane_headers.
+        return _with_data_plane_headers(response, request_id)
 
     response = await _handle_ses_messages_request(method, path, headers, query_params)
     if response is not None:
@@ -764,11 +768,12 @@ async def _handle_admin_config_request(path: str, method: str, body: bytes):
     return 200, {"Content-Type": "application/json"}, json.dumps({"applied": applied}).encode()
 
 
-async def _handle_post_body_shortcuts(method: str, path: str, headers: dict, body: bytes, query_params: dict):
+async def _handle_post_body_shortcuts(method: str, path: str, headers: dict, body: bytes, query_params: dict, request_id: str):
     """Handle body-dependent routes before the generic service router."""
     response = await _handle_cognito_body_request(method, path, headers, body, query_params)
     if response is not None:
-        return response
+        # See _handle_pre_body_request: browser-based OIDC clients need CORS.
+        return _with_data_plane_headers(response, request_id)
     return await _handle_admin_config_request(path, method, body)
 
 
@@ -1436,7 +1441,7 @@ async def app(scope, receive, send):
 
     body = await _read_request_body(receive, method, headers)
 
-    if await _send_if_handled(send, await _handle_post_body_shortcuts(method, path, headers, body, query_params)):
+    if await _send_if_handled(send, await _handle_post_body_shortcuts(method, path, headers, body, query_params, request_id)):
         return
 
     if await _send_if_handled(

--- a/tests/test_cognito.py
+++ b/tests/test_cognito.py
@@ -1119,6 +1119,47 @@ def test_cognito_openid_configuration():
     assert "token_endpoint" in data
 
 
+def test_cognito_browser_endpoints_send_cors_headers():
+    """Cognito's OAuth2/OIDC endpoints must send `Access-Control-Allow-Origin`
+    so browser-based OIDC clients can fetch them. Regression for the bug
+    where the dispatcher in app.py returned raw response tuples for
+    /.well-known/*, /oauth2/*, /login and /logout, bypassing the
+    `_with_data_plane_headers` wrapper that every other data-plane response
+    goes through."""
+    import urllib.request
+
+    from conftest import make_client
+    cognito = make_client("cognito-idp")
+    pool_id = cognito.create_user_pool(PoolName="cors-pool")["UserPool"]["Id"]
+
+    # Public well-known endpoints — fetched cross-origin during OIDC discovery.
+    for path in (
+        f"/{pool_id}/.well-known/openid-configuration",
+        f"/{pool_id}/.well-known/jwks.json",
+    ):
+        with urllib.request.urlopen(f"http://localhost:4566{path}") as r:
+            assert r.headers.get("Access-Control-Allow-Origin") == "*", (
+                f"missing CORS header on {path}"
+            )
+
+    # Token endpoint — POSTed cross-origin by the OIDC client. We don't care
+    # about the body (an empty form yields a 4xx) — only that the CORS header
+    # is present on the response.
+    req = urllib.request.Request(
+        "http://localhost:4566/oauth2/token",
+        data=b"grant_type=authorization_code",
+        method="POST",
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    try:
+        resp = urllib.request.urlopen(req)
+    except urllib.error.HTTPError as e:
+        resp = e
+    assert resp.headers.get("Access-Control-Allow-Origin") == "*", (
+        "missing CORS header on /oauth2/token"
+    )
+
+
 # ===========================================================================
 # Identity Provider CRUD
 # ===========================================================================


### PR DESCRIPTION
## Summary

Cognito's browser-facing endpoints — Hosted UI (`/oauth2/authorize`, `/login`), `/oauth2/token`, `/oauth2/userInfo`, `/logout`, `/.well-known/openid-configuration`, `/.well-known/jwks.json` — are dispatched in `app.py` via `_handle_cognito_get_request` and `_handle_cognito_body_request`. Both return raw `(status, headers, body)` tuples that bypass `_with_data_plane_headers`, the helper every other data-plane response goes through and which adds the wildcard `Access-Control-Allow-Origin: *` header that browser-based OIDC clients require.

The `OPTIONS` preflight handler does send CORS headers, so preflight succeeds, but the actual response is missing the header and the browser blocks it. Symptom: any `react-oidc-context` / `oidc-client-ts` / Amplify-style OIDC client running against MiniStack fails on discovery and on `/oauth2/token` with:

> No 'Access-Control-Allow-Origin' header is present on the requested resource.

## Fix

Route both Cognito dispatchers through `_with_data_plane_headers` at their call sites in `_handle_pre_body_request` and `_handle_post_body_shortcuts`. Same wildcard CORS that every other data-plane response gets — no new CORS logic, just plugging the gap.

Threads `request_id` through `_handle_post_body_shortcuts` so the helper can also stamp `x-amzn-requestid` alongside the CORS header, matching every other data-plane response.

## Test plan

- [x] New regression test (`test_cognito_browser_endpoints_send_cors_headers`) asserts `Access-Control-Allow-Origin: *` on `/<pool>/.well-known/openid-configuration`, `/<pool>/.well-known/jwks.json`, and `/oauth2/token`.
- [x] Full `tests/test_cognito.py` suite passes (101/101).
- [x] No other test files reference these dispatch points; threading `request_id` through `_handle_post_body_shortcuts` is purely additive.

## Notes

- Independent of #588 (which fixes the discovery doc's URLs to point at MiniStack instead of real AWS); the two changes compose — discovery returns local URLs, and now the responses to those URLs carry CORS headers.
- The form action in `_login_page_html` is left as `/login` (absolute path on origin). Since the Hosted UI is served from MiniStack's own origin, that resolves correctly. Reverse-proxying MiniStack at a path prefix (e.g. `/cognito/oauth2/authorize`) would break it, but with CORS now working there's no reason to proxy in the first place.