### PR TITLE
Scope Step Functions state by region

### DIFF
--- a/ministack/services/eventbridge.py
+++ b/ministack/services/eventbridge.py
@@ -32,6 +32,7 @@ import threading
 import time
 from datetime import datetime, timedelta, timezone
 
+from ministack.core.arn import ArnParseError, parse_arn
 from ministack.core.responses import (
     AccountScopedDict,
     error_response_json,
@@ -40,6 +41,7 @@ from ministack.core.responses import (
     json_response,
     new_uuid,
     set_request_account_id,
+    set_request_region,
 )
 
 logger = logging.getLogger("events")
@@ -2154,28 +2156,54 @@ def _tick_scheduled_rules():
         targets = _targets._data.get((account_id, rule_key), [])
         if not targets:
             continue
-        # Set the account context so ARN-building and Lambda dispatch use the
-        # correct account for this rule's tenant.
+        try:
+            rule_arn = parse_arn(rule.get("Arn", ""))
+        except ArnParseError:
+            logger.warning(
+                "EventBridge scheduler: skipping rule %s with malformed ARN %s",
+                rule_key,
+                rule.get("Arn", ""),
+            )
+            continue
+        if (
+            rule_arn.service != "events"
+            or not rule_arn.region
+            or rule_arn.account_id != account_id
+            or not rule_arn.resource.startswith("rule/")
+        ):
+            logger.warning(
+                "EventBridge scheduler: skipping rule %s with out-of-scope ARN %s",
+                rule_key,
+                rule.get("Arn", ""),
+            )
+            continue
+        previous_account = get_account_id()
+        previous_region = get_region()
         set_request_account_id(account_id)
-        event = {
-            "EventId": new_uuid(),
-            "Source": "aws.events",
-            "DetailType": "Scheduled Event",
-            "Detail": "{}",
-            "EventBusName": rule.get("EventBusName", "default"),
-            "Time": now,
-            "Resources": [rule.get("Arn", "")],
-            "Account": account_id,
-            "Region": get_region(),
-        }
-        for target in targets:
-            try:
-                _invoke_target(target, event, rule)
-            except Exception:
-                logger.exception(
-                    "EventBridge scheduler: dispatch error for rule %s account %s",
-                    rule_key, account_id,
-                )
+        set_request_region(rule_arn.region)
+        try:
+            event = {
+                "EventId": new_uuid(),
+                "Source": "aws.events",
+                "DetailType": "Scheduled Event",
+                "Detail": "{}",
+                "EventBusName": rule.get("EventBusName", "default"),
+                "Time": now,
+                "Resources": [rule.get("Arn", "")],
+                "Account": account_id,
+                "Region": get_region(),
+            }
+            for target in targets:
+                try:
+                    _invoke_target(target, event, rule)
+                except Exception:
+                    logger.exception(
+                        "EventBridge scheduler: dispatch error for rule %s account %s",
+                        rule_key, account_id,
+                    )
+        finally:
+            set_request_account_id(previous_account)
+            set_request_region(previous_region)
 
 
 def _scheduler_loop():

--- a/ministack/services/stepfunctions.py
+++ b/ministack/services/stepfunctions.py
@@ -38,8 +38,10 @@ from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import wait as futures_wait
 from datetime import datetime, timezone
 
+from ministack.core.arn import ArnParseError, parse_arn
 from ministack.core.persistence import PERSIST_STATE, load_state
 from ministack.core.responses import (
+    AccountRegionScopedDict,
     AccountScopedDict,
     error_response_json,
     get_account_id,
@@ -119,24 +121,24 @@ def _get_mock_response(sm_name: str, test_case: str, state_name: str, attempt: i
                 continue
     return None
 
-_state_machines = AccountScopedDict()
-_executions = AccountScopedDict()
-_task_tokens = AccountScopedDict()
-_tags = AccountScopedDict()
-_activities = AccountScopedDict()
-_activity_tasks = AccountScopedDict()
+_state_machines = AccountRegionScopedDict()
+_executions = AccountRegionScopedDict()
+_task_tokens = AccountRegionScopedDict()
+_tags = AccountRegionScopedDict()
+_activities = AccountRegionScopedDict()
+_activity_tasks = AccountRegionScopedDict()
 
 # version_arn -> {stateMachineVersionArn, stateMachineRevisionId,
 #                 description, creationDate, definition, roleArn, type,
 #                 loggingConfiguration}
 # Version ARN shape: arn:aws:states:<region>:<acct>:stateMachine:<name>:<N>
-_state_machine_versions = AccountScopedDict()
+_state_machine_versions = AccountRegionScopedDict()
 
 # alias_arn -> {stateMachineAliasArn, name, description,
 #               routingConfiguration: [{stateMachineVersionArn, weight}],
 #               creationDate, updateDate}
 # Alias ARN shape: arn:aws:states:<region>:<acct>:stateMachine:<name>:<aliasName>
-_state_machine_aliases = AccountScopedDict()
+_state_machine_aliases = AccountRegionScopedDict()
 
 # ── Persistence ────────────────────────────────────────────
 
@@ -162,7 +164,7 @@ def restore_state(data):
     _state_machine_aliases.update(data.get("state_machine_aliases", {}))
     # Executions that were RUNNING when the process died cannot resume —
     # mark them FAILED, following the ECS precedent (tasks → STOPPED).
-    for exc in _executions.values():
+    for exc in _executions.all_values():
         if exc.get("status") == "RUNNING":
             exc["status"] = "FAILED"
             exc["stopDate"] = now_iso()
@@ -570,12 +572,12 @@ def _start_execution(data):
         ],
     }
 
-    # Propagate the request's contextvars (notably the account ID set by
+    # Propagate the request's contextvars (notably the account ID and region set by
     # set_request_account_id) into the background execution thread. Python's
     # threading.Thread does NOT automatically copy contextvars, so without
-    # this snapshot the worker runs under the default account and silently
-    # fails to find the execution stored in AccountScopedDict under the
-    # caller's account. See issue #639.
+    # this snapshot the worker runs under the default scope and silently
+    # fails to find the execution stored under the caller's account and
+    # region. See issue #639.
     ctx_snapshot = contextvars.copy_context()
     threading.Thread(
         target=ctx_snapshot.run,
@@ -891,7 +893,11 @@ async def _get_activity_task(data):
 def _tag_resource(data):
     arn = data.get("resourceArn")
     new_tags = data.get("tags", [])
-    existing = _tags.setdefault(arn, [])
+    account_id, region = _scope_from_resource_arn(arn)
+    existing = _tags.get_scoped(account_id, region, arn)
+    if existing is None:
+        existing = []
+        _tags.set_scoped(account_id, region, arn, existing)
     existing_map = {t["key"]: i for i, t in enumerate(existing)}
     for tag in new_tags:
         idx = existing_map.get(tag["key"])
@@ -906,14 +912,31 @@ def _tag_resource(data):
 def _untag_resource(data):
     arn = data.get("resourceArn")
     keys_to_remove = set(data.get("tagKeys", []))
-    existing = _tags.get(arn, [])
-    _tags[arn] = [t for t in existing if t["key"] not in keys_to_remove]
+    account_id, region = _scope_from_resource_arn(arn)
+    existing = _tags.get_scoped(account_id, region, arn, [])
+    _tags.set_scoped(
+        account_id,
+        region,
+        arn,
+        [t for t in existing if t["key"] not in keys_to_remove],
+    )
     return json_response({})
 
 
 def _list_tags_for_resource(data):
     arn = data.get("resourceArn")
-    return json_response({"tags": _tags.get(arn, [])})
+    account_id, region = _scope_from_resource_arn(arn)
+    return json_response({"tags": _tags.get_scoped(account_id, region, arn, [])})
+
+
+def _scope_from_resource_arn(arn):
+    try:
+        spec = parse_arn(arn)
+    except ArnParseError:
+        return get_account_id(), get_region()
+    if spec.service != "states":
+        return get_account_id(), get_region()
+    return get_account_id(), spec.region or get_region()
 
 
 # ---------------------------------------------------------------------------
@@ -1807,7 +1830,7 @@ def _execute_parallel(state_def, raw_input, execution, ctx):
             errors[idx] = exc
 
     # Each branch runs in its own thread; propagate the parent's contextvars
-    # so AccountScopedDict lookups (account ID, region) keep resolving to the
+    # so scoped store lookups (account ID, region) keep resolving to the
     # current execution's tenant. Take a fresh copy_context() per branch —
     # a single Context cannot be entered by two threads concurrently. See
     # issue #639.
@@ -1873,7 +1896,7 @@ def _execute_map(state_def, raw_input, execution, ctx):
     workers = max_conc if max_conc > 0 else (len(items) or 1)
     # ThreadPoolExecutor workers do not inherit the submitting thread's
     # contextvars, so wrap each submitted callable with copy_context().run
-    # to keep AccountScopedDict lookups bound to the current tenant. Take
+    # to keep scoped store lookups bound to the current tenant. Take
     # a fresh copy_context() per item — a single Context cannot be entered
     # by two threads concurrently. See issue #639.
     with ThreadPoolExecutor(max_workers=workers) as pool:
@@ -2882,7 +2905,7 @@ def _jsonata_now(*args):
     # With picture: XPath-3.1 date/time picture (subset — see
     # `_format_datetime_picture`). With timezone: "+HH:MM" / "-HH:MM" offset
     # applied before formatting.
-    from datetime import datetime, timezone, timedelta
+    from datetime import datetime, timedelta, timezone
     if len(args) > 2:
         raise ValueError("$now expects 0, 1, or 2 arguments")
     now = datetime.now(timezone.utc)

--- a/tests/test_eventbridge.py
+++ b/tests/test_eventbridge.py
@@ -1341,6 +1341,7 @@ def test_eventbridge_log_config_round_trip(eb):
 # ---------------------------------------------------------------------------
 
 import pytest as _pytest
+
 from ministack.services import eventbridge as _eb
 
 
@@ -1435,6 +1436,36 @@ def test_scheduler_fires_after_interval(isolated_scheduler):
     assert target_arg["Id"] == "t1"
 
 
+def test_scheduler_restores_rule_region_while_dispatching(isolated_scheduler):
+    from ministack.core.responses import get_region, set_request_region
+
+    original_region = get_region()
+    observed = []
+    try:
+        set_request_region("us-east-1")
+        _seed_rule()
+        _eb._rules._data[_STATE_KEY]["Arn"] = (
+            "arn:aws:events:us-west-2:000000000000:rule/unit-test-rule"
+        )
+        _eb._targets._data[_STATE_KEY] = [
+            {
+                "Id": "sfn",
+                "Arn": "arn:aws:states:us-west-2:000000000000:stateMachine:scheduled",
+            }
+        ]
+        _eb._rule_last_fired[_STATE_KEY] = _eb._now_ts() - 65
+        isolated_scheduler.side_effect = (
+            lambda _target, event, _rule: observed.append((_eb.get_region(), event["Region"]))
+        )
+
+        _eb._tick_scheduled_rules()
+
+        assert observed == [("us-west-2", "us-west-2")]
+        assert get_region() == "us-east-1"
+    finally:
+        set_request_region(original_region)
+
+
 def test_scheduler_skips_rule_before_interval(isolated_scheduler):
     """Tick must NOT dispatch when interval hasn't elapsed."""
     _seed_rule()
@@ -1479,7 +1510,8 @@ def test_scheduler_parse_cron_fields_validity(expr, valid):
 
 def test_scheduler_cron_next_fire_same_day():
     """cron(0 12 * * ? *): next noon after 11:00 is 12:00 same day."""
-    from datetime import datetime as _dt, timezone as _tz
+    from datetime import datetime as _dt
+    from datetime import timezone as _tz
     fields = _eb._parse_cron_fields("cron(0 12 * * ? *)")
     after = _dt(2024, 1, 1, 11, 0, tzinfo=_tz.utc)
     assert _eb._cron_next_fire(fields, after) == _dt(2024, 1, 1, 12, 0, tzinfo=_tz.utc)
@@ -1487,7 +1519,8 @@ def test_scheduler_cron_next_fire_same_day():
 
 def test_scheduler_cron_next_fire_wraps_to_next_day():
     """cron(0 12 * * ? *): after noon, next occurrence is noon tomorrow."""
-    from datetime import datetime as _dt, timezone as _tz
+    from datetime import datetime as _dt
+    from datetime import timezone as _tz
     fields = _eb._parse_cron_fields("cron(0 12 * * ? *)")
     after = _dt(2024, 1, 1, 12, 0, tzinfo=_tz.utc)
     assert _eb._cron_next_fire(fields, after) == _dt(2024, 1, 2, 12, 0, tzinfo=_tz.utc)
@@ -1495,7 +1528,8 @@ def test_scheduler_cron_next_fire_wraps_to_next_day():
 
 def test_scheduler_cron_next_fire_weekday():
     """cron(0 0 ? * MON-FRI *): after Friday 23:00, next is Monday 00:00."""
-    from datetime import datetime as _dt, timezone as _tz
+    from datetime import datetime as _dt
+    from datetime import timezone as _tz
     fields = _eb._parse_cron_fields("cron(0 0 ? * MON-FRI *)")
     after = _dt(2024, 1, 5, 23, 0, tzinfo=_tz.utc)   # Friday
     assert _eb._cron_next_fire(fields, after) == _dt(2024, 1, 8, 0, 0, tzinfo=_tz.utc)  # Monday
@@ -1529,7 +1563,8 @@ def test_scheduler_cron_skips_before_scheduled_time(isolated_scheduler):
 
 def test_scheduler_cron_last_day_of_month():
     """cron(0 0 L * ? *): next fire after Jan 30 is Jan 31 (last day)."""
-    from datetime import datetime as _dt, timezone as _tz
+    from datetime import datetime as _dt
+    from datetime import timezone as _tz
     fields = _eb._parse_cron_fields("cron(0 0 L * ? *)")
     after = _dt(2024, 1, 30, 12, 0, tzinfo=_tz.utc)
     # Jan has 31 days
@@ -1541,7 +1576,8 @@ def test_scheduler_cron_last_day_of_month():
 
 def test_scheduler_cron_last_weekday_of_month():
     """cron(0 0 LW * ? *): last Mon-Fri of the month."""
-    from datetime import datetime as _dt, timezone as _tz
+    from datetime import datetime as _dt
+    from datetime import timezone as _tz
     fields = _eb._parse_cron_fields("cron(0 0 LW * ? *)")
     # March 2024: 31st = Sunday → last weekday is Fri Mar 29.
     after = _dt(2024, 3, 1, 0, 0, tzinfo=_tz.utc)
@@ -1550,7 +1586,8 @@ def test_scheduler_cron_last_weekday_of_month():
 
 def test_scheduler_cron_nearest_weekday():
     """cron(0 12 15W * ? *): nearest Mon-Fri to the 15th, never crossing month."""
-    from datetime import datetime as _dt, timezone as _tz
+    from datetime import datetime as _dt
+    from datetime import timezone as _tz
     fields = _eb._parse_cron_fields("cron(0 12 15W * ? *)")
     # Jan 15 2024 = Monday → fires on the 15th itself.
     assert _eb._cron_next_fire(fields, _dt(2024, 1, 14, 0, 0, tzinfo=_tz.utc)) == _dt(2024, 1, 15, 12, 0, tzinfo=_tz.utc)
@@ -1562,7 +1599,8 @@ def test_scheduler_cron_nearest_weekday():
 
 def test_scheduler_cron_last_dow_of_month():
     """cron(0 12 ? * 6L *): last Friday of the month (AWS Friday = 6)."""
-    from datetime import datetime as _dt, timezone as _tz
+    from datetime import datetime as _dt
+    from datetime import timezone as _tz
     fields = _eb._parse_cron_fields("cron(0 12 ? * 6L *)")
     # Jan 2024: Fridays are 5, 12, 19, 26 → last is Fri Jan 26.
     assert _eb._cron_next_fire(fields, _dt(2024, 1, 1, 0, 0, tzinfo=_tz.utc)) == _dt(2024, 1, 26, 12, 0, tzinfo=_tz.utc)
@@ -1572,7 +1610,8 @@ def test_scheduler_cron_last_dow_of_month():
 
 def test_scheduler_cron_nth_dow_of_month():
     """cron(0 9 ? * 2#1 *): first Monday of every month (AWS Monday = 2)."""
-    from datetime import datetime as _dt, timezone as _tz
+    from datetime import datetime as _dt
+    from datetime import timezone as _tz
     fields = _eb._parse_cron_fields("cron(0 9 ? * 2#1 *)")
     # Jan 2024: Mondays are 1, 8, 15, 22, 29 → 1st Monday = Jan 1.
     assert _eb._cron_next_fire(fields, _dt(2023, 12, 31, 0, 0, tzinfo=_tz.utc)) == _dt(2024, 1, 1, 9, 0, tzinfo=_tz.utc)

--- a/tests/test_stepfunctions.py
+++ b/tests/test_stepfunctions.py
@@ -6,8 +6,11 @@ import uuid as _uuid_mod
 import zipfile
 from urllib.parse import urlparse
 
+import boto3
 import pytest
+from botocore.config import Config
 from botocore.exceptions import ClientError
+from conftest import ENDPOINT
 
 
 def _make_zip(code: str) -> bytes:
@@ -26,6 +29,134 @@ def _wait_sfn(sfn, exec_arn, timeout=10):
         if desc["status"] != "RUNNING":
             return desc
     return desc
+
+
+def _regional_sfn(region):
+    return boto3.client(
+        "stepfunctions",
+        endpoint_url=ENDPOINT,
+        aws_access_key_id="test",
+        aws_secret_access_key="test",
+        region_name=region,
+        config=Config(
+            region_name=region,
+            retries={"mode": "standard"},
+            max_pool_connections=50,
+        ),
+    )
+
+
+def _pass_definition(result="ok"):
+    return json.dumps(
+        {
+            "StartAt": "P",
+            "States": {"P": {"Type": "Pass", "Result": result, "End": True}},
+        }
+    )
+
+
+def test_sfn_state_machines_are_region_scoped():
+    east = _regional_sfn("us-east-1")
+    west = _regional_sfn("us-west-2")
+    name = f"sfn-region-scope-{_uuid_mod.uuid4().hex}"
+
+    east_sm = east.create_state_machine(
+        name=name,
+        definition=_pass_definition("east"),
+        roleArn="arn:aws:iam::000000000000:role/R",
+    )
+    west_sm = west.create_state_machine(
+        name=name,
+        definition=_pass_definition("west"),
+        roleArn="arn:aws:iam::000000000000:role/R",
+    )
+
+    assert ":us-east-1:" in east_sm["stateMachineArn"]
+    assert ":us-west-2:" in west_sm["stateMachineArn"]
+    assert east_sm["stateMachineArn"] != west_sm["stateMachineArn"]
+
+    east_arns = {sm["stateMachineArn"] for sm in east.list_state_machines()["stateMachines"]}
+    west_arns = {sm["stateMachineArn"] for sm in west.list_state_machines()["stateMachines"]}
+    assert east_sm["stateMachineArn"] in east_arns
+    assert east_sm["stateMachineArn"] not in west_arns
+    assert west_sm["stateMachineArn"] in west_arns
+    assert west_sm["stateMachineArn"] not in east_arns
+
+    with pytest.raises(ClientError) as exc:
+        west.describe_state_machine(stateMachineArn=east_sm["stateMachineArn"])
+    assert exc.value.response["Error"]["Code"] == "StateMachineDoesNotExist"
+
+
+def test_sfn_executions_are_region_scoped():
+    east = _regional_sfn("us-east-1")
+    west = _regional_sfn("us-west-2")
+    name = f"sfn-exec-region-scope-{_uuid_mod.uuid4().hex}"
+    execution_name = "same-execution-name"
+
+    east_sm = east.create_state_machine(
+        name=name,
+        definition=_pass_definition("east"),
+        roleArn="arn:aws:iam::000000000000:role/R",
+    )
+    west_sm = west.create_state_machine(
+        name=name,
+        definition=_pass_definition("west"),
+        roleArn="arn:aws:iam::000000000000:role/R",
+    )
+
+    east_ex = east.start_execution(
+        stateMachineArn=east_sm["stateMachineArn"],
+        name=execution_name,
+        input="{}",
+    )
+    west_ex = west.start_execution(
+        stateMachineArn=west_sm["stateMachineArn"],
+        name=execution_name,
+        input="{}",
+    )
+
+    assert ":us-east-1:" in east_ex["executionArn"]
+    assert ":us-west-2:" in west_ex["executionArn"]
+    assert east_ex["executionArn"] != west_ex["executionArn"]
+
+    east_desc = _wait_sfn(east, east_ex["executionArn"])
+    west_desc = _wait_sfn(west, west_ex["executionArn"])
+    assert east_desc["status"] == "SUCCEEDED"
+    assert west_desc["status"] == "SUCCEEDED"
+    assert json.loads(east_desc["output"]) == "east"
+    assert json.loads(west_desc["output"]) == "west"
+
+    east_exec_arns = {
+        ex["executionArn"]
+        for ex in east.list_executions(stateMachineArn=east_sm["stateMachineArn"])["executions"]
+    }
+    west_exec_arns = {
+        ex["executionArn"]
+        for ex in west.list_executions(stateMachineArn=west_sm["stateMachineArn"])["executions"]
+    }
+    assert east_ex["executionArn"] in east_exec_arns
+    assert east_ex["executionArn"] not in west_exec_arns
+    assert west_ex["executionArn"] in west_exec_arns
+    assert west_ex["executionArn"] not in east_exec_arns
+
+    with pytest.raises(ClientError) as exc:
+        west.describe_execution(executionArn=east_ex["executionArn"])
+    assert exc.value.response["Error"]["Code"] == "ExecutionDoesNotExist"
+
+
+def test_sfn_start_execution_rejects_cross_region_state_machine_arn():
+    east = _regional_sfn("us-east-1")
+    west = _regional_sfn("us-west-2")
+    name = f"sfn-cross-region-start-{_uuid_mod.uuid4().hex}"
+    east_sm = east.create_state_machine(
+        name=name,
+        definition=_pass_definition("east"),
+        roleArn="arn:aws:iam::000000000000:role/R",
+    )
+
+    with pytest.raises(ClientError) as exc:
+        west.start_execution(stateMachineArn=east_sm["stateMachineArn"], input="{}")
+    assert exc.value.response["Error"]["Code"] == "StateMachineDoesNotExist"
 
 def test_sfn_create_execute(sfn):
     definition = json.dumps(
@@ -254,6 +385,49 @@ def test_sfn_tags_v2(sfn):
     tags3 = sfn.list_tags_for_resource(resourceArn=arn)["tags"]
     assert not any(t["key"] == "init" for t in tags3)
     assert any(t["key"] == "env" for t in tags3)
+
+
+def test_sfn_tags_scope_by_resource_arn_region():
+    from ministack.core.responses import (
+        get_account_id,
+        get_region,
+        set_request_account_id,
+        set_request_region,
+    )
+    from ministack.services import stepfunctions as m
+
+    original_account = get_account_id()
+    original_region = get_region()
+    original_tags = dict(m._tags._data)
+    arn = "arn:aws:states:us-west-2:000000000000:stateMachine:tagged-west"
+
+    try:
+        m._tags.clear()
+        set_request_account_id("000000000000")
+        set_request_region("us-east-1")
+
+        m._tag_resource({"resourceArn": arn, "tags": [{"key": "env", "value": "west"}]})
+
+        assert m._tags.get_scoped("000000000000", "us-west-2", arn) == [
+            {"key": "env", "value": "west"},
+        ]
+        assert m._tags.get_scoped("000000000000", "us-east-1", arn) is None
+
+        _status, _headers, body = m._list_tags_for_resource({"resourceArn": arn})
+        assert json.loads(body)["tags"] == [{"key": "env", "value": "west"}]
+
+        foreign_arn = "arn:aws:states:us-west-2:111111111111:stateMachine:foreign"
+        m._tag_resource({"resourceArn": foreign_arn, "tags": [{"key": "owner", "value": "other"}]})
+        assert m._tags.get_scoped("111111111111", "us-west-2", foreign_arn) is None
+        assert m._tags.get_scoped("000000000000", "us-west-2", foreign_arn) == [
+            {"key": "owner", "value": "other"},
+        ]
+    finally:
+        m._tags.clear()
+        m._tags._data.update(original_tags)
+        set_request_account_id(original_account)
+        set_request_region(original_region)
+
 
 def test_sfn_intrinsic_string_to_json(sfn, sfn_sync):
     """States.StringToJson parses a JSON string into structured data."""
@@ -4112,10 +4286,10 @@ def test_sfn_execution_proceeds_under_non_default_account_id():
 
     When a caller uses a 12-digit access-key as their account ID (the
     documented per-account-isolation pattern), the execution record is stored
-    in AccountScopedDict under that account. Without contextvars propagation
-    into the threading.Thread that runs _run_execution, the worker thread
-    looks up the execution under the default account and silently returns,
-    leaving the execution stuck at ExecutionStarted forever.
+    under that account and region. Without contextvars propagation into the
+    threading.Thread that runs _run_execution, the worker thread looks up the
+    execution under the default scope and silently returns, leaving the
+    execution stuck at ExecutionStarted forever.
 
     Regression for #639. The fix wraps the background thread target with
     contextvars.copy_context().run so the request's account/region context


### PR DESCRIPTION
## Summary

- Move Step Functions state stores to account-and-region scoped storage.
- Scope Step Functions tag operations by the resource ARN region while preserving the current request account.
- Preserve EventBridge scheduler account and region context when dispatching scheduled targets.
- Add regression coverage for regional Step Functions state machines, executions, tag scoping, cross-region start rejection, and scheduled EventBridge dispatch region restoration.

## Tests

- `ruff check ministack/services/eventbridge.py tests/test_eventbridge.py ministack/services/stepfunctions.py tests/test_stepfunctions.py`
- `PYTHONPATH=$PWD MINISTACK_ENDPOINT=http://localhost:14566 python -m pytest tests/test_stepfunctions.py tests/test_eventbridge.py -v` (`239 passed in 33.52s`)
