### PR TITLE
feat(EC2): add EC2 VPN Connection support

### DIFF
--- a/ministack/services/ec2.py
+++ b/ministack/services/ec2.py
@@ -98,6 +98,7 @@ _egress_igws = AccountScopedDict()     # eigw_id -> egress-only internet gateway
 _prefix_lists = AccountScopedDict()    # pl_id -> managed prefix list record
 _vpn_gateways = AccountScopedDict()    # vgw_id -> VPN gateway record
 _customer_gateways = AccountScopedDict()  # cgw_id -> customer gateway record
+_vpn_connections = AccountScopedDict()    # vpn_id -> VPN connection record
 _launch_templates = AccountScopedDict()   # lt_id -> launch template record (includes versions list)
 
 
@@ -127,6 +128,7 @@ def get_state():
         "prefix_lists": copy.deepcopy(_prefix_lists),
         "vpn_gateways": copy.deepcopy(_vpn_gateways),
         "customer_gateways": copy.deepcopy(_customer_gateways),
+        "vpn_connections": copy.deepcopy(_vpn_connections),
         "launch_templates": copy.deepcopy(_launch_templates),
     }
 
@@ -155,6 +157,7 @@ def restore_state(data):
         _prefix_lists.update(data.get("prefix_lists", {}))
         _vpn_gateways.update(data.get("vpn_gateways", {}))
         _customer_gateways.update(data.get("customer_gateways", {}))
+        _vpn_connections.update(data.get("vpn_connections", {}))
         _launch_templates.update(data.get("launch_templates", {}))
 
 
@@ -2339,7 +2342,7 @@ def _rtb_fields_xml(rtb, tag="item"):
         <ownerId>{rtb['OwnerId']}</ownerId>
         <routeSet>{routes}</routeSet>
         <associationSet>{assocs}</associationSet>
-        <propagatingVgwSet/>
+        <propagatingVgwSet>{"".join(f"<item><gatewayId>{g}</gatewayId></item>" for g in rtb.get("PropagatingVgws", []))}</propagatingVgwSet>
         {_tag_set_xml(rtb['RouteTableId'])}
     </{tag}>"""
 
@@ -3711,6 +3714,88 @@ def _cgw_xml(cgw, tag="item"):
 
 
 # ---------------------------------------------------------------------------
+# VPN Connections
+# ---------------------------------------------------------------------------
+
+def _create_vpn_connection(p):
+    conn_type = _p(p, "Type") or "ipsec.1"
+    cgw_id = _p(p, "CustomerGatewayId")
+    vgw_id = _p(p, "VpnGatewayId") or ""
+    tgw_id = _p(p, "TransitGatewayId") or ""
+    static_only = _p(p, "Options.StaticRoutesOnly") or "false"
+    tags = _parse_tags(p)
+    vpn_id = "vpn-" + "".join(random.choices(string.hexdigits[:16], k=17))
+    _vpn_connections[vpn_id] = {
+        "VpnConnectionId": vpn_id, "State": "available", "Type": conn_type,
+        "CustomerGatewayId": cgw_id, "VpnGatewayId": vgw_id,
+        "TransitGatewayId": tgw_id, "Category": "VPN",
+        "Options": {"StaticRoutesOnly": static_only.lower() == "true"},
+        "Routes": [], "Tags": tags, "OwnerId": get_account_id(),
+    }
+    if tags:
+        _tags[vpn_id] = tags
+    return _xml(200, "CreateVpnConnectionResponse", _vpn_conn_xml(_vpn_connections[vpn_id], tag="vpnConnection"))
+
+
+def _vpn_conn_xml(vpn, tag="item"):
+    routes = "".join(
+        f"<item><destinationCidrBlock>{r['DestinationCidrBlock']}</destinationCidrBlock><state>{r['State']}</state></item>"
+        for r in vpn.get("Routes", [])
+    )
+    return f"""<{tag}>
+        <vpnConnectionId>{vpn['VpnConnectionId']}</vpnConnectionId>
+        <state>{vpn['State']}</state>
+        <type>{vpn['Type']}</type>
+        <customerGatewayId>{vpn['CustomerGatewayId']}</customerGatewayId>
+        <vpnGatewayId>{vpn['VpnGatewayId']}</vpnGatewayId>
+        <transitGatewayId>{vpn['TransitGatewayId']}</transitGatewayId>
+        <category>{vpn['Category']}</category>
+        <options><staticRoutesOnly>{'true' if vpn['Options']['StaticRoutesOnly'] else 'false'}</staticRoutesOnly></options>
+        <routes>{routes}</routes>
+        {_tag_set_xml(vpn['VpnConnectionId'])}
+    </{tag}>"""
+
+
+def _describe_vpn_connections(p):
+    filter_ids = _parse_member_list(p, "VpnConnectionId")
+    items = ""
+    for vpn in _vpn_connections.values():
+        if filter_ids and vpn["VpnConnectionId"] not in filter_ids:
+            continue
+        items += _vpn_conn_xml(vpn)
+    return _xml(200, "DescribeVpnConnectionsResponse", f"<vpnConnectionSet>{items}</vpnConnectionSet>")
+
+
+def _delete_vpn_connection(p):
+    vpn_id = _p(p, "VpnConnectionId")
+    if vpn_id not in _vpn_connections:
+        return _error("InvalidVpnConnectionID.NotFound", f"VPN connection '{vpn_id}' not found", 400)
+    _vpn_connections[vpn_id]["State"] = "deleted"
+    del _vpn_connections[vpn_id]
+    return _xml(200, "DeleteVpnConnectionResponse", "<return>true</return>")
+
+
+def _create_vpn_connection_route(p):
+    vpn_id = _p(p, "VpnConnectionId")
+    cidr = _p(p, "DestinationCidrBlock")
+    if vpn_id not in _vpn_connections:
+        return _error("InvalidVpnConnectionID.NotFound", f"VPN connection '{vpn_id}' not found", 400)
+    routes = _vpn_connections[vpn_id]["Routes"]
+    if not any(r["DestinationCidrBlock"] == cidr for r in routes):
+        routes.append({"DestinationCidrBlock": cidr, "State": "available"})
+    return _xml(200, "CreateVpnConnectionRouteResponse", "<return>true</return>")
+
+
+def _delete_vpn_connection_route(p):
+    vpn_id = _p(p, "VpnConnectionId")
+    cidr = _p(p, "DestinationCidrBlock")
+    if vpn_id not in _vpn_connections:
+        return _error("InvalidVpnConnectionID.NotFound", f"VPN connection '{vpn_id}' not found", 400)
+    _vpn_connections[vpn_id]["Routes"] = [r for r in _vpn_connections[vpn_id]["Routes"] if r["DestinationCidrBlock"] != cidr]
+    return _xml(200, "DeleteVpnConnectionRouteResponse", "<return>true</return>")
+
+
+# ---------------------------------------------------------------------------
 # Reset
 # ---------------------------------------------------------------------------
 
@@ -3737,6 +3822,7 @@ def reset():
     _prefix_lists.clear()
     _vpn_gateways.clear()
     _customer_gateways.clear()
+    _vpn_connections.clear()
     _launch_templates.clear()
     _init_defaults()
 
@@ -4554,6 +4640,12 @@ _ACTION_MAP = {
     "CreateCustomerGateway": _create_customer_gateway,
     "DescribeCustomerGateways": _describe_customer_gateways,
     "DeleteCustomerGateway": _delete_customer_gateway,
+    # VPN Connections
+    "CreateVpnConnection": _create_vpn_connection,
+    "DescribeVpnConnections": _describe_vpn_connections,
+    "DeleteVpnConnection": _delete_vpn_connection,
+    "CreateVpnConnectionRoute": _create_vpn_connection_route,
+    "DeleteVpnConnectionRoute": _delete_vpn_connection_route,
     # EBS Volumes
     "CreateVolume": _create_volume,
     "DeleteVolume": _delete_volume,

--- a/ministack/services/ec2.py
+++ b/ministack/services/ec2.py
@@ -46,7 +46,10 @@ Supports:
                    DeleteManagedPrefixList
   VPN Gateways:    CreateVpnGateway, DescribeVpnGateways, AttachVpnGateway,
                    DetachVpnGateway, DeleteVpnGateway,
-                   EnableVgwRoutePropagation, DisableVgwRoutePropagation
+                   EnableVgwRoutePropagation, DisableVgwRoutePropagation,
+                   CreateVpnConnection, DescribeVpnConnections,
+                   DeleteVpnConnection, CreateVpnConnectionRoute,
+                   DeleteVpnConnectionRoute
   Customer GW:     CreateCustomerGateway, DescribeCustomerGateways,
                    DeleteCustomerGateway
   Launch Tmpl:     CreateLaunchTemplate, CreateLaunchTemplateVersion,

--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -1174,7 +1174,7 @@ def test_ec2_vpn_gateway_crud(ec2):
         ec2.delete_vpc(VpcId=vpc_id)
 
 def test_ec2_vgw_route_propagation(ec2):
-    """EnableVgwRoutePropagation / DisableVgwRoutePropagation."""
+    """EnableVgwRoutePropagation / DisableVgwRoutePropagation with DescribeRouteTables verification."""
     vpc = ec2.create_vpc(CidrBlock="10.94.0.0/16")
     vpc_id = vpc["Vpc"]["VpcId"]
     try:
@@ -1183,11 +1183,23 @@ def test_ec2_vgw_route_propagation(ec2):
         vgw = ec2.create_vpn_gateway(Type="ipsec.1")
         vgw_id = vgw["VpnGateway"]["VpnGatewayId"]
 
+        # Enable and verify it appears in DescribeRouteTables
         ec2.enable_vgw_route_propagation(RouteTableId=rtb_id, GatewayId=vgw_id)
-        # No error = success (propagation stored server-side)
+        desc = ec2.describe_route_tables(RouteTableIds=[rtb_id])
+        propagating = desc["RouteTables"][0].get("PropagatingVgws", [])
+        assert {"GatewayId": vgw_id} in propagating
 
+        # Idempotent — enabling again doesn't duplicate
+        ec2.enable_vgw_route_propagation(RouteTableId=rtb_id, GatewayId=vgw_id)
+        desc = ec2.describe_route_tables(RouteTableIds=[rtb_id])
+        propagating = desc["RouteTables"][0].get("PropagatingVgws", [])
+        assert len([v for v in propagating if v["GatewayId"] == vgw_id]) == 1
+
+        # Disable and verify it's removed
         ec2.disable_vgw_route_propagation(RouteTableId=rtb_id, GatewayId=vgw_id)
-        # No error = success
+        desc = ec2.describe_route_tables(RouteTableIds=[rtb_id])
+        propagating = desc["RouteTables"][0].get("PropagatingVgws", [])
+        assert {"GatewayId": vgw_id} not in propagating
 
         ec2.delete_vpn_gateway(VpnGatewayId=vgw_id)
         ec2.delete_route_table(RouteTableId=rtb_id)
@@ -1211,6 +1223,68 @@ def test_ec2_customer_gateway_crud(ec2):
     desc = ec2.describe_customer_gateways(CustomerGatewayIds=[cgw_id])
     assert len(desc["CustomerGateways"]) == 0
 
+
+def test_ec2_vpn_connection_crud(ec2):
+    """CreateVpnConnection, DescribeVpnConnections, DeleteVpnConnection."""
+    cgw = ec2.create_customer_gateway(BgpAsn=65000, IpAddress="203.0.113.1", Type="ipsec.1")
+    cgw_id = cgw["CustomerGateway"]["CustomerGatewayId"]
+    vgw = ec2.create_vpn_gateway(Type="ipsec.1")
+    vgw_id = vgw["VpnGateway"]["VpnGatewayId"]
+
+    vpn = ec2.create_vpn_connection(
+        Type="ipsec.1",
+        CustomerGatewayId=cgw_id,
+        VpnGatewayId=vgw_id,
+        Options={"StaticRoutesOnly": True},
+    )
+    conn = vpn["VpnConnection"]
+    vpn_id = conn["VpnConnectionId"]
+    assert vpn_id.startswith("vpn-")
+    assert conn["State"] == "available"
+    assert conn["Type"] == "ipsec.1"
+    assert conn["CustomerGatewayId"] == cgw_id
+    assert conn["VpnGatewayId"] == vgw_id
+    assert conn["Options"]["StaticRoutesOnly"] is True
+
+    # Describe
+    desc = ec2.describe_vpn_connections(VpnConnectionIds=[vpn_id])
+    assert len(desc["VpnConnections"]) == 1
+    assert desc["VpnConnections"][0]["VpnConnectionId"] == vpn_id
+
+    # Delete
+    ec2.delete_vpn_connection(VpnConnectionId=vpn_id)
+    desc = ec2.describe_vpn_connections(VpnConnectionIds=[vpn_id])
+    assert len(desc["VpnConnections"]) == 0
+
+    ec2.delete_vpn_gateway(VpnGatewayId=vgw_id)
+    ec2.delete_customer_gateway(CustomerGatewayId=cgw_id)
+
+
+
+def test_ec2_vpn_connection_route(ec2):
+    """CreateVpnConnectionRoute / DeleteVpnConnectionRoute."""
+    cgw = ec2.create_customer_gateway(BgpAsn=65000, IpAddress="203.0.113.2", Type="ipsec.1")
+    cgw_id = cgw["CustomerGateway"]["CustomerGatewayId"]
+    vgw = ec2.create_vpn_gateway(Type="ipsec.1")
+    vgw_id = vgw["VpnGateway"]["VpnGatewayId"]
+    vpn = ec2.create_vpn_connection(Type="ipsec.1", CustomerGatewayId=cgw_id, VpnGatewayId=vgw_id, Options={"StaticRoutesOnly": True})
+    vpn_id = vpn["VpnConnection"]["VpnConnectionId"]
+
+    # Create route
+    ec2.create_vpn_connection_route(VpnConnectionId=vpn_id, DestinationCidrBlock="10.0.0.0/16")
+    desc = ec2.describe_vpn_connections(VpnConnectionIds=[vpn_id])
+    routes = desc["VpnConnections"][0]["Routes"]
+    assert any(r["DestinationCidrBlock"] == "10.0.0.0/16" for r in routes)
+
+    # Delete route
+    ec2.delete_vpn_connection_route(VpnConnectionId=vpn_id, DestinationCidrBlock="10.0.0.0/16")
+    desc = ec2.describe_vpn_connections(VpnConnectionIds=[vpn_id])
+    routes = desc["VpnConnections"][0]["Routes"]
+    assert not any(r["DestinationCidrBlock"] == "10.0.0.0/16" for r in routes)
+
+    ec2.delete_vpn_connection(VpnConnectionId=vpn_id)
+    ec2.delete_vpn_gateway(VpnGatewayId=vgw_id)
+    ec2.delete_customer_gateway(CustomerGatewayId=cgw_id)
 def test_ec2_create_route_nat_gateway(ec2):
     """CreateRoute with NatGatewayId stores it separately from GatewayId."""
     vpc = ec2.create_vpc(CidrBlock="10.93.0.0/16")


### PR DESCRIPTION
 # Add EC2 VPN Connection support

 ## Summary

 Adds full CRUD for VPN Connections and static route management to the EC2 service emulator.

 ## Changes

 New EC2 actions:

  - CreateVpnConnection creates a VPN connection (ipsec.1) between a VPN gateway and customer gateway, with optional static routes mode
  - DescribeVpnConnections filter by VPN connection IDs
  - DeleteVpnConnection removes a VPN connection
  - CreateVpnConnectionRoute  adds a static route (CIDR) to a VPN connection
  - DeleteVpnConnectionRoute  removes a static route by CIDR

 ## Improved test coverage:

  - test_ec2_vgw_route_propagation now verifies PropagatingVgws appears in DescribeRouteTables response and tests idempotency
  - test_ec2_vpn_connection_crud full lifecycle: create, describe, delete
  - test_ec2_vpn_connection_route create and delete static routes with describe verification

 ## Testing
```
pytest -q tests/test_ec2.py --tb=short
110 passed
```

```
ruff check ministack/services/ec2.py
All checks passed!
```
