### PR TITLE
Adopt ARN parsing in RDS Data

### DIFF
--- a/ministack/services/rds_data.py
+++ b/ministack/services/rds_data.py
@@ -6,16 +6,14 @@ Routes SQL to real database containers managed by the RDS service emulator.
 
 import json
 import logging
-import os
 import re
 import threading
 import uuid
 
-from ministack.core.responses import AccountScopedDict, error_response_json, get_account_id, get_region, json_response
+from ministack.core.arn import ArnParseError, parse_arn
+from ministack.core.responses import AccountScopedDict, error_response_json, json_response
 
 logger = logging.getLogger("rds-data")
-
-REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 
 # Active transactions: txn_id -> {conn, engine, resourceArn, database}
 _transactions: dict = {}
@@ -72,10 +70,16 @@ def _stub_success():
 
 def _cluster_id_from_arn(resource_arn):
     """Extract cluster identifier from an ARN."""
-    parts = resource_arn.split(":")
-    if len(parts) >= 7:
-        return parts[6]
-    return resource_arn
+    try:
+        spec = parse_arn(resource_arn)
+    except ArnParseError:
+        return resource_arn
+    if spec.service != "rds":
+        return resource_arn
+    _resource_type, sep, resource_id = spec.resource.partition(":")
+    if not sep:
+        return resource_arn
+    return resource_id
 
 
 _CREATE_DB_RE = re.compile(
@@ -225,25 +229,26 @@ def _resolve_cluster(resource_arn):
     """Find RDS cluster and a member instance from a resourceArn."""
     from ministack.services import rds
 
-    # Parse ARN: arn:aws:rds:REGION:ACCOUNT:cluster:IDENTIFIER
-    parts = resource_arn.split(":")
-    if len(parts) >= 7 and parts[5] == "cluster":
-        cluster_id = parts[6]
-    elif len(parts) >= 7 and parts[5] == "db":
-        # Instance ARN: arn:aws:rds:REGION:ACCOUNT:db:IDENTIFIER
-        instance_id = parts[6]
-        instance = rds._instances.get(instance_id)
+    parsed = rds._parse_rds_arn(resource_arn)
+    if not parsed:
+        return None, None
+
+    _spec, resource_type, _resource_id = parsed
+    if resource_type == "db":
+        instance = rds._resolve_instance(resource_arn)
         if instance:
             return instance, instance.get("Engine", "postgres")
         return None, None
-    else:
+
+    if resource_type != "cluster":
         return None, None
 
-    cluster = rds._clusters.get(cluster_id)
+    cluster = rds._resolve_cluster(resource_arn)
     if not cluster:
         return None, None
 
     engine = cluster.get("Engine", "postgres")
+    cluster_id = cluster["DBClusterIdentifier"]
 
     # Find an instance belonging to this cluster
     for inst in rds._instances.values():

--- a/tests/test_rds_data.py
+++ b/tests/test_rds_data.py
@@ -10,8 +10,11 @@ Since no real DB containers are available in CI, these tests focus on:
 import json
 import os
 import urllib.request
+import uuid
 
+import boto3
 import pytest
+from botocore.config import Config
 from botocore.exceptions import ClientError
 
 ENDPOINT = os.environ.get("MINISTACK_ENDPOINT", "http://localhost:4566")
@@ -42,6 +45,17 @@ def _raw_post(path, body):
         return resp.status, json.loads(resp.read())
     except urllib.error.HTTPError as e:
         return e.code, json.loads(e.read())
+
+
+def _regional_client(service, region, access_key_id="test"):
+    return boto3.client(
+        service,
+        endpoint_url=ENDPOINT,
+        aws_access_key_id=access_key_id,
+        aws_secret_access_key="test",
+        region_name=region,
+        config=Config(region_name=region, retries={"mode": "standard"}),
+    )
 
 
 # ── Routing tests ──────────────────────────────────────────
@@ -127,6 +141,73 @@ def test_execute_nonexistent_cluster():
     })
     assert status == 400
     assert "not found" in body.get("message", body.get("Message", "")).lower()
+
+
+def test_execute_rejects_foreign_region_cluster_arn():
+    """ExecuteStatement should not resolve a cluster ARN from another region."""
+    west = _regional_client("rds", "us-west-2")
+    cluster_id = f"rds-data-foreign-region-{uuid.uuid4().hex[:8]}"
+
+    try:
+        cluster = west.create_db_cluster(
+            DBClusterIdentifier=cluster_id,
+            Engine="aurora-mysql",
+            MasterUsername="admin",
+            MasterUserPassword="password123",
+        )["DBCluster"]
+
+        status, body = _raw_post("/Execute", {
+            "resourceArn": cluster["DBClusterArn"],
+            "secretArn": FAKE_SECRET_ARN,
+            "sql": "SELECT 1",
+        })
+        assert status == 400
+        assert "not found" in body.get("message", body.get("Message", "")).lower()
+    finally:
+        try:
+            west.delete_db_cluster(DBClusterIdentifier=cluster_id, SkipFinalSnapshot=True)
+        except ClientError:
+            pass
+
+
+def test_execute_rejects_foreign_account_cluster_arn():
+    """ExecuteStatement should not resolve a cluster ARN from another account."""
+    owner_account = "111111111111"
+    owner = _regional_client("rds", REGION, access_key_id=owner_account)
+    cluster_id = f"rds-data-foreign-account-{uuid.uuid4().hex[:8]}"
+
+    try:
+        cluster = owner.create_db_cluster(
+            DBClusterIdentifier=cluster_id,
+            Engine="aurora-mysql",
+            MasterUsername="admin",
+            MasterUserPassword="password123",
+        )["DBCluster"]
+
+        assert f":{owner_account}:" in cluster["DBClusterArn"]
+        status, body = _raw_post("/Execute", {
+            "resourceArn": cluster["DBClusterArn"],
+            "secretArn": FAKE_SECRET_ARN,
+            "sql": "SELECT 1",
+        })
+        assert status == 400
+        assert "not found" in body.get("message", body.get("Message", "")).lower()
+    finally:
+        try:
+            owner.delete_db_cluster(DBClusterIdentifier=cluster_id, SkipFinalSnapshot=True)
+        except ClientError:
+            pass
+
+
+def test_cluster_id_from_arn_preserves_colon_resource_tail():
+    from ministack.services import rds_data
+
+    assert (
+        rds_data._cluster_id_from_arn(
+            "arn:aws:rds:us-east-1:000000000000:cluster:cluster-id:tail",
+        )
+        == "cluster-id:tail"
+    )
 
 
 def test_begin_transaction_nonexistent_cluster():


### PR DESCRIPTION
## Summary

Adopts the shared ARN parser in the RDS Data service for `resourceArn` handling while preserving single-region behavior.

This routes RDS Data cluster and instance ARN resolution through the RDS service's scoped resolver helpers, so RDS Data no longer falls back to parsing ARN strings by colon position or resolving out-of-scope resources by identifier tail.

## Details

- Use the shared ARN parser when extracting RDS Data cluster identifiers.
- Resolve RDS Data cluster and instance ARNs through RDS request-scope helpers.
- Reject foreign-region and foreign-account cluster ARNs instead of resolving same-named local resources.
- Preserve colon-containing RDS resource tails when parsing cluster ARNs.
- Add regression coverage for RDS Data ARN scope handling.

## Testing

- `.venv/bin/ruff check ministack/services/rds_data.py tests/test_rds_data.py`
- `MINISTACK_ENDPOINT=http://localhost:4567 .venv/bin/pytest tests/test_arn.py tests/test_rds_arn_adoption.py tests/test_rds_data.py -v`
  - `62 passed`