### PR TITLE
S3: Delete persisted objects when deleting keys in a batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [1.3.47] — 2026-05-22
+
+### Fixed
+- **S3 `DeleteObjects`** — Objects deleted in a batch will now be deleted from disk, much like `DeleteObject`.
+
+---
+
 ## [1.3.46] — 2026-05-21
 
 ### Added

--- a/ministack/services/s3.py
+++ b/ministack/services/s3.py
@@ -3148,6 +3148,7 @@ def _delete_objects(bucket_name: str, body: bytes, headers: dict = None):
             _object_tags.pop((bucket_name, k), None)
             _object_retention.pop((bucket_name, k), None)
             _object_legal_hold.pop((bucket_name, k), None)
+            _delete_persisted_object(bucket_name, k)
             deleted_keys.append(k)
 
     resp = Element("DeleteResult", xmlns=S3_NS)


### PR DESCRIPTION
When deleting a single object in S3 (using `_delete_object`), the file was deleted from local disk, however when doing so in batch (using `_delete_objects`), the files weren't. This PR fixes that problem.

The changelog has also been updated.