### PR TITLE
Add shared ARN parsing helper

### DIFF
--- a/ministack/core/arn.py
+++ b/ministack/core/arn.py
@@ -1,0 +1,62 @@
+"""Small Amazon Resource Name parsing helpers.
+
+The top-level ARN shape is service-agnostic:
+
+    arn:partition:service:region:account-id:resource
+
+The resource part is service-specific and may itself contain colons or slashes,
+so callers should parse that tail separately.
+"""
+
+from dataclasses import dataclass
+
+_ARN_PREFIX = "arn:"
+_ARN_SECTIONS = 6
+
+
+class ArnParseError(ValueError):
+    """Raised when a string is not shaped like an ARN."""
+
+
+@dataclass(frozen=True)
+class Arn:
+    partition: str
+    service: str
+    region: str
+    account_id: str
+    resource: str
+
+    def __str__(self) -> str:
+        return f"arn:{self.partition}:{self.service}:{self.region}:{self.account_id}:{self.resource}"
+
+
+def parse_arn(value: str) -> Arn:
+    """Parse an ARN into its six top-level sections.
+
+    This mirrors the AWS SDK Go v2 parser behavior: split only the fixed ARN
+    header fields and preserve the entire service-specific resource tail.
+
+    Request handlers should validate ``service``, account, and region before
+    interpreting ``resource``. Malformed or out-of-scope ARNs should return the
+    owning service's normal error shape, not fall back to a same-named local
+    resource.
+    """
+    if not isinstance(value, str) or not value.startswith(_ARN_PREFIX):
+        raise ArnParseError("arn: invalid prefix")
+
+    sections = value.split(":", _ARN_SECTIONS - 1)
+    if len(sections) != _ARN_SECTIONS:
+        raise ArnParseError("arn: not enough sections")
+
+    return Arn(
+        partition=sections[1],
+        service=sections[2],
+        region=sections[3],
+        account_id=sections[4],
+        resource=sections[5],
+    )
+
+
+def is_arn(value: str) -> bool:
+    """Return whether a value is shaped like an ARN."""
+    return isinstance(value, str) and value.startswith(_ARN_PREFIX) and value.count(":") >= _ARN_SECTIONS - 1

--- a/tests/test_arn.py
+++ b/tests/test_arn.py
@@ -1,0 +1,97 @@
+import pytest
+
+from ministack.core.arn import Arn, ArnParseError, is_arn, parse_arn
+
+
+def test_parse_arn_rejects_invalid_prefix():
+    with pytest.raises(ArnParseError, match="arn: invalid prefix"):
+        parse_arn("invalid")
+
+
+def test_parse_arn_rejects_too_few_sections():
+    with pytest.raises(ArnParseError, match="arn: not enough sections"):
+        parse_arn("arn:nope")
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (
+            "arn:aws:ecr:us-west-2:123456789012:repository/foo/bar",
+            Arn(
+                partition="aws",
+                service="ecr",
+                region="us-west-2",
+                account_id="123456789012",
+                resource="repository/foo/bar",
+            ),
+        ),
+        (
+            "arn:aws:elasticbeanstalk:us-east-1:123456789012:environment/My App/MyEnvironment",
+            Arn(
+                partition="aws",
+                service="elasticbeanstalk",
+                region="us-east-1",
+                account_id="123456789012",
+                resource="environment/My App/MyEnvironment",
+            ),
+        ),
+        (
+            "arn:aws:iam::123456789012:user/David",
+            Arn(
+                partition="aws",
+                service="iam",
+                region="",
+                account_id="123456789012",
+                resource="user/David",
+            ),
+        ),
+        (
+            "arn:aws:rds:eu-west-1:123456789012:db:mysql-db",
+            Arn(
+                partition="aws",
+                service="rds",
+                region="eu-west-1",
+                account_id="123456789012",
+                resource="db:mysql-db",
+            ),
+        ),
+        (
+            "arn:aws:s3:::my_corporate_bucket/exampleobject.png",
+            Arn(
+                partition="aws",
+                service="s3",
+                region="",
+                account_id="",
+                resource="my_corporate_bucket/exampleobject.png",
+            ),
+        ),
+    ],
+)
+def test_parse_arn_matches_aws_sdk_go_v2_examples(value, expected):
+    assert parse_arn(value) == expected
+
+
+def test_parse_arn_preserves_resource_tail_colons():
+    spec = parse_arn("arn:aws:lambda:us-east-1:123456789012:function:my-func:live")
+
+    assert spec.region == "us-east-1"
+    assert spec.account_id == "123456789012"
+    assert spec.resource == "function:my-func:live"
+    assert str(spec) == "arn:aws:lambda:us-east-1:123456789012:function:my-func:live"
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("arn:aws:service:us-west-2:123456789012:restype/resvalue", True),
+        ("arn:aws:service:us-west-2:123456789012:restype:resvalue", True),
+        ("arn:aws:service:us-west-2:123456789012:*", True),
+        ("arn:::::", True),
+        ("some random string", False),
+        ("arn:aws:service:us-west-2:123456789012", False),
+        (None, False),
+    ],
+)
+def test_is_arn_matches_aws_sdk_go_v2_shape_check(value, expected):
+    assert is_arn(value) is expected


### PR DESCRIPTION
## Why
Add a small shared ARN parser as the first building block for feature-branch multi-region work.

## What
- Add `ministack.core.arn` with a service-agnostic top-level ARN parser
- Preserve service-specific resource tails, including colon-delimited tails
- Add focused parser tests based on AWS SDK Go v2 ARN shape behavior

## Risk Assessment
Low. This only adds an unused helper and tests; no service behavior changes are introduced. README and CHANGELOG are intentionally unchanged because this does not add user-facing service support.

## References
Validation:
- `uv run --extra dev ruff check ministack/core/arn.py tests/test_arn.py`
- `uv run --extra dev pytest tests/test_arn.py` — 15 passed
