### PR TITLE
security(pull_request_target) fix

### DIFF
--- a/.github/workflows/docker-publish-on-pr.yml
+++ b/.github/workflows/docker-publish-on-pr.yml
@@ -1,7 +1,7 @@
 name: Docker Publish on PR
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened, labeled]
 
 env:
@@ -9,6 +9,10 @@ env:
 
 jobs:
   publish-pr:
+    # Only publish preview images for trusted PRs whose source branch lives in
+    # this repository. Forked PRs run without repository secrets on
+    # `pull_request`, and this guard prevents accidental publish attempts, and cache poisoning.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
 
     permissions:


### PR DESCRIPTION
## Summary

Switch Docker preview publishing from `pull_request_target` to `pull_request`.

This avoids the risky pattern highlighted in the [TanStack supply-chain compromise postmortem](https://tanstack.com/blog/npm-supply-chain-compromise-postmortem): running untrusted PR code in a privileged workflow with access to secrets, and poison caches.

## Changes

- Replaced `pull_request_target` with `pull_request`.
- Added a same-repository guard so Docker preview images are only published for trusted internal PR branches.
- Forked PRs no longer attempt to publish images or access Docker Hub secrets.

## Testing

Not run locally, GitHub Actions workflow-only change.

---

if you don't think this is needed, feel free to close this pr - i found this while doing my other PR, and thought it might be helpful.