### PR TITLE
feat(s3): support virtual-hosted bucket request routing

### DIFF
--- a/ministack/app.py
+++ b/ministack/app.py
@@ -122,6 +122,18 @@ def _extract_s3_vhost_bucket(host: str):
         host = host.rsplit(":", 1)[0]
     if not host or _IPV4_RE.match(host) or "." not in host:
         return None
+    labels = host.split(".")
+
+    # ex: dotted.mybucket.s3.us-east-1.localhost -> bucket dotted.mybucket.
+    for idx, label in enumerate(labels[1:], start=1):
+        if label == "s3" or label.startswith(("s3-", "s3express-")):
+            candidate = ".".join(labels[:idx])
+            if not _BUCKET_LABEL_RE.match(candidate):
+                return None
+            if ".." in candidate or _IPV4_RE.match(candidate):
+                return None
+            return candidate
+
     candidate, tail = host.split(".", 1)
     if not tail or tail.startswith("."):
         return None
@@ -129,12 +141,14 @@ def _extract_s3_vhost_bucket(host: str):
         return None
     if ".." in candidate or _IPV4_RE.match(candidate):
         return None
+    if candidate == "s3":
+        return None
     if tail == _MINISTACK_HOST or tail.endswith("." + _MINISTACK_HOST):
         return candidate
-    first_tail_segment = tail.split(".", 1)[0]
-    if first_tail_segment == "s3" or first_tail_segment.startswith(("s3-", "s3express-")):
-        return candidate
-    return None
+    # Custom local endpoint names are common in Docker/dev setups, e.g.
+    # `bucket.ministack:4566`. Treat any valid leading DNS label as the bucket;
+    # service-host false positives are filtered by _handle_s3_vhost_request.
+    return candidate
 _S3_VHOST_EXCLUDE_RE = re.compile(r"\.(execute-api|alb|emr|efs|elasticache|s3-control|appsync-api|appsync-realtime-api|iot)\.")
 _HEALTH_PATHS = ("/_ministack/health", "/_localstack/health", "/health")
 _BODY_METHODS = ("POST", "PUT", "PATCH")
@@ -1205,7 +1219,7 @@ async def _handle_s3_vhost_request(host: str, path: str, method: str, headers: d
     ):
         return None
 
-    vhost_path = "/" + bucket + path if path != "/" else "/" + bucket + "/"
+    vhost_path = "/" + bucket + path if path != "/" else "/" + bucket
     try:
         return await _get_module("s3").handle_request(method, vhost_path, headers, body, query_params)
     except Exception as e:

--- a/tests/test_ministack.py
+++ b/tests/test_ministack.py
@@ -698,6 +698,9 @@ class TestExtractS3VhostBucket:
     def test_bare_bucket(self):
         assert _extract_s3_vhost_bucket("mybucket.localhost") == "mybucket"
 
+    def test_custom_local_endpoint_bucket(self):
+        assert _extract_s3_vhost_bucket("bucket.ministack:4566") == "bucket"
+
     def test_single_segment_s3_nested_bucket(self):
         assert _extract_s3_vhost_bucket("mybucket.s3.localhost") == "mybucket"
 
@@ -707,7 +710,6 @@ class TestExtractS3VhostBucket:
     def test_single_segment_region_nested_bucket_with_port(self):
         assert _extract_s3_vhost_bucket("mybucket.s3.us-east-1.localhost:4566") == "mybucket"
 
-    @pytest.mark.skip(reason="Dotted Nested Bucket is not supported yet")
     def test_double_segment_s3_nested_bucket(self):
         assert _extract_s3_vhost_bucket("dotted.mybucket.s3.localhost") == "dotted.mybucket"
 


### PR DESCRIPTION
## Summary

Adds virtual-hosted-style S3 request routing so MiniStack can handle bucket-addressed S3 requests like:

```txt
Host: bucket.ministack:4566
PUT /
GET /key
PUT /key
```

and route them internally through the existing path-style S3 handler as:

```txt
/bucket
/bucket/key
```

This follows AWS S3 virtual-hosted-style bucket addressing documented in:

- [Virtual hosting of buckets — S3 user guide](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html)
- [Bucket naming rules — S3 user guide](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html)

| Request shape | AWS behavior | This PR |
|---|---|---|
| `Host: bucket.ministack:4566`, `PUT /` | bucket name comes from host | ✅ routes as `/bucket` |
| `Host: bucket.ministack:4566`, `GET /key` | bucket name comes from host, key from path | ✅ routes as `/bucket/key` |
| `Host: bucket.s3.localhost:4566`, `GET /key` | explicit S3 virtual-host form | ✅ routes as `/bucket/key` |
| `Host: bucket.s3.us-east-1.localhost:4566`, `GET /key` | region-qualified S3 virtual-host form | ✅ routes as `/bucket/key` |
| `Host: dotted.mybucket.s3.localhost:4566`, `GET /key` | dotted bucket names are valid S3 buckets | ✅ routes as `/dotted.mybucket/key` |
| `Host: s3.us-east-1.localhost:4566` | bare S3 service endpoint, not a bucket | ✅ not treated as virtual-hosted bucket |

## Implementation

The change lives at the gateway layer in `ministack/app.py`.

`_extract_s3_vhost_bucket` now recognizes:

- custom local virtual-host endpoints, e.g. `bucket.ministack:4566`
- explicit S3 virtual-host endpoints, e.g. `bucket.s3.localhost`
- region-qualified S3 endpoints, e.g. `bucket.s3.us-east-1.localhost`
- dotted bucket names for explicit S3 endpoints, e.g. `dotted.mybucket.s3.localhost`

`_handle_s3_vhost_request` then rewrites the incoming request path before dispatching to the existing S3 service module:

```python
bucket = _extract_s3_vhost_bucket(host)
vhost_path = f"/{bucket}" if path == "/" else f"/{bucket}{path}"
return await s3.handle_request(method, vhost_path, headers, body, query_params)
```

This keeps the S3 service implementation itself path-style internally, while allowing clients to use virtual-hosted-style addressing.

The implementation also keeps existing safeguards so service-looking hosts are not accidentally routed to S3, including exclusions for hosts such as:

- `execute-api`
- `alb`
- `emr`
- `efs`
- `elasticache`
- `s3-control`
- `appsync-api`
- `appsync-realtime-api`
- `iot`

## Motivation

AWS SDKs commonly use virtual-hosted-style S3 addressing, especially when configured with `addressing_style = "virtual"` or when using endpoint URLs that support bucket host prefixes.

Without this routing, requests like:

```txt
Host: bucket.ministack:4566
GET /key
```

do not naturally reach the existing MiniStack S3 path-style handler as `/bucket/key`.

This can cause integration tests to behave differently against MiniStack than against AWS S3 or LocalStack-style local endpoints. Normalizing virtual-hosted requests at the gateway closes that parity gap while reusing the existing S3 implementation.

## Tests

Updated `tests/test_ministack.py::TestExtractS3VhostBucket`.

New/changed coverage includes:

- `test_custom_local_endpoint_bucket` — verifies `bucket.ministack:4566` extracts bucket `bucket`
- `test_double_segment_s3_nested_bucket` — unskipped and now verifies `dotted.mybucket.s3.localhost` extracts bucket `dotted.mybucket`

Existing coverage continues to verify:

- `mybucket.localhost`
- `mybucket.s3.localhost`
- `mybucket.s3.us-east-1.localhost`
- `mybucket.s3.us-east-1.localhost:4566`
- bare S3 service hosts like `s3.us-east-1.localhost` are not treated as buckets
- service host exclusions remain in place

Targeted test run:

```sh
.venv/bin/pytest tests/test_ministack.py::TestExtractS3VhostBucket -q
```

Result:

```txt
8 passed in 0.06s
```

## Known limitation

Dotted bucket support is currently implemented for explicit S3 virtual-host forms such as:

```txt
dotted.mybucket.s3.localhost
```

Generic local endpoints without an explicit `s3` separator, such as:

```txt
dotted.mybucket.ministack
```

are ambiguous without knowing exactly where the bucket name ends and the local endpoint suffix begins. This PR keeps that case conservative and only extracts the first label for generic local virtual-host forms.

## Out of scope

- S3 access point hostnames, e.g. `accesspoint-account.s3-accesspoint.region.amazonaws.com`
- S3 Object Lambda hostnames
- Multi-Region Access Point aliases
- Full AWS bucket-name reserved-prefix/reserved-suffix validation
- Strict SigV4 validation against original virtual-hosted request targets
- Full end-to-end ASGI routing tests for virtual-hosted S3 request dispatch; this PR focuses on bucket extraction and path normalization behavior.
