### PR TITLE
feat(s3): support If-None-Match / If-Match preconditions on PutObject

### DIFF
--- a/ministack/services/s3.py
+++ b/ministack/services/s3.py
@@ -405,6 +405,83 @@ def _validate_content_md5(headers: dict, body: bytes):
     return None
 
 
+def _check_put_preconditions(headers: dict, existing_obj: dict | None):
+    """Evaluate `If-Match` and `If-None-Match` on PUT.
+
+    AWS S3 added native conditional writes on PutObject in November 2024:
+      - `If-None-Match: "*"` — succeed only when no object exists at the key.
+        Used to implement create-once semantics (idempotent writes, distributed
+        leader election via S3, two-file pair serialization).
+      - `If-None-Match: "<etag>"` — succeed only when the existing object's
+        ETag does NOT match.
+      - `If-Match: "*"` — succeed only when an object already exists.
+      - `If-Match: "<etag>"` — succeed only when the existing object's ETag
+        matches.
+
+    Returns a 412 PreconditionFailed tuple when a condition is violated;
+    otherwise returns None and the caller proceeds with the PUT.
+
+    ETag comparison strips surrounding quotes on both sides — S3 stores ETags
+    with quotes but client code is inconsistent about including them.
+    """
+    if_none_match = headers.get("if-none-match", "").strip()
+    if_match = headers.get("if-match", "").strip()
+
+    if not if_none_match and not if_match:
+        return None
+
+    existing_etag = (
+        existing_obj["etag"].strip('"') if existing_obj is not None else None
+    )
+
+    if if_none_match:
+        # "*" form: any existing object violates the condition.
+        if if_none_match == "*":
+            if existing_obj is not None:
+                return _error(
+                    "PreconditionFailed",
+                    "At least one of the pre-conditions you specified did not hold",
+                    412,
+                )
+        # ETag form: existing object with matching ETag violates the condition.
+        elif existing_obj is not None and if_none_match.strip('"') == existing_etag:
+            return _error(
+                "PreconditionFailed",
+                "At least one of the pre-conditions you specified did not hold",
+                412,
+            )
+
+    if if_match:
+        # "*" form: any existing object satisfies the condition; missing → 412 per RFC 7232.
+        # (AWS docs don't explicitly document If-Match:* for PutObject, but the inverse case
+        # is well-defined by RFC and real S3 follows it.)
+        if if_match == "*":
+            if existing_obj is None:
+                return _error(
+                    "PreconditionFailed",
+                    "At least one of the pre-conditions you specified did not hold",
+                    412,
+                )
+        elif existing_obj is None:
+            # AWS S3 specifically returns 404 (NoSuchKey) — not 412 — when If-Match: <etag>
+            # targets a key that doesn't exist (or whose current version is a delete marker).
+            # Documented under "Conditional write behavior" in the user guide:
+            # https://docs.aws.amazon.com/AmazonS3/latest/userguide/conditional-writes.html#conditional-error-response
+            return _error(
+                "NoSuchKey",
+                "The specified key does not exist.",
+                404,
+            )
+        elif if_match.strip('"') != existing_etag:
+            return _error(
+                "PreconditionFailed",
+                "At least one of the pre-conditions you specified did not hold",
+                412,
+            )
+
+    return None
+
+
 def _find_xml_tag(parent, tag_name, ns=S3_NS):
     el = parent.find("{%s}%s" % (ns, tag_name))
     if el is None:
@@ -1775,6 +1852,10 @@ def _put_object(bucket_name: str, key: str, body: bytes, headers: dict):
     _, sc_err = _resolve_storage_class(headers)
     if sc_err:
         return sc_err
+
+    precondition_err = _check_put_preconditions(headers, bucket.get("objects", {}).get(key))
+    if precondition_err:
+        return precondition_err
 
     etag = f'"{md5_hash(body)}"'
     obj = _build_object_record(body, headers, etag=etag)

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -75,6 +75,170 @@ def test_s3_put_object_no_bucket(s3):
         s3.put_object(Bucket="intg-s3-nobucket-xyz", Key="k", Body=b"x")
     assert exc.value.response["Error"]["Code"] == "NoSuchBucket"
 
+
+# ─── Conditional PUT (If-Match / If-None-Match) ──────────────────────────────
+
+def test_s3_put_object_if_none_match_star_no_existing(s3):
+    """If-None-Match: * succeeds when no object exists at the key (create-once)."""
+    bucket = "intg-s3-ifnm-star-create"
+    s3.create_bucket(Bucket=bucket)
+
+    # botocore strips IfNoneMatch on PutObject (added by S3 in 2024); send via low-level
+    # event handler so the header reaches the wire.
+    def _add_ifnm(request, **_kwargs):
+        request.headers["If-None-Match"] = "*"
+
+    s3.meta.events.register_first(
+        "before-send.s3.PutObject", _add_ifnm,
+    )
+    try:
+        s3.put_object(Bucket=bucket, Key="first.txt", Body=b"hello")
+    finally:
+        s3.meta.events.unregister("before-send.s3.PutObject", _add_ifnm)
+
+    resp = s3.get_object(Bucket=bucket, Key="first.txt")
+    assert resp["Body"].read() == b"hello"
+
+
+def test_s3_put_object_if_none_match_star_existing_fails(s3):
+    """If-None-Match: * returns 412 when an object already exists at the key."""
+    bucket = "intg-s3-ifnm-star-conflict"
+    s3.create_bucket(Bucket=bucket)
+    s3.put_object(Bucket=bucket, Key="taken.txt", Body=b"original")
+
+    def _add_ifnm(request, **_kwargs):
+        request.headers["If-None-Match"] = "*"
+
+    s3.meta.events.register_first(
+        "before-send.s3.PutObject", _add_ifnm,
+    )
+    try:
+        with pytest.raises(ClientError) as exc:
+            s3.put_object(Bucket=bucket, Key="taken.txt", Body=b"second")
+    finally:
+        s3.meta.events.unregister("before-send.s3.PutObject", _add_ifnm)
+
+    assert exc.value.response["Error"]["Code"] == "PreconditionFailed"
+    assert exc.value.response["ResponseMetadata"]["HTTPStatusCode"] == 412
+
+    # The original bytes must remain — the failed PUT must not overwrite.
+    resp = s3.get_object(Bucket=bucket, Key="taken.txt")
+    assert resp["Body"].read() == b"original"
+
+
+def test_s3_put_object_if_none_match_etag(s3):
+    """If-None-Match: <etag> succeeds when existing ETag differs, fails when it matches."""
+    bucket = "intg-s3-ifnm-etag"
+    s3.create_bucket(Bucket=bucket)
+    first = s3.put_object(Bucket=bucket, Key="obj.txt", Body=b"v1")
+    first_etag = first["ETag"]
+
+    # Wrong ETag → condition satisfied, PUT succeeds.
+    def _add_wrong(request, **_kwargs):
+        request.headers["If-None-Match"] = '"00000000000000000000000000000000"'
+
+    s3.meta.events.register_first("before-send.s3.PutObject", _add_wrong)
+    try:
+        s3.put_object(Bucket=bucket, Key="obj.txt", Body=b"v2")
+    finally:
+        s3.meta.events.unregister("before-send.s3.PutObject", _add_wrong)
+
+    # Matching ETag → condition violated, PUT fails 412.
+    def _add_match(request, **_kwargs):
+        # Use the new ETag from v2.
+        v2_etag = s3.head_object(Bucket=bucket, Key="obj.txt")["ETag"]
+        request.headers["If-None-Match"] = v2_etag
+
+    s3.meta.events.register_first("before-send.s3.PutObject", _add_match)
+    try:
+        with pytest.raises(ClientError) as exc:
+            s3.put_object(Bucket=bucket, Key="obj.txt", Body=b"v3")
+    finally:
+        s3.meta.events.unregister("before-send.s3.PutObject", _add_match)
+
+    assert exc.value.response["Error"]["Code"] == "PreconditionFailed"
+    _ = first_etag  # unused; kept to show v1 etag captured at write time
+
+
+def test_s3_put_object_if_match_star_requires_existing(s3):
+    """If-Match: * succeeds when an object exists, fails when none does."""
+    bucket = "intg-s3-ifm-star"
+    s3.create_bucket(Bucket=bucket)
+
+    def _add_ifm_star(request, **_kwargs):
+        request.headers["If-Match"] = "*"
+
+    # No existing object → 412.
+    s3.meta.events.register_first("before-send.s3.PutObject", _add_ifm_star)
+    try:
+        with pytest.raises(ClientError) as exc:
+            s3.put_object(Bucket=bucket, Key="missing.txt", Body=b"x")
+    finally:
+        s3.meta.events.unregister("before-send.s3.PutObject", _add_ifm_star)
+    assert exc.value.response["Error"]["Code"] == "PreconditionFailed"
+
+    # Now create it, then If-Match: * succeeds.
+    s3.put_object(Bucket=bucket, Key="present.txt", Body=b"a")
+    s3.meta.events.register_first("before-send.s3.PutObject", _add_ifm_star)
+    try:
+        s3.put_object(Bucket=bucket, Key="present.txt", Body=b"b")
+    finally:
+        s3.meta.events.unregister("before-send.s3.PutObject", _add_ifm_star)
+    assert s3.get_object(Bucket=bucket, Key="present.txt")["Body"].read() == b"b"
+
+
+def test_s3_put_object_if_match_etag(s3):
+    """If-Match: <etag> succeeds when ETag matches, 412 when stale."""
+    bucket = "intg-s3-ifm-etag"
+    s3.create_bucket(Bucket=bucket)
+    initial = s3.put_object(Bucket=bucket, Key="obj.txt", Body=b"v1")
+    initial_etag = initial["ETag"]
+
+    def _add_match(request, **_kwargs):
+        request.headers["If-Match"] = initial_etag
+
+    # Matching ETag → succeed.
+    s3.meta.events.register_first("before-send.s3.PutObject", _add_match)
+    try:
+        s3.put_object(Bucket=bucket, Key="obj.txt", Body=b"v2")
+    finally:
+        s3.meta.events.unregister("before-send.s3.PutObject", _add_match)
+
+    # Old (stale) ETag against the new object → 412.
+    s3.meta.events.register_first("before-send.s3.PutObject", _add_match)
+    try:
+        with pytest.raises(ClientError) as exc:
+            s3.put_object(Bucket=bucket, Key="obj.txt", Body=b"v3")
+    finally:
+        s3.meta.events.unregister("before-send.s3.PutObject", _add_match)
+
+    assert exc.value.response["Error"]["Code"] == "PreconditionFailed"
+    assert exc.value.response["ResponseMetadata"]["HTTPStatusCode"] == 412
+
+
+def test_s3_put_object_if_match_etag_missing_object_returns_404(s3):
+    """If-Match: <etag> against a non-existent key returns 404 NoSuchKey (per AWS docs).
+
+    AWS S3 specifically returns 404 — not 412 — when If-Match: <etag> targets a key
+    that doesn't exist (or whose current version is a delete marker). Documented at
+    https://docs.aws.amazon.com/AmazonS3/latest/userguide/conditional-writes.html#conditional-error-response
+    """
+    bucket = "intg-s3-ifm-missing"
+    s3.create_bucket(Bucket=bucket)
+
+    def _add_etag(request, **_kwargs):
+        request.headers["If-Match"] = '"00000000000000000000000000000000"'
+
+    s3.meta.events.register_first("before-send.s3.PutObject", _add_etag)
+    try:
+        with pytest.raises(ClientError) as exc:
+            s3.put_object(Bucket=bucket, Key="absent.txt", Body=b"x")
+    finally:
+        s3.meta.events.unregister("before-send.s3.PutObject", _add_etag)
+
+    assert exc.value.response["Error"]["Code"] == "NoSuchKey"
+    assert exc.value.response["ResponseMetadata"]["HTTPStatusCode"] == 404
+
 def test_s3_put_get_json_chunked(s3):
     """AWS SDK v2 sends PutObject with chunked Transfer-Encoding — body must be decoded cleanly."""
     import json as _json


### PR DESCRIPTION
## Summary

Implements the conditional-write headers AWS S3 added in November 2024, following the behaviors documented in:

- [PutObject API reference — request headers](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html)
- [Conditional writes — user guide](https://docs.aws.amazon.com/AmazonS3/latest/userguide/conditional-writes.html)

| Header | AWS spec | This PR |
|---|---|---|
| `If-None-Match: "*"` | *"expects the asterisk value"* — fails 412 when key exists | ✅ matches |
| `If-Match: "<etag>"` | *"expects the ETag value as a string"* — fails 412 when ETag differs | ✅ matches |
| `If-Match: "<etag>"` against missing key | **404 NoSuchKey** ([user guide](https://docs.aws.amazon.com/AmazonS3/latest/userguide/conditional-writes.html#conditional-error-response): *"the operation fails with a 404 Not Found error"*) | ✅ matches |
| `If-None-Match: "<etag>"` | not explicitly documented for PutObject; RFC 7232 default | ✅ 412 (RFC behavior) |
| `If-Match: "*"` | not explicitly documented for PutObject; RFC 7232 default | ✅ 412 (RFC behavior) |

## Implementation

Small helper `_check_put_preconditions` next to the existing `_validate_content_md5`. `_put_object` calls it after MD5 and storage-class validation, before mutating bucket state. ETag comparison strips surrounding quotes on both sides — clients are inconsistent about including them.

The existing `_copy_object` already supports `x-amz-copy-source-if-match` / `x-amz-copy-source-if-none-match`; this fills the symmetric gap on plain `PutObject`.

## Motivation

We use a single shared S3 slot serializing concurrent arrivals through `If-None-Match: "*"` to pair two-file inbound batches in our transformation pipeline. Real S3 enforces it; MiniStack Community currently silently accepts the second PUT and overwrites — so integration tests against MiniStack would produce false positives for code we know is correct against AWS. This closes that parity gap.

## Tests

Six new tests in `tests/test_s3.py`:

- `test_s3_put_object_if_none_match_star_no_existing` — succeeds when key empty
- `test_s3_put_object_if_none_match_star_existing_fails` — 412 when key exists; original bytes preserved
- `test_s3_put_object_if_none_match_etag` — succeeds on mismatched ETag, fails on matching
- `test_s3_put_object_if_match_star_requires_existing` — 412 when missing; succeeds when present
- `test_s3_put_object_if_match_etag` — succeeds on matching ETag, 412 on stale
- `test_s3_put_object_if_match_etag_missing_object_returns_404` — covers the AWS-specific 404 case

All six pass locally. Pre-existing failures in `tests/test_s3.py` (multipart-copy range parsing, chunked-upload tests) are unrelated and exist on `main` without these changes.

botocore strips `IfNoneMatch` / `IfMatch` from `put_object` calls on older SDK versions (params added in late 2024), so the tests inject the headers via `before-send.s3.PutObject` event handlers to ensure they reach the wire. This makes the tests robust across botocore versions.

## Known limitation

AWS S3 returns `409 Conflict` (not `412`) for concurrent operations — e.g. when a delete or another conditional write completes between the read-back and the write. MiniStack's in-memory single-threaded model has no distributed-system race window to detect, so this PR always returns 412 for any precondition violation. Users testing concurrent-conflict code paths against MiniStack should be aware of this — it's a backend-emulation limit, not a correctness issue.

## Out of scope

- `DeleteObject` conditional headers — same precondition shape; separate PR if there's interest.
- `CompleteMultipartUpload` conditional writes — AWS supports the same headers there per the [user guide](https://docs.aws.amazon.com/AmazonS3/latest/userguide/conditional-writes.html); could follow.