### PR TITLE
Fix CloudFront invalidation caller reference idempotency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 ## [1.3.47] — 2026-05-22
 
 ### Fixed
+- **CloudFront invalidations** — repeated `CreateInvalidation` calls with the same `CallerReference` now return the existing invalidation for that distribution.
 - **S3 `DeleteObjects`** — Objects deleted in a batch will now be deleted from disk, much like `DeleteObject`.
 
 ---

--- a/ministack/services/cloudfront.py
+++ b/ministack/services/cloudfront.py
@@ -927,6 +927,29 @@ def _create_invalidation(dist_id, body):
                 if child.text:
                     path_items.append(child.text)
 
+    invs = _invalidations[dist_id]
+    for existing in invs:
+        if existing["InvalidationBatch"]["CallerReference"] == caller_ref:
+            existing_paths = existing["InvalidationBatch"]["Paths"]["Items"]
+            if existing_paths != path_items:
+                return _error(
+                    "InvalidationBatchAlreadyExists",
+                    "An invalidation batch with this CallerReference already exists.",
+                    400,
+                )
+
+            def build(root, _inv=existing):
+                _build_invalidation_xml(root, _inv)
+
+            return _xml_response(
+                "Invalidation",
+                build,
+                status=201,
+                extra_headers={
+                    "Location": f"/2020-05-31/distribution/{dist_id}/invalidation/{existing['Id']}",
+                },
+            )
+
     inv_id = _inv_id()
     now = _now_iso()
     inv = {

--- a/tests/test_cloudfront.py
+++ b/tests/test_cloudfront.py
@@ -185,6 +185,60 @@ def test_cloudfront_create_invalidation(cloudfront):
     assert inv_resp["ResponseMetadata"]["HTTPStatusCode"] == 201
 
 
+def test_cloudfront_create_get_list_invalidation_idempotent(cloudfront):
+    cfg = {
+        **_CF_DIST_CONFIG,
+        "CallerReference": f"cf-inv-basic-{_uuid_mod.uuid4().hex[:12]}",
+        "Comment": "inv-basic-test",
+    }
+    create_resp = cloudfront.create_distribution(DistributionConfig=cfg)
+    dist_id = create_resp["Distribution"]["Id"]
+    caller_ref = f"inv-basic-{_uuid_mod.uuid4().hex[:12]}"
+
+    resp = cloudfront.create_invalidation(
+        DistributionId=dist_id,
+        InvalidationBatch={
+            "Paths": {
+                "Quantity": 2,
+                "Items": ["/index.html", "/assets/*"],
+            },
+            "CallerReference": caller_ref,
+        },
+    )
+
+    invalidation = resp["Invalidation"]
+    invalidation_id = invalidation["Id"]
+    assert invalidation_id.startswith("I")
+    assert invalidation["Status"] == "Completed"
+    assert invalidation["InvalidationBatch"]["CallerReference"] == caller_ref
+    assert invalidation["InvalidationBatch"]["Paths"]["Quantity"] == 2
+    assert "/index.html" in invalidation["InvalidationBatch"]["Paths"]["Items"]
+
+    duplicate_resp = cloudfront.create_invalidation(
+        DistributionId=dist_id,
+        InvalidationBatch={
+            "Paths": {
+                "Quantity": 2,
+                "Items": ["/index.html", "/assets/*"],
+            },
+            "CallerReference": caller_ref,
+        },
+    )
+    assert duplicate_resp["Invalidation"]["Id"] == invalidation_id
+
+    get_resp = cloudfront.get_invalidation(
+        DistributionId=dist_id,
+        Id=invalidation_id,
+    )
+    assert get_resp["Invalidation"]["Id"] == invalidation_id
+    assert get_resp["Invalidation"]["Status"] == "Completed"
+
+    list_resp = cloudfront.list_invalidations(DistributionId=dist_id)
+    inv_list = list_resp["InvalidationList"]
+    assert inv_list["Quantity"] == 1
+    assert inv_list["Items"][0]["Id"] == invalidation_id
+
+
 def test_cloudfront_list_invalidations(cloudfront):
     cfg = {**_CF_DIST_CONFIG, "CallerReference": "cf-listinv-1", "Comment": "listinv-test"}
     create_resp = cloudfront.create_distribution(DistributionConfig=cfg)
@@ -224,6 +278,46 @@ def test_cloudfront_get_invalidation(cloudfront):
     assert inv["Id"] == inv_id
     assert inv["Status"] == "Completed"
     assert "/getinv-path" in inv["InvalidationBatch"]["Paths"]["Items"]
+
+
+def test_cloudfront_get_missing_invalidation_returns_error(cloudfront):
+    cfg = {
+        **_CF_DIST_CONFIG,
+        "CallerReference": f"cf-inv-missing-{_uuid_mod.uuid4().hex[:12]}",
+        "Comment": "inv-missing-test",
+    }
+    create_resp = cloudfront.create_distribution(DistributionConfig=cfg)
+    dist_id = create_resp["Distribution"]["Id"]
+
+    with pytest.raises(ClientError) as exc:
+        cloudfront.get_invalidation(
+            DistributionId=dist_id,
+            Id="IMISSING1234567",
+        )
+    assert exc.value.response["Error"]["Code"] == "NoSuchInvalidation"
+
+
+def test_cloudfront_create_invalidation_same_caller_reference_different_paths_errors(cloudfront):
+    cfg = {
+        **_CF_DIST_CONFIG,
+        "CallerReference": f"cf-inv-conflict-{_uuid_mod.uuid4().hex[:12]}",
+        "Comment": "inv-conflict-test",
+    }
+    create_resp = cloudfront.create_distribution(DistributionConfig=cfg)
+    dist_id = create_resp["Distribution"]["Id"]
+    caller_ref = f"inv-conflict-{_uuid_mod.uuid4().hex[:12]}"
+
+    cloudfront.create_invalidation(
+        DistributionId=dist_id,
+        InvalidationBatch={"Paths": {"Quantity": 1, "Items": ["/one"]}, "CallerReference": caller_ref},
+    )
+
+    with pytest.raises(ClientError) as exc:
+        cloudfront.create_invalidation(
+            DistributionId=dist_id,
+            InvalidationBatch={"Paths": {"Quantity": 1, "Items": ["/two"]}, "CallerReference": caller_ref},
+        )
+    assert exc.value.response["Error"]["Code"] == "InvalidationBatchAlreadyExists"
 
 
 def test_cloudfront_tags(cloudfront):

--- a/tests/test_cloudfront.py
+++ b/tests/test_cloudfront.py
@@ -318,6 +318,7 @@ def test_cloudfront_create_invalidation_same_caller_reference_different_paths_er
             InvalidationBatch={"Paths": {"Quantity": 1, "Items": ["/two"]}, "CallerReference": caller_ref},
         )
     assert exc.value.response["Error"]["Code"] == "InvalidationBatchAlreadyExists"
+    assert cloudfront.list_invalidations(DistributionId=dist_id)["InvalidationList"]["Quantity"] == 1
 
 
 def test_cloudfront_tags(cloudfront):


### PR DESCRIPTION
## Summary
- Return the existing CloudFront invalidation when `CreateInvalidation` is retried with the same `CallerReference` and identical paths.
- Return `InvalidationBatchAlreadyExists` when the same `CallerReference` is reused with different paths.
- Add regression coverage for both idempotent retry and conflicting batch behavior.

## Tests
- `python3 -m py_compile ministack/services/cloudfront.py tests/test_cloudfront.py`
- `ruff check ministack/services/cloudfront.py tests/test_cloudfront.py`
- `pytest tests/test_cloudfront.py -v -k invalidation`