### PR TITLE
Add account-region scoped persistence support

### DIFF
--- a/ministack/core/persistence.py
+++ b/ministack/core/persistence.py
@@ -10,7 +10,7 @@ import logging
 import os
 import tempfile
 
-from ministack.core.responses import AccountScopedDict
+from ministack.core.responses import AccountRegionScopedDict, AccountScopedDict
 
 logger = logging.getLogger("persistence")
 
@@ -19,7 +19,7 @@ STATE_DIR = os.environ.get("STATE_DIR", "/tmp/ministack-state")
 
 
 def _json_default(obj):
-    """JSON encoder fallback for AccountScopedDict, tuple keys, and bytes.
+    """JSON encoder fallback for scoped dicts, tuple keys, and bytes.
 
     Historically, several S3 (and other service) stores held raw request
     bodies as ``bytes``. ``json.dump`` raised ``TypeError`` and
@@ -27,6 +27,13 @@ def _json_default(obj):
     absent on disk (issue #422). Bytes are now serialized as base64 inside a
     tagged dict so round-trip fidelity is preserved even for non-UTF-8
     payloads."""
+    if isinstance(obj, AccountRegionScopedDict):
+        # Serialize all accounts' and regions' data with string keys
+        result = {}
+        for k, v in obj._data.items():
+            # k is (account_id, region, original_key) tuple
+            result[f"{k[0]}\x00{k[1]}\x00{k[2]!r}"] = v
+        return {"__account_region_scoped__": True, "data": result}
     if isinstance(obj, AccountScopedDict):
         # Serialize all accounts' data with string keys
         result = {}
@@ -41,7 +48,18 @@ def _json_default(obj):
 
 
 def _json_object_hook(obj):
-    """JSON decoder hook to restore AccountScopedDict and bytes from serialized form."""
+    """JSON decoder hook to restore scoped dicts and bytes from serialized form."""
+    if obj.get("__account_region_scoped__"):
+        arsd = AccountRegionScopedDict()
+        for k, v in obj["data"].items():
+            account_id, region, key_repr = k.split("\x00", 2)
+            # Restore the original key (was serialized with repr())
+            try:
+                original_key = ast.literal_eval(key_repr)
+            except (ValueError, SyntaxError):
+                original_key = key_repr
+            arsd._data[(account_id, region, original_key)] = v
+        return arsd
     if obj.get("__scoped__"):
         asd = AccountScopedDict()
         for k, v in obj["data"].items():

--- a/ministack/core/responses.py
+++ b/ministack/core/responses.py
@@ -13,6 +13,8 @@ import uuid
 from datetime import datetime, timezone
 from xml.etree.ElementTree import Element, SubElement, tostring
 
+from ministack.core.arn import ArnParseError, parse_arn
+
 # Request-scoped account ID for multi-tenancy.
 # Set per-request in app.py from the Authorization header.
 _request_account_id: contextvars.ContextVar[str] = contextvars.ContextVar(
@@ -122,6 +124,18 @@ class AccountScopedDict:
     def get(self, key, default=None):
         return self._data.get(self._scoped(key), default)
 
+    def get_scoped(self, account_id, region, key, default=None):
+        return self._data.get((account_id, key), default)
+
+    def set_scoped(self, account_id, region, key, value):
+        self._data[(account_id, key)] = value
+
+    def contains_scoped(self, account_id, region, key):
+        return (account_id, key) in self._data
+
+    def pop_scoped(self, account_id, region, key, *args):
+        return self._data.pop((account_id, key), *args)
+
     def pop(self, key, *args):
         return self._data.pop(self._scoped(key), *args)
 
@@ -162,6 +176,173 @@ class AccountScopedDict:
 
     def __repr__(self):
         return f"AccountScopedDict({dict(self.items())})"
+
+
+class AccountRegionScopedDict:
+    """A dict-like container that namespaces keys by account ID and region.
+
+    This mirrors ``AccountScopedDict`` while adding the current request region
+    to the internal key. It lets regional services keep their existing module
+    stores and dict operations while preventing same-name regional resources
+    from colliding or leaking across requests.
+    """
+
+    __slots__ = ("_data",)
+
+    def __init__(self):
+        self._data: dict = {}
+
+    # -- internal helpers --------------------------------------------------
+
+    def _scoped(self, key):
+        return (get_account_id(), get_region(), key)
+
+    def _unscope(self, scoped_key):
+        return scoped_key[2]
+
+    def _prefix(self):
+        return (get_account_id(), get_region())
+
+    def _is_mine(self, scoped_key):
+        return scoped_key[:2] == self._prefix()
+
+    # -- dict interface ----------------------------------------------------
+
+    def __setitem__(self, key, value):
+        self._data[self._scoped(key)] = value
+
+    def __getitem__(self, key):
+        return self._data[self._scoped(key)]
+
+    def __delitem__(self, key):
+        del self._data[self._scoped(key)]
+
+    def __contains__(self, key):
+        return self._scoped(key) in self._data
+
+    def __len__(self):
+        return sum(1 for k in self._data if self._is_mine(k))
+
+    def __bool__(self):
+        return any(self._is_mine(k) for k in self._data)
+
+    def __iter__(self):
+        for k in self._data:
+            if self._is_mine(k):
+                yield self._unscope(k)
+
+    def get(self, key, default=None):
+        return self._data.get(self._scoped(key), default)
+
+    def get_scoped(self, account_id, region, key, default=None):
+        return self._data.get((account_id, region, key), default)
+
+    def set_scoped(self, account_id, region, key, value):
+        self._data[(account_id, region, key)] = value
+
+    def contains_scoped(self, account_id, region, key):
+        return (account_id, region, key) in self._data
+
+    def pop_scoped(self, account_id, region, key, *args):
+        return self._data.pop((account_id, region, key), *args)
+
+    def pop(self, key, *args):
+        return self._data.pop(self._scoped(key), *args)
+
+    def setdefault(self, key, default=None):
+        return self._data.setdefault(self._scoped(key), default)
+
+    def keys(self):
+        return [self._unscope(k) for k in self._data if self._is_mine(k)]
+
+    def values(self):
+        return [v for k, v in self._data.items() if self._is_mine(k)]
+
+    def items(self):
+        return [(self._unscope(k), v) for k, v in self._data.items() if self._is_mine(k)]
+
+    def values_scoped(self, account_id, region):
+        return [v for k, v in self._data.items() if k[:2] == (account_id, region)]
+
+    def items_scoped(self, account_id, region):
+        return [(self._unscope(k), v) for k, v in self._data.items() if k[:2] == (account_id, region)]
+
+    def all_values(self):
+        return list(self._data.values())
+
+    def all_items(self):
+        return list(self._data.items())
+
+    def has_any(self):
+        return bool(self._data)
+
+    def _region_for_legacy_value(self, key, value):
+        return (
+            _best_effort_region_from_arnish(key)
+            or _best_effort_region_from_arnish(value)
+            or get_region()
+        )
+
+    def update(self, other):
+        if isinstance(other, AccountRegionScopedDict):
+            self._data.update(other._data)
+        elif isinstance(other, AccountScopedDict):
+            for (account_id, key), value in other._data.items():
+                region = self._region_for_legacy_value(key, value)
+                self._data[(account_id, region, key)] = value
+        elif isinstance(other, dict):
+            for k, v in other.items():
+                region = self._region_for_legacy_value(k, v)
+                self._data[(get_account_id(), region, k)] = v
+
+    def clear(self):
+        """Clear ALL accounts' and regions' data (used by reset)."""
+        self._data.clear()
+
+    def to_dict(self):
+        """Convert ALL accounts' and regions' data to a plain dict."""
+        return dict(self._data)
+
+    @classmethod
+    def from_dict(cls, data):
+        """Restore from a plain dict produced by to_dict()."""
+        obj = cls()
+        obj._data = dict(data)
+        return obj
+
+    def __repr__(self):
+        return f"AccountRegionScopedDict({dict(self.items())})"
+
+
+def _best_effort_region_from_arnish(value):
+    """Find a region in legacy persisted data without validating request input."""
+    if isinstance(value, str):
+        if not value.startswith("arn:"):
+            return None
+        try:
+            region = parse_arn(value).region
+        except ArnParseError:
+            return None
+        return region or None
+
+    if isinstance(value, dict):
+        for key, candidate in value.items():
+            if isinstance(key, str) and key.lower().endswith("arn"):
+                region = _best_effort_region_from_arnish(candidate)
+                if region:
+                    return region
+        for candidate in value.values():
+            region = _best_effort_region_from_arnish(candidate)
+            if region:
+                return region
+        return None
+
+    if isinstance(value, (list, tuple, set)):
+        for candidate in value:
+            region = _best_effort_region_from_arnish(candidate)
+            if region:
+                return region
+    return None
 
 
 def xml_response(root_tag: str, namespace: str, children: dict, status: int = 200) -> tuple:

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -34,6 +34,231 @@ def _module(mod_name):
     return importlib.import_module(f"ministack.services.{mod_name}")
 
 
+def test_account_region_scoped_dict_isolates_account_and_region():
+    """Account+region scoped stores keep same-name resources independent."""
+    from ministack.core.responses import (
+        AccountRegionScopedDict,
+        get_account_id,
+        get_region,
+        set_request_account_id,
+        set_request_region,
+    )
+
+    original_account = get_account_id()
+    original_region = get_region()
+
+    try:
+        store = AccountRegionScopedDict()
+        set_request_account_id("111111111111")
+        set_request_region("us-east-1")
+        store["same-name"] = {"scope": "111/east"}
+
+        set_request_region("us-west-2")
+        store["same-name"] = {"scope": "111/west"}
+
+        set_request_account_id("222222222222")
+        set_request_region("us-east-1")
+        store["same-name"] = {"scope": "222/east"}
+
+        assert len(store) == 1
+        assert store["same-name"] == {"scope": "222/east"}
+
+        set_request_account_id("111111111111")
+        assert store["same-name"] == {"scope": "111/east"}
+        set_request_region("us-west-2")
+        assert store["same-name"] == {"scope": "111/west"}
+    finally:
+        set_request_account_id(original_account)
+        set_request_region(original_region)
+
+
+def test_account_region_scoped_dict_persistence_round_trip(monkeypatch, tmp_path):
+    """Account+region scoped stores must survive the JSON persistence path."""
+    from ministack.core.responses import (
+        AccountRegionScopedDict,
+        get_account_id,
+        get_region,
+        set_request_account_id,
+        set_request_region,
+    )
+
+    original_account = get_account_id()
+    original_region = get_region()
+    monkeypatch.setattr(persistence, "PERSIST_STATE", True)
+    monkeypatch.setattr(persistence, "STATE_DIR", str(tmp_path))
+
+    try:
+        store = AccountRegionScopedDict()
+        set_request_account_id("111111111111")
+        set_request_region("us-east-1")
+        store["same-name"] = {"region": "us-east-1"}
+        store[("compound", "key")] = {"region": "us-east-1"}
+        set_request_region("us-west-2")
+        store["same-name"] = {"region": "us-west-2"}
+
+        persistence.save_state("account-region-scoped", {"store": store})
+        loaded = persistence.load_state("account-region-scoped")
+        assert loaded is not None
+
+        restored = loaded["store"]
+        set_request_region("us-east-1")
+        assert restored["same-name"] == {"region": "us-east-1"}
+        assert restored[("compound", "key")] == {"region": "us-east-1"}
+        set_request_region("us-west-2")
+        assert restored["same-name"] == {"region": "us-west-2"}
+    finally:
+        set_request_account_id(original_account)
+        set_request_region(original_region)
+
+
+def test_account_region_scoped_dict_adopts_legacy_values_to_arn_region():
+    """Legacy account-scoped stores should migrate into the region in the value ARN."""
+    from ministack.core.responses import (
+        AccountRegionScopedDict,
+        AccountScopedDict,
+        get_account_id,
+        get_region,
+        set_request_account_id,
+        set_request_region,
+    )
+
+    original_account = get_account_id()
+    original_region = get_region()
+
+    try:
+        legacy = AccountScopedDict()
+        legacy._data[("111111111111", "west-sm")] = {
+            "stateMachineArn": "arn:aws:states:us-west-2:111111111111:stateMachine:west-sm",
+        }
+        legacy._data[("111111111111", "no-arn")] = {"name": "no-arn"}
+
+        restored = AccountRegionScopedDict()
+        set_request_account_id("111111111111")
+        set_request_region("us-east-1")
+        restored.update(legacy)
+
+        assert restored.get_scoped("111111111111", "us-west-2", "west-sm") == {
+            "stateMachineArn": "arn:aws:states:us-west-2:111111111111:stateMachine:west-sm",
+        }
+        assert restored.get_scoped("111111111111", "us-east-1", "west-sm") is None
+        assert restored.get_scoped("111111111111", "us-east-1", "no-arn") == {"name": "no-arn"}
+    finally:
+        set_request_account_id(original_account)
+        set_request_region(original_region)
+
+
+def test_account_region_scoped_dict_update_preserves_tuple_resource_keys():
+    """Plain dict updates should treat tuple keys as normal resource keys."""
+    from ministack.core.responses import (
+        AccountRegionScopedDict,
+        get_account_id,
+        get_region,
+        set_request_account_id,
+        set_request_region,
+    )
+
+    original_account = get_account_id()
+    original_region = get_region()
+
+    try:
+        store = AccountRegionScopedDict()
+        set_request_account_id("111111111111")
+        set_request_region("us-east-1")
+        store.update({("bucket", "object-key"): {"value": "east"}})
+
+        assert store[("bucket", "object-key")] == {"value": "east"}
+        assert store.get_scoped("111111111111", "us-east-1", ("bucket", "object-key")) == {"value": "east"}
+        assert store.get_scoped("bucket", "us-east-1", "object-key") is None
+    finally:
+        set_request_account_id(original_account)
+        set_request_region(original_region)
+
+
+def test_account_region_scoped_dict_update_adopts_plain_values_to_arn_region():
+    """Plain legacy dict restores should use the resource ARN region when present."""
+    from ministack.core.responses import (
+        AccountRegionScopedDict,
+        get_account_id,
+        get_region,
+        set_request_account_id,
+        set_request_region,
+    )
+
+    original_account = get_account_id()
+    original_region = get_region()
+
+    try:
+        store = AccountRegionScopedDict()
+        set_request_account_id("111111111111")
+        set_request_region("us-east-1")
+        store.update({
+            "west-sm": {
+                "stateMachineArn": "arn:aws:states:us-west-2:111111111111:stateMachine:west-sm",
+            },
+        })
+
+        assert store.get_scoped("111111111111", "us-west-2", "west-sm") == {
+            "stateMachineArn": "arn:aws:states:us-west-2:111111111111:stateMachine:west-sm",
+        }
+        assert store.get_scoped("111111111111", "us-east-1", "west-sm") is None
+    finally:
+        set_request_account_id(original_account)
+        set_request_region(original_region)
+
+
+def test_account_region_scoped_dict_update_prefers_key_arn_region():
+    """Legacy ARN-keyed stores should not be scoped by unrelated value ARNs."""
+    from ministack.core.responses import (
+        AccountRegionScopedDict,
+        get_account_id,
+        get_region,
+        set_request_account_id,
+        set_request_region,
+    )
+
+    original_account = get_account_id()
+    original_region = get_region()
+    east_arn = "arn:aws:states:us-east-1:111111111111:stateMachine:east-sm"
+    west_role_arn = "arn:aws:iam:us-west-2:111111111111:role/west-role"
+
+    try:
+        store = AccountRegionScopedDict()
+        set_request_account_id("111111111111")
+        set_request_region("us-west-2")
+        store.update({east_arn: {"RoleArn": west_role_arn}})
+
+        assert store.get_scoped("111111111111", "us-east-1", east_arn) == {"RoleArn": west_role_arn}
+        assert store.get_scoped("111111111111", "us-west-2", east_arn) is None
+    finally:
+        set_request_account_id(original_account)
+        set_request_region(original_region)
+
+
+def test_account_scoped_dict_helpers_remain_account_only():
+    """Scoped helper methods on AccountScopedDict continue to ignore region."""
+    from ministack.core.responses import (
+        AccountScopedDict,
+        get_account_id,
+        set_request_account_id,
+    )
+
+    original_account = get_account_id()
+
+    try:
+        store = AccountScopedDict()
+        store.set_scoped("111111111111", "us-west-2", "same-name", {"value": "helper"})
+        set_request_account_id("111111111111")
+
+        assert store["same-name"] == {"value": "helper"}
+        store["normal"] = {"value": "normal"}
+        assert store.get_scoped("111111111111", "us-east-1", "normal") == {"value": "normal"}
+        assert store.contains_scoped("111111111111", "us-west-2", "normal")
+        assert store.pop_scoped("111111111111", "us-west-2", "normal") == {"value": "normal"}
+        assert "normal" not in store
+    finally:
+        set_request_account_id(original_account)
+
+
 @pytest.mark.parametrize("svc_key,mod_name", ALL_PERSISTED_SERVICES)
 def test_service_has_restore_path(svc_key, mod_name):
     """Every service in `_state_map` must expose a way to restore its own state.


### PR DESCRIPTION
## Summary

Adds the service-neutral persistence foundation needed for later multi-region service work.

This PR:

- Adds `AccountRegionScopedDict`, a dict-like state container that scopes keys by account ID and request region.
- Adds JSON persistence encode/decode support for account+region scoped state using a distinct `__account_region_scoped__` marker.
- Preserves existing `AccountScopedDict` behavior and its existing `__scoped__` persistence format.
- Adds scoped helper methods (`get_scoped`, `set_scoped`, `contains_scoped`, `pop_scoped`) so follow-up service PRs can access explicit account/region state without changing request context.
- Handles legacy account-scoped/plain persisted state by inferring region from ARN-shaped keys or values when possible.
- Adds regression coverage for same-name regional isolation, tuple resource keys, legacy ARN-region adoption, and key-ARN precedence.

No services are converted to use `AccountRegionScopedDict` in this PR.

## Validation

- `ruff check ministack/core/responses.py ministack/core/persistence.py tests/test_persistence.py`
- `PYTHONPATH=$PWD .../python -m pytest tests/test_persistence.py -v`
  - `128 passed`
