### PR TITLE
fix(s3): UploadPartCopy x-amz-copy-source-range validation

### DIFF
--- a/ministack/services/s3.py
+++ b/ministack/services/s3.py
@@ -3087,10 +3087,34 @@ def _upload_part_copy(bucket_name: str, dest_key: str, query_params: dict, heade
 
     # Handle x-amz-copy-source-range
     copy_range = headers.get("x-amz-copy-source-range", "")
-    if copy_range and copy_range.startswith("bytes="):
-        rng = copy_range[6:]
-        start, end = rng.split("-")
-        src_body = src_body[int(start):int(end) + 1]
+    if copy_range:
+        _malformed = _error(
+            "InvalidArgument",
+            "The x-amz-copy-source-range value must be of the form "
+            "bytes=first-last where first and last are the zero-based offsets "
+            "of the first and last bytes to copy",
+            400,
+        )
+        if not copy_range.startswith("bytes=") or "," in copy_range:
+            return _malformed
+        rng = copy_range[len("bytes="):]
+        parts = rng.split("-")
+        if len(parts) != 2 or parts[0] == "" or parts[1] == "":
+            return _malformed
+        try:
+            start, end = int(parts[0]), int(parts[1])
+        except ValueError:
+            return _malformed
+        if start < 0 or end < start:
+            return _malformed
+        object_size = len(src_body)
+        if start > object_size - 1 or end > object_size - 1:
+            return _error(
+                "InvalidArgument",
+                f"Range specified is not valid for source object of size: {object_size}",
+                400,
+            )
+        src_body = src_body[start:end + 1]
 
     etag = f'"{md5_hash(src_body)}"'
     _multipart_uploads[upload_id]["parts"][part_number] = {

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -1775,6 +1775,84 @@ def test_s3_upload_part_copy(s3):
     resp = s3.get_object(Bucket=bkt, Key=dst_key)
     assert resp["Body"].read() == src_data
 
+
+def test_s3_upload_part_copy_with_valid_range(s3):
+    """UploadPartCopy with a valid x-amz-copy-source-range slices the source."""
+    bkt = "intg-s3-partcopy-range"
+    s3.create_bucket(Bucket=bkt)
+    s3.put_object(Bucket=bkt, Key="src", Body=b"0123456789")
+
+    mpu = s3.create_multipart_upload(Bucket=bkt, Key="dst")
+    upload_id = mpu["UploadId"]
+    resp = s3.upload_part_copy(
+        Bucket=bkt, Key="dst", UploadId=upload_id, PartNumber=1,
+        CopySource={"Bucket": bkt, "Key": "src"},
+        CopySourceRange="bytes=2-5",
+    )
+    s3.complete_multipart_upload(
+        Bucket=bkt, Key="dst", UploadId=upload_id,
+        MultipartUpload={"Parts": [{"PartNumber": 1, "ETag": resp["CopyPartResult"]["ETag"]}]},
+    )
+    assert s3.get_object(Bucket=bkt, Key="dst")["Body"].read() == b"2345"
+
+
+@pytest.mark.parametrize("bad_range", [
+    "bytes=garbage",        # no hyphen
+    "bytes=abc-def",        # non-numeric
+    "bytes=10-20-30",       # too many segments
+    "bytes=-",              # both empty
+    "bytes=5-",             # missing end
+    "bytes=-5",             # missing start
+    "bytes=5-2",            # reversed
+    "bytes=0-1,3-4",        # multi-range not allowed for UploadPartCopy
+    "rows=0-5",             # wrong unit
+    "0-5",                  # missing bytes= prefix
+])
+def test_s3_upload_part_copy_rejects_malformed_range(s3, bad_range):
+    """Malformed x-amz-copy-source-range must return 400 InvalidArgument, not 500."""
+    import requests
+    bkt = "intg-s3-partcopy-bad-" + str(abs(hash(bad_range)))[:8]
+    s3.create_bucket(Bucket=bkt)
+    s3.put_object(Bucket=bkt, Key="src", Body=b"0123456789")
+
+    upload_id = s3.create_multipart_upload(Bucket=bkt, Key="dst")["UploadId"]
+    endpoint = os.environ.get("MINISTACK_ENDPOINT", "http://localhost:4566")
+    r = requests.put(
+        f"{endpoint}/{bkt}/dst",
+        params={"partNumber": 1, "uploadId": upload_id},
+        headers={
+            "x-amz-copy-source": f"/{bkt}/src",
+            "x-amz-copy-source-range": bad_range,
+        },
+        timeout=10,
+    )
+    assert r.status_code == 400, f"got {r.status_code} for {bad_range!r}: {r.text[:200]}"
+    assert b"InvalidArgument" in r.content
+
+
+def test_s3_upload_part_copy_rejects_out_of_bounds_range(s3):
+    """Range past the end of the source object must return 400 InvalidArgument."""
+    import requests
+    bkt = "intg-s3-partcopy-oob"
+    s3.create_bucket(Bucket=bkt)
+    s3.put_object(Bucket=bkt, Key="src", Body=b"0123456789")  # 10 bytes
+
+    upload_id = s3.create_multipart_upload(Bucket=bkt, Key="dst")["UploadId"]
+    endpoint = os.environ.get("MINISTACK_ENDPOINT", "http://localhost:4566")
+    r = requests.put(
+        f"{endpoint}/{bkt}/dst",
+        params={"partNumber": 1, "uploadId": upload_id},
+        headers={
+            "x-amz-copy-source": f"/{bkt}/src",
+            "x-amz-copy-source-range": "bytes=0-99",
+        },
+        timeout=10,
+    )
+    assert r.status_code == 400
+    assert b"InvalidArgument" in r.content
+    assert b"size: 10" in r.content
+
+
 def test_s3_event_to_sqs(s3, sqs):
     """S3 notification delivers event to SQS on object creation and deletion."""
     bucket = "intg-s3evt-sqs"


### PR DESCRIPTION
## Summary

  `UploadPartCopy` parses `x-amz-copy-source-range` with `start, end = rng.split("-")` and no validation. Malformed values raise an unhandled `ValueError`, which surfaces as HTTP 500 with an empty body.
  Out-of-bounds and reversed ranges pass silently and corrupt the part body.

  Observed behavior:

  | Input | Expected | Actual |
  |---|---|---|
  | `bytes=garbage` | 400 `InvalidArgument` | 500 (unhandled `ValueError`) |
  | `bytes=abc-def` | 400 `InvalidArgument` | 500 (unhandled `ValueError`) |
  | `bytes=5-2` (reversed) | 400 `InvalidArgument` | 200 (empty slice) |
  | `bytes=0-99` on 10-byte source | 400 `InvalidArgument` | 200 (silently truncated to 10 bytes) |

  The silent cases are the worst — `CompleteMultipartUpload` succeeds and the assembled object is wrong size, with no error anywhere in the client.

  boto3 retries 5xx but fails fast on 4xx, so clients hit infinite retry loops against MiniStack while failing immediately against real S3 — masking the underlying client bug and hanging CI.

  ## Fix

  Validate `x-amz-copy-source-range` in `_upload_part_copy` (`ministack/services/s3.py`) before slicing:

  - require `bytes=` prefix
  - reject multi-range values (containing `,`)
  - require exactly two non-empty segments
  - require both segments to be integers
  - require `start >= 0` and `end >= start`
  - require the range to fit inside the source object

  Any failure returns 400 `InvalidArgument` with the source object size in the message when applicable. Valid ranges and requests without the header are unchanged.

  ## Test added

  `tests/test_s3.py`:

  - `test_s3_upload_part_copy_with_valid_range` — regression check for the valid-range happy path
  - `test_s3_upload_part_copy_rejects_malformed_range` — parametrized over 10 malformed inputs (no-hyphen, non-numeric, too many segments, both-empty, missing-start, missing-end, reversed, multi-range, wrong unit,
  missing prefix); each must return 400 `InvalidArgument`
  - `test_s3_upload_part_copy_rejects_out_of_bounds_range` — range past the end of the source returns 400 with the object size in the message

  The existing `test_s3_upload_part_copy` happy-path test is unchanged.

  Verified locally:

  pytest tests/test_s3.py -k upload_part_copy -v
  ...
  tests/test_s3.py::test_s3_upload_part_copy PASSED
  tests/test_s3.py::test_s3_upload_part_copy_with_valid_range PASSED
  tests/test_s3.py::test_s3_upload_part_copy_rejects_malformed_range[bytes=garbage] PASSED
  tests/test_s3.py::test_s3_upload_part_copy_rejects_malformed_range[bytes=abc-def] PASSED
  tests/test_s3.py::test_s3_upload_part_copy_rejects_malformed_range[bytes=10-20-30] PASSED
  tests/test_s3.py::test_s3_upload_part_copy_rejects_malformed_range[bytes=-] PASSED
  tests/test_s3.py::test_s3_upload_part_copy_rejects_malformed_range[bytes=5-] PASSED
  tests/test_s3.py::test_s3_upload_part_copy_rejects_malformed_range[bytes=-5] PASSED
  tests/test_s3.py::test_s3_upload_part_copy_rejects_malformed_range[bytes=5-2] PASSED
  tests/test_s3.py::test_s3_upload_part_copy_rejects_malformed_range[bytes=0-1,3-4] PASSED
  tests/test_s3.py::test_s3_upload_part_copy_rejects_malformed_range[rows=0-5] PASSED
  tests/test_s3.py::test_s3_upload_part_copy_rejects_malformed_range[0-5] PASSED
  tests/test_s3.py::test_s3_upload_part_copy_rejects_out_of_bounds_range PASSED

  13 passed

  ## References

  - `UploadPartCopy` API reference — https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPartCopy.html