### PR TITLE
Adopt ARN parsing for RDS identifiers

### DIFF
--- a/ministack/services/rds.py
+++ b/ministack/services/rds.py
@@ -30,9 +30,9 @@ clients can call DescribeDBInstances and other operations without ``Action=`` qu
 parameters.
 """
 
+import contextvars
 import copy
 import datetime
-import contextvars
 import json
 import logging
 import os
@@ -42,6 +42,7 @@ import time
 from urllib.parse import parse_qs
 from xml.sax.saxutils import escape as _esc
 
+from ministack.core.arn import ArnParseError, parse_arn
 from ministack.core.persistence import load_state
 from ministack.core.responses import AccountScopedDict, apply_image_prefix, get_account_id, get_region, new_uuid
 
@@ -411,16 +412,134 @@ async def handle_request(method, path, headers, body, query_params):
 # Instance resolution helpers
 # ---------------------------------------------------------------------------
 
+def _parse_rds_arn(value):
+    try:
+        spec = parse_arn(value)
+    except ArnParseError:
+        return None
+    if spec.service != "rds":
+        return None
+    resource_type, sep, resource_id = spec.resource.partition(":")
+    if not sep or not resource_type or not resource_id:
+        return None
+    return spec, resource_type, resource_id
+
+
+def _request_region_identifier(identifier, resource_type, store=None, arn_key=None):
+    resource_id = _request_region_resource_identifier(identifier, resource_type)
+    if resource_id is None:
+        return None
+    if store is not None and arn_key is not None and _parse_rds_arn(identifier):
+        resource = store.get(resource_id)
+        if not resource or resource.get(arn_key) != identifier:
+            return None
+    return resource_id
+
+
+def _request_region_resource_identifier(identifier, resource_type):
+    parsed = _parse_rds_arn(identifier)
+    if not parsed:
+        return identifier
+    spec, parsed_type, resource_id = parsed
+    if (
+        parsed_type == resource_type
+        and spec.account_id == get_account_id()
+        and spec.region == get_region()
+    ):
+        return resource_id
+    return None
+
+
+def _record_arn_in_request_scope(record, arn_key):
+    parsed = _parse_rds_arn(record.get(arn_key, ""))
+    if not parsed:
+        return False
+    spec, _resource_type, _resource_id = parsed
+    return spec.account_id == get_account_id() and spec.region == get_region()
+
+
+def _same_account_foreign_region_arn(identifier, resource_type):
+    parsed = _parse_rds_arn(identifier)
+    if not parsed:
+        return None
+    spec, parsed_type, _ = parsed
+    if parsed_type != resource_type:
+        return None
+    if spec.account_id != get_account_id():
+        return None
+    if spec.region == get_region():
+        return None
+    return spec
+
+
+def _request_scope_mismatch_arn(identifier, resource_type):
+    parsed = _parse_rds_arn(identifier)
+    if not parsed:
+        return None
+    spec, parsed_type, _ = parsed
+    if parsed_type != resource_type:
+        return None
+    if spec.account_id != get_account_id() or spec.region != get_region():
+        return spec
+    return None
+
+
+def _invalid_region_arn_error(identifier, parameter_name):
+    spec = _same_account_foreign_region_arn(identifier, "cluster")
+    if not spec:
+        return None
+    return _error(
+        "InvalidParameterValue",
+        f"The provided ARN ({identifier}) is invalid for this parameter "
+        f"({parameter_name}). Expected region = {get_region()}, "
+        f"actual region = {spec.region}",
+        400,
+    )
+
+
+def _invalid_db_instance_identifier_error(identifier, parameter_name="DBInstanceIdentifier"):
+    if not _request_scope_mismatch_arn(identifier, "db"):
+        return None
+    return _error(
+        "InvalidParameterValue",
+        f"The parameter {parameter_name} is not a valid identifier because it is longer than 63 characters.",
+        400,
+    )
+
+
+def _invalid_cluster_identifier_error(identifier):
+    if not _same_account_foreign_region_arn(identifier, "cluster"):
+        return None
+    return _error(
+        "InvalidParameterValue",
+        f"Invalid database cluster identifier:  {identifier}",
+        400,
+    )
+
+
+def _resource_not_found_error_for_arn(identifier):
+    if not _same_account_foreign_region_arn(identifier, "cluster"):
+        return None
+    return _error("ResourceNotFoundFault", f"DB cluster ARN {identifier} wasn't found.", 404)
+
+
+def _resolve_cluster(cluster_id):
+    """Look up a DB cluster by identifier or same-region ARN."""
+    cluster_id = _request_region_identifier(cluster_id, "cluster", _clusters, "DBClusterArn")
+    return _clusters.get(cluster_id) if cluster_id is not None else None
+
+
 def _resolve_instance(db_id):
     """Look up an instance by DBInstanceIdentifier or DbiResourceId.
 
     AWS accepts either value for the DBInstanceIdentifier parameter in
     DescribeDBInstances and related APIs.
     """
+    db_id = _request_region_identifier(db_id, "db", _instances, "DBInstanceArn")
     inst = _instances.get(db_id)
     if inst:
         return inst
-    if db_id.startswith("db-"):
+    if isinstance(db_id, str) and db_id.startswith("db-"):
         for inst in _instances.values():
             if inst.get("DbiResourceId") == db_id:
                 return inst
@@ -499,14 +618,20 @@ def _create_db_instance(p):
 
     # Inherit credentials from cluster when instance is a cluster member.
     cluster_id_param = _p(p, "DBClusterIdentifier")
-    if cluster_id_param and cluster_id_param in _clusters:
-        parent = _clusters[cluster_id_param]
+    parent = _resolve_cluster(cluster_id_param) if cluster_id_param else None
+    if parent:
+        cluster_id_param = parent["DBClusterIdentifier"]
         if not _p(p, "MasterUsername"):
             master_user = parent.get("MasterUsername", master_user)
         if not _p(p, "MasterUserPassword"):
             master_pass = parent.get("_MasterUserPassword", master_pass)
         if not db_name:
             db_name = parent.get("DatabaseName", "")
+    elif _parse_rds_arn(cluster_id_param):
+        wrong_region = _invalid_cluster_identifier_error(cluster_id_param)
+        if wrong_region:
+            return wrong_region
+        return _error("DBClusterNotFoundFault", f"DBCluster {cluster_id_param} not found.", 404)
     if not db_name:
         db_name = "mydb"
     allocated_storage = int(_p(p, "AllocatedStorage") or "20")
@@ -581,7 +706,7 @@ def _create_db_instance(p):
             except Exception as e:
                 logger.warning("RDS: Docker failed for %s: %s", db_id, e)
 
-    cluster_id = _p(p, "DBClusterIdentifier")
+    cluster_id = cluster_id_param
     param_group_name = _p(p, "DBParameterGroupName") or f"default.{engine}{engine_version.split('.')[0]}"
     now_ts = time.time()
 
@@ -777,13 +902,17 @@ def _delete_db_instance(p):
     db_id = _p(p, "DBInstanceIdentifier")
     instance = _resolve_instance(db_id)
     if not instance:
+        invalid_arn = _invalid_db_instance_identifier_error(db_id)
+        if invalid_arn:
+            return invalid_arn
         return _error("DBInstanceNotFound", f"DBInstance {db_id} not found.", 404)
-
-    _unregister_instance_from_clusters(db_id)
+    instance_id = instance["DBInstanceIdentifier"]
 
     if instance.get("DeletionProtection"):
         return _error("InvalidParameterCombination",
             "Cannot delete a DB instance when DeletionProtection is enabled.", 400)
+
+    _unregister_instance_from_clusters(instance_id)
 
     docker_client = _get_docker()
     if docker_client and instance.get("_docker_container_id"):
@@ -791,9 +920,9 @@ def _delete_db_instance(p):
             c = docker_client.containers.get(instance["_docker_container_id"])
             c.stop(timeout=5)
             c.remove(v=True)
-            logger.info("RDS: removed container for %s", db_id)
+            logger.info("RDS: removed container for %s", instance_id)
         except Exception as e:
-            logger.warning("RDS: failed to remove container for %s: %s", db_id, e)
+            logger.warning("RDS: failed to remove container for %s: %s", instance_id, e)
 
     skip_snapshot = _p(p, "SkipFinalSnapshot") == "true"
     final_snap_id = _p(p, "FinalDBSnapshotIdentifier")
@@ -803,7 +932,7 @@ def _delete_db_instance(p):
     instance["DBInstanceStatus"] = "deleting"
     arn = instance["DBInstanceArn"]
     _tags.pop(arn, None)
-    del _instances[db_id]
+    del _instances[instance_id]
     return _single_instance_response("DeleteDBInstanceResponse", "DeleteDBInstanceResult", instance)
 
 
@@ -812,6 +941,9 @@ def _describe_db_instances(p):
     if db_id:
         instance = _resolve_instance(db_id)
         if not instance:
+            invalid_arn = _invalid_db_instance_identifier_error(db_id, "Filter: db-instance-id")
+            if invalid_arn:
+                return invalid_arn
             return _error("DBInstanceNotFound", f"DBInstance {db_id} not found.", 404)
         instances = [instance]
     else:
@@ -883,6 +1015,9 @@ def _modify_db_instance(p):
     db_id = _p(p, "DBInstanceIdentifier")
     instance = _resolve_instance(db_id)
     if not instance:
+        invalid_arn = _invalid_db_instance_identifier_error(db_id)
+        if invalid_arn:
+            return invalid_arn
         return _error("DBInstanceNotFound", f"DBInstance {db_id} not found.", 404)
 
     apply_immediately = _p(p, "ApplyImmediately") == "true"
@@ -955,6 +1090,9 @@ def _start_db_instance(p):
     db_id = _p(p, "DBInstanceIdentifier")
     instance = _resolve_instance(db_id)
     if not instance:
+        invalid_arn = _invalid_db_instance_identifier_error(db_id)
+        if invalid_arn:
+            return invalid_arn
         return _error("DBInstanceNotFound", f"DBInstance {db_id} not found.", 404)
     instance["DBInstanceStatus"] = "available"
     return _single_instance_response("StartDBInstanceResponse", "StartDBInstanceResult", instance)
@@ -964,6 +1102,9 @@ def _stop_db_instance(p):
     db_id = _p(p, "DBInstanceIdentifier")
     instance = _resolve_instance(db_id)
     if not instance:
+        invalid_arn = _invalid_db_instance_identifier_error(db_id)
+        if invalid_arn:
+            return invalid_arn
         return _error("DBInstanceNotFound", f"DBInstance {db_id} not found.", 404)
     instance["DBInstanceStatus"] = "stopped"
     return _single_instance_response("StopDBInstanceResponse", "StopDBInstanceResult", instance)
@@ -973,6 +1114,9 @@ def _reboot_db_instance(p):
     db_id = _p(p, "DBInstanceIdentifier")
     instance = _resolve_instance(db_id)
     if not instance:
+        invalid_arn = _invalid_db_instance_identifier_error(db_id)
+        if invalid_arn:
+            return invalid_arn
         return _error("DBInstanceNotFound", f"DBInstance {db_id} not found.", 404)
     instance["DBInstanceStatus"] = "available"
     return _single_instance_response("RebootDBInstanceResponse", "RebootDBInstanceResult", instance)
@@ -988,7 +1132,11 @@ def _create_read_replica(p):
 
     source = _resolve_instance(source_id)
     if not source:
+        invalid_arn = _invalid_db_instance_identifier_error(source_id, "SourceDBInstanceIdentifier")
+        if invalid_arn:
+            return invalid_arn
         return _error("DBInstanceNotFound", f"DBInstance {source_id} not found.", 404)
+    source_id = source["DBInstanceIdentifier"]
     if replica_id in _instances:
         return _error("DBInstanceAlreadyExistsFault", f"DBInstance {replica_id} already exists.", 400)
 
@@ -1179,8 +1327,11 @@ def _create_db_cluster(p):
 
 def _delete_db_cluster(p):
     cluster_id = _p(p, "DBClusterIdentifier")
-    cluster = _clusters.get(cluster_id)
+    cluster = _resolve_cluster(cluster_id)
     if not cluster:
+        wrong_region = _invalid_cluster_identifier_error(cluster_id)
+        if wrong_region:
+            return wrong_region
         return _error("DBClusterNotFoundFault", f"DBCluster {cluster_id} not found.", 404)
 
     if cluster.get("DeletionProtection"):
@@ -1194,7 +1345,7 @@ def _delete_db_cluster(p):
 
     cluster["Status"] = "deleting"
     _tags.pop(cluster["DBClusterArn"], None)
-    del _clusters[cluster_id]
+    del _clusters[cluster["DBClusterIdentifier"]]
     return _xml(200, "DeleteDBClusterResponse",
         f"<DeleteDBClusterResult><DBCluster>{_cluster_xml(cluster)}</DBCluster></DeleteDBClusterResult>")
 
@@ -1202,8 +1353,11 @@ def _delete_db_cluster(p):
 def _describe_db_clusters(p):
     cluster_id = _p(p, "DBClusterIdentifier")
     if cluster_id:
-        cluster = _clusters.get(cluster_id)
+        cluster = _resolve_cluster(cluster_id)
         if not cluster:
+            wrong_region = _invalid_region_arn_error(cluster_id, "DBClusterIdentifier")
+            if wrong_region:
+                return wrong_region
             return _error("DBClusterNotFoundFault", f"DBCluster {cluster_id} not found.", 404)
         clusters = [cluster]
     else:
@@ -1253,8 +1407,11 @@ def _rotate_real_password(cluster, old_pass, new_pass):
 
 def _modify_db_cluster(p):
     cluster_id = _p(p, "DBClusterIdentifier")
-    cluster = _clusters.get(cluster_id)
+    cluster = _resolve_cluster(cluster_id)
     if not cluster:
+        wrong_region = _invalid_cluster_identifier_error(cluster_id)
+        if wrong_region:
+            return wrong_region
         return _error("DBClusterNotFoundFault", f"DBCluster {cluster_id} not found.", 404)
 
     if _p(p, "EngineVersion"):
@@ -1345,6 +1502,9 @@ def _create_db_snapshot(p):
 
     instance = _resolve_instance(db_id)
     if not instance:
+        invalid_arn = _invalid_db_instance_identifier_error(db_id)
+        if invalid_arn:
+            return invalid_arn
         return _error("DBInstanceNotFound", f"DBInstance {db_id} not found.", 404)
 
     snap = _create_snapshot_internal(snap_id, instance)
@@ -1382,7 +1542,14 @@ def _describe_db_snapshots(p):
     else:
         snaps = list(_snapshots.values())
         if db_id:
+            invalid_arn = _invalid_db_instance_identifier_error(db_id)
+            if invalid_arn:
+                return invalid_arn
+            filter_by_arn = _parse_rds_arn(db_id) is not None
+            db_id = _request_region_resource_identifier(db_id, "db")
             snaps = [s for s in snaps if s["DBInstanceIdentifier"] == db_id]
+            if filter_by_arn:
+                snaps = [s for s in snaps if _record_arn_in_request_scope(s, "DBSnapshotArn")]
         if snap_type:
             snaps = [s for s in snaps if s["SnapshotType"] == snap_type]
 
@@ -1790,9 +1957,13 @@ def _create_db_cluster_snapshot(p):
         return _error("DBClusterSnapshotAlreadyExistsFault",
             f"DB cluster snapshot {snap_id} already exists.", 400)
 
-    cluster = _clusters.get(cluster_id)
+    cluster = _resolve_cluster(cluster_id)
     if not cluster:
+        wrong_region = _invalid_region_arn_error(cluster_id, "DBClusterIdentifier")
+        if wrong_region:
+            return wrong_region
         return _error("DBClusterNotFoundFault", f"DBCluster {cluster_id} not found.", 404)
+    cluster_id = cluster["DBClusterIdentifier"]
 
     arn = f"arn:aws:rds:{get_region()}:{get_account_id()}:cluster-snapshot:{snap_id}"
     now_ts = time.time()
@@ -1844,7 +2015,17 @@ def _describe_db_cluster_snapshots(p):
     else:
         snaps = list(_db_cluster_snapshots.values())
         if cluster_id:
+            wrong_region = _invalid_region_arn_error(cluster_id, "DBClusterIdentifier")
+            if wrong_region:
+                return wrong_region
+            filter_by_arn = _parse_rds_arn(cluster_id) is not None
+            cluster_id = _request_region_resource_identifier(cluster_id, "cluster")
             snaps = [s for s in snaps if s["DBClusterIdentifier"] == cluster_id]
+            if filter_by_arn:
+                snaps = [
+                    s for s in snaps
+                    if _record_arn_in_request_scope(s, "DBClusterSnapshotArn")
+                ]
         if snap_type:
             snaps = [s for s in snaps if s["SnapshotType"] == snap_type]
 
@@ -1896,8 +2077,11 @@ def _modify_subnet_group(p):
 
 def _start_db_cluster(p):
     cluster_id = _p(p, "DBClusterIdentifier")
-    cluster = _clusters.get(cluster_id)
+    cluster = _resolve_cluster(cluster_id)
     if not cluster:
+        wrong_region = _invalid_cluster_identifier_error(cluster_id)
+        if wrong_region:
+            return wrong_region
         return _error("DBClusterNotFoundFault", f"DBCluster {cluster_id} not found.", 404)
     cluster["Status"] = "available"
     return _xml(200, "StartDBClusterResponse",
@@ -1906,8 +2090,11 @@ def _start_db_cluster(p):
 
 def _stop_db_cluster(p):
     cluster_id = _p(p, "DBClusterIdentifier")
-    cluster = _clusters.get(cluster_id)
+    cluster = _resolve_cluster(cluster_id)
     if not cluster:
+        wrong_region = _invalid_cluster_identifier_error(cluster_id)
+        if wrong_region:
+            return wrong_region
         return _error("DBClusterNotFoundFault", f"DBCluster {cluster_id} not found.", 404)
     cluster["Status"] = "stopped"
     return _xml(200, "StopDBClusterResponse",
@@ -2003,11 +2190,34 @@ def _describe_pending_maintenance_actions(p):
 # Tags
 # ---------------------------------------------------------------------------
 
+def _tag_resource_scope_error(arn):
+    parsed = _parse_rds_arn(arn)
+    if not parsed:
+        return None
+    spec, resource_type, _ = parsed
+    if spec.account_id != get_account_id():
+        return _error(
+            "InvalidParameterValue",
+            "The specified resource name does not match an RDS resource in this region.",
+            400,
+        )
+    if resource_type != "global-cluster" and spec.region and spec.region != get_region():
+        return _error(
+            "InvalidParameterValue",
+            "The specified resource name does not match an RDS resource in this region.",
+            400,
+        )
+    return None
+
+
 def _add_tags(p):
     arn = _p(p, "ResourceName")
     new_tags = _parse_tags(p)
     if not arn:
         return _error("MissingParameter", "ResourceName is required", 400)
+    scope_error = _tag_resource_scope_error(arn)
+    if scope_error:
+        return scope_error
 
     existing = _tags.get(arn, [])
     existing_keys = {t["Key"]: i for i, t in enumerate(existing)}
@@ -2029,6 +2239,9 @@ def _remove_tags(p):
     keys_to_remove = set(_parse_member_list(p, "TagKeys"))
     if not arn:
         return _error("MissingParameter", "ResourceName is required", 400)
+    scope_error = _tag_resource_scope_error(arn)
+    if scope_error:
+        return scope_error
 
     existing = _tags.get(arn, [])
     _tags[arn] = [t for t in existing if t["Key"] not in keys_to_remove]
@@ -2042,6 +2255,9 @@ def _list_tags(p):
     if not arn:
         return _xml(200, "ListTagsForResourceResponse",
             "<ListTagsForResourceResult><TagList/></ListTagsForResourceResult>")
+    scope_error = _tag_resource_scope_error(arn)
+    if scope_error:
+        return scope_error
 
     tag_list = _tags.get(arn, [])
     members = "".join(f"<Tag><Key>{_esc(t['Key'])}</Key><Value>{_esc(t['Value'])}</Value></Tag>" for t in tag_list)
@@ -2066,6 +2282,16 @@ def _sync_tag_list_to_resource(arn):
             return
 
 
+def _invalid_global_cluster_identifier_error(global_id):
+    parsed = _parse_rds_arn(global_id)
+    if not parsed:
+        return None
+    _, resource_type, _ = parsed
+    if resource_type != "global-cluster":
+        return None
+    return _error("InvalidParameterValue", f"Invalid global cluster identifier:  {global_id}", 400)
+
+
 # ---------------------------------------------------------------------------
 # Global Clusters
 #
@@ -2080,6 +2306,9 @@ def _create_global_cluster(p):
     gc_id = _p(p, "GlobalClusterIdentifier")
     if not gc_id:
         return _error("MissingParameter", "GlobalClusterIdentifier is required", 400)
+    invalid_id = _invalid_global_cluster_identifier_error(gc_id)
+    if invalid_id:
+        return invalid_id
     if gc_id in _global_clusters:
         return _error("GlobalClusterAlreadyExistsFault",
             f"Global cluster {gc_id} already exists.", 400)
@@ -2093,20 +2322,20 @@ def _create_global_cluster(p):
     arn = f"arn:aws:rds::{get_account_id()}:global-cluster:{gc_id}"
     resource_id = f"cluster-{new_uuid().replace('-', '')[:20].lower()}"
 
-    members = []
+    source_cluster = None
     if source_cluster_id:
-        source_arn = source_cluster_id
-        for cl in _clusters.values():
-            if cl["DBClusterIdentifier"] == source_cluster_id or cl["DBClusterArn"] == source_cluster_id:
-                source_arn = cl["DBClusterArn"]
-                engine = cl["Engine"]
-                engine_version = cl["EngineVersion"]
-                break
-        members.append({
-            "DBClusterArn": source_arn,
-            "IsWriter": True,
-            "GlobalWriteForwardingStatus": "disabled",
-        })
+        source_cluster = _resolve_cluster(source_cluster_id)
+        if not source_cluster:
+            wrong_region = _invalid_region_arn_error(
+                source_cluster_id,
+                "SourceDBClusterIdentifier",
+            )
+            if wrong_region:
+                return wrong_region
+            return _error("DBClusterNotFoundFault",
+                f"DBCluster {source_cluster_id} not found.", 404)
+        engine = source_cluster["Engine"]
+        engine_version = source_cluster["EngineVersion"]
 
     gc = {
         "GlobalClusterIdentifier": gc_id,
@@ -2117,9 +2346,15 @@ def _create_global_cluster(p):
         "Status": "available",
         "StorageEncrypted": storage_encrypted,
         "DeletionProtection": deletion_protection,
-        "GlobalClusterMembers": members,
+        "GlobalClusterMembers": [],
         "DatabaseName": _p(p, "DatabaseName") or "",
     }
+    if source_cluster:
+        gc["GlobalClusterMembers"].append({
+            "DBClusterArn": source_cluster["DBClusterArn"],
+            "IsWriter": True,
+            "GlobalWriteForwardingStatus": "disabled",
+        })
     _global_clusters[gc_id] = gc
     return _xml(200, "CreateGlobalClusterResponse",
         f"<CreateGlobalClusterResult><GlobalCluster>{_global_cluster_xml(gc)}</GlobalCluster></CreateGlobalClusterResult>")
@@ -2128,6 +2363,9 @@ def _create_global_cluster(p):
 def _describe_global_clusters(p):
     gc_id = _p(p, "GlobalClusterIdentifier")
     if gc_id:
+        invalid_arn = _invalid_global_cluster_identifier_error(gc_id)
+        if invalid_arn:
+            return invalid_arn
         gc = _global_clusters.get(gc_id)
         if not gc:
             return _error("GlobalClusterNotFoundFault",
@@ -2145,6 +2383,9 @@ def _describe_global_clusters(p):
 
 def _delete_global_cluster(p):
     gc_id = _p(p, "GlobalClusterIdentifier")
+    invalid_arn = _invalid_global_cluster_identifier_error(gc_id)
+    if invalid_arn:
+        return invalid_arn
     gc = _global_clusters.get(gc_id)
     if not gc:
         return _error("GlobalClusterNotFoundFault",
@@ -2168,6 +2409,9 @@ def _delete_global_cluster(p):
 def _remove_from_global_cluster(p):
     gc_id = _p(p, "GlobalClusterIdentifier")
     db_cluster_id = _p(p, "DbClusterIdentifier")
+    invalid_arn = _invalid_global_cluster_identifier_error(gc_id)
+    if invalid_arn:
+        return invalid_arn
     gc = _global_clusters.get(gc_id)
     if not gc:
         return _error("GlobalClusterNotFoundFault",
@@ -2189,6 +2433,9 @@ def _remove_from_global_cluster(p):
 
 def _modify_global_cluster(p):
     gc_id = _p(p, "GlobalClusterIdentifier")
+    invalid_arn = _invalid_global_cluster_identifier_error(gc_id)
+    if invalid_arn:
+        return invalid_arn
     gc = _global_clusters.get(gc_id)
     if not gc:
         return _error("GlobalClusterNotFoundFault",
@@ -2196,6 +2443,9 @@ def _modify_global_cluster(p):
 
     new_id = _p(p, "NewGlobalClusterIdentifier")
     if new_id and new_id != gc_id:
+        invalid_new_id = _invalid_global_cluster_identifier_error(new_id)
+        if invalid_new_id:
+            return invalid_new_id
         if new_id in _global_clusters:
             return _error("GlobalClusterAlreadyExistsFault",
                 f"Global cluster {new_id} already exists.", 400)
@@ -2215,6 +2465,9 @@ def _modify_global_cluster(p):
 
 def _enable_http_endpoint(p):
     arn = _p(p, "ResourceArn")
+    wrong_region = _resource_not_found_error_for_arn(arn)
+    if wrong_region:
+        return wrong_region
     for cluster in _clusters.values():
         if cluster.get("DBClusterArn") == arn:
             cluster["HttpEndpointEnabled"] = True

--- a/tests/test_rds.py
+++ b/tests/test_rds.py
@@ -87,6 +87,8 @@ def test_rds_create_instance_v2(rds):
     )
     inst = resp["DBInstance"]
     assert inst["DBInstanceIdentifier"] == "rds-ci-v2"
+    assert inst["DBInstanceStatus"] in ("creating", "available")
+    inst = _wait_for_rds(rds, "rds-ci-v2")
     assert inst["DBInstanceStatus"] == "available"
     assert inst["Engine"] == "postgres"
     assert "Address" in inst["Endpoint"]
@@ -1050,6 +1052,7 @@ def test_rds_modify_instance_password(rds):
         MasterUserPassword="old_pass",
         AllocatedStorage=20,
     )
+    _wait_for_rds(rds, "pw-mod-inst")
     # Password change should succeed without error
     rds.modify_db_instance(
         DBInstanceIdentifier="pw-mod-inst",
@@ -1455,11 +1458,6 @@ import zipfile
 
 import pytest
 
-pytestmark = pytest.mark.skipif(
-    not os.environ.get("DOCKER_NETWORK"),
-    reason="DOCKER_NETWORK not set — skipping network connectivity test",
-)
-
 _LAMBDA_ROLE = "arn:aws:iam::000000000000:role/lambda-role"
 
 
@@ -1489,6 +1487,10 @@ def _wait_for_rds(rds_client, db_id, timeout=120):
     raise TimeoutError(f"RDS instance {db_id} not available after {timeout}s")
 
 
+@pytest.mark.skipif(
+    not os.environ.get("DOCKER_NETWORK"),
+    reason="DOCKER_NETWORK not set -- skipping network connectivity test",
+)
 def test_rds_lambda_network_connectivity(rds, lam):
     """Prove that Lambda containers can TCP-connect to an RDS container."""
     db_id = "net-test-pg"

--- a/tests/test_rds_arn_adoption.py
+++ b/tests/test_rds_arn_adoption.py
@@ -1,0 +1,525 @@
+import uuid
+
+import boto3
+import pytest
+from botocore.config import Config
+from botocore.exceptions import ClientError
+from conftest import ENDPOINT
+
+
+def _regional_rds(region, access_key_id="test"):
+    return boto3.client(
+        "rds",
+        endpoint_url=ENDPOINT,
+        aws_access_key_id=access_key_id,
+        aws_secret_access_key="test",
+        region_name=region,
+        config=Config(region_name=region, retries={"mode": "standard"}),
+    )
+
+
+def _delete_cluster(client, cluster_id):
+    try:
+        client.delete_db_cluster(DBClusterIdentifier=cluster_id, SkipFinalSnapshot=True)
+    except ClientError:
+        pass
+
+
+def _delete_instance(client, instance_id):
+    try:
+        client.delete_db_instance(DBInstanceIdentifier=instance_id, SkipFinalSnapshot=True)
+    except ClientError:
+        pass
+
+
+def _delete_global_cluster(client, global_id):
+    try:
+        client.modify_global_cluster(
+            GlobalClusterIdentifier=global_id,
+            DeletionProtection=False,
+        )
+    except ClientError:
+        pass
+    try:
+        client.delete_global_cluster(GlobalClusterIdentifier=global_id)
+    except ClientError:
+        pass
+
+
+def test_rds_cluster_arn_lookup_rejects_foreign_account():
+    account_a = _regional_rds("us-west-2", access_key_id="111111111111")
+    account_b = _regional_rds("us-west-2", access_key_id="222222222222")
+    cluster_id = f"rds-cross-account-{uuid.uuid4().hex[:8]}"
+
+    try:
+        cluster = account_a.create_db_cluster(
+            DBClusterIdentifier=cluster_id,
+            Engine="aurora-mysql",
+            MasterUsername="admin",
+            MasterUserPassword="password123",
+        )["DBCluster"]
+
+        same_account = account_a.describe_db_clusters(
+            DBClusterIdentifier=cluster["DBClusterArn"],
+        )["DBClusters"][0]
+        assert same_account["DBClusterIdentifier"] == cluster_id
+
+        with pytest.raises(ClientError) as exc:
+            account_b.describe_db_clusters(DBClusterIdentifier=cluster["DBClusterArn"])
+        assert exc.value.response["Error"]["Code"] == "DBClusterNotFoundFault"
+    finally:
+        _delete_cluster(account_a, cluster_id)
+
+
+def test_rds_regional_cluster_apis_reject_foreign_region_arns():
+    east = _regional_rds("us-east-1")
+    west = _regional_rds("us-west-2")
+    cluster_id = f"rds-foreign-region-{uuid.uuid4().hex[:8]}"
+    instance_id = f"rds-foreign-region-{uuid.uuid4().hex[:8]}"
+    global_id = f"global-foreign-region-{uuid.uuid4().hex[:8]}"
+
+    try:
+        cluster = west.create_db_cluster(
+            DBClusterIdentifier=cluster_id,
+            Engine="aurora-mysql",
+            MasterUsername="admin",
+            MasterUserPassword="password123",
+        )["DBCluster"]
+        cluster_arn = cluster["DBClusterArn"]
+
+        same_region = west.describe_db_clusters(
+            DBClusterIdentifier=cluster_arn,
+        )["DBClusters"][0]
+        assert same_region["DBClusterIdentifier"] == cluster_id
+
+        with pytest.raises(ClientError) as exc:
+            east.describe_db_clusters(DBClusterIdentifier=cluster_arn)
+        assert exc.value.response["Error"]["Code"] == "InvalidParameterValue"
+
+        with pytest.raises(ClientError) as exc:
+            east.modify_db_cluster(
+                DBClusterIdentifier=cluster_arn,
+                BackupRetentionPeriod=1,
+                ApplyImmediately=True,
+            )
+        assert exc.value.response["Error"]["Code"] == "InvalidParameterValue"
+
+        with pytest.raises(ClientError) as exc:
+            east.delete_db_cluster(DBClusterIdentifier=cluster_arn, SkipFinalSnapshot=True)
+        assert exc.value.response["Error"]["Code"] == "InvalidParameterValue"
+
+        with pytest.raises(ClientError) as exc:
+            east.enable_http_endpoint(ResourceArn=cluster_arn)
+        assert exc.value.response["Error"]["Code"] == "ResourceNotFoundFault"
+
+        with pytest.raises(ClientError) as exc:
+            east.create_db_instance(
+                DBInstanceIdentifier=instance_id,
+                DBClusterIdentifier=cluster_arn,
+                DBInstanceClass="db.t3.micro",
+                Engine="aurora-mysql",
+            )
+        assert exc.value.response["Error"]["Code"] == "InvalidParameterValue"
+
+        with pytest.raises(ClientError) as exc:
+            east.create_global_cluster(
+                GlobalClusterIdentifier=global_id,
+                SourceDBClusterIdentifier=cluster_arn,
+            )
+        assert exc.value.response["Error"]["Code"] == "InvalidParameterValue"
+
+        with pytest.raises(ClientError) as exc:
+            west.describe_db_instances(DBInstanceIdentifier=instance_id)
+        assert exc.value.response["Error"]["Code"] == "DBInstanceNotFound"
+    finally:
+        _delete_global_cluster(east, global_id)
+        _delete_instance(west, instance_id)
+        _delete_cluster(west, cluster_id)
+
+
+def test_rds_same_region_arn_lookup_requires_stored_resource_arn_match():
+    east = _regional_rds("us-east-1")
+    west = _regional_rds("us-west-2")
+    suffix = uuid.uuid4().hex[:8]
+    cluster_id = f"rds-fabricated-arn-{suffix}"
+    instance_id = f"rds-fabricated-arn-{suffix}"
+
+    try:
+        cluster = west.create_db_cluster(
+            DBClusterIdentifier=cluster_id,
+            Engine="aurora-mysql",
+            MasterUsername="admin",
+            MasterUserPassword="password123",
+        )["DBCluster"]
+        instance = west.create_db_instance(
+            DBInstanceIdentifier=instance_id,
+            DBInstanceClass="db.t3.micro",
+            Engine="postgres",
+            MasterUsername="admin",
+            MasterUserPassword="pass",
+            AllocatedStorage=10,
+        )["DBInstance"]
+
+        fabricated_cluster_arn = cluster["DBClusterArn"].replace(":us-west-2:", ":us-east-1:")
+        fabricated_instance_arn = instance["DBInstanceArn"].replace(":us-west-2:", ":us-east-1:")
+
+        with pytest.raises(ClientError) as exc:
+            east.describe_db_clusters(DBClusterIdentifier=fabricated_cluster_arn)
+        assert exc.value.response["Error"]["Code"] == "DBClusterNotFoundFault"
+
+        with pytest.raises(ClientError) as exc:
+            east.describe_db_instances(DBInstanceIdentifier=fabricated_instance_arn)
+        assert exc.value.response["Error"]["Code"] == "DBInstanceNotFound"
+    finally:
+        _delete_instance(west, instance_id)
+        _delete_cluster(west, cluster_id)
+
+
+def test_rds_regional_instance_apis_reject_foreign_region_arns():
+    east = _regional_rds("us-east-1")
+    west = _regional_rds("us-west-2")
+    instance_id = f"rds-inst-arn-{uuid.uuid4().hex[:8]}"
+    snapshot_id = f"rds-inst-arn-snap-{uuid.uuid4().hex[:8]}"
+
+    try:
+        instance = west.create_db_instance(
+            DBInstanceIdentifier=instance_id,
+            DBInstanceClass="db.t3.micro",
+            Engine="postgres",
+            MasterUsername="admin",
+            MasterUserPassword="pass",
+            AllocatedStorage=10,
+        )["DBInstance"]
+        instance_arn = instance["DBInstanceArn"]
+
+        same_region = west.describe_db_instances(DBInstanceIdentifier=instance_arn)["DBInstances"][0]
+        assert same_region["DBInstanceIdentifier"] == instance_id
+
+        with pytest.raises(ClientError) as exc:
+            east.describe_db_instances(DBInstanceIdentifier=instance_arn)
+        assert exc.value.response["Error"]["Code"] == "InvalidParameterValue"
+
+        with pytest.raises(ClientError) as exc:
+            east.modify_db_instance(
+                DBInstanceIdentifier=instance_arn,
+                DBInstanceClass="db.t3.small",
+                ApplyImmediately=True,
+            )
+        assert exc.value.response["Error"]["Code"] == "InvalidParameterValue"
+
+        with pytest.raises(ClientError) as exc:
+            east.create_db_snapshot(
+                DBSnapshotIdentifier=snapshot_id,
+                DBInstanceIdentifier=instance_arn,
+            )
+        assert exc.value.response["Error"]["Code"] == "InvalidParameterValue"
+
+        with pytest.raises(ClientError) as exc:
+            east.delete_db_instance(DBInstanceIdentifier=instance_arn, SkipFinalSnapshot=True)
+        assert exc.value.response["Error"]["Code"] == "InvalidParameterValue"
+    finally:
+        try:
+            west.delete_db_instance(DBInstanceIdentifier=instance_id, SkipFinalSnapshot=True)
+        except ClientError:
+            pass
+
+
+def test_rds_db_snapshot_filter_by_instance_arn_survives_source_deletion():
+    east = _regional_rds("us-east-1")
+    suffix = uuid.uuid4().hex[:8]
+    instance_id = f"rds-snap-src-arn-{suffix}"
+    snapshot_id = f"rds-snap-src-arn-{suffix}"
+
+    try:
+        instance = east.create_db_instance(
+            DBInstanceIdentifier=instance_id,
+            DBInstanceClass="db.t3.micro",
+            Engine="postgres",
+            MasterUsername="admin",
+            MasterUserPassword="pass",
+            AllocatedStorage=10,
+        )["DBInstance"]
+        east.create_db_snapshot(
+            DBSnapshotIdentifier=snapshot_id,
+            DBInstanceIdentifier=instance["DBInstanceArn"],
+        )
+        east.delete_db_instance(DBInstanceIdentifier=instance_id, SkipFinalSnapshot=True)
+
+        by_source_arn = east.describe_db_snapshots(
+            DBInstanceIdentifier=instance["DBInstanceArn"],
+        )["DBSnapshots"]
+        assert any(s["DBSnapshotIdentifier"] == snapshot_id for s in by_source_arn)
+    finally:
+        try:
+            east.delete_db_snapshot(DBSnapshotIdentifier=snapshot_id)
+        except ClientError:
+            pass
+        _delete_instance(east, instance_id)
+
+
+def test_rds_create_instance_with_cluster_arn_stores_canonical_cluster_id():
+    east = _regional_rds("us-east-1")
+    suffix = uuid.uuid4().hex[:8]
+    cluster_id = f"rds-inst-cluster-arn-{suffix}"
+    instance_id = f"rds-inst-cluster-arn-{suffix}"
+
+    try:
+        cluster = east.create_db_cluster(
+            DBClusterIdentifier=cluster_id,
+            Engine="aurora-mysql",
+            MasterUsername="admin",
+            MasterUserPassword="password123",
+        )["DBCluster"]
+        east.create_db_instance(
+            DBInstanceIdentifier=instance_id,
+            DBClusterIdentifier=cluster["DBClusterArn"],
+            DBInstanceClass="db.t3.micro",
+            Engine="aurora-mysql",
+        )
+
+        instance = east.describe_db_instances(DBInstanceIdentifier=instance_id)["DBInstances"][0]
+        assert instance["DBClusterIdentifier"] == cluster_id
+
+        cluster = east.describe_db_clusters(DBClusterIdentifier=cluster_id)["DBClusters"][0]
+        members = cluster["DBClusterMembers"]
+        assert any(member["DBInstanceIdentifier"] == instance_id for member in members)
+    finally:
+        _delete_instance(east, instance_id)
+        _delete_cluster(east, cluster_id)
+
+
+def test_rds_protected_cluster_member_delete_preserves_membership():
+    east = _regional_rds("us-east-1")
+    suffix = uuid.uuid4().hex[:8]
+    cluster_id = f"rds-protected-member-{suffix}"
+    instance_id = f"rds-protected-member-{suffix}"
+
+    try:
+        cluster = east.create_db_cluster(
+            DBClusterIdentifier=cluster_id,
+            Engine="aurora-mysql",
+            MasterUsername="admin",
+            MasterUserPassword="password123",
+        )["DBCluster"]
+        instance = east.create_db_instance(
+            DBInstanceIdentifier=instance_id,
+            DBClusterIdentifier=cluster["DBClusterArn"],
+            DBInstanceClass="db.t3.micro",
+            Engine="aurora-mysql",
+            DeletionProtection=True,
+        )["DBInstance"]
+
+        for identifier in (instance["DBInstanceArn"], instance["DbiResourceId"]):
+            with pytest.raises(ClientError) as exc:
+                east.delete_db_instance(
+                    DBInstanceIdentifier=identifier,
+                    SkipFinalSnapshot=True,
+                )
+            assert exc.value.response["Error"]["Code"] == "InvalidParameterCombination"
+
+            cluster_after = east.describe_db_clusters(
+                DBClusterIdentifier=cluster_id,
+            )["DBClusters"][0]
+            members = cluster_after["DBClusterMembers"]
+            assert any(
+                member["DBInstanceIdentifier"] == instance_id
+                for member in members
+            )
+    finally:
+        try:
+            east.modify_db_instance(
+                DBInstanceIdentifier=instance_id,
+                DeletionProtection=False,
+                ApplyImmediately=True,
+            )
+        except ClientError:
+            pass
+        _delete_instance(east, instance_id)
+        _delete_cluster(east, cluster_id)
+
+
+def test_rds_read_replica_from_instance_arn_stores_canonical_source_id():
+    east = _regional_rds("us-east-1")
+    suffix = uuid.uuid4().hex[:8]
+    source_id = f"rds-replica-arn-src-{suffix}"
+    replica_id = f"rds-replica-arn-{suffix}"
+
+    try:
+        source = east.create_db_instance(
+            DBInstanceIdentifier=source_id,
+            DBInstanceClass="db.t3.micro",
+            Engine="postgres",
+            MasterUsername="admin",
+            MasterUserPassword="pass",
+            AllocatedStorage=10,
+        )["DBInstance"]
+        replica = east.create_db_instance_read_replica(
+            DBInstanceIdentifier=replica_id,
+            SourceDBInstanceIdentifier=source["DBInstanceArn"],
+        )["DBInstance"]
+
+        assert replica["ReadReplicaSourceDBInstanceIdentifier"] == source_id
+
+        source = east.describe_db_instances(DBInstanceIdentifier=source_id)["DBInstances"][0]
+        assert replica_id in source["ReadReplicaDBInstanceIdentifiers"]
+    finally:
+        _delete_instance(east, replica_id)
+        _delete_instance(east, source_id)
+
+
+def test_rds_tag_resource_arns_are_request_region_scoped():
+    east = _regional_rds("us-east-1")
+    west = _regional_rds("us-west-2")
+    cluster_id = f"rds-tag-scope-{uuid.uuid4().hex[:8]}"
+
+    try:
+        cluster = west.create_db_cluster(
+            DBClusterIdentifier=cluster_id,
+            Engine="aurora-mysql",
+            MasterUsername="admin",
+            MasterUserPassword="password123",
+        )["DBCluster"]
+        cluster_arn = cluster["DBClusterArn"]
+        bogus_account_arn = cluster_arn.replace(":000000000000:", ":111111111111:")
+
+        west.add_tags_to_resource(
+            ResourceName=cluster_arn,
+            Tags=[{"Key": "scope", "Value": "west"}],
+        )
+        assert west.list_tags_for_resource(ResourceName=cluster_arn)["TagList"] == [
+            {"Key": "scope", "Value": "west"},
+        ]
+
+        with pytest.raises(ClientError) as exc:
+            east.add_tags_to_resource(
+                ResourceName=cluster_arn,
+                Tags=[{"Key": "scope", "Value": "east"}],
+            )
+        assert exc.value.response["Error"]["Code"] == "InvalidParameterValue"
+
+        with pytest.raises(ClientError) as exc:
+            east.list_tags_for_resource(ResourceName=cluster_arn)
+        assert exc.value.response["Error"]["Code"] == "InvalidParameterValue"
+
+        with pytest.raises(ClientError) as exc:
+            west.add_tags_to_resource(
+                ResourceName=bogus_account_arn,
+                Tags=[{"Key": "scope", "Value": "bogus"}],
+            )
+        assert exc.value.response["Error"]["Code"] == "InvalidParameterValue"
+
+        cluster = west.describe_db_clusters(DBClusterIdentifier=cluster_id)["DBClusters"][0]
+        assert cluster["TagList"] == [{"Key": "scope", "Value": "west"}]
+    finally:
+        _delete_cluster(west, cluster_id)
+
+
+def test_rds_cluster_snapshot_from_arn_stores_canonical_cluster_id():
+    east = _regional_rds("us-east-1")
+    suffix = uuid.uuid4().hex[:8]
+    cluster_id = f"rds-snap-arn-{suffix}"
+    snapshot_id = f"rds-snap-arn-{suffix}"
+
+    try:
+        cluster = east.create_db_cluster(
+            DBClusterIdentifier=cluster_id,
+            Engine="aurora-mysql",
+            MasterUsername="admin",
+            MasterUserPassword="password123",
+        )["DBCluster"]
+        east.create_db_cluster_snapshot(
+            DBClusterSnapshotIdentifier=snapshot_id,
+            DBClusterIdentifier=cluster["DBClusterArn"],
+        )
+
+        by_snapshot = east.describe_db_cluster_snapshots(
+            DBClusterSnapshotIdentifier=snapshot_id,
+        )["DBClusterSnapshots"][0]
+        assert by_snapshot["DBClusterIdentifier"] == cluster_id
+
+        by_cluster = east.describe_db_cluster_snapshots(
+            DBClusterIdentifier=cluster["DBClusterArn"],
+        )["DBClusterSnapshots"]
+        assert any(s["DBClusterSnapshotIdentifier"] == snapshot_id for s in by_cluster)
+
+        east.delete_db_cluster(DBClusterIdentifier=cluster_id, SkipFinalSnapshot=True)
+
+        by_deleted_source_arn = east.describe_db_cluster_snapshots(
+            DBClusterIdentifier=cluster["DBClusterArn"],
+        )["DBClusterSnapshots"]
+        assert any(
+            s["DBClusterSnapshotIdentifier"] == snapshot_id
+            for s in by_deleted_source_arn
+        )
+    finally:
+        try:
+            east.delete_db_cluster_snapshot(DBClusterSnapshotIdentifier=snapshot_id)
+        except ClientError:
+            pass
+        _delete_cluster(east, cluster_id)
+
+
+def test_describe_global_clusters_rejects_global_cluster_arns():
+    account_a = _regional_rds("us-east-1", access_key_id="111111111111")
+    account_b = _regional_rds("us-east-1", access_key_id="222222222222")
+    global_id = f"global-cross-account-{uuid.uuid4().hex[:8]}"
+    global_arn_id = f"arn:aws:rds::{111111111111}:global-cluster:{global_id}-arn"
+
+    try:
+        with pytest.raises(ClientError) as exc:
+            account_a.create_global_cluster(
+                GlobalClusterIdentifier=global_arn_id,
+                Engine="aurora-mysql",
+            )
+        assert exc.value.response["Error"]["Code"] == "InvalidParameterValue"
+
+        global_cluster = account_a.create_global_cluster(
+            GlobalClusterIdentifier=global_id,
+            Engine="aurora-mysql",
+        )["GlobalCluster"]
+
+        same_account = account_a.describe_global_clusters(
+            GlobalClusterIdentifier=global_id,
+        )["GlobalClusters"][0]
+        assert same_account["GlobalClusterIdentifier"] == global_id
+
+        with pytest.raises(ClientError) as exc:
+            account_a.describe_global_clusters(
+                GlobalClusterIdentifier=global_cluster["GlobalClusterArn"],
+            )
+        assert exc.value.response["Error"]["Code"] == "InvalidParameterValue"
+
+        with pytest.raises(ClientError) as exc:
+            account_b.describe_global_clusters(
+                GlobalClusterIdentifier=global_cluster["GlobalClusterArn"],
+            )
+        assert exc.value.response["Error"]["Code"] == "InvalidParameterValue"
+
+        with pytest.raises(ClientError) as exc:
+            account_a.modify_global_cluster(
+                GlobalClusterIdentifier=global_cluster["GlobalClusterArn"],
+                DeletionProtection=False,
+            )
+        assert exc.value.response["Error"]["Code"] == "InvalidParameterValue"
+
+        with pytest.raises(ClientError) as exc:
+            account_a.modify_global_cluster(
+                GlobalClusterIdentifier=global_id,
+                NewGlobalClusterIdentifier=global_arn_id,
+            )
+        assert exc.value.response["Error"]["Code"] == "InvalidParameterValue"
+
+        with pytest.raises(ClientError) as exc:
+            account_a.remove_from_global_cluster(
+                GlobalClusterIdentifier=global_cluster["GlobalClusterArn"],
+                DbClusterIdentifier="does-not-matter",
+            )
+        assert exc.value.response["Error"]["Code"] == "InvalidParameterValue"
+
+        with pytest.raises(ClientError) as exc:
+            account_a.delete_global_cluster(
+                GlobalClusterIdentifier=global_cluster["GlobalClusterArn"],
+            )
+        assert exc.value.response["Error"]["Code"] == "InvalidParameterValue"
+    finally:
+        _delete_global_cluster(account_a, global_id)


### PR DESCRIPTION
## Summary

Adopts the shared ARN parser in the RDS service for regional RDS identifiers while preserving single-region behavior.

This adds RDS-specific identifier resolution for same-account, same-region ARNs and rejects ARN inputs that are out of scope for the current request region/account. It also keeps stored RDS state canonical by resolving accepted ARNs back to resource identifiers where AWS-style APIs expect identifiers.

## Details

- Add RDS ARN parsing helpers for request-scope validation.
- Support same-region ARN lookup for DB instances, clusters, snapshots, and tag operations where appropriate.
- Reject foreign-account and foreign-region RDS ARNs for regional APIs.
- Preserve canonical stored identifiers when resources are referenced by ARN.
- Add regression coverage for ARN adoption behavior.
- Update RDS tests to account for async Docker-backed instance creation by waiting for availability where needed.
- Narrow the `DOCKER_NETWORK` skip to the Lambda/RDS network connectivity test instead of skipping the whole RDS test module.

## Testing

- `.venv/bin/ruff check ministack/services/rds.py tests/test_rds.py tests/test_rds_arn_adoption.py`
- `git diff --check`
- `MINISTACK_ENDPOINT=http://localhost:4567 .venv/bin/pytest tests/test_arn.py tests/test_rds.py tests/test_rds_arn_adoption.py -v -n 4 --dist=loadfile -m "not serial"`
  - `93 passed`
- `MINISTACK_ENDPOINT=http://localhost:4567 .venv/bin/pytest tests/test_rds.py -v -m serial`
  - `1 skipped, 67 deselected`

Note: the skipped serial test is `test_rds_lambda_network_connectivity`, which requires `DOCKER_NETWORK`.