### PR TITLE
fix(rds): honor PreferredMaintenanceWindow on CreateDBInstance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- **RDS `CreateDBInstance` honors `PreferredMaintenanceWindow`** — the field was hardcoded to `sun:05:00-sun:06:00` on the instance record at creation time, silently discarding any caller-supplied value. `ModifyDBInstance` already honored it, and the cluster-level `PreferredMaintenanceWindow` already worked, so the divergence was per-instance only and only on create. The create path now reads the user value and only falls back to `sun:05:00-sun:06:00` when none is supplied. Closes #612. Surfaced by Terraform `aws_rds_cluster_instance.preferred_maintenance_window` round-trip diffing against a real-AWS capture.
+
+---
+
 ## [1.3.34] — 2026-05-11
 
 ### Added

--- a/ministack/services/rds.py
+++ b/ministack/services/rds.py
@@ -469,7 +469,7 @@ def _create_db_instance(p):
         }],
         "AvailabilityZone": _p(p, "AvailabilityZone") or f"{get_region()}a",
         "DBSubnetGroup": subnet_group,
-        "PreferredMaintenanceWindow": "sun:05:00-sun:06:00",
+        "PreferredMaintenanceWindow": _p(p, "PreferredMaintenanceWindow") or "sun:05:00-sun:06:00",
         "PendingModifiedValues": {},
         "LatestRestorableTime": _format_time(now_ts),
         "MultiAZ": _p(p, "MultiAZ") == "true",

--- a/tests/test_rds.py
+++ b/tests/test_rds.py
@@ -119,6 +119,36 @@ def test_rds_modify_instance_v2(rds):
     assert inst["DBInstanceClass"] == "db.t3.small"
     assert inst["AllocatedStorage"] == 50
 
+def test_rds_create_instance_honors_preferred_maintenance_window(rds):
+    # Regression: CreateDBInstance previously hardcoded
+    # PreferredMaintenanceWindow to "sun:05:00-sun:06:00", silently
+    # discarding any user-supplied value.
+    rds.create_db_instance(
+        DBInstanceIdentifier="rds-pmw-v2",
+        DBInstanceClass="db.t3.micro",
+        Engine="postgres",
+        MasterUsername="admin",
+        MasterUserPassword="pass",
+        AllocatedStorage=20,
+        PreferredMaintenanceWindow="tue:03:00-tue:04:00",
+    )
+    resp = rds.describe_db_instances(DBInstanceIdentifier="rds-pmw-v2")
+    inst = resp["DBInstances"][0]
+    assert inst["PreferredMaintenanceWindow"] == "tue:03:00-tue:04:00"
+
+def test_rds_create_instance_default_preferred_maintenance_window(rds):
+    rds.create_db_instance(
+        DBInstanceIdentifier="rds-pmw-default-v2",
+        DBInstanceClass="db.t3.micro",
+        Engine="postgres",
+        MasterUsername="admin",
+        MasterUserPassword="pass",
+        AllocatedStorage=20,
+    )
+    resp = rds.describe_db_instances(DBInstanceIdentifier="rds-pmw-default-v2")
+    inst = resp["DBInstances"][0]
+    assert inst["PreferredMaintenanceWindow"] == "sun:05:00-sun:06:00"
+
 def test_rds_create_cluster_v2(rds):
     resp = rds.create_db_cluster(
         DBClusterIdentifier="rds-cc-v2",


### PR DESCRIPTION
Closes #612.

## Summary

`CreateDBInstance` hardcoded `PreferredMaintenanceWindow` to `"sun:05:00-sun:06:00"` on the instance record, silently discarding any caller-supplied value. The create path now reads the user value and falls back to the default only when none is supplied.

## Bug detail

```python
# ministack/services/rds.py — _create_db_instance (line 472, before)
"PreferredMaintenanceWindow": "sun:05:00-sun:06:00",
```

The cluster-level field at `_create_db_cluster` (line 915) already honored the user value (`_p(p, "PreferredMaintenanceWindow") or "sun:05:00-sun:06:00"`), and `_modify_db_instance` (line 670) wires the field through correctly. The divergence was per-instance and only on create.

`RestoreDBInstanceFromDBSnapshot` (line 837) has the same hardcoded default but it's intentionally left alone: the real AWS RDS API does not accept `PreferredMaintenanceWindow` on that operation (botocore rejects the parameter at validation time), so the field is set via a follow-up `ModifyDBInstance`. That path is already correct.

## Reproduction (against `ministackorg/ministack:1.3.34`)

```hcl
resource "aws_rds_cluster" "c" {
  cluster_identifier           = "mw-probe-cluster"
  engine                       = "aurora-mysql"
  engine_version               = "8.0.mysql_aurora.3.06.0"
  master_username              = "admin"
  master_password              = "Password123!"
  db_subnet_group_name         = aws_db_subnet_group.sg.name
  skip_final_snapshot          = true
  preferred_maintenance_window = "mon:01:00-mon:02:00"
}

resource "aws_rds_cluster_instance" "i" {
  identifier                   = "mw-probe-instance-01"
  cluster_identifier           = aws_rds_cluster.c.id
  instance_class               = "db.t3.medium"
  engine                       = aws_rds_cluster.c.engine
  engine_version               = aws_rds_cluster.c.engine_version
  preferred_maintenance_window = "tue:03:00-tue:04:00"
}
```

```bash
$ aws --endpoint-url http://localhost:4566 rds describe-db-clusters \
    --db-cluster-identifier mw-probe-cluster \
    --query 'DBClusters[0].PreferredMaintenanceWindow' --output text
mon:01:00-mon:02:00          # cluster honored ✓

$ aws --endpoint-url http://localhost:4566 rds describe-db-instances \
    --db-instance-identifier mw-probe-instance-01 \
    --query 'DBInstances[0].PreferredMaintenanceWindow' --output text
sun:05:00-sun:06:00          # instance overridden ✗  (expected: tue:03:00-tue:04:00)
```

After this change, the instance returns `tue:03:00-tue:04:00` as expected (verified end-to-end against a local hypercorn run of this branch).

## Tests

Two regression tests added to `tests/test_rds.py`:

- `test_rds_create_instance_honors_preferred_maintenance_window` — explicit value is preserved.
- `test_rds_create_instance_default_preferred_maintenance_window` — default `sun:05:00-sun:06:00` still applied when caller omits the field.

Both pass against the patched server. Full `tests/test_rds.py` continues to pass (60/61; the unrelated `test_rds_lambda_network_connectivity` requires a live Docker network).

## PR Checklist

- [x] Bug fix isolated to `ministack/services/rds.py`
- [x] Regression tests added (`tests/test_rds.py`)
- [x] `ruff check ministack/services/rds.py tests/test_rds.py` passes
- [x] `CHANGELOG.md` updated under `[Unreleased]`
