### PR TITLE
fix(sqs): DeleteQueue to raise QueueDoesNotExist for missing queues

### DIFF
--- a/ministack/services/sqs.py
+++ b/ministack/services/sqs.py
@@ -236,9 +236,9 @@ def _act_create_queue(data: dict, _u: str) -> dict:
 
 def _act_delete_queue(data: dict, qurl: str) -> dict:
     url = data.get("QueueUrl", qurl)
-    if url in _queues:
-        _queue_name_to_url.pop(_queues[url]["name"], None)
-        del _queues[url]
+    q = _get_q(url)
+    canonical_url = _queue_name_to_url.pop(q["name"], url)
+    _queues.pop(canonical_url, None)
     return {}
 
 

--- a/tests/test_sqs.py
+++ b/tests/test_sqs.py
@@ -29,6 +29,14 @@ def test_sqs_delete_queue(sqs):
     with pytest.raises(ClientError):
         sqs.get_queue_attributes(QueueUrl=url, AttributeNames=["All"])
 
+def test_sqs_delete_queue_nonexistent_raises(sqs):
+    url = sqs.create_queue(QueueName="intg-sqs-delete-404")["QueueUrl"]
+    sqs.delete_queue(QueueUrl=url)
+    with pytest.raises(ClientError) as exc:
+        sqs.delete_queue(QueueUrl=url)          # second delete — queue is already gone
+    assert exc.value.response["Error"]["Code"] == "AWS.SimpleQueueService.NonExistentQueue"
+    assert exc.value.response["ResponseMetadata"]["HTTPStatusCode"] == 400
+
 def test_sqs_list_queues(sqs):
     sqs.create_queue(QueueName="intg-sqs-list-alpha")
     sqs.create_queue(QueueName="intg-sqs-list-beta")


### PR DESCRIPTION
## Summary

`DeleteQueue` checks `if url in _queues:` and silently returns `{}` when the queue doesn't exist. Real AWS returns HTTP 400 `AWS.SimpleQueueService.NonExistentQueue`. The failure is silent — no error, no log line, exit code 0 — so clients believe the delete happened (or was idempotent) when in fact the URL was wrong and no queue was ever deleted.

`_act_delete_queue` (`ministack/services/sqs.py:237-242`) is the only `_act_*` in the file using this silent-skip pattern. Every other action (`_act_get_queue_url`, `_act_send_message`, `_act_receive_message`, `_act_get_queue_attributes`, `_act_set_queue_attributes`, `_act_change_message_visibility`, etc.) already uses the `_get_q(url)` helper, which raises `QueueDoesNotExist`.

### Observed Behavior

DeleteQueue on a URL that was never created:

| Target | Expected | Actual |
|---|---|---|
| MiniStack | 400 `AWS.SimpleQueueService.NonExistentQueue` | 200 OK, empty body, exit 0 |

The silent 200 is the problem — a typo in a queue URL in a CI cleanup script, a stale URL after a `reset`, or a URL with the wrong account ID all succeed locally and then fail against real AWS. The bug masks the underlying client mistake: against MiniStack the script looks correct; against real AWS it raises and the author has to debug from scratch.

## Fix

Replace the `if url in _queues:` check in `_act_delete_queue` (`ministack/services/sqs.py`) with a call to the existing `_get_q(url)` helper. `_get_q` raises `_Err("QueueDoesNotExist", ...)` (HTTP 400, awsQueryCompatible code `AWS.SimpleQueueService.NonExistentQueue`) for missing queues, and also handles the URL-hostname fallback (resolving by queue name when the request hostname differs from the stored URL — e.g. `ministack` vs `localhost` in docker-compose setups). The deletion then uses the canonical URL recovered from `_queue_name_to_url`, so the cleanup works regardless of which hostname the client sent.

## Tests Added

**`tests/test_sqs.py`:**

- `test_sqs_delete_queue_nonexistent_raises` — creates a queue, deletes it, then calls `DeleteQueue` a second time on the same URL and asserts `ClientError` with `Error.Code == "AWS.SimpleQueueService.NonExistentQueue"` and HTTP 400. Uses the real `QueueUrl` returned by `create_queue`, so it stays portable across endpoints and account IDs.

The existing `test_sqs_delete_queue` happy-path test is unchanged.

### Verification

```
pytest tests/test_sqs.py -v
...
tests/test_sqs.py::test_sqs_create_queue PASSED
tests/test_sqs.py::test_sqs_delete_queue PASSED
tests/test_sqs.py::test_sqs_delete_queue_nonexistent_raises PASSED
tests/test_sqs.py::test_sqs_list_queues PASSED
...
```