### PR TITLE
fix(rds): correct DescribeDBClusters serialization for DatabaseName, NetworkType, EngineLifecycleSupport

### DIFF
--- a/ministack/services/rds.py
+++ b/ministack/services/rds.py
@@ -900,7 +900,9 @@ def _create_db_cluster(p):
         "Status": "available",
         "MasterUsername": master_user,
         "_MasterUserPassword": master_pass,
-        "DatabaseName": _p(p, "DatabaseName") or "",
+        "DatabaseName": _p(p, "DatabaseName") or None,
+        "NetworkType": _p(p, "NetworkType") or "IPV4",
+        "EngineLifecycleSupport": _p(p, "EngineLifecycleSupport") or "open-source-rds-extended-support",
         "Endpoint": f"{cluster_id}.cluster-{unique_suffix}.{get_region()}.rds.amazonaws.com",
         "ReaderEndpoint": f"{cluster_id}.cluster-ro-{unique_suffix}.{get_region()}.rds.amazonaws.com",
         "Port": port,
@@ -2273,6 +2275,11 @@ def _cluster_xml(c):
     for t in c.get("TagList", []):
         tag_xml += f"<Tag><Key>{_esc(t['Key'])}</Key><Value>{_esc(t['Value'])}</Value></Tag>"
 
+    # AWS omits <DatabaseName> entirely when no initial database was specified;
+    # emitting an empty element would surface as "" instead of None to clients.
+    db_name = c.get("DatabaseName")
+    db_name_xml = f"<DatabaseName>{db_name}</DatabaseName>" if db_name else ""
+
     return f"""<DBClusterIdentifier>{c['DBClusterIdentifier']}</DBClusterIdentifier>
         <DBClusterArn>{c['DBClusterArn']}</DBClusterArn>
         <Engine>{c['Engine']}</Engine>
@@ -2280,7 +2287,7 @@ def _cluster_xml(c):
         <EngineMode>{c.get('EngineMode','provisioned')}</EngineMode>
         <Status>{c['Status']}</Status>
         <MasterUsername>{c.get('MasterUsername','admin')}</MasterUsername>
-        <DatabaseName>{c.get('DatabaseName','')}</DatabaseName>
+        {db_name_xml}
         <Endpoint>{c.get('Endpoint','')}</Endpoint>
         <ReaderEndpoint>{c.get('ReaderEndpoint','')}</ReaderEndpoint>
         <Port>{c['Port']}</Port>
@@ -2308,7 +2315,9 @@ def _cluster_xml(c):
         <AssociatedRoles/>
         <TagList>{tag_xml}</TagList>
         <AllocatedStorage>{c.get('AllocatedStorage',1)}</AllocatedStorage>
-        <ActivityStreamStatus>{c.get('ActivityStreamStatus','stopped')}</ActivityStreamStatus>"""
+        <ActivityStreamStatus>{c.get('ActivityStreamStatus','stopped')}</ActivityStreamStatus>
+        <NetworkType>{c.get('NetworkType','IPV4')}</NetworkType>
+        <EngineLifecycleSupport>{c.get('EngineLifecycleSupport','open-source-rds-extended-support')}</EngineLifecycleSupport>"""
 
 
 def _snapshot_xml(s):

--- a/tests/test_rds.py
+++ b/tests/test_rds.py
@@ -42,6 +42,39 @@ def test_rds_cluster(rds):
     resp = rds.describe_db_clusters(DBClusterIdentifier="test-cluster")
     assert resp["DBClusters"][0]["DBClusterIdentifier"] == "test-cluster"
 
+def test_rds_cluster_default_field_serialization(rds):
+    """Regression: DescribeDBClusters defaults must match real AWS for
+    DatabaseName (absent/None), NetworkType ("IPV4"), and EngineLifecycleSupport
+    ("open-source-rds-extended-support") when not supplied at create time."""
+    rds.create_db_cluster(
+        DBClusterIdentifier="cluster-defaults",
+        Engine="aurora-mysql",
+        MasterUsername="root",
+        MasterUserPassword="password123",
+    )
+    cluster = rds.describe_db_clusters(DBClusterIdentifier="cluster-defaults")["DBClusters"][0]
+    # AWS returns null/absent when no initial database was specified, not "".
+    assert cluster.get("DatabaseName") is None
+    assert cluster.get("NetworkType") == "IPV4"
+    assert cluster.get("EngineLifecycleSupport") == "open-source-rds-extended-support"
+
+def test_rds_cluster_explicit_field_round_trip(rds):
+    """Explicit DatabaseName / NetworkType / EngineLifecycleSupport round-trip
+    through DescribeDBClusters."""
+    rds.create_db_cluster(
+        DBClusterIdentifier="cluster-explicit",
+        Engine="aurora-mysql",
+        MasterUsername="root",
+        MasterUserPassword="password123",
+        DatabaseName="mydb",
+        NetworkType="DUAL",
+        EngineLifecycleSupport="open-source-rds-extended-support-disabled",
+    )
+    cluster = rds.describe_db_clusters(DBClusterIdentifier="cluster-explicit")["DBClusters"][0]
+    assert cluster.get("DatabaseName") == "mydb"
+    assert cluster.get("NetworkType") == "DUAL"
+    assert cluster.get("EngineLifecycleSupport") == "open-source-rds-extended-support-disabled"
+
 def test_rds_create_instance_v2(rds):
     resp = rds.create_db_instance(
         DBInstanceIdentifier="rds-ci-v2",


### PR DESCRIPTION
## Summary

Three confirmed bugs in `DescribeDBClusters` response shape, all in the same code path (`_create_db_cluster` + `_cluster_xml` in `ministack/services/rds.py`). See full investigation report in [`/tmp/ministack-dbcluster-fields-bug-report.md`](file:///tmp/ministack-dbcluster-fields-bug-report.md).

| # | Field | Real AWS | MiniStack (before) | MiniStack (after) |
|---|---|---|---|---|
| B1 | `DatabaseName`           | `null`                                         | `""`            | `null` |
| B2 | `NetworkType`            | `"IPV4"`                                       | absent (null)   | `"IPV4"` |
| B3 | `EngineLifecycleSupport` | `"open-source-rds-extended-support"`           | absent (null)   | `"open-source-rds-extended-support"` |

## Per-bug fix

- **B1 — `DatabaseName: ""` → `null`**: `_create_db_cluster` stored `_p(p, "DatabaseName") or ""` and `_cluster_xml` always emitted the element, so botocore parsed it as `""`. Now stored as `None` when unset, and the `<DatabaseName>` element is only emitted when truthy — matching how real RDS renders it.
- **B2 — `NetworkType` missing**: the field was never stored or serialized. Now accepted from the request (defaults to `"IPV4"`) and emitted from `_cluster_xml`, mirroring the existing instance-serializer at line 2245.
- **B3 — `EngineLifecycleSupport` missing**: same — the field never existed in the cluster code path. Now accepted from the request (defaults to `"open-source-rds-extended-support"`) and emitted from `_cluster_xml`.

Diff is ~10 lines plus tests.

## Tests added

In `tests/test_rds.py`:

- `test_rds_cluster_default_field_serialization` — creates a cluster with no `DatabaseName` / `NetworkType` / `EngineLifecycleSupport` and asserts the AWS-correct defaults come back (`DatabaseName is None`, `NetworkType == "IPV4"`, `EngineLifecycleSupport == "open-source-rds-extended-support"`).
- `test_rds_cluster_explicit_field_round_trip` — creates a cluster with explicit `DatabaseName="mydb"`, `NetworkType="DUAL"`, `EngineLifecycleSupport="open-source-rds-extended-support-disabled"` and asserts they round-trip through `DescribeDBClusters`.

Both new tests pass, plus all other `test_rds.py::test_rds_cluster*` tests pass. (Only the unrelated `test_rds_lambda_network_connectivity` test failed locally, because it requires a real Docker network — no behavior change there.)

## Codex review summary

Ran `amp review`:

> Updates RDS cluster creation and serialization to align with AWS behavior regarding default fields and optional database names.
> - Ensures DatabaseName is omitted from responses when not specified, rather than returning an empty string.
> - Adds support for NetworkType and EngineLifecycleSupport fields with standard AWS defaults.
>
> **No issues found.** (untrusted-pr: ok, meta-review: ok)

## Origin

This came out of a brownfield-import diff investigation in another repo (`squareup/personal-jayj-metacluster-provider` PR #79), where MiniStack-captured Aurora fixtures diverged from real-AWS-captured fixtures on exactly these three fields. Audit note from the bug report: the same gaps likely exist in `RestoreDBClusterFromSnapshot`, `RestoreDBClusterToPointInTime`, and `ModifyDBCluster` — out of scope for this PR but worth a follow-up sweep.