### PR TITLE
fix(glue): persist ViewOriginalText/ViewExpandedText in _create_table

### DIFF
--- a/ministack/services/glue.py
+++ b/ministack/services/glue.py
@@ -267,6 +267,8 @@ def _create_table(data):
         "PartitionKeys": table_input.get("PartitionKeys", []),
         "TableType": table_input.get("TableType", "EXTERNAL_TABLE"),
         "Parameters": table_input.get("Parameters", {}),
+        "ViewOriginalText": table_input.get("ViewOriginalText"),
+        "ViewExpandedText": table_input.get("ViewExpandedText"),
         "IsRegisteredWithLakeFormation": False,
         "CatalogId": get_account_id(),
     }

--- a/tests/test_glue.py
+++ b/tests/test_glue.py
@@ -123,6 +123,36 @@ def test_glue_table_v2(glue):
         glue.get_table(DatabaseName="glue_tbl_v2db", Name="tbl_v2")
     assert exc.value.response["Error"]["Code"] == "EntityNotFoundException"
 
+def test_glue_view_original_text_roundtrip(glue):
+    glue.create_database(DatabaseInput={"Name": "glue_view_db"})
+    original = "/* Presto View: eyJjYXRhbG9nIjoiaWNlYmVyZyJ9 */"
+    expanded = "/* Presto View */"
+    glue.create_table(
+        DatabaseName="glue_view_db",
+        TableInput={
+            "Name": "vw_x",
+            "TableType": "VIRTUAL_VIEW",
+            "ViewOriginalText": original,
+            "ViewExpandedText": expanded,
+        },
+    )
+    resp = glue.get_table(DatabaseName="glue_view_db", Name="vw_x")
+    assert resp["Table"]["ViewOriginalText"] == original
+    assert resp["Table"]["ViewExpandedText"] == expanded
+
+    glue.update_table(
+        DatabaseName="glue_view_db",
+        TableInput={
+            "Name": "vw_x",
+            "TableType": "VIRTUAL_VIEW",
+            "ViewOriginalText": original + " v2",
+            "ViewExpandedText": expanded + " v2",
+        },
+    )
+    resp2 = glue.get_table(DatabaseName="glue_view_db", Name="vw_x")
+    assert resp2["Table"]["ViewOriginalText"] == original + " v2"
+    assert resp2["Table"]["ViewExpandedText"] == expanded + " v2"
+
 def test_glue_list_v2(glue):
     glue.create_database(DatabaseInput={"Name": "glue_lst_v2db"})
     glue.create_table(


### PR DESCRIPTION
## Summary

`_create_table` in `ministack/services/glue.py` builds the stored table dict without reading `ViewOriginalText` / `ViewExpandedText` from `TableInput`, so the SQL body of Hive/Presto-style views is dropped on creation. The matching `_update_table` handler already lists both fields in its `safe_keys`, so this just mirrors that there.

Two-line change in `_create_table` plus a regression test.

Fixes #706.

## Test plan

All steps verified locally. Baseline is `ministackorg/ministack:1.3.48`; fixed image is `ministack:fix-views` built from this branch. The end-to-end stack used Trino 476 + MinIO `RELEASE.2025-09-07T16-13-09Z` on isolated ports (MiniStack 4569, MinIO 9200/9201, Trino 8091).

- [x] **`aws glue create-table` with `ViewOriginalText`/`ViewExpandedText` followed by `get-table` returns both fields.**

  Baseline (`1.3.48`):
  ```
  ["vw_x", "VIRTUAL_VIEW", null, null]
  ```
  Fixed image:
  ```
  ["vw_x", "VIRTUAL_VIEW", "/* Presto View: eyJjYXRhbG9nIjoiaWNlYmVyZyJ9 */", "/* Presto View */"]
  ```

- [x] **Trino `CREATE OR REPLACE VIEW` + `SELECT * FROM <view>` against MiniStack-backed Glue catalog no longer fails with `viewOriginalText must be present`.**

  Against an isolated Trino + MinIO + fixed-image MiniStack stack:
  ```sql
  CREATE SCHEMA iceberg.repro WITH (location='s3://repro-bucket/');           -- CREATE SCHEMA
  CREATE TABLE iceberg.repro.dim_x (id varchar, name varchar)
    WITH (format='PARQUET', location='s3://repro-bucket/dim_x/');             -- CREATE TABLE
  INSERT INTO iceberg.repro.dim_x VALUES ('a','Alice'),('b','Bob');           -- INSERT: 2 rows
  CREATE OR REPLACE VIEW iceberg.repro.vw_x AS SELECT id, name FROM iceberg.repro.dim_x;  -- CREATE VIEW
  SELECT * FROM iceberg.repro.vw_x ORDER BY id;
  -- "a","Alice"
  -- "b","Bob"
  ```

- [x] **Existing non-view `CreateTable` calls are unaffected (fields default to `None`, matching real Glue behavior).**

  Against the fixed image, creating an `EXTERNAL_TABLE` with no `View*Text` in `TableInput` and then calling `get-table`:
  ```
  ["dim_x", "EXTERNAL_TABLE", null, null]
  ```

- [x] **`pytest tests/test_glue.py::test_glue_view_original_text_roundtrip tests/test_glue.py::test_glue_table_v2`** both pass against the fixed image (new view-roundtrip test + existing non-view table test, confirming no regression to the EXTERNAL_TABLE path).