### PR TITLE
fix(apigateway-v1): parses boolean field when updating stage

### DIFF
--- a/ministack/services/apigateway_v1.py
+++ b/ministack/services/apigateway_v1.py
@@ -448,6 +448,11 @@ def _apply_stage_patch(stage, patch_ops):
     leftover = []
     for op in patch_ops:
         if not _try_apply_method_settings_patch(stage, op):
+            if "value" in op:
+                path = op.get("path", "")
+                if "tracingEnabled" in path or "cacheClusterEnabled" in path:
+                    # UpdateStage sends patch `value` as strings (e.g. `"true"` for `tracingEnabled`)
+                    op["value"] = str(op["value"]).lower() == "true"
             leftover.append(op)
     if leftover:
         _apply_patch(stage, leftover)

--- a/tests/test_apigatewayv1.py
+++ b/tests/test_apigatewayv1.py
@@ -275,10 +275,14 @@ def test_apigwv1_update_stage(apigw_v1):
     apigw_v1.update_stage(
         restApiId=api_id,
         stageName="dev",
-        patchOperations=[{"op": "replace", "path": "/variables/myVar", "value": "myVal"}],
+        patchOperations=[
+            {"op": "replace", "path": "/variables/myVar", "value": "myVal"},
+            {"op": "replace", "path": "/tracingEnabled", "value": "true"},
+        ],
     )
     resp = apigw_v1.get_stage(restApiId=api_id, stageName="dev")
     assert resp["variables"]["myVar"] == "myVal"
+    assert resp["tracingEnabled"] is True
     apigw_v1.delete_rest_api(restApiId=api_id)
 
 


### PR DESCRIPTION
POST (`CreateStage`) sends a normal JSON body. `handle_request` parses it with `json.loads`, so `"tracingEnabled": true` becomes a Python bool.
PATCH (`UpdateStage`) uses `patchOperations`. On the real AWS API Gateway, each patch value is a [string](https://docs.aws.amazon.com/apigateway/latest/api/API_UpdateStage.html): `{"op": "replace", "path": "/tracingEnabled", "value": "true"}`. `_apply_stage_patch` routed those ops through generic `_apply_patch`, which assigns value as-is with no type coercion. Method-setting patches already had `_parse_stage_method_setting_value`; root fields like `tracingEnabled` did not, which creates the following errors in Pulumi:

```
Diagnostics:
  aws:apigateway:Stage (v1):
    error:   sdk-v2/provider2.go:572: sdk.helper_schema: updating API Gateway Stage (ags-28feae3a-v1): operation error API Gateway: UpdateStage, https response error StatusCode: 200, RequestID: fce8ce30-54f3-4914-935a-bbaf6e0a1286, deserialization failed, failed to decode response body with invalid JSON, expected Boolean to be of type *bool, got string instead: provider=aws@7.16.0
    error: 1 error occurred:
        * creating urn:pulumi:dev::test-api::aws:apigateway/stage:Stage::v1: 1 error occurred:
        * updating API Gateway Stage (ags-28feae3a-v1): operation error API Gateway: UpdateStage, https response error StatusCode: 200, RequestID: fce8ce30-54f3-4914-935a-bbaf6e0a1286, deserialization failed, failed to decode response body with invalid JSON, expected Boolean to be of type *bool, got string instead
```

This PR converts the those fields from string to boolean before updating the Stage.