### PR TITLE
fix(sns): allow FIFO topic to subscribe a standard SQS queue

### DIFF
--- a/ministack/services/sns.py
+++ b/ministack/services/sns.py
@@ -10,7 +10,7 @@ Supports: CreateTopic, DeleteTopic, ListTopics, GetTopicAttributes, SetTopicAttr
 SNS → Lambda fanout dispatches via _execute_function (synchronous).
 FIFO topics: .fifo naming validation, MessageGroupId/MessageDeduplicationId enforcement,
              5-minute deduplication window, sequence numbers, content-based deduplication,
-             FIFO SQS subscription validation, PublishBatch FIFO support.
+             PublishBatch FIFO support.
 """
 
 import asyncio
@@ -293,16 +293,6 @@ def _subscribe(params):
 
     if not protocol:
         return _error("InvalidParameterException", "Protocol is required", 400)
-
-    # FIFO subscription validation: SQS endpoints must be FIFO queues
-    if _is_fifo_topic(topic) and protocol == "sqs":
-        queue_name = (endpoint or "").split(":")[-1]
-        if not queue_name.endswith(".fifo"):
-            return _error(
-                "InvalidParameterException",
-                "Invalid parameter: Invalid parameter: Topic with FIFO requires a subscription to a FIFO SQS Queue",
-                400,
-            )
 
     for existing in topic["subscriptions"]:
         if existing["protocol"] == protocol and existing["endpoint"] == endpoint:

--- a/tests/test_sns.py
+++ b/tests/test_sns.py
@@ -727,22 +727,22 @@ def test_sns_fifo_sequence_numbers_monotonically_increasing(sns):
 # ---------------------------------------------------------------------------
 
 
-def test_sns_fifo_subscribe_non_fifo_sqs_queue_returns_error(sns, sqs):
-    """Subscribing a non-FIFO SQS queue to a FIFO topic returns InvalidParameterException."""
+def test_sns_fifo_subscribe_standard_sqs_queue_succeeds(sns, sqs):
+    """Subscribing a standard SQS queue to a FIFO topic succeeds."""
     uid = _uuid_mod.uuid4().hex[:8]
     topic_arn = sns.create_topic(
-        Name=f"intg-fifo-sub-nonfifo-{uid}.fifo",
+        Name=f"intg-fifo-sub-std-{uid}.fifo",
         Attributes={"FifoTopic": "true"},
     )["TopicArn"]
 
-    q_url = sqs.create_queue(QueueName=f"intg-fifo-sub-nonfifo-q-{uid}")["QueueUrl"]
+    q_url = sqs.create_queue(QueueName=f"intg-fifo-sub-std-q-{uid}")["QueueUrl"]
     q_arn = sqs.get_queue_attributes(
         QueueUrl=q_url, AttributeNames=["QueueArn"],
     )["Attributes"]["QueueArn"]
 
-    with pytest.raises(ClientError) as exc:
-        sns.subscribe(TopicArn=topic_arn, Protocol="sqs", Endpoint=q_arn)
-    assert exc.value.response["Error"]["Code"] == "InvalidParameterException"
+    resp = sns.subscribe(TopicArn=topic_arn, Protocol="sqs", Endpoint=q_arn)
+    assert "SubscriptionArn" in resp
+    assert resp["SubscriptionArn"] != "PendingConfirmation"
 
 
 def test_sns_fifo_subscribe_fifo_sqs_queue_succeeds(sns, sqs):


### PR DESCRIPTION
  ## Summary
  
  Currently, ministack rejects subscribing a standard SQS queue to a FIFO SNS topic with:

  ```
  InvalidParameterException: Invalid parameter: Topic with FIFO requires a subscription to a FIFO SQS
   Queue
  ```

  This was the AWS rule until **2023-09-14**, when AWS added support for FIFO SNS topics fanning out
  to standard SQS queues. 

  References:
  - AWS announcement: https://aws.amazon.com/about-aws/whats-new/2023/09/amazon-sns-fifo-topics-message-delivery-sqs-standard-queues/ (if link does not directly work, change the language to english and filter the announcements with "Amazon SNS FIFO topics now support message delivery to Amazon SQS Standard queues")
  - AWS docs: https://docs.aws.amazon.com/sns/latest/dg/fifo-topic-message-ordering.html
    > "An Amazon SNS FIFO topic always delivers messages to subscribed Amazon SQS queues in the exact order in which the messages are published to the topic, and only once. With an Amazon SQS standard queue subscribed, however, the consumer of the queue may receive messages out of order, and more than once."