### PR TITLE
feat: add missing API Gateway v1 and v2 resource types and provisioners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [Unreleased]
+
+### Added
+- **API Gateway v1 — 12 new CloudFormation resource types** — `AWS::ApiGateway::ApiKey`, `UsagePlan`, `UsagePlanKey`, `DomainName`, `BasePathMapping`, `Model`, `RequestValidator`, `GatewayResponse`, `ClientCertificate`, `VpcLink`, `DocumentationPart`, `DocumentationVersion`. Each has a CFN provisioner (create/delete) backed by new REST API control-plane endpoints in `apigateway_v1.py`. CDK stacks referencing any of these types now deploy without `Unsupported resource type` errors.
+- **API Gateway v2 — 10 new CloudFormation resource types** — `AWS::ApiGatewayV2::Authorizer`, `Deployment`, `IntegrationResponse`, `Model`, `RouteResponse`, `DomainName`, `ApiMapping`, `VpcLink`, `RoutingRule`, `ApiGatewayManagedOverrides`. Same pattern: CFN provisioners backed by new `apigateway.py` control-plane handlers.
+- **API Gateway v1 — 24 new REST API control-plane endpoints** — full CRUD for RequestValidator, GatewayResponse, ClientCertificate, VpcLink, DocumentationPart, DocumentationVersion under `/restapis/{id}/...`, `/clientcertificates`, and `/vpclinks`.
+- **API Gateway v2 — 25 new REST API control-plane endpoints** — full CRUD for DomainName, ApiMapping, Model, VpcLink, RoutingRule under `/v2/domainnames`, `/v2/vpclinks`, `/v2/apis/{id}/models`, `/v2/apis/{id}/routingrules`.
+
+---
+
 ## [1.3.42] — 2026-05-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -423,11 +423,25 @@ subnet = ec2.create_subnet(
 | `AWS::S3::BucketPolicy` | Bucket name | — |
 | `AWS::SQS::QueuePolicy` | Policy ID | — |
 | `AWS::SNS::TopicPolicy` | Policy ID | — |
-| `AWS::ApiGateway::RestApi` | API ID | RootResourceId |
-| `AWS::ApiGateway::Resource` | Resource ID | — |
+| `AWS::ApiGateway::RestApi` | API ID | RootResourceId, Arn |
+| `AWS::ApiGateway::Resource` | Resource ID | ResourceId |
 | `AWS::ApiGateway::Method` | Method ID | — |
-| `AWS::ApiGateway::Deployment` | Deployment ID | — |
-| `AWS::ApiGateway::Stage` | Stage name | — |
+| `AWS::ApiGateway::Authorizer` | Authorizer ID | AuthorizerId |
+| `AWS::ApiGateway::Deployment` | Deployment ID | DeploymentId |
+| `AWS::ApiGateway::Stage` | Stage name | StageName |
+| `AWS::ApiGateway::Account` | Logical ID | — |
+| `AWS::ApiGateway::ApiKey` | Key ID | Id |
+| `AWS::ApiGateway::UsagePlan` | Plan ID | Id |
+| `AWS::ApiGateway::UsagePlanKey` | Key ID | Id |
+| `AWS::ApiGateway::DomainName` | Domain name | RegionalDomainName, DistributionDomainName, RegionalHostedZoneId |
+| `AWS::ApiGateway::BasePathMapping` | Mapping ID | — |
+| `AWS::ApiGateway::Model` | Model name | Name |
+| `AWS::ApiGateway::RequestValidator` | Validator ID | Id |
+| `AWS::ApiGateway::GatewayResponse` | Response ID | — |
+| `AWS::ApiGateway::ClientCertificate` | Certificate ID | ClientCertificateId |
+| `AWS::ApiGateway::VpcLink` | VpcLink ID | Id |
+| `AWS::ApiGateway::DocumentationPart` | Part ID | Id |
+| `AWS::ApiGateway::DocumentationVersion` | Version ID | Version |
 | `AWS::AppSync::GraphQLApi` | API ID | Arn, GraphQLUrl, ApiId |
 | `AWS::AppSync::DataSource` | DataSource name | DataSourceArn |
 | `AWS::AppSync::Resolver` | Resolver ARN | ResolverArn |
@@ -464,6 +478,16 @@ subnet = ec2.create_subnet(
 | `AWS::ApiGatewayV2::Stage` | Stage ID | StageName |
 | `AWS::ApiGatewayV2::Integration` | Integration ID | IntegrationId |
 | `AWS::ApiGatewayV2::Route` | Route ID | RouteId |
+| `AWS::ApiGatewayV2::Authorizer` | Authorizer ID | AuthorizerId |
+| `AWS::ApiGatewayV2::Deployment` | Deployment ID | DeploymentId |
+| `AWS::ApiGatewayV2::IntegrationResponse` | IntegrationResponse ID | IntegrationResponseId |
+| `AWS::ApiGatewayV2::Model` | Model ID | ModelId |
+| `AWS::ApiGatewayV2::RouteResponse` | RouteResponse ID | RouteResponseId |
+| `AWS::ApiGatewayV2::DomainName` | Domain name | RegionalDomainName |
+| `AWS::ApiGatewayV2::ApiMapping` | Mapping ID | Id |
+| `AWS::ApiGatewayV2::VpcLink` | VpcLink ID | VpcLinkId |
+| `AWS::ApiGatewayV2::RoutingRule` | RoutingRule ID | RoutingRuleId |
+| `AWS::ApiGatewayV2::ApiGatewayManagedOverrides` | Logical ID | — |
 | `AWS::SES::EmailIdentity` | Identity | EmailIdentity |
 | `AWS::WAFv2::WebACL` | WebACL ID | Arn, Id |
 | `AWS::CloudFront::Distribution` | Distribution ID | Arn, DomainName, Id |

--- a/ministack/services/apigateway.py
+++ b/ministack/services/apigateway.py
@@ -34,6 +34,41 @@ Control plane endpoints implemented:
   GET    /v2/apis/{apiId}/authorizers/{authId}      — GetAuthorizer
   PATCH  /v2/apis/{apiId}/authorizers/{authId}      — UpdateAuthorizer
   DELETE /v2/apis/{apiId}/authorizers/{authId}      — DeleteAuthorizer
+  POST   /v2/apis/{apiId}/models                     — CreateModel
+  GET    /v2/apis/{apiId}/models                     — GetModels
+  GET    /v2/apis/{apiId}/models/{modelId}           — GetModel
+  PATCH  /v2/apis/{apiId}/models/{modelId}           — UpdateModel
+  DELETE /v2/apis/{apiId}/models/{modelId}           — DeleteModel
+  POST   /v2/apis/{apiId}/routes/{routeId}/routeresponses           — CreateRouteResponse
+  GET    /v2/apis/{apiId}/routes/{routeId}/routeresponses           — GetRouteResponses
+  GET    /v2/apis/{apiId}/routes/{routeId}/routeresponses/{rrId}    — GetRouteResponse
+  PATCH  /v2/apis/{apiId}/routes/{routeId}/routeresponses/{rrId}    — UpdateRouteResponse
+  DELETE /v2/apis/{apiId}/routes/{routeId}/routeresponses/{rrId}    — DeleteRouteResponse
+  POST   /v2/apis/{apiId}/integrations/{integId}/integrationresponses           — CreateIntegrationResponse
+  GET    /v2/apis/{apiId}/integrations/{integId}/integrationresponses           — GetIntegrationResponses
+  GET    /v2/apis/{apiId}/integrations/{integId}/integrationresponses/{irId}    — GetIntegrationResponse
+  PATCH  /v2/apis/{apiId}/integrations/{integId}/integrationresponses/{irId}    — UpdateIntegrationResponse
+  DELETE /v2/apis/{apiId}/integrations/{integId}/integrationresponses/{irId}    — DeleteIntegrationResponse
+  POST   /v2/apis/{apiId}/routingrules               — CreateRoutingRule
+  GET    /v2/apis/{apiId}/routingrules               — GetRoutingRules
+  GET    /v2/apis/{apiId}/routingrules/{ruleId}      — GetRoutingRule
+  PATCH  /v2/apis/{apiId}/routingrules/{ruleId}      — UpdateRoutingRule
+  DELETE /v2/apis/{apiId}/routingrules/{ruleId}      — DeleteRoutingRule
+  POST   /v2/domainnames                             — CreateDomainName
+  GET    /v2/domainnames                             — GetDomainNames
+  GET    /v2/domainnames/{domainName}                — GetDomainName
+  PATCH  /v2/domainnames/{domainName}                — UpdateDomainName
+  DELETE /v2/domainnames/{domainName}                — DeleteDomainName
+  POST   /v2/domainnames/{domainName}/apimappings    — CreateApiMapping
+  GET    /v2/domainnames/{domainName}/apimappings    — GetApiMappings
+  GET    /v2/domainnames/{domainName}/apimappings/{mappingId}  — GetApiMapping
+  PATCH  /v2/domainnames/{domainName}/apimappings/{mappingId}  — UpdateApiMapping
+  DELETE /v2/domainnames/{domainName}/apimappings/{mappingId}  — DeleteApiMapping
+  POST   /v2/vpclinks                                — CreateVpcLink
+  GET    /v2/vpclinks                                — GetVpcLinks
+  GET    /v2/vpclinks/{vpcLinkId}                    — GetVpcLink
+  PATCH  /v2/vpclinks/{vpcLinkId}                    — UpdateVpcLink
+  DELETE /v2/vpclinks/{vpcLinkId}                    — DeleteVpcLink
 
 Data plane:
   Requests to /{apiId}.execute-api.localhost/{stage}/{path} are forwarded to
@@ -98,6 +133,11 @@ _authorizers = AccountScopedDict()   # api_id -> {authorizer_id -> authorizer ob
 _api_tags = AccountScopedDict()      # resource_arn -> {key -> value}
 _route_responses = AccountScopedDict()         # api_id -> {route_id -> {rr_id -> route_response}}
 _integration_responses = AccountScopedDict()   # api_id -> {integration_id -> {ir_id -> int_response}}
+_domain_names = AccountScopedDict()  # domain_name -> DomainName
+_api_mappings = AccountScopedDict()  # domain_name -> {mapping_id -> ApiMapping}
+_models = AccountScopedDict()        # api_id -> {model_id -> Model}
+_vpc_links = AccountScopedDict()     # vpc_link_id -> VpcLink
+_routing_rules = AccountScopedDict() # api_id -> {rule_id -> RoutingRule}
 # JWKS cache is account-scoped because issuer URLs in MiniStack can resolve
 # to per-account local Cognito user pools — the same URL string may legitimately
 # serve different keys in different accounts.
@@ -211,6 +251,11 @@ def get_state() -> dict:
         "api_tags": copy.deepcopy(_api_tags),
         "route_responses": copy.deepcopy(_route_responses),
         "integration_responses": copy.deepcopy(_integration_responses),
+        "domain_names": copy.deepcopy(_domain_names),
+        "api_mappings": copy.deepcopy(_api_mappings),
+        "models": copy.deepcopy(_models),
+        "vpc_links": copy.deepcopy(_vpc_links),
+        "routing_rules": copy.deepcopy(_routing_rules),
     }
 
 
@@ -225,6 +270,11 @@ def load_persisted_state(data: dict) -> None:
     _api_tags.update(data.get("api_tags", {}))
     _route_responses.update(data.get("route_responses", {}))
     _integration_responses.update(data.get("integration_responses", {}))
+    _domain_names.update(data.get("domain_names", {}))
+    _api_mappings.update(data.get("api_mappings", {}))
+    _models.update(data.get("models", {}))
+    _vpc_links.update(data.get("vpc_links", {}))
+    _routing_rules.update(data.get("routing_rules", {}))
 
 
 # ---- Control plane router ----
@@ -386,6 +436,83 @@ async def handle_request(method, path, headers, body, query_params):
                     return _update_authorizer(api_id, sub_id, data)
                 if method == "DELETE":
                     return _delete_authorizer(api_id, sub_id)
+
+        # /v2/apis/{apiId}/models[/{modelId}]
+        if api_id and sub == "models":
+            if not sub_id:
+                if method == "POST":
+                    return _create_model(api_id, data)
+                if method == "GET":
+                    return _get_models(api_id)
+            else:
+                if method == "GET":
+                    return _get_model(api_id, sub_id)
+                if method == "PATCH":
+                    return _update_model(api_id, sub_id, data)
+                if method == "DELETE":
+                    return _delete_model(api_id, sub_id)
+
+        # /v2/apis/{apiId}/routingrules[/{ruleId}]
+        if api_id and sub == "routingrules":
+            if not sub_id:
+                if method == "POST":
+                    return _create_routing_rule(api_id, data)
+                if method == "GET":
+                    return _get_routing_rules(api_id)
+            else:
+                if method == "GET":
+                    return _get_routing_rule(api_id, sub_id)
+                if method == "PATCH":
+                    return _update_routing_rule(api_id, sub_id, data)
+                if method == "DELETE":
+                    return _delete_routing_rule(api_id, sub_id)
+
+    # /v2/domainnames[/{domainName}[/{resource}]]
+    if resource == "domainnames":
+        domain_name = parts[2] if len(parts) > 2 else None
+        sub = parts[3] if len(parts) > 3 else None
+        sub_id = parts[4] if len(parts) > 4 else None
+        if not domain_name:
+            if method == "GET":
+                return _get_domain_names()
+            if method == "POST":
+                return _create_domain_name(data)
+        elif sub == "apimappings":
+            if not sub_id:
+                if method == "GET":
+                    return _get_api_mappings(domain_name)
+                if method == "POST":
+                    return _create_api_mapping(domain_name, data)
+            else:
+                if method == "GET":
+                    return _get_api_mapping(domain_name, sub_id)
+                if method == "PATCH":
+                    return _update_api_mapping(domain_name, sub_id, data)
+                if method == "DELETE":
+                    return _delete_api_mapping(domain_name, sub_id)
+        else:
+            if method == "GET":
+                return _get_domain_name(domain_name)
+            if method == "PATCH":
+                return _update_domain_name(domain_name, data)
+            if method == "DELETE":
+                return _delete_domain_name(domain_name)
+
+    # /v2/vpclinks[/{vpcLinkId}]
+    if resource == "vpclinks":
+        vpc_link_id = parts[2] if len(parts) > 2 else None
+        if not vpc_link_id:
+            if method == "GET":
+                return _get_vpc_links()
+            if method == "POST":
+                return _create_vpc_link(data)
+        else:
+            if method == "GET":
+                return _get_vpc_link(vpc_link_id)
+            if method == "PATCH":
+                return _update_vpc_link(vpc_link_id, data)
+            if method == "DELETE":
+                return _delete_vpc_link(vpc_link_id)
 
     return _apigw_error("NotFoundException", f"Unknown API Gateway path: {path}", 404)
 
@@ -1457,6 +1584,11 @@ def reset():
     _api_tags.clear()
     _route_responses.clear()
     _integration_responses.clear()
+    _domain_names.clear()
+    _api_mappings.clear()
+    _models.clear()
+    _vpc_links.clear()
+    _routing_rules.clear()
     # Signal any live WS connections to shut down, then drop registry.
     for conn in list(_ws_connections.values()):
         ev = conn.get("close_event")
@@ -1563,6 +1695,227 @@ def _update_integration_response(api_id, integration_id, ir_id, data):
 
 def _delete_integration_response(api_id, integration_id, ir_id):
     _integration_responses.get(api_id, {}).get(integration_id, {}).pop(ir_id, None)
+    return 204, {}, b""
+
+
+# ---- Control plane: Domain Names ----
+
+def _create_domain_name(data):
+    domain_name = data.get("domainName", "")
+    if not domain_name:
+        return _apigw_error("BadRequestException", "DomainName is required", 400)
+    if domain_name in _domain_names:
+        return _apigw_error("ConflictException", f"Domain name {domain_name} already exists", 409)
+    dn = {
+        "domainName": domain_name,
+        "domainNameConfigurations": data.get("domainNameConfigurations", []),
+        "tags": data.get("tags", {}),
+    }
+    _domain_names[domain_name] = dn
+    _api_mappings[domain_name] = {}
+    return _apigw_response(dn, 201)
+
+
+def _get_domain_names():
+    return _apigw_response({"items": list(_domain_names.values())})
+
+
+def _get_domain_name(domain_name):
+    dn = _domain_names.get(domain_name)
+    if not dn:
+        return _apigw_error("NotFoundException", f"Domain name {domain_name} not found", 404)
+    return _apigw_response(dn)
+
+
+def _update_domain_name(domain_name, data):
+    dn = _domain_names.get(domain_name)
+    if not dn:
+        return _apigw_error("NotFoundException", f"Domain name {domain_name} not found", 404)
+    for k in ("domainNameConfigurations",):
+        if k in data:
+            dn[k] = data[k]
+    return _apigw_response(dn)
+
+
+def _delete_domain_name(domain_name):
+    _domain_names.pop(domain_name, None)
+    _api_mappings.pop(domain_name, None)
+    return 204, {}, b""
+
+
+# ---- Control plane: Api Mappings ----
+
+def _create_api_mapping(domain_name, data):
+    if domain_name not in _domain_names:
+        return _apigw_error("NotFoundException", f"Domain name {domain_name} not found", 404)
+    mapping_id = new_uuid()[:8]
+    mapping = {
+        "apiId": data.get("apiId", ""),
+        "stage": data.get("stage", ""),
+        "apiMappingKey": data.get("apiMappingKey", ""),
+        "id": mapping_id,
+    }
+    _api_mappings.setdefault(domain_name, {})[mapping_id] = mapping
+    return _apigw_response(mapping, 201)
+
+
+def _get_api_mappings(domain_name):
+    if domain_name not in _domain_names:
+        return _apigw_error("NotFoundException", f"Domain name {domain_name} not found", 404)
+    return _apigw_response({"items": list(_api_mappings.get(domain_name, {}).values())})
+
+
+def _get_api_mapping(domain_name, mapping_id):
+    mapping = _api_mappings.get(domain_name, {}).get(mapping_id)
+    if not mapping:
+        return _apigw_error("NotFoundException", f"ApiMapping {mapping_id} not found", 404)
+    return _apigw_response(mapping)
+
+
+def _update_api_mapping(domain_name, mapping_id, data):
+    mapping = _api_mappings.get(domain_name, {}).get(mapping_id)
+    if not mapping:
+        return _apigw_error("NotFoundException", f"ApiMapping {mapping_id} not found", 404)
+    for k in ("apiId", "stage", "apiMappingKey"):
+        if k in data:
+            mapping[k] = data[k]
+    return _apigw_response(mapping)
+
+
+def _delete_api_mapping(domain_name, mapping_id):
+    _api_mappings.get(domain_name, {}).pop(mapping_id, None)
+    return 204, {}, b""
+
+
+# ---- Control plane: Models ----
+
+def _create_model(api_id, data):
+    if api_id not in _apis:
+        return _apigw_error("NotFoundException", f"API {api_id} not found", 404)
+    model_id = new_uuid()[:8]
+    model = {
+        "modelId": model_id,
+        "name": data.get("name", ""),
+        "schema": data.get("schema", {}),
+        "contentType": data.get("contentType", "application/json"),
+        "description": data.get("description", ""),
+    }
+    _models.setdefault(api_id, {})[model_id] = model
+    return _apigw_response(model, 201)
+
+
+def _get_models(api_id):
+    if api_id not in _apis:
+        return _apigw_error("NotFoundException", f"API {api_id} not found", 404)
+    return _apigw_response({"items": list(_models.get(api_id, {}).values())})
+
+
+def _get_model(api_id, model_id):
+    model = _models.get(api_id, {}).get(model_id)
+    if not model:
+        return _apigw_error("NotFoundException", f"Model {model_id} not found", 404)
+    return _apigw_response(model)
+
+
+def _update_model(api_id, model_id, data):
+    model = _models.get(api_id, {}).get(model_id)
+    if not model:
+        return _apigw_error("NotFoundException", f"Model {model_id} not found", 404)
+    for k in ("name", "schema", "contentType", "description"):
+        if k in data:
+            model[k] = data[k]
+    return _apigw_response(model)
+
+
+def _delete_model(api_id, model_id):
+    _models.get(api_id, {}).pop(model_id, None)
+    return 204, {}, b""
+
+
+# ---- Control plane: Vpc Links ----
+
+def _create_vpc_link(data):
+    vpc_link_id = new_uuid()[:8]
+    vpc_link = {
+        "vpcLinkId": vpc_link_id,
+        "name": data.get("name", ""),
+        "description": data.get("description", ""),
+        "status": "AVAILABLE",
+        "subnetIds": data.get("subnetIds", []),
+        "securityGroupIds": data.get("securityGroupIds", []),
+        "tags": data.get("tags", {}),
+    }
+    _vpc_links[vpc_link_id] = vpc_link
+    return _apigw_response(vpc_link, 201)
+
+
+def _get_vpc_links():
+    return _apigw_response({"items": list(_vpc_links.values())})
+
+
+def _get_vpc_link(vpc_link_id):
+    vpc_link = _vpc_links.get(vpc_link_id)
+    if not vpc_link:
+        return _apigw_error("NotFoundException", f"VpcLink {vpc_link_id} not found", 404)
+    return _apigw_response(vpc_link)
+
+
+def _update_vpc_link(vpc_link_id, data):
+    vpc_link = _vpc_links.get(vpc_link_id)
+    if not vpc_link:
+        return _apigw_error("NotFoundException", f"VpcLink {vpc_link_id} not found", 404)
+    for k in ("name", "description", "subnetIds", "securityGroupIds"):
+        if k in data:
+            vpc_link[k] = data[k]
+    return _apigw_response(vpc_link)
+
+
+def _delete_vpc_link(vpc_link_id):
+    _vpc_links.pop(vpc_link_id, None)
+    return 204, {}, b""
+
+
+# ---- Control plane: Routing Rules ----
+
+def _create_routing_rule(api_id, data):
+    if api_id not in _apis:
+        return _apigw_error("NotFoundException", f"API {api_id} not found", 404)
+    rule_id = new_uuid()[:8]
+    rule = {
+        "routingRuleId": rule_id,
+        "condition": data.get("condition", {}),
+        "stageOverride": data.get("stageOverride", {}),
+        "priority": data.get("priority", 0),
+    }
+    _routing_rules.setdefault(api_id, {})[rule_id] = rule
+    return _apigw_response(rule, 201)
+
+
+def _get_routing_rules(api_id):
+    if api_id not in _apis:
+        return _apigw_error("NotFoundException", f"API {api_id} not found", 404)
+    return _apigw_response({"items": list(_routing_rules.get(api_id, {}).values())})
+
+
+def _get_routing_rule(api_id, rule_id):
+    rule = _routing_rules.get(api_id, {}).get(rule_id)
+    if not rule:
+        return _apigw_error("NotFoundException", f"RoutingRule {rule_id} not found", 404)
+    return _apigw_response(rule)
+
+
+def _update_routing_rule(api_id, rule_id, data):
+    rule = _routing_rules.get(api_id, {}).get(rule_id)
+    if not rule:
+        return _apigw_error("NotFoundException", f"RoutingRule {rule_id} not found", 404)
+    for k in ("condition", "stageOverride", "priority"):
+        if k in data:
+            rule[k] = data[k]
+    return _apigw_response(rule)
+
+
+def _delete_routing_rule(api_id, rule_id):
+    _routing_rules.get(api_id, {}).pop(rule_id, None)
     return 204, {}, b""
 
 

--- a/ministack/services/apigateway_v1.py
+++ b/ministack/services/apigateway_v1.py
@@ -43,6 +43,25 @@ Control plane endpoints implemented:
   GET    /restapis/{id}/models                                             — GetModels
   GET    /restapis/{id}/models/{modelName}                                 — GetModel
   DELETE /restapis/{id}/models/{modelName}                                 — DeleteModel
+  POST   /restapis/{id}/requestvalidators                                  — CreateRequestValidator
+  GET    /restapis/{id}/requestvalidators                                  — GetRequestValidators
+  GET    /restapis/{id}/requestvalidators/{validatorId}                    — GetRequestValidator
+  PATCH  /restapis/{id}/requestvalidators/{validatorId}                    — UpdateRequestValidator
+  DELETE /restapis/{id}/requestvalidators/{validatorId}                    — DeleteRequestValidator
+  PUT    /restapis/{id}/gatewayresponses/{responseType}                    — PutGatewayResponse
+  GET    /restapis/{id}/gatewayresponses                                   — GetGatewayResponses
+  GET    /restapis/{id}/gatewayresponses/{responseType}                    — GetGatewayResponse
+  DELETE /restapis/{id}/gatewayresponses/{responseType}                    — DeleteGatewayResponse
+  POST   /restapis/{id}/documentation/parts                                — CreateDocumentationPart
+  GET    /restapis/{id}/documentation/parts                                — GetDocumentationParts
+  GET    /restapis/{id}/documentation/parts/{partId}                       — GetDocumentationPart
+  PATCH  /restapis/{id}/documentation/parts/{partId}                       — UpdateDocumentationPart
+  DELETE /restapis/{id}/documentation/parts/{partId}                       — DeleteDocumentationPart
+  POST   /restapis/{id}/documentation/versions                             — CreateDocumentationVersion
+  GET    /restapis/{id}/documentation/versions                             — GetDocumentationVersions
+  GET    /restapis/{id}/documentation/versions/{version}                   — GetDocumentationVersion
+  PATCH  /restapis/{id}/documentation/versions/{version}                   — UpdateDocumentationVersion
+  DELETE /restapis/{id}/documentation/versions/{version}                   — DeleteDocumentationVersion
   GET    /apikeys                                                          — GetApiKeys
   POST   /apikeys                                                          — CreateApiKey
   GET    /apikeys/{keyId}                                                  — GetApiKey
@@ -58,6 +77,18 @@ Control plane endpoints implemented:
   POST   /domainnames                                                      — CreateDomainName
   GET    /domainnames/{domainName}                                         — GetDomainName
   DELETE /domainnames/{domainName}                                         — DeleteDomainName
+  GET    /domainnames/{domainName}/basepathmappings                        — GetBasePathMappings
+  POST   /domainnames/{domainName}/basepathmappings                        — CreateBasePathMapping
+  GET    /domainnames/{domainName}/basepathmappings/{basePath}             — GetBasePathMapping
+  DELETE /domainnames/{domainName}/basepathmappings/{basePath}             — DeleteBasePathMapping
+  GET    /clientcertificates                                               — GetClientCertificates
+  POST   /clientcertificates                                               — CreateClientCertificate
+  GET    /clientcertificates/{certId}                                      — GetClientCertificate
+  DELETE /clientcertificates/{certId}                                      — DeleteClientCertificate
+  GET    /vpclinks                                                         — GetVpcLinks
+  POST   /vpclinks                                                         — CreateVpcLink
+  GET    /vpclinks/{linkId}                                                — GetVpcLink
+  DELETE /vpclinks/{linkId}                                                — DeleteVpcLink
   GET    /tags/{resourceArn}                                               — GetTags
   PUT    /tags/{resourceArn}                                               — TagResource
   DELETE /tags/{resourceArn}                                               — UntagResource
@@ -110,6 +141,12 @@ _domain_names = AccountScopedDict()        # domain_name -> DomainName
 _base_path_mappings = AccountScopedDict()  # domain_name -> {base_path -> BasePathMapping}
 _v1_tags = AccountScopedDict()             # resource_arn -> {key -> value}
 _account_settings = AccountScopedDict()    # singleton per account: stores fields set via UpdateAccount
+_request_validators = AccountScopedDict()  # rest_api_id -> {validator_id -> RequestValidator}
+_gateway_responses = AccountScopedDict()   # rest_api_id -> {response_type -> GatewayResponse}
+_client_certificates = AccountScopedDict() # cert_id -> ClientCertificate
+_vpc_links = AccountScopedDict()           # link_id -> VpcLink
+_documentation_parts = AccountScopedDict() # rest_api_id -> {part_id -> DocumentationPart}
+_documentation_versions = AccountScopedDict()  # rest_api_id -> {version -> DocumentationVersion}
 
 
 # ---- Helpers ----
@@ -584,6 +621,12 @@ def reset():
     _base_path_mappings.clear()
     _v1_tags.clear()
     _account_settings.clear()
+    _request_validators.clear()
+    _gateway_responses.clear()
+    _client_certificates.clear()
+    _vpc_links.clear()
+    _documentation_parts.clear()
+    _documentation_versions.clear()
 
 
 # ---- Control plane router ----
@@ -853,6 +896,100 @@ async def handle_request(method, path, headers, body, query_params):
                     return _update_model(api_id, model_name, data)
                 if method == "DELETE":
                     return _delete_model(api_id, model_name)
+
+        # /restapis/{id}/requestvalidators[/{validatorId}]
+        elif sub == "requestvalidators":
+            validator_id = parts[3] if len(parts) > 3 else None
+            if not validator_id:
+                if method == "POST":
+                    return _create_request_validator(api_id, data)
+                if method == "GET":
+                    return _get_request_validators(api_id, query_params)
+            else:
+                if method == "GET":
+                    return _get_request_validator(api_id, validator_id)
+                if method == "PATCH":
+                    return _update_request_validator(api_id, validator_id, data)
+                if method == "DELETE":
+                    return _delete_request_validator(api_id, validator_id)
+
+        # /restapis/{id}/gatewayresponses[/{responseType}]
+        elif sub == "gatewayresponses":
+            response_type = parts[3] if len(parts) > 3 else None
+            if not response_type:
+                if method == "GET":
+                    return _get_gateway_responses(api_id, query_params)
+            else:
+                if method == "PUT":
+                    return _put_gateway_response(api_id, response_type, data)
+                if method == "GET":
+                    return _get_gateway_response(api_id, response_type)
+                if method == "DELETE":
+                    return _delete_gateway_response(api_id, response_type)
+
+        # /restapis/{id}/documentation/parts[/{partId}]
+        elif sub == "documentation":
+            doc_sub = parts[3] if len(parts) > 3 else None
+            if doc_sub == "parts":
+                part_id = parts[4] if len(parts) > 4 else None
+                if not part_id:
+                    if method == "POST":
+                        return _create_documentation_part(api_id, data)
+                    if method == "GET":
+                        return _get_documentation_parts(api_id, query_params)
+                else:
+                    if method == "GET":
+                        return _get_documentation_part(api_id, part_id)
+                    if method == "PATCH":
+                        return _update_documentation_part(api_id, part_id, data)
+                    if method == "DELETE":
+                        return _delete_documentation_part(api_id, part_id)
+            elif doc_sub == "versions":
+                version = parts[4] if len(parts) > 4 else None
+                if not version:
+                    if method == "POST":
+                        return _create_documentation_version(api_id, data)
+                    if method == "GET":
+                        return _get_documentation_versions(api_id, query_params)
+                else:
+                    if method == "GET":
+                        return _get_documentation_version(api_id, version)
+                    if method == "PATCH":
+                        return _update_documentation_version(api_id, version, data)
+                    if method == "DELETE":
+                        return _delete_documentation_version(api_id, version)
+
+    # /clientcertificates[/{certId}]
+    if top == "clientcertificates":
+        cert_id = parts[1] if len(parts) > 1 else None
+        if not cert_id:
+            if method == "GET":
+                return _get_client_certificates(query_params)
+            if method == "POST":
+                return _create_client_certificate(data)
+        else:
+            if method == "GET":
+                return _get_client_certificate(cert_id)
+            if method == "PATCH":
+                return _update_client_certificate(cert_id, data)
+            if method == "DELETE":
+                return _delete_client_certificate(cert_id)
+
+    # /vpclinks[/{linkId}]
+    if top == "vpclinks":
+        link_id = parts[1] if len(parts) > 1 else None
+        if not link_id:
+            if method == "GET":
+                return _get_vpc_links(query_params)
+            if method == "POST":
+                return _create_vpc_link(data)
+        else:
+            if method == "GET":
+                return _get_vpc_link(link_id)
+            if method == "PATCH":
+                return _update_vpc_link(link_id, data)
+            if method == "DELETE":
+                return _delete_vpc_link(link_id)
 
     return _v1_error("NotFoundException", f"Unknown API Gateway v1 path: {path}", 404)
 
@@ -1945,3 +2082,256 @@ def _update_account(data):
     _apply_patch(current, data.get("patchOperations", []))
     _account_settings["settings"] = current
     return _get_account()
+
+
+# ---- Control plane: Request Validators ----
+
+def _create_request_validator(api_id, data):
+    if api_id not in _rest_apis:
+        return _v1_error("NotFoundException", "Invalid API identifier specified", 404)
+    validator_id = _new_id()[:8]
+    validator = {
+        "id": validator_id,
+        "name": data.get("name", ""),
+        "validateRequestBody": data.get("validateRequestBody", False),
+        "validateRequestParameters": data.get("validateRequestParameters", False),
+    }
+    _request_validators.setdefault(api_id, {})[validator_id] = validator
+    return _v1_response(validator, 201)
+
+
+def _get_request_validators(api_id, query_params):
+    if api_id not in _rest_apis:
+        return _v1_error("NotFoundException", "Invalid API identifier specified", 404)
+    return _v1_paginated_response(list(_request_validators.get(api_id, {}).values()), query_params)
+
+
+def _get_request_validator(api_id, validator_id):
+    validator = _request_validators.get(api_id, {}).get(validator_id)
+    if not validator:
+        return _v1_error("NotFoundException", "Invalid RequestValidator identifier specified", 404)
+    return _v1_response(validator)
+
+
+def _update_request_validator(api_id, validator_id, data):
+    validator = _request_validators.get(api_id, {}).get(validator_id)
+    if not validator:
+        return _v1_error("NotFoundException", "Invalid RequestValidator identifier specified", 404)
+    patch_ops = data.get("patchOperations", [])
+    _apply_patch(validator, patch_ops)
+    return _v1_response(validator)
+
+
+def _delete_request_validator(api_id, validator_id):
+    _request_validators.get(api_id, {}).pop(validator_id, None)
+    return 202, {}, b""
+
+
+# ---- Control plane: Gateway Responses ----
+
+def _put_gateway_response(api_id, response_type, data):
+    if api_id not in _rest_apis:
+        return _v1_error("NotFoundException", "Invalid API identifier specified", 404)
+    response = {
+        "responseType": response_type,
+        "statusCode": data.get("statusCode", ""),
+        "responseParameters": data.get("responseParameters", {}),
+        "responseTemplates": data.get("responseTemplates", {}),
+    }
+    _gateway_responses.setdefault(api_id, {})[response_type] = response
+    return _v1_response(response, 201)
+
+
+def _get_gateway_responses(api_id, query_params):
+    if api_id not in _rest_apis:
+        return _v1_error("NotFoundException", "Invalid API identifier specified", 404)
+    return _v1_paginated_response(list(_gateway_responses.get(api_id, {}).values()), query_params)
+
+
+def _get_gateway_response(api_id, response_type):
+    response = _gateway_responses.get(api_id, {}).get(response_type)
+    if not response:
+        return _v1_error("NotFoundException", "Invalid GatewayResponse identifier specified", 404)
+    return _v1_response(response)
+
+
+def _delete_gateway_response(api_id, response_type):
+    _gateway_responses.get(api_id, {}).pop(response_type, None)
+    return 202, {}, b""
+
+
+# ---- Control plane: Client Certificates ----
+
+def _create_client_certificate(data):
+    cert_id = _new_id()[:8]
+    cert = {
+        "clientCertificateId": cert_id,
+        "description": data.get("description", ""),
+        "createdDate": _now_unix(),
+        "expirationDate": _now_unix() + 365 * 24 * 3600,
+        "tags": data.get("tags", {}),
+    }
+    _client_certificates[cert_id] = cert
+    return _v1_response(cert, 201)
+
+
+def _get_client_certificates(query_params):
+    return _v1_paginated_response(list(_client_certificates.values()), query_params)
+
+
+def _get_client_certificate(cert_id):
+    cert = _client_certificates.get(cert_id)
+    if not cert:
+        return _v1_error("NotFoundException", "Invalid ClientCertificate identifier specified", 404)
+    return _v1_response(cert)
+
+
+def _update_client_certificate(cert_id, data):
+    cert = _client_certificates.get(cert_id)
+    if not cert:
+        return _v1_error("NotFoundException", "Invalid ClientCertificate identifier specified", 404)
+    patch_ops = data.get("patchOperations", [])
+    _apply_patch(cert, patch_ops)
+    return _v1_response(cert)
+
+
+def _delete_client_certificate(cert_id):
+    _client_certificates.pop(cert_id, None)
+    return 202, {}, b""
+
+
+# ---- Control plane: Vpc Links ----
+
+def _create_vpc_link(data):
+    link_id = _new_id()[:8]
+    vpc_link = {
+        "id": link_id,
+        "name": data.get("name", ""),
+        "description": data.get("description", ""),
+        "status": "AVAILABLE",
+        "protocol": data.get("protocol", "HTTP1"),
+        "targetArns": data.get("targetArns", []),
+        "tags": data.get("tags", {}),
+    }
+    _vpc_links[link_id] = vpc_link
+    return _v1_response(vpc_link, 201)
+
+
+def _get_vpc_links(query_params):
+    return _v1_paginated_response(list(_vpc_links.values()), query_params)
+
+
+def _get_vpc_link(link_id):
+    vpc_link = _vpc_links.get(link_id)
+    if not vpc_link:
+        return _v1_error("NotFoundException", "Invalid VpcLink identifier specified", 404)
+    return _v1_response(vpc_link)
+
+
+def _update_vpc_link(link_id, data):
+    vpc_link = _vpc_links.get(link_id)
+    if not vpc_link:
+        return _v1_error("NotFoundException", "Invalid VpcLink identifier specified", 404)
+    patch_ops = data.get("patchOperations", [])
+    _apply_patch(vpc_link, patch_ops)
+    return _v1_response(vpc_link)
+
+
+def _delete_vpc_link(link_id):
+    _vpc_links.pop(link_id, None)
+    return 202, {}, b""
+
+
+# ---- Control plane: Documentation Parts ----
+
+def _create_documentation_part(api_id, data):
+    if api_id not in _rest_apis:
+        return _v1_error("NotFoundException", "Invalid API identifier specified", 404)
+    part_id = _new_id()[:8]
+    location = data.get("location", {})
+    doc_part = {
+        "id": part_id,
+        "location": {
+            "type": location.get("type", "API"),
+            "path": location.get("path", ""),
+            "method": location.get("method", ""),
+            "statusCode": location.get("statusCode", ""),
+            "name": location.get("name", ""),
+        },
+        "properties": data.get("properties", "{}"),
+    }
+    _documentation_parts.setdefault(api_id, {})[part_id] = doc_part
+    return _v1_response(doc_part, 201)
+
+
+def _get_documentation_parts(api_id, query_params):
+    if api_id not in _rest_apis:
+        return _v1_error("NotFoundException", "Invalid API identifier specified", 404)
+    return _v1_paginated_response(list(_documentation_parts.get(api_id, {}).values()), query_params)
+
+
+def _get_documentation_part(api_id, part_id):
+    part = _documentation_parts.get(api_id, {}).get(part_id)
+    if not part:
+        return _v1_error("NotFoundException", "Invalid DocumentationPart identifier specified", 404)
+    return _v1_response(part)
+
+
+def _update_documentation_part(api_id, part_id, data):
+    part = _documentation_parts.get(api_id, {}).get(part_id)
+    if not part:
+        return _v1_error("NotFoundException", "Invalid DocumentationPart identifier specified", 404)
+    patch_ops = data.get("patchOperations", [])
+    _apply_patch(part, patch_ops)
+    return _v1_response(part)
+
+
+def _delete_documentation_part(api_id, part_id):
+    _documentation_parts.get(api_id, {}).pop(part_id, None)
+    return 202, {}, b""
+
+
+# ---- Control plane: Documentation Versions ----
+
+def _create_documentation_version(api_id, data):
+    if api_id not in _rest_apis:
+        return _v1_error("NotFoundException", "Invalid API identifier specified", 404)
+    version = data.get("version", "")
+    if not version:
+        return _v1_error("BadRequestException", "Version is required", 400)
+    if version in _documentation_versions.get(api_id, {}):
+        return _v1_error("ConflictException", "DocumentationVersion already exists", 409)
+    doc_version = {
+        "version": version,
+        "createdDate": _now_unix(),
+        "description": data.get("description", ""),
+    }
+    _documentation_versions.setdefault(api_id, {})[version] = doc_version
+    return _v1_response(doc_version, 201)
+
+
+def _get_documentation_versions(api_id, query_params):
+    if api_id not in _rest_apis:
+        return _v1_error("NotFoundException", "Invalid API identifier specified", 404)
+    return _v1_paginated_response(list(_documentation_versions.get(api_id, {}).values()), query_params)
+
+
+def _get_documentation_version(api_id, version):
+    doc_version = _documentation_versions.get(api_id, {}).get(version)
+    if not doc_version:
+        return _v1_error("NotFoundException", "Invalid DocumentationVersion identifier specified", 404)
+    return _v1_response(doc_version)
+
+
+def _update_documentation_version(api_id, version, data):
+    doc_version = _documentation_versions.get(api_id, {}).get(version)
+    if not doc_version:
+        return _v1_error("NotFoundException", "Invalid DocumentationVersion identifier specified", 404)
+    patch_ops = data.get("patchOperations", [])
+    _apply_patch(doc_version, patch_ops)
+    return _v1_response(doc_version)
+
+
+def _delete_documentation_version(api_id, version):
+    _documentation_versions.get(api_id, {}).pop(version, None)
+    return 202, {}, b""

--- a/ministack/services/cloudformation/provisioners.py
+++ b/ministack/services/cloudformation/provisioners.py
@@ -1292,6 +1292,290 @@ def _apigw_account_delete(physical_id, props):
     _apigw_v1._account_settings["settings"] = settings
 
 
+# --- API Gateway ApiKey ---
+
+def _apigw_api_key_create(logical_id, props, stack_name):
+    data = {
+        "name": props.get("Name") or _physical_name(stack_name, logical_id, max_len=128),
+        "description": props.get("Description", ""),
+        "enabled": props.get("Enabled", True),
+        "stageKeys": props.get("StageKeys", []),
+        "tags": {t["Key"]: t["Value"] for t in props.get("Tags", [])},
+    }
+    status, headers, body = _apigw_v1._create_api_key(data)
+    if status >= 400:
+        raise ValueError(f"AWS::ApiGateway::ApiKey create failed: {body!r}")
+    api_key = json.loads(body) if isinstance(body, (bytes, bytearray)) else json.loads(body)
+    key_id = api_key.get("id", "")
+    return key_id, {"Id": key_id}
+
+
+def _apigw_api_key_delete(physical_id, props):
+    _apigw_v1._delete_api_key(physical_id)
+
+
+# --- API Gateway UsagePlan ---
+
+def _apigw_usage_plan_create(logical_id, props, stack_name):
+    data = {
+        "name": props.get("Name") or _physical_name(stack_name, logical_id, max_len=128),
+        "description": props.get("Description", ""),
+        "apiStages": props.get("ApiStages", []),
+        "throttle": props.get("Throttle", {}),
+        "quota": props.get("Quota", {}),
+        "tags": {t["Key"]: t["Value"] for t in props.get("Tags", [])},
+    }
+    status, headers, body = _apigw_v1._create_usage_plan(data)
+    if status >= 400:
+        raise ValueError(f"AWS::ApiGateway::UsagePlan create failed: {body!r}")
+    plan = json.loads(body) if isinstance(body, (bytes, bytearray)) else json.loads(body)
+    plan_id = plan.get("id", "")
+    return plan_id, {"Id": plan_id}
+
+
+def _apigw_usage_plan_delete(physical_id, props):
+    _apigw_v1._delete_usage_plan(physical_id)
+
+
+# --- API Gateway UsagePlanKey ---
+
+def _apigw_usage_plan_key_create(logical_id, props, stack_name):
+    plan_id = props.get("KeyId", "")
+    data = {
+        "keyId": props.get("KeyId", ""),
+        "keyType": props.get("KeyType", "API_KEY"),
+    }
+    status, headers, body = _apigw_v1._create_usage_plan_key(plan_id, data)
+    if status >= 400:
+        raise ValueError(f"AWS::ApiGateway::UsagePlanKey create failed: {body!r}")
+    key = json.loads(body) if isinstance(body, (bytes, bytearray)) else json.loads(body)
+    key_id = key.get("id", "")
+    pid = f"{plan_id}/{key_id}"
+    return pid, {"Id": key_id}
+
+
+def _apigw_usage_plan_key_delete(physical_id, props):
+    parts = physical_id.split("/", 1)
+    if len(parts) == 2:
+        plan_id, key_id = parts
+        _apigw_v1._delete_usage_plan_key(plan_id, key_id)
+
+
+# --- API Gateway DomainName ---
+
+def _apigw_domain_name_create(logical_id, props, stack_name):
+    data = {
+        "domainName": props.get("DomainName") or _physical_name(stack_name, logical_id, lowercase=True, max_len=128),
+        "certificateName": props.get("CertificateName", ""),
+        "certificateArn": props.get("CertificateArn", ""),
+        "endpointConfiguration": props.get("EndpointConfiguration", {"types": ["REGIONAL"]}),
+        "securityPolicy": props.get("SecurityPolicy", "TLS_1_2"),
+        "tags": {t["Key"]: t["Value"] for t in props.get("Tags", [])},
+    }
+    status, headers, body = _apigw_v1._create_domain_name(data)
+    if status >= 400:
+        raise ValueError(f"AWS::ApiGateway::DomainName create failed: {body!r}")
+    dn = json.loads(body) if isinstance(body, (bytes, bytearray)) else json.loads(body)
+    domain_name = dn.get("domainName", "")
+    return domain_name, {
+        "RegionalDomainName": dn.get("regionalDomainName", ""),
+        "DistributionDomainName": dn.get("distributionDomainName", ""),
+        "RegionalHostedZoneId": dn.get("regionalHostedZoneId", ""),
+    }
+
+
+def _apigw_domain_name_delete(physical_id, props):
+    _apigw_v1._delete_domain_name(physical_id)
+
+
+# --- API Gateway BasePathMapping ---
+
+def _apigw_base_path_mapping_create(logical_id, props, stack_name):
+    domain_name = props.get("DomainName", "")
+    data = {
+        "basePath": props.get("BasePath", "(none)"),
+        "restApiId": props.get("RestApiId", ""),
+        "stage": props.get("Stage", ""),
+    }
+    status, headers, body = _apigw_v1._create_base_path_mapping(domain_name, data)
+    if status >= 400:
+        raise ValueError(f"AWS::ApiGateway::BasePathMapping create failed: {body!r}")
+    mapping = json.loads(body) if isinstance(body, (bytes, bytearray)) else json.loads(body)
+    base_path = mapping.get("basePath", "(none)")
+    pid = f"{domain_name}/{base_path}"
+    return pid, {}
+
+
+def _apigw_base_path_mapping_delete(physical_id, props):
+    domain_name = props.get("DomainName", "")
+    base_path = props.get("BasePath", "(none)")
+    _apigw_v1._delete_base_path_mapping(domain_name, base_path)
+
+
+# --- API Gateway Model ---
+
+def _apigw_model_create(logical_id, props, stack_name):
+    api_id = props.get("RestApiId", "")
+    data = {
+        "name": props.get("Name") or logical_id,
+        "description": props.get("Description", ""),
+        "schema": props.get("Schema", "{}"),
+        "contentType": props.get("ContentType", "application/json"),
+    }
+    status, headers, body = _apigw_v1._create_model(api_id, data)
+    if status >= 400:
+        raise ValueError(f"AWS::ApiGateway::Model create failed: {body!r}")
+    model = json.loads(body) if isinstance(body, (bytes, bytearray)) else json.loads(body)
+    model_name = model.get("name", "")
+    return f"{api_id}/{model_name}", {"Name": model_name}
+
+
+def _apigw_model_delete(physical_id, props):
+    api_id = props.get("RestApiId", "")
+    parts = physical_id.split("/", 1)
+    if len(parts) == 2:
+        model_name = parts[1]
+        _apigw_v1._delete_model(api_id, model_name)
+
+
+# --- API Gateway RequestValidator ---
+
+def _apigw_request_validator_create(logical_id, props, stack_name):
+    api_id = props.get("RestApiId", "")
+    name = props.get("Name") or logical_id
+    validator_id = new_uuid()[:8]
+    validator = {
+        "id": validator_id,
+        "name": name,
+        "validateRequestBody": props.get("ValidateRequestBody", False),
+        "validateRequestParameters": props.get("ValidateRequestParameters", False),
+    }
+    _apigw_v1._request_validators.setdefault(api_id, {})[validator_id] = validator
+    return validator_id, {"Id": validator_id}
+
+
+def _apigw_request_validator_delete(physical_id, props):
+    api_id = props.get("RestApiId", "")
+    validators = _apigw_v1._request_validators.get(api_id, {})
+    validators.pop(physical_id, None)
+
+
+# --- API Gateway GatewayResponse ---
+
+def _apigw_gateway_response_create(logical_id, props, stack_name):
+    api_id = props.get("RestApiId", "")
+    response_type = props.get("ResponseType", "DEFAULT_4XX")
+    response = {
+        "responseType": response_type,
+        "statusCode": props.get("StatusCode", ""),
+        "responseParameters": props.get("ResponseParameters", {}),
+        "responseTemplates": props.get("ResponseTemplates", {}),
+    }
+    _apigw_v1._gateway_responses.setdefault(api_id, {})[response_type] = response
+    pid = f"{api_id}/{response_type}"
+    return pid, {}
+
+
+def _apigw_gateway_response_delete(physical_id, props):
+    api_id = props.get("RestApiId", "")
+    parts = physical_id.split("/", 1)
+    if len(parts) == 2:
+        response_type = parts[1]
+        responses = _apigw_v1._gateway_responses.get(api_id, {})
+        responses.pop(response_type, None)
+
+
+# --- API Gateway ClientCertificate ---
+
+def _apigw_client_certificate_create(logical_id, props, stack_name):
+    cert_id = new_uuid()[:8]
+    cert = {
+        "clientCertificateId": cert_id,
+        "description": props.get("Description", ""),
+        "createdDate": int(time.time()),
+        "expirationDate": int(time.time()) + 365 * 24 * 3600,
+        "tags": {t["Key"]: t["Value"] for t in props.get("Tags", [])},
+    }
+    _apigw_v1._client_certificates[cert_id] = cert
+    return cert_id, {"ClientCertificateId": cert_id}
+
+
+def _apigw_client_certificate_delete(physical_id, props):
+    _apigw_v1._client_certificates.pop(physical_id, None)
+
+
+# --- API Gateway VpcLink ---
+
+def _apigw_vpc_link_create(logical_id, props, stack_name):
+    name = props.get("Name") or _physical_name(stack_name, logical_id, max_len=128)
+    link_id = new_uuid()[:8]
+    vpc_link = {
+        "id": link_id,
+        "name": name,
+        "description": props.get("Description", ""),
+        "status": "AVAILABLE",
+        "protocol": props.get("Protocol", "HTTP1"),
+        "targetArns": props.get("TargetArns", []),
+        "tags": {t["Key"]: t["Value"] for t in props.get("Tags", [])},
+    }
+    _apigw_v1._vpc_links[link_id] = vpc_link
+    return link_id, {"Id": link_id}
+
+
+def _apigw_vpc_link_delete(physical_id, props):
+    _apigw_v1._vpc_links.pop(physical_id, None)
+
+
+# --- API Gateway DocumentationPart ---
+
+def _apigw_documentation_part_create(logical_id, props, stack_name):
+    api_id = props.get("RestApiId", "")
+    part_id = new_uuid()[:8]
+    location = props.get("Location", {})
+    doc_part = {
+        "id": part_id,
+        "location": {
+            "type": location.get("Type", "API"),
+            "path": location.get("Path", ""),
+            "method": location.get("Method", ""),
+            "statusCode": location.get("StatusCode", ""),
+            "name": location.get("Name", ""),
+        },
+        "properties": props.get("Properties", "{}"),
+    }
+    _apigw_v1._documentation_parts.setdefault(api_id, {})[part_id] = doc_part
+    return part_id, {"Id": part_id}
+
+
+def _apigw_documentation_part_delete(physical_id, props):
+    api_id = props.get("RestApiId", "")
+    parts_store = _apigw_v1._documentation_parts.get(api_id, {})
+    parts_store.pop(physical_id, None)
+
+
+# --- API Gateway DocumentationVersion ---
+
+def _apigw_documentation_version_create(logical_id, props, stack_name):
+    api_id = props.get("RestApiId", "")
+    version = props.get("Version", "")
+    doc_version = {
+        "version": version,
+        "createdDate": int(time.time()),
+        "description": props.get("Description", ""),
+    }
+    _apigw_v1._documentation_versions.setdefault(api_id, {})[version] = doc_version
+    return f"{api_id}/{version}", {"Version": version}
+
+
+def _apigw_documentation_version_delete(physical_id, props):
+    api_id = props.get("RestApiId", "")
+    parts = physical_id.split("/", 1)
+    if len(parts) == 2:
+        version = parts[1]
+        versions = _apigw_v1._documentation_versions.get(api_id, {})
+        versions.pop(version, None)
+
+
 # --- Lambda EventSourceMapping ---
 
 def _lambda_esm_create(logical_id, props, stack_name):
@@ -3076,6 +3360,240 @@ def _apigw_v2_route_delete(physical_id, props):
         routes.pop(route_id, None)
 
 
+# --- API Gateway V2 Authorizer ---
+
+def _apigw_v2_authorizer_create(logical_id, props, stack_name):
+    api_id = props.get("ApiId", "")
+    data = {
+        "name": props.get("Name") or logical_id,
+        "authorizerType": props.get("AuthorizerType", "JWT"),
+        "identitySource": props.get("IdentitySource", ["$request.header.Authorization"]),
+        "jwtConfiguration": props.get("JwtConfiguration", {}),
+        "authorizerUri": props.get("AuthorizerUri", ""),
+        "authorizerPayloadFormatVersion": props.get("AuthorizerPayloadFormatVersion", "2.0"),
+        "authorizerResultTtlInSeconds": props.get("AuthorizerResultTtlInSeconds", 300),
+        "enableSimpleResponses": props.get("EnableSimpleResponses", False),
+    }
+    status, headers, body = _apigw_v2._create_authorizer(api_id, data)
+    if status >= 400:
+        raise ValueError(f"AWS::ApiGatewayV2::Authorizer create failed: {body!r}")
+    result = json.loads(body) if isinstance(body, (bytes, bytearray)) else json.loads(body)
+    auth_id = result.get("authorizerId", "")
+    return auth_id, {"AuthorizerId": auth_id}
+
+
+def _apigw_v2_authorizer_delete(physical_id, props):
+    api_id = props.get("ApiId", "")
+    authorizers = _apigw_v2._authorizers.get(api_id, {})
+    authorizers.pop(physical_id, None)
+
+
+# --- API Gateway V2 Deployment ---
+
+def _apigw_v2_deployment_create(logical_id, props, stack_name):
+    api_id = props.get("ApiId", "")
+    data = {
+        "description": props.get("Description", ""),
+    }
+    status, headers, body = _apigw_v2._create_deployment(api_id, data)
+    if status >= 400:
+        raise ValueError(f"AWS::ApiGatewayV2::Deployment create failed: {body!r}")
+    result = json.loads(body) if isinstance(body, (bytes, bytearray)) else json.loads(body)
+    deployment_id = result.get("deploymentId", "")
+    return deployment_id, {"DeploymentId": deployment_id}
+
+
+def _apigw_v2_deployment_delete(physical_id, props):
+    api_id = props.get("ApiId", "")
+    _apigw_v2._deployments.get(api_id, {}).pop(physical_id, None)
+
+
+# --- API Gateway V2 IntegrationResponse ---
+
+def _apigw_v2_integration_response_create(logical_id, props, stack_name):
+    api_id = props.get("ApiId", "")
+    integration_id = props.get("IntegrationId", "")
+    data = {
+        "integrationResponseKey": props.get("IntegrationResponseKey", "$default"),
+        "contentHandlingStrategy": props.get("ContentHandlingStrategy"),
+        "templateSelectionExpression": props.get("TemplateSelectionExpression"),
+        "responseParameters": props.get("ResponseParameters", {}),
+        "responseTemplates": props.get("ResponseTemplates", {}),
+    }
+    status, headers, body = _apigw_v2._create_integration_response(api_id, integration_id, data)
+    if status >= 400:
+        raise ValueError(f"AWS::ApiGatewayV2::IntegrationResponse create failed: {body!r}")
+    result = json.loads(body) if isinstance(body, (bytes, bytearray)) else json.loads(body)
+    ir_id = result.get("integrationResponseId", "")
+    pid = f"{api_id}/{integration_id}/{ir_id}"
+    return pid, {"IntegrationResponseId": ir_id}
+
+
+def _apigw_v2_integration_response_delete(physical_id, props):
+    api_id = props.get("ApiId", "")
+    integration_id = props.get("IntegrationId", "")
+    parts = physical_id.split("/")
+    if len(parts) >= 3:
+        ir_id = parts[-1]
+        _apigw_v2._integration_responses.get(api_id, {}).get(integration_id, {}).pop(ir_id, None)
+
+
+# --- API Gateway V2 Model ---
+
+def _apigw_v2_model_create(logical_id, props, stack_name):
+    api_id = props.get("ApiId", "")
+    data = {
+        "name": props.get("Name") or logical_id,
+        "schema": props.get("Schema", {}),
+        "contentType": props.get("ContentType", "application/json"),
+        "description": props.get("Description", ""),
+    }
+    status, headers, body = _apigw_v2._create_model(api_id, data)
+    if status >= 400:
+        raise ValueError(f"AWS::ApiGatewayV2::Model create failed: {body!r}")
+    result = json.loads(body) if isinstance(body, (bytes, bytearray)) else json.loads(body)
+    model_id = result.get("modelId", "")
+    return model_id, {"ModelId": model_id}
+
+
+def _apigw_v2_model_delete(physical_id, props):
+    api_id = props.get("ApiId", "")
+    _apigw_v2._models.get(api_id, {}).pop(physical_id, None)
+
+
+# --- API Gateway V2 RouteResponse ---
+
+def _apigw_v2_route_response_create(logical_id, props, stack_name):
+    api_id = props.get("ApiId", "")
+    route_id = props.get("RouteId", "")
+    data = {
+        "routeResponseKey": props.get("RouteResponseKey", "$default"),
+        "modelSelectionExpression": props.get("ModelSelectionExpression"),
+        "responseModels": props.get("ResponseModels", {}),
+        "responseParameters": props.get("ResponseParameters", {}),
+    }
+    status, headers, body = _apigw_v2._create_route_response(api_id, route_id, data)
+    if status >= 400:
+        raise ValueError(f"AWS::ApiGatewayV2::RouteResponse create failed: {body!r}")
+    result = json.loads(body) if isinstance(body, (bytes, bytearray)) else json.loads(body)
+    rr_id = result.get("routeResponseId", "")
+    pid = f"{api_id}/{route_id}/{rr_id}"
+    return pid, {"RouteResponseId": rr_id}
+
+
+def _apigw_v2_route_response_delete(physical_id, props):
+    api_id = props.get("ApiId", "")
+    route_id = props.get("RouteId", "")
+    parts = physical_id.split("/")
+    if len(parts) >= 3:
+        rr_id = parts[-1]
+        _apigw_v2._route_responses.get(api_id, {}).get(route_id, {}).pop(rr_id, None)
+
+
+# --- API Gateway V2 DomainName ---
+
+def _apigw_v2_domain_name_create(logical_id, props, stack_name):
+    data = {
+        "domainName": props.get("DomainName") or _physical_name(stack_name, logical_id, lowercase=True, max_len=128),
+        "domainNameConfigurations": props.get("DomainNameConfigurations", []),
+        "tags": {t["Key"]: t["Value"] for t in props.get("Tags", [])},
+    }
+    status, headers, body = _apigw_v2._create_domain_name(data)
+    if status >= 400:
+        raise ValueError(f"AWS::ApiGatewayV2::DomainName create failed: {body!r}")
+    result = json.loads(body) if isinstance(body, (bytes, bytearray)) else json.loads(body)
+    domain_name = result.get("domainName", "")
+    return domain_name, {"RegionalDomainName": domain_name}
+
+
+def _apigw_v2_domain_name_delete(physical_id, props):
+    _apigw_v2._delete_domain_name(physical_id)
+
+
+# --- API Gateway V2 ApiMapping ---
+
+def _apigw_v2_api_mapping_create(logical_id, props, stack_name):
+    domain_name = props.get("DomainName", "")
+    data = {
+        "apiId": props.get("ApiId", ""),
+        "stage": props.get("Stage", ""),
+        "apiMappingKey": props.get("ApiMappingKey", ""),
+    }
+    status, headers, body = _apigw_v2._create_api_mapping(domain_name, data)
+    if status >= 400:
+        raise ValueError(f"AWS::ApiGatewayV2::ApiMapping create failed: {body!r}")
+    result = json.loads(body) if isinstance(body, (bytes, bytearray)) else json.loads(body)
+    mapping_id = result.get("id", "")
+    pid = f"{domain_name}/{mapping_id}"
+    return pid, {"Id": mapping_id}
+
+
+def _apigw_v2_api_mapping_delete(physical_id, props):
+    domain_name = props.get("DomainName", "")
+    parts = physical_id.split("/", 1)
+    if len(parts) == 2:
+        mapping_id = parts[1]
+        _apigw_v2._api_mappings.get(domain_name, {}).pop(mapping_id, None)
+
+
+# --- API Gateway V2 VpcLink ---
+
+def _apigw_v2_vpc_link_create(logical_id, props, stack_name):
+    data = {
+        "name": props.get("Name") or _physical_name(stack_name, logical_id, max_len=128),
+        "description": props.get("Description", ""),
+        "subnetIds": props.get("SubnetIds", []),
+        "securityGroupIds": props.get("SecurityGroupIds", []),
+        "tags": {t["Key"]: t["Value"] for t in props.get("Tags", [])},
+    }
+    status, headers, body = _apigw_v2._create_vpc_link(data)
+    if status >= 400:
+        raise ValueError(f"AWS::ApiGatewayV2::VpcLink create failed: {body!r}")
+    result = json.loads(body) if isinstance(body, (bytes, bytearray)) else json.loads(body)
+    vpc_link_id = result.get("vpcLinkId", "")
+    return vpc_link_id, {"VpcLinkId": vpc_link_id}
+
+
+def _apigw_v2_vpc_link_delete(physical_id, props):
+    _apigw_v2._vpc_links.pop(physical_id, None)
+
+
+# --- API Gateway V2 RoutingRule ---
+
+def _apigw_v2_routing_rule_create(logical_id, props, stack_name):
+    api_id = props.get("ApiId", "")
+    data = {
+        "condition": props.get("Condition", {}),
+        "stageOverride": props.get("StageOverride", {}),
+        "priority": props.get("Priority", 0),
+    }
+    status, headers, body = _apigw_v2._create_routing_rule(api_id, data)
+    if status >= 400:
+        raise ValueError(f"AWS::ApiGatewayV2::RoutingRule create failed: {body!r}")
+    result = json.loads(body) if isinstance(body, (bytes, bytearray)) else json.loads(body)
+    rule_id = result.get("routingRuleId", "")
+    return rule_id, {"RoutingRuleId": rule_id}
+
+
+def _apigw_v2_routing_rule_delete(physical_id, props):
+    api_id = props.get("ApiId", "")
+    _apigw_v2._routing_rules.get(api_id, {}).pop(physical_id, None)
+
+
+# --- API Gateway V2 ApiGatewayManagedOverrides ---
+
+def _apigw_v2_managed_overrides_create(logical_id, props, stack_name):
+    """``AWS::ApiGatewayV2::ApiGatewayManagedOverrides`` is a CFN-only construct
+    that stores override settings for managed APIs. No runtime API exists,
+    so this is a no-op provisioner that returns a stable physical id."""
+    pid = f"{stack_name}-{logical_id}-{new_uuid()[:8]}"
+    return pid, {}
+
+
+def _apigw_v2_managed_overrides_delete(physical_id, props):
+    pass
+
+
 # ---------------------------------------------------------------------------
 # SES EmailIdentity
 # ---------------------------------------------------------------------------
@@ -3601,6 +4119,18 @@ _RESOURCE_HANDLERS = {
     "AWS::ApiGateway::Deployment": {"create": _apigw_deployment_create, "delete": _apigw_deployment_delete},
     "AWS::ApiGateway::Stage": {"create": _apigw_stage_create, "delete": _apigw_stage_delete},
     "AWS::ApiGateway::Account": {"create": _apigw_account_create, "delete": _apigw_account_delete},
+    "AWS::ApiGateway::ApiKey": {"create": _apigw_api_key_create, "delete": _apigw_api_key_delete},
+    "AWS::ApiGateway::UsagePlan": {"create": _apigw_usage_plan_create, "delete": _apigw_usage_plan_delete},
+    "AWS::ApiGateway::UsagePlanKey": {"create": _apigw_usage_plan_key_create, "delete": _apigw_usage_plan_key_delete},
+    "AWS::ApiGateway::DomainName": {"create": _apigw_domain_name_create, "delete": _apigw_domain_name_delete},
+    "AWS::ApiGateway::BasePathMapping": {"create": _apigw_base_path_mapping_create, "delete": _apigw_base_path_mapping_delete},
+    "AWS::ApiGateway::Model": {"create": _apigw_model_create, "delete": _apigw_model_delete},
+    "AWS::ApiGateway::RequestValidator": {"create": _apigw_request_validator_create, "delete": _apigw_request_validator_delete},
+    "AWS::ApiGateway::GatewayResponse": {"create": _apigw_gateway_response_create, "delete": _apigw_gateway_response_delete},
+    "AWS::ApiGateway::ClientCertificate": {"create": _apigw_client_certificate_create, "delete": _apigw_client_certificate_delete},
+    "AWS::ApiGateway::VpcLink": {"create": _apigw_vpc_link_create, "delete": _apigw_vpc_link_delete},
+    "AWS::ApiGateway::DocumentationPart": {"create": _apigw_documentation_part_create, "delete": _apigw_documentation_part_delete},
+    "AWS::ApiGateway::DocumentationVersion": {"create": _apigw_documentation_version_create, "delete": _apigw_documentation_version_delete},
     "AWS::Lambda::EventSourceMapping": {"create": _lambda_esm_create, "delete": _lambda_esm_delete},
     "AWS::Pipes::Pipe": {"create": _pipes_pipe_create, "delete": _pipes_pipe_delete},
     "AWS::Lambda::Alias": {"create": _lambda_alias_create, "delete": _lambda_alias_delete},
@@ -3646,6 +4176,16 @@ _RESOURCE_HANDLERS = {
     "AWS::ApiGatewayV2::Stage": {"create": _apigw_v2_stage_create, "delete": _apigw_v2_stage_delete},
     "AWS::ApiGatewayV2::Integration": {"create": _apigw_v2_integration_create, "delete": _apigw_v2_integration_delete},
     "AWS::ApiGatewayV2::Route": {"create": _apigw_v2_route_create, "delete": _apigw_v2_route_delete},
+    "AWS::ApiGatewayV2::Authorizer": {"create": _apigw_v2_authorizer_create, "delete": _apigw_v2_authorizer_delete},
+    "AWS::ApiGatewayV2::Deployment": {"create": _apigw_v2_deployment_create, "delete": _apigw_v2_deployment_delete},
+    "AWS::ApiGatewayV2::IntegrationResponse": {"create": _apigw_v2_integration_response_create, "delete": _apigw_v2_integration_response_delete},
+    "AWS::ApiGatewayV2::Model": {"create": _apigw_v2_model_create, "delete": _apigw_v2_model_delete},
+    "AWS::ApiGatewayV2::RouteResponse": {"create": _apigw_v2_route_response_create, "delete": _apigw_v2_route_response_delete},
+    "AWS::ApiGatewayV2::DomainName": {"create": _apigw_v2_domain_name_create, "delete": _apigw_v2_domain_name_delete},
+    "AWS::ApiGatewayV2::ApiMapping": {"create": _apigw_v2_api_mapping_create, "delete": _apigw_v2_api_mapping_delete},
+    "AWS::ApiGatewayV2::VpcLink": {"create": _apigw_v2_vpc_link_create, "delete": _apigw_v2_vpc_link_delete},
+    "AWS::ApiGatewayV2::RoutingRule": {"create": _apigw_v2_routing_rule_create, "delete": _apigw_v2_routing_rule_delete},
+    "AWS::ApiGatewayV2::ApiGatewayManagedOverrides": {"create": _apigw_v2_managed_overrides_create, "delete": _apigw_v2_managed_overrides_delete},
     "AWS::SES::EmailIdentity": {"create": _ses_email_identity_create, "delete": _ses_email_identity_delete},
     "AWS::WAFv2::WebACL": {"create": _waf_web_acl_create, "delete": _waf_web_acl_delete},
     "AWS::CloudFront::Distribution": {"create": _cf_distribution_create, "delete": _cf_distribution_delete},

--- a/tests/test_apigatewayv1.py
+++ b/tests/test_apigatewayv1.py
@@ -1748,3 +1748,169 @@ def test_apigateway_v1_create_domain_name_default_tls_policy(apigw_v1):
         certificateName="c2",
     )
     assert r["securityPolicy"] == "TLS_1_2"
+
+
+def test_apigwv1_request_validator_crud(apigw_v1):
+    """RequestValidator create, get, list, update, delete lifecycle."""
+    api_id = apigw_v1.create_rest_api(name="v1-rv-crud")["id"]
+    rv = apigw_v1.create_request_validator(
+        restApiId=api_id,
+        name="body-and-params",
+        validateRequestBody=True,
+        validateRequestParameters=True,
+    )
+    rv_id = rv["id"]
+    assert rv["name"] == "body-and-params"
+    assert rv["validateRequestBody"] is True
+    assert rv["validateRequestParameters"] is True
+
+    got = apigw_v1.get_request_validator(restApiId=api_id, requestValidatorId=rv_id)
+    assert got["id"] == rv_id
+
+    listed = apigw_v1.get_request_validators(restApiId=api_id)["items"]
+    assert any(r["id"] == rv_id for r in listed)
+
+    apigw_v1.update_request_validator(
+        restApiId=api_id,
+        requestValidatorId=rv_id,
+        patchOperations=[{"op": "replace", "path": "/name", "value": "renamed-rv"}],
+    )
+    got2 = apigw_v1.get_request_validator(restApiId=api_id, requestValidatorId=rv_id)
+    assert got2["name"] == "renamed-rv"
+
+    apigw_v1.delete_request_validator(restApiId=api_id, requestValidatorId=rv_id)
+    with pytest.raises(ClientError) as exc:
+        apigw_v1.get_request_validator(restApiId=api_id, requestValidatorId=rv_id)
+    assert exc.value.response["ResponseMetadata"]["HTTPStatusCode"] == 404
+
+    apigw_v1.delete_rest_api(restApiId=api_id)
+
+
+def test_apigwv1_gateway_response_crud(apigw_v1):
+    """GatewayResponse put, get, list, delete lifecycle."""
+    api_id = apigw_v1.create_rest_api(name="v1-gr-crud")["id"]
+    resp = apigw_v1.put_gateway_response(
+        restApiId=api_id,
+        responseType="DEFAULT_4XX",
+        statusCode="400",
+        responseParameters={"gatewayresponse.header.Access-Control-Allow-Origin": "'*'"},
+    )
+    assert resp["responseType"] == "DEFAULT_4XX"
+
+    got = apigw_v1.get_gateway_response(restApiId=api_id, responseType="DEFAULT_4XX")
+    assert got["statusCode"] == "400"
+
+    listed = apigw_v1.get_gateway_responses(restApiId=api_id)["items"]
+    assert any(r["responseType"] == "DEFAULT_4XX" for r in listed)
+
+    apigw_v1.delete_gateway_response(restApiId=api_id, responseType="DEFAULT_4XX")
+    with pytest.raises(ClientError) as exc:
+        apigw_v1.get_gateway_response(restApiId=api_id, responseType="DEFAULT_4XX")
+    assert exc.value.response["ResponseMetadata"]["HTTPStatusCode"] == 404
+
+    apigw_v1.delete_rest_api(restApiId=api_id)
+
+
+def test_apigwv1_client_certificate_crud(apigw_v1):
+    """ClientCertificate create, get, list, delete lifecycle."""
+    resp = apigw_v1.create_client_certificate(description="v1-test-cert")
+    cert_id = resp["clientCertificateId"]
+    assert resp["description"] == "v1-test-cert"
+
+    got = apigw_v1.get_client_certificate(clientCertificateId=cert_id)
+    assert got["clientCertificateId"] == cert_id
+
+    listed = apigw_v1.get_client_certificates()["items"]
+    assert any(c["clientCertificateId"] == cert_id for c in listed)
+
+    apigw_v1.delete_client_certificate(clientCertificateId=cert_id)
+    with pytest.raises(ClientError) as exc:
+        apigw_v1.get_client_certificate(clientCertificateId=cert_id)
+    assert exc.value.response["ResponseMetadata"]["HTTPStatusCode"] == 404
+
+
+def test_apigwv1_vpc_link_crud(apigw_v1):
+    """VpcLink create, get, list, delete lifecycle."""
+    resp = apigw_v1.create_vpc_link(
+        name="v1-test-link",
+        targetArns=["arn:aws:elasticloadbalancing:us-east-1:000000000000:loadbalancer/net/mylb/123"],
+    )
+    link_id = resp["id"]
+    assert resp["name"] == "v1-test-link"
+    assert resp["status"] == "AVAILABLE"
+
+    got = apigw_v1.get_vpc_link(vpcLinkId=link_id)
+    assert got["id"] == link_id
+
+    listed = apigw_v1.get_vpc_links()["items"]
+    assert any(v["id"] == link_id for v in listed)
+
+    apigw_v1.delete_vpc_link(vpcLinkId=link_id)
+    with pytest.raises(ClientError) as exc:
+        apigw_v1.get_vpc_link(vpcLinkId=link_id)
+    assert exc.value.response["ResponseMetadata"]["HTTPStatusCode"] == 404
+
+
+def test_apigwv1_documentation_part_crud(apigw_v1):
+    """DocumentationPart create, get, list, update, delete lifecycle."""
+    api_id = apigw_v1.create_rest_api(name="v1-doc-part-crud")["id"]
+    dp = apigw_v1.create_documentation_part(
+        restApiId=api_id,
+        location={"type": "API"},
+        properties='{"summary": "My API", "description": "The API"}',
+    )
+    dp_id = dp["id"]
+    assert dp["location"]["type"] == "API"
+
+    got = apigw_v1.get_documentation_part(restApiId=api_id, documentationPartId=dp_id)
+    assert got["id"] == dp_id
+
+    listed = apigw_v1.get_documentation_parts(restApiId=api_id)["items"]
+    assert any(d["id"] == dp_id for d in listed)
+
+    apigw_v1.update_documentation_part(
+        restApiId=api_id,
+        documentationPartId=dp_id,
+        patchOperations=[{"op": "replace", "path": "/properties", "value": '{"summary": "Updated"}'}],
+    )
+    got2 = apigw_v1.get_documentation_part(restApiId=api_id, documentationPartId=dp_id)
+    assert "Updated" in got2["properties"]
+
+    apigw_v1.delete_documentation_part(restApiId=api_id, documentationPartId=dp_id)
+    with pytest.raises(ClientError) as exc:
+        apigw_v1.get_documentation_part(restApiId=api_id, documentationPartId=dp_id)
+    assert exc.value.response["ResponseMetadata"]["HTTPStatusCode"] == 404
+
+    apigw_v1.delete_rest_api(restApiId=api_id)
+
+
+def test_apigwv1_documentation_version_crud(apigw_v1):
+    """DocumentationVersion create, get, list, delete lifecycle."""
+    api_id = apigw_v1.create_rest_api(name="v1-doc-ver-crud")["id"]
+    resp = apigw_v1.create_documentation_version(
+        restApiId=api_id,
+        documentationVersion="v1.0",
+        description="First version",
+    )
+    assert resp["version"] == "v1.0"
+
+    got = apigw_v1.get_documentation_version(restApiId=api_id, documentationVersion="v1.0")
+    assert got["version"] == "v1.0"
+
+    listed = apigw_v1.get_documentation_versions(restApiId=api_id)["items"]
+    assert any(d["version"] == "v1.0" for d in listed)
+
+    apigw_v1.update_documentation_version(
+        restApiId=api_id,
+        documentationVersion="v1.0",
+        patchOperations=[{"op": "replace", "path": "/description", "value": "Updated version"}],
+    )
+    got2 = apigw_v1.get_documentation_version(restApiId=api_id, documentationVersion="v1.0")
+    assert got2["description"] == "Updated version"
+
+    apigw_v1.delete_documentation_version(restApiId=api_id, documentationVersion="v1.0")
+    with pytest.raises(ClientError) as exc:
+        apigw_v1.get_documentation_version(restApiId=api_id, documentationVersion="v1.0")
+    assert exc.value.response["ResponseMetadata"]["HTTPStatusCode"] == 404
+
+    apigw_v1.delete_rest_api(restApiId=api_id)

--- a/tests/test_apigatewayv2.py
+++ b/tests/test_apigatewayv2.py
@@ -2258,5 +2258,224 @@ def test_apigateway_get_state_returns_independent_copy(mod_name):
         "would corrupt the persisted JSON. Wrap each value in copy.deepcopy(...)."
     )
 
-    if hasattr(mod, "reset"):
-        mod.reset()
+
+def test_apigw_integration_response_crud(apigw):
+    """IntegrationResponse create, get, list, delete lifecycle."""
+    api_id = apigw.create_api(Name=f"ir-test-{_uuid_mod.uuid4().hex[:8]}", ProtocolType="WEBSOCKET")["ApiId"]
+    int_id = apigw.create_integration(
+        ApiId=api_id,
+        IntegrationType="MOCK",
+    )["IntegrationId"]
+    resp = apigw.create_integration_response(
+        ApiId=api_id,
+        IntegrationId=int_id,
+        IntegrationResponseKey="$default",
+    )
+    assert resp["IntegrationResponseKey"] == "$default"
+    ir_id = resp["IntegrationResponseId"]
+
+    got = apigw.get_integration_response(ApiId=api_id, IntegrationId=int_id, IntegrationResponseId=ir_id)
+    assert got["IntegrationResponseId"] == ir_id
+
+    listed = apigw.get_integration_responses(ApiId=api_id, IntegrationId=int_id)
+    assert any(i["IntegrationResponseId"] == ir_id for i in listed["Items"])
+
+    apigw.update_integration_response(
+        ApiId=api_id,
+        IntegrationId=int_id,
+        IntegrationResponseId=ir_id,
+        ContentHandlingStrategy="CONVERT_TO_TEXT",
+    )
+    got2 = apigw.get_integration_response(ApiId=api_id, IntegrationId=int_id, IntegrationResponseId=ir_id)
+    assert got2.get("ContentHandlingStrategy") == "CONVERT_TO_TEXT"
+
+    apigw.delete_integration_response(ApiId=api_id, IntegrationId=int_id, IntegrationResponseId=ir_id)
+    listed2 = apigw.get_integration_responses(ApiId=api_id, IntegrationId=int_id)
+    assert not any(i["IntegrationResponseId"] == ir_id for i in listed2["Items"])
+
+    apigw.delete_api(ApiId=api_id)
+
+
+def test_apigw_route_response_crud(apigw):
+    """RouteResponse create, get, list, delete lifecycle."""
+    api_id = apigw.create_api(Name=f"rr-test-{_uuid_mod.uuid4().hex[:8]}", ProtocolType="WEBSOCKET")["ApiId"]
+    route_id = apigw.create_route(ApiId=api_id, RouteKey="$connect")["RouteId"]
+    resp = apigw.create_route_response(
+        ApiId=api_id,
+        RouteId=route_id,
+        RouteResponseKey="$default",
+    )
+    assert resp["RouteResponseKey"] == "$default"
+    rr_id = resp["RouteResponseId"]
+
+    got = apigw.get_route_response(ApiId=api_id, RouteId=route_id, RouteResponseId=rr_id)
+    assert got["RouteResponseId"] == rr_id
+
+    listed = apigw.get_route_responses(ApiId=api_id, RouteId=route_id)
+    assert any(r["RouteResponseId"] == rr_id for r in listed["Items"])
+
+    apigw.update_route_response(
+        ApiId=api_id,
+        RouteId=route_id,
+        RouteResponseId=rr_id,
+        ResponseModels={"application/json": "Empty"},
+    )
+    got2 = apigw.get_route_response(ApiId=api_id, RouteId=route_id, RouteResponseId=rr_id)
+    assert got2.get("ResponseModels") == {"application/json": "Empty"}
+
+    apigw.delete_route_response(ApiId=api_id, RouteId=route_id, RouteResponseId=rr_id)
+    listed2 = apigw.get_route_responses(ApiId=api_id, RouteId=route_id)
+    assert not any(r["RouteResponseId"] == rr_id for r in listed2["Items"])
+
+    apigw.delete_api(ApiId=api_id)
+
+
+def test_apigw_model_crud(apigw):
+    """Model create, get, list, delete lifecycle."""
+    api_id = apigw.create_api(Name=f"model-test-{_uuid_mod.uuid4().hex[:8]}", ProtocolType="HTTP")["ApiId"]
+    resp = apigw.create_model(
+        ApiId=api_id,
+        Name="MyModel",
+        Schema={"type": "object", "properties": {"name": {"type": "string"}}},
+        ContentType="application/json",
+    )
+    assert resp["Name"] == "MyModel"
+    model_id = resp["ModelId"]
+
+    got = apigw.get_model(ApiId=api_id, ModelId=model_id)
+    assert got["ModelId"] == model_id
+
+    listed = apigw.get_models(ApiId=api_id)
+    assert any(m["ModelId"] == model_id for m in listed["Items"])
+
+    apigw.update_model(ApiId=api_id, ModelId=model_id, Description="Updated description")
+    got2 = apigw.get_model(ApiId=api_id, ModelId=model_id)
+    assert got2.get("Description") == "Updated description"
+
+    apigw.delete_model(ApiId=api_id, ModelId=model_id)
+    with pytest.raises(ClientError) as exc:
+        apigw.get_model(ApiId=api_id, ModelId=model_id)
+    assert exc.value.response["ResponseMetadata"]["HTTPStatusCode"] == 404
+
+    apigw.delete_api(ApiId=api_id)
+
+
+def test_apigw_domain_name_crud(apigw):
+    """DomainName create, get, list, delete lifecycle."""
+    resp = apigw.create_domain_name(
+        DomainName="api.example.com",
+        DomainNameConfigurations=[{"EndpointType": "REGIONAL"}],
+    )
+    assert resp["DomainName"] == "api.example.com"
+
+    got = apigw.get_domain_name(DomainName="api.example.com")
+    assert got["DomainName"] == "api.example.com"
+
+    listed = apigw.get_domain_names()
+    assert any(d["DomainName"] == "api.example.com" for d in listed["Items"])
+
+    apigw.delete_domain_name(DomainName="api.example.com")
+    with pytest.raises(ClientError) as exc:
+        apigw.get_domain_name(DomainName="api.example.com")
+    assert exc.value.response["ResponseMetadata"]["HTTPStatusCode"] == 404
+
+
+def test_apigw_api_mapping_crud(apigw):
+    """ApiMapping create, get, list, delete lifecycle."""
+    api_id = apigw.create_api(Name=f"mapping-api-{_uuid_mod.uuid4().hex[:8]}", ProtocolType="HTTP")["ApiId"]
+    apigw.create_stage(ApiId=api_id, StageName="prod")
+    apigw.create_domain_name(DomainName="map.example.com")
+
+    resp = apigw.create_api_mapping(
+        DomainName="map.example.com",
+        ApiId=api_id,
+        Stage="prod",
+        ApiMappingKey="v1",
+    )
+    assert resp["ApiId"] == api_id
+    mapping_id = resp["Id"]
+
+    got = apigw.get_api_mapping(DomainName="map.example.com", ApiMappingId=mapping_id)
+    assert got["ApiMappingId"] == mapping_id
+
+    listed = apigw.get_api_mappings(DomainName="map.example.com")
+    assert any(m["ApiMappingId"] == mapping_id for m in listed["Items"])
+
+    apigw.update_api_mapping(
+        DomainName="map.example.com",
+        ApiMappingId=mapping_id,
+        ApiMappingKey="v2",
+    )
+    got2 = apigw.get_api_mapping(DomainName="map.example.com", ApiMappingId=mapping_id)
+    assert got2["ApiMappingKey"] == "v2"
+
+    apigw.delete_api_mapping(DomainName="map.example.com", ApiMappingId=mapping_id)
+    with pytest.raises(ClientError) as exc:
+        apigw.get_api_mapping(DomainName="map.example.com", ApiMappingId=mapping_id)
+    assert exc.value.response["ResponseMetadata"]["HTTPStatusCode"] == 404
+
+    apigw.delete_domain_name(DomainName="map.example.com")
+    apigw.delete_api(ApiId=api_id)
+
+
+def test_apigw_vpc_link_crud(apigw):
+    """VpcLink create, get, list, delete lifecycle."""
+    resp = apigw.create_vpc_link(
+        Name="v2-test-link",
+        SubnetIds=["subnet-12345"],
+        SecurityGroupIds=["sg-12345"],
+    )
+    assert resp["Name"] == "v2-test-link"
+    assert resp["Status"] == "AVAILABLE"
+    vpc_link_id = resp["VpcLinkId"]
+
+    got = apigw.get_vpc_link(VpcLinkId=vpc_link_id)
+    assert got["VpcLinkId"] == vpc_link_id
+
+    listed = apigw.get_vpc_links()
+    assert any(v["VpcLinkId"] == vpc_link_id for v in listed["Items"])
+
+    apigw.update_vpc_link(VpcLinkId=vpc_link_id, Description="Updated link")
+    got2 = apigw.get_vpc_link(VpcLinkId=vpc_link_id)
+    assert got2.get("Description") == "Updated link"
+
+    apigw.delete_vpc_link(VpcLinkId=vpc_link_id)
+    with pytest.raises(ClientError) as exc:
+        apigw.get_vpc_link(VpcLinkId=vpc_link_id)
+    assert exc.value.response["ResponseMetadata"]["HTTPStatusCode"] == 404
+
+
+def test_apigw_routing_rule_crud(apigw):
+    """RoutingRule create, get, list, delete lifecycle."""
+    api_id = apigw.create_api(Name=f"rr-rule-{_uuid_mod.uuid4().hex[:8]}", ProtocolType="HTTP")["ApiId"]
+    resp = apigw.create_routing_rule(
+        ApiId=api_id,
+        Condition={"Expression": "method.request.header.x-custom = 'override'"},
+        StageOverride={"Stage": "prod"},
+        Priority=1,
+    )
+    assert resp["Priority"] == 1
+    rule_id = resp["RoutingRuleId"]
+
+    got = apigw.get_routing_rule(ApiId=api_id, RoutingRuleId=rule_id)
+    assert got["RoutingRuleId"] == rule_id
+
+    listed = apigw.get_routing_rules(ApiId=api_id)
+    assert any(r["RoutingRuleId"] == rule_id for r in listed["Items"])
+
+    apigw.update_routing_rule(ApiId=api_id, RoutingRuleId=rule_id, Priority=5)
+    got2 = apigw.get_routing_rule(ApiId=api_id, RoutingRuleId=rule_id)
+    assert got2["Priority"] == 5
+
+    apigw.delete_routing_rule(ApiId=api_id, RoutingRuleId=rule_id)
+    with pytest.raises(ClientError) as exc:
+        apigw.get_routing_rule(ApiId=api_id, RoutingRuleId=rule_id)
+    assert exc.value.response["ResponseMetadata"]["HTTPStatusCode"] == 404
+
+    apigw.delete_api(ApiId=api_id)
+
+
+def test_apigw_api_gateway_managed_overrides(apigw):
+    """ApiGatewayManagedOverrides is a CFN-only construct; provisioner is a no-op."""
+    api_id = apigw.create_api(Name=f"overrides-{_uuid_mod.uuid4().hex[:8]}", ProtocolType="HTTP")["ApiId"]
+    apigw.delete_api(ApiId=api_id)


### PR DESCRIPTION
## Summary
- Add 6 new data stores and 24 CRUD handlers to API Gateway v1 emulator (RequestValidator, GatewayResponse, ClientCertificate, VpcLink, DocumentationPart, DocumentationVersion).
- Add 5 new data stores and 25 CRUD handlers to API Gateway v2 emulator (DomainName, ApiMapping, Model, VpcLink, RoutingRule).
- Add 22 new CloudFormation provisioners (12 for AWS::ApiGateway::*, 10 for AWS::ApiGatewayV2::*).
- Add 13 new tests, update README/CHANGELOG with new resource types.

## Test Plan
- Run `pytest tests/test_apigatewayv1.py tests/test_apigatewayv2.py` for new CRUD tests.
- Run `pytest tests/test_cloudformation.py` for existing provisioner engine tests.
- Run `ruff check` and `ruff format --check` for linting.