### PR TITLE
fix(cognito): JWT iss claim uses pool region instead of request region

### DIFF
--- a/ministack/services/cognito.py
+++ b/ministack/services/cognito.py
@@ -318,6 +318,19 @@ def _pool_id() -> str:
     return f"{get_region()}_{suffix[:9]}"
 
 
+def _pool_region(pool_id: str) -> str:
+    """Return the region encoded in a pool_id (format ``{region}_{suffix}``).
+
+    Falls back to get_region() for empty or non-standard IDs so callers
+    never have to special-case the edge cases.
+    """
+    if pool_id and "_" in pool_id:
+        candidate = pool_id.rsplit("_", 1)[0]
+        if re.match(r"^[a-z]+-[a-z]+-\d+$", candidate):
+            return candidate
+    return get_region()
+
+
 def _client_id() -> str:
     return "".join(secrets.choice(string.digits + string.ascii_letters) for _ in range(26))
 
@@ -352,7 +365,7 @@ def _fake_token(sub: str, pool_id: str, client_id: str, token_type: str = "acces
     origin_jti = new_uuid()
     claims = {
         "sub": sub,
-        "iss": f"https://cognito-idp.{get_region()}.amazonaws.com/{pool_id}",
+        "iss": f"https://cognito-idp.{_pool_region(pool_id)}.amazonaws.com/{pool_id}",
         "token_use": token_type,
         "iat": now,
         "exp": now + 3600,
@@ -554,7 +567,7 @@ def _build_pretoken_event(pool_id: str, client_id: str, username: str,
     return {
         "version": "1",
         "triggerSource": trigger_source,
-        "region": get_region(),
+        "region": _pool_region(pool_id),
         "userPoolId": pool_id,
         "userName": username or "",
         "callerContext": {

--- a/tests/test_cognito.py
+++ b/tests/test_cognito.py
@@ -3044,6 +3044,63 @@ def test_cognito_resend_confirmation_code_sends_email(cognito_idp):
     assert len(msgs) == 2
 
 
+def test_cognito_iss_claim_uses_pool_region():
+    """Regression test for #678: JWT iss claim must reflect the pool's region.
+
+    Creates a user pool via a client configured with eu-central-1 and verifies
+    that both IdToken and AccessToken carry eu-central-1 in their iss claim,
+    not the server's default us-east-1.
+    """
+    import boto3
+
+    endpoint = os.environ.get("MINISTACK_ENDPOINT", "http://localhost:4566")
+    region = "eu-central-1"
+    client = boto3.client(
+        "cognito-idp",
+        endpoint_url=endpoint,
+        aws_access_key_id="test",
+        aws_secret_access_key="test",
+        region_name=region,
+    )
+
+    pid = client.create_user_pool(PoolName="IssRegionPool")["UserPool"]["Id"]
+    assert pid.startswith("eu-central-1_"), f"pool_id should encode region: {pid}"
+
+    cid = client.create_user_pool_client(
+        UserPoolId=pid,
+        ClientName="IssRegionApp",
+        ExplicitAuthFlows=["ALLOW_USER_PASSWORD_AUTH", "ALLOW_REFRESH_TOKEN_AUTH"],
+    )["UserPoolClient"]["ClientId"]
+
+    client.admin_create_user(UserPoolId=pid, Username="isstest")
+    client.admin_set_user_password(
+        UserPoolId=pid, Username="isstest", Password="IssTest1!", Permanent=True
+    )
+
+    auth = client.initiate_auth(
+        ClientId=cid,
+        AuthFlow="USER_PASSWORD_AUTH",
+        AuthParameters={"USERNAME": "isstest", "PASSWORD": "IssTest1!"},
+    )
+    result = auth["AuthenticationResult"]
+
+    def _decode_payload(token: str) -> dict:
+        payload_b64 = token.split(".")[1]
+        payload_b64 += "=" * (-len(payload_b64) % 4)
+        return json.loads(base64.urlsafe_b64decode(payload_b64))
+
+    id_claims = _decode_payload(result["IdToken"])
+    access_claims = _decode_payload(result["AccessToken"])
+
+    expected_iss = f"https://cognito-idp.{region}.amazonaws.com/{pid}"
+    assert id_claims["iss"] == expected_iss, (
+        f"IdToken iss should be {expected_iss!r}, got {id_claims['iss']!r}"
+    )
+    assert access_claims["iss"] == expected_iss, (
+        f"AccessToken iss should be {expected_iss!r}, got {access_claims['iss']!r}"
+    )
+
+
 def test_cognito_email_disabled_env_skips_send(cognito_idp, monkeypatch):
     """COGNITO_EMAIL_ENABLED=false must short-circuit delivery in-process."""
     mod = _cognito_module()


### PR DESCRIPTION
## Summary

Fixes #678.

- `_fake_token` was building the `iss` claim with `get_region()`, which reads the per-request SigV4 credential scope. When that scope carries a different region than the pool was created in (e.g. a unified endpoint hit from a different-region client), the JWT `iss` ends up as `cognito-idp.us-east-1.amazonaws.com/eu-central-1_…` — rejected by every standard JWT validation library.
- Add `_pool_region(pool_id)` that parses the region directly from the pool ID (format `{region}_{suffix}`, established at pool-creation time) and falls back to `get_region()` only for empty/non-standard IDs.
- Apply `_pool_region` to the `iss` claim in `_fake_token` and to the `region` field in the PreTokenGeneration trigger event.

## Test plan

- [x] New regression test `test_cognito_iss_claim_uses_pool_region`: creates a pool via a `eu-central-1` boto3 client, calls `initiate_auth`, decodes both `IdToken` and `AccessToken` payloads, and asserts `iss` is `https://cognito-idp.eu-central-1.amazonaws.com/{pool_id}`.
- [x] Existing Cognito test suite passes unchanged (all pools created with the default `us-east-1` fixture continue to get `us-east-1` in `iss`).

