### PR TITLE
feat(s3): enforce Deny statements in bucket policy

### DIFF
--- a/ministack/services/s3.py
+++ b/ministack/services/s3.py
@@ -25,6 +25,7 @@ Storage: In-memory (optionally backed by S3_DATA_DIR).
 import base64
 import copy
 import datetime as _dt
+import fnmatch
 import hashlib
 import json
 import logging
@@ -37,7 +38,6 @@ from urllib.parse import quote as url_quote
 from urllib.parse import unquote as url_unquote
 from xml.etree.ElementTree import Element, SubElement, tostring
 from xml.sax.saxutils import escape as _esc
-import fnmatch
 
 from defusedxml.ElementTree import fromstring
 

--- a/ministack/services/s3.py
+++ b/ministack/services/s3.py
@@ -37,6 +37,7 @@ from urllib.parse import quote as url_quote
 from urllib.parse import unquote as url_unquote
 from xml.etree.ElementTree import Element, SubElement, tostring
 from xml.sax.saxutils import escape as _esc
+import fnmatch
 
 from defusedxml.ElementTree import fromstring
 
@@ -408,6 +409,27 @@ async def handle_request(
 ) -> tuple:
     bucket, key = _parse_bucket_key(path, headers)
 
+    # Enforce bucket-policy Deny statements before dispatch.
+    if bucket:
+        # Policy management always escapes — otherwise a deny-all bricks the bucket.
+        if "policy" in query_params and method in ("GET", "PUT", "DELETE"):
+            action = None
+        else:
+            action_map = {
+                "GET":    "s3:GetObject" if key else "s3:ListBucket",
+                "HEAD":   "s3:GetObject" if key else "s3:ListBucket",
+                "PUT":    "s3:PutObject" if key else "s3:CreateBucket",
+                "POST":   "s3:PutObject",
+                "DELETE": "s3:DeleteObject" if key else "s3:DeleteBucket",
+            }
+            action = action_map.get(method)
+        if action:
+            denied = _check_bucket_policy(bucket, action, key)
+            if denied:
+                status, h, body_out = denied
+                h.setdefault("x-amz-request-id", new_uuid())
+                return status, h, body_out
+
     result = _dispatch(method, bucket, key, headers, body, query_params)
 
     status, resp_headers, resp_body = result
@@ -749,6 +771,54 @@ def _delete_bucket_policy(name: str):
         return _no_such_bucket(name)
     _bucket_policies.pop(name, None)
     return 204, {}, b""
+
+# ---------------------------------------------------------------------------
+# Bucket-policy enforcement (minimal: explicit Deny only)
+# ---------------------------------------------------------------------------
+
+
+def _check_bucket_policy(bucket_name: str, action: str, key: str = ""):
+    """Return an _error tuple if a Deny statement matches the request, else None.
+
+    Honors only Effect=Deny on Action + Resource. Conditions, Principal
+    scoping, and Allow logic are not implemented — everything not explicitly
+    denied is allowed (bucket-owner default).
+    """
+    raw = _bucket_policies.get(bucket_name)
+    if not raw:
+        return None
+    try:
+        policy = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return None
+
+    statements = policy.get("Statement", [])
+    if isinstance(statements, dict):
+        statements = [statements]
+
+    bucket_arn = f"arn:aws:s3:::{bucket_name}"
+    object_arn = f"arn:aws:s3:::{bucket_name}/{key}" if key else bucket_arn
+
+    for stmt in statements:
+        if stmt.get("Effect") != "Deny":
+            continue
+        actions = stmt.get("Action", [])
+        if isinstance(actions, str):
+            actions = [actions]
+        if not any(fnmatch.fnmatchcase(action, a) for a in actions):
+            continue
+        resources = stmt.get("Resource", [])
+        if isinstance(resources, str):
+            resources = [resources]
+        if any(fnmatch.fnmatchcase(c, r)
+               for r in resources for c in (bucket_arn, object_arn)):
+            return _error(
+                "AccessDenied",
+                "User is not authorized to perform this action on the resource.",
+                403,
+                f"/{bucket_name}/{key}" if key else f"/{bucket_name}",
+            )
+    return None
 
 
 def _get_bucket_versioning(name: str):

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -526,6 +526,196 @@ def test_s3_bucket_policy(s3):
     assert stored["Version"] == "2012-10-17"
     assert len(stored["Statement"]) == 1
 
+
+def _deny_all_policy(bkt: str) -> str:
+    return json.dumps({
+        "Version": "2012-10-17",
+        "Statement": [{
+            "Sid": "DenyAll",
+            "Effect": "Deny",
+            "Principal": "*",
+            "Action": "s3:*",
+            "Resource": [f"arn:aws:s3:::{bkt}", f"arn:aws:s3:::{bkt}/*"],
+        }],
+    })
+
+
+def test_s3_policy_deny_blocks_get_object(s3):
+    bkt = "intg-s3-policy-deny-get"
+    s3.create_bucket(Bucket=bkt)
+    s3.put_object(Bucket=bkt, Key="secret.txt", Body=b"secret")
+    s3.put_bucket_policy(Bucket=bkt, Policy=_deny_all_policy(bkt))
+
+    with pytest.raises(ClientError) as exc:
+        s3.get_object(Bucket=bkt, Key="secret.txt")
+    assert exc.value.response["Error"]["Code"] == "AccessDenied"
+    assert exc.value.response["ResponseMetadata"]["HTTPStatusCode"] == 403
+
+
+def test_s3_policy_deny_blocks_head_object(s3):
+    bkt = "intg-s3-policy-deny-head"
+    s3.create_bucket(Bucket=bkt)
+    s3.put_object(Bucket=bkt, Key="secret.txt", Body=b"secret")
+    s3.put_bucket_policy(Bucket=bkt, Policy=_deny_all_policy(bkt))
+
+    with pytest.raises(ClientError) as exc:
+        s3.head_object(Bucket=bkt, Key="secret.txt")
+    # HEAD responses carry no body — botocore reports an empty error code.
+    assert exc.value.response["ResponseMetadata"]["HTTPStatusCode"] == 403
+
+
+def test_s3_policy_deny_blocks_list_objects(s3):
+    bkt = "intg-s3-policy-deny-list"
+    s3.create_bucket(Bucket=bkt)
+    s3.put_object(Bucket=bkt, Key="a.txt", Body=b"a")
+    s3.put_bucket_policy(Bucket=bkt, Policy=_deny_all_policy(bkt))
+
+    with pytest.raises(ClientError) as exc:
+        s3.list_objects_v2(Bucket=bkt)
+    assert exc.value.response["Error"]["Code"] == "AccessDenied"
+
+
+def test_s3_policy_deny_blocks_put_object(s3):
+    bkt = "intg-s3-policy-deny-put"
+    s3.create_bucket(Bucket=bkt)
+    s3.put_bucket_policy(Bucket=bkt, Policy=_deny_all_policy(bkt))
+
+    with pytest.raises(ClientError) as exc:
+        s3.put_object(Bucket=bkt, Key="new.txt", Body=b"nope")
+    assert exc.value.response["Error"]["Code"] == "AccessDenied"
+
+
+def test_s3_policy_deny_blocks_delete_object(s3):
+    bkt = "intg-s3-policy-deny-del"
+    s3.create_bucket(Bucket=bkt)
+    s3.put_object(Bucket=bkt, Key="doomed.txt", Body=b"x")
+    s3.put_bucket_policy(Bucket=bkt, Policy=_deny_all_policy(bkt))
+
+    with pytest.raises(ClientError) as exc:
+        s3.delete_object(Bucket=bkt, Key="doomed.txt")
+    assert exc.value.response["Error"]["Code"] == "AccessDenied"
+
+
+def test_s3_policy_deny_scoped_to_specific_action(s3):
+    """Deny s3:GetObject should NOT block PutObject."""
+    bkt = "intg-s3-policy-deny-scoped"
+    s3.create_bucket(Bucket=bkt)
+    s3.put_object(Bucket=bkt, Key="existing.txt", Body=b"x")
+
+    policy = json.dumps({
+        "Version": "2012-10-17",
+        "Statement": [{
+            "Effect": "Deny",
+            "Principal": "*",
+            "Action": "s3:GetObject",
+            "Resource": f"arn:aws:s3:::{bkt}/*",
+        }],
+    })
+    s3.put_bucket_policy(Bucket=bkt, Policy=policy)
+
+    # Get is denied
+    with pytest.raises(ClientError) as exc:
+        s3.get_object(Bucket=bkt, Key="existing.txt")
+    assert exc.value.response["Error"]["Code"] == "AccessDenied"
+
+    # Put is not — different action
+    s3.put_object(Bucket=bkt, Key="allowed.txt", Body=b"ok")
+
+
+def test_s3_policy_deny_scoped_to_specific_object(s3):
+    """Deny on arn:aws:s3:::bkt/private/* should not block bkt/public/*."""
+    bkt = "intg-s3-policy-deny-prefix"
+    s3.create_bucket(Bucket=bkt)
+    s3.put_object(Bucket=bkt, Key="private/hidden.txt", Body=b"hush")
+    s3.put_object(Bucket=bkt, Key="public/open.txt", Body=b"hi")
+
+    policy = json.dumps({
+        "Version": "2012-10-17",
+        "Statement": [{
+            "Effect": "Deny",
+            "Principal": "*",
+            "Action": "s3:GetObject",
+            "Resource": f"arn:aws:s3:::{bkt}/private/*",
+        }],
+    })
+    s3.put_bucket_policy(Bucket=bkt, Policy=policy)
+
+    with pytest.raises(ClientError) as exc:
+        s3.get_object(Bucket=bkt, Key="private/hidden.txt")
+    assert exc.value.response["Error"]["Code"] == "AccessDenied"
+
+    resp = s3.get_object(Bucket=bkt, Key="public/open.txt")
+    assert resp["Body"].read() == b"hi"
+
+
+def test_s3_policy_management_escapes_deny(s3):
+    """Even under a deny-all policy, Get/Put/Delete-BucketPolicy must keep working.
+
+    Without this escape hatch, applying a blanket deny would brick the bucket —
+    there would be no way to inspect or remove the policy via the API.
+    """
+    bkt = "intg-s3-policy-escape"
+    s3.create_bucket(Bucket=bkt)
+    s3.put_bucket_policy(Bucket=bkt, Policy=_deny_all_policy(bkt))
+
+    # Still readable
+    resp = s3.get_bucket_policy(Bucket=bkt)
+    assert "DenyAll" in resp["Policy"]
+
+    # Still replaceable
+    s3.put_bucket_policy(Bucket=bkt, Policy=_deny_all_policy(bkt))
+
+    # Still deletable — and after deletion, access is restored
+    s3.delete_bucket_policy(Bucket=bkt)
+    s3.put_object(Bucket=bkt, Key="after.txt", Body=b"free")
+    resp = s3.get_object(Bucket=bkt, Key="after.txt")
+    assert resp["Body"].read() == b"free"
+
+
+def test_s3_policy_allow_statements_are_ignored(s3):
+    """Current evaluator is Deny-only — Allow statements shouldn't grant or
+    revoke access on their own. This test documents the intentional gap so a
+    future implementer notices it if they add Allow logic.
+    """
+    bkt = "intg-s3-policy-allow-noop"
+    s3.create_bucket(Bucket=bkt)
+    s3.put_object(Bucket=bkt, Key="hello.txt", Body=b"hi")
+
+    # An Allow-only policy — in real AWS this wouldn't grant anything extra
+    # beyond the default owner access; we just verify it doesn't break GET.
+    policy = json.dumps({
+        "Version": "2012-10-17",
+        "Statement": [{
+            "Effect": "Allow",
+            "Principal": "*",
+            "Action": "s3:GetObject",
+            "Resource": f"arn:aws:s3:::{bkt}/*",
+        }],
+    })
+    s3.put_bucket_policy(Bucket=bkt, Policy=policy)
+
+    resp = s3.get_object(Bucket=bkt, Key="hello.txt")
+    assert resp["Body"].read() == b"hi"
+
+
+def test_s3_policy_malformed_json_does_not_crash_evaluator(s3):
+    """A stored non-JSON policy should not raise from the evaluator — it
+    should fail open (log-and-continue) rather than 500 on every request.
+    """
+    bkt = "intg-s3-policy-malformed"
+    s3.create_bucket(Bucket=bkt)
+    s3.put_object(Bucket=bkt, Key="ok.txt", Body=b"ok")
+
+    # Bypass the CRUD API to plant garbage directly. Even against AWS-SDK
+    # validation this would fail; here we reach into the store.
+    from ministack.services.s3 import _bucket_policies
+    _bucket_policies[bkt] = "not a json document"
+
+    # Must not crash; request should proceed as if no policy existed.
+    resp = s3.get_object(Bucket=bkt, Key="ok.txt")
+    assert resp["Body"].read() == b"ok"
+
+
 def test_s3_object_tagging(s3):
     bkt = "intg-s3-objtags"
     s3.create_bucket(Bucket=bkt)


### PR DESCRIPTION
## Summary

  S3 bucket policies were stored on `PutBucketPolicy` and round-tripped on `GetBucketPolicy`, but never evaluated against incoming requests. As a result every request succeeded regardless of policy — `Effect: Deny`
   statements were silently ignored. Tests written against MiniStack to verify "deny-all" or "deny `s3:GetObject` on this prefix" patterns would pass locally and ship buckets that are wide open in prod.

  ## Fix

  Add a minimal policy evaluator and wire it into the request pipeline:

  - `_check_bucket_policy` (`ministack/services/s3.py`, after `_delete_bucket_policy`) — parses the stored JSON and returns `AccessDenied` (HTTP 403) when any `Effect: Deny` statement matches the request on both
  `Action` (with `fnmatch` wildcards, e.g. `s3:*`) and `Resource` (bucket and object ARN forms). Conditions, Principal scoping, and `Effect: Allow` are intentionally not implemented — bucket-owner default-allow
  remains in force for everything not explicitly denied.
  - `handle_request` (`ministack/services/s3.py`) — invokes `_check_bucket_policy` before `_dispatch`, with an `action_map` covering `GET/HEAD → s3:GetObject|s3:ListBucket`, `PUT → s3:PutObject|s3:CreateBucket`,
  `POST → s3:PutObject`, `DELETE → s3:DeleteObject|s3:DeleteBucket`.
  - Escape hatch: requests carrying `?policy` (`Get/Put/DeleteBucketPolicy`) skip enforcement so a deny-all does not brick the bucket — without this, a policy applied through the API could not be inspected or
  removed via the API.

  ## Test added

  `tests/test_s3.py` — 9 new tests plus a `_deny_all_policy` helper:

  - `test_s3_policy_deny_blocks_get_object` / `_head_object` / `_list_objects` / `_put_object` / `_delete_object` — deny-all blocks each verb with `AccessDenied` (HTTP 403)
  - `test_s3_policy_deny_scoped_to_specific_action` — `Deny s3:GetObject` does not block PutObject
  - `test_s3_policy_deny_scoped_to_specific_object` — `Deny ... bkt/private/*` does not block `bkt/public/*`
  - `test_s3_policy_management_escapes_deny` — `Get/Put/Delete-BucketPolicy` keep working under deny-all
  - `test_s3_policy_allow_statements_are_ignored` — documents the intentional Deny-only scope
  - `test_s3_policy_malformed_json_does_not_crash_evaluator` — fail-open on garbage policy

  The existing `test_s3_bucket_policy` (round-trip only) is unchanged and continues to pass.

  Verified locally:

  pytest tests/test_s3.py -v -k policy
  ...
  tests/test_s3.py::test_s3_bucket_policy PASSED
  tests/test_s3.py::test_s3_policy_deny_blocks_get_object PASSED
  tests/test_s3.py::test_s3_policy_deny_blocks_head_object PASSED
  tests/test_s3.py::test_s3_policy_deny_blocks_list_objects PASSED
  tests/test_s3.py::test_s3_policy_deny_blocks_put_object PASSED
  tests/test_s3.py::test_s3_policy_deny_blocks_delete_object PASSED
  tests/test_s3.py::test_s3_policy_deny_scoped_to_specific_action PASSED
  tests/test_s3.py::test_s3_policy_deny_scoped_to_specific_object PASSED
  tests/test_s3.py::test_s3_policy_management_escapes_deny PASSED
  tests/test_s3.py::test_s3_policy_allow_statements_are_ignored PASSED
  tests/test_s3.py::test_s3_policy_malformed_json_does_not_crash_evaluator PASSED

  ## References

  - AWS bucket policy examples — https://docs.aws.amazon.com/AmazonS3/latest/userguide/example-bucket-policies.html