### PR TITLE
Validate S3 notification target regions

### DIFF
--- a/ministack/services/s3.py
+++ b/ministack/services/s3.py
@@ -41,6 +41,7 @@ from xml.sax.saxutils import escape as _esc
 
 from defusedxml.ElementTree import fromstring
 
+from ministack.core.arn import ArnParseError, parse_arn
 from ministack.core.persistence import PERSIST_STATE, load_state
 from ministack.core.responses import (
     AccountScopedDict,
@@ -1330,7 +1331,13 @@ def _get_bucket_notification(name: str):
 def _put_bucket_notification(name: str, body: bytes):
     if name not in _buckets:
         return _no_such_bucket(name)
-    _bucket_notifications[name] = body.decode("utf-8", errors="replace")
+    raw = body.decode("utf-8", errors="replace")
+    configs = _parse_notification_config_raw(raw)
+    bucket_region = _buckets[name].get("region") or os.environ.get("MINISTACK_REGION", "us-east-1")
+    validation_error = _validate_notification_configs(configs, bucket_region)
+    if validation_error:
+        return validation_error
+    _bucket_notifications[name] = raw
     # Fire the s3:TestEvent synchronously so it's delivered before PutBucketNotification
     # returns — matches AWS's effective behaviour and avoids a race where the
     # client polls the destination queue/topic before the background thread has
@@ -1516,8 +1523,12 @@ def _list_object_versions(bucket_name: str, query_params: dict):
 
 
 def _parse_notification_config(bucket_name: str) -> list[dict]:
-    """Parse the raw notification XML into structured config dicts."""
-    raw = _bucket_notifications.get(bucket_name)
+    """Parse the stored notification XML into structured config dicts."""
+    return _parse_notification_config_raw(_bucket_notifications.get(bucket_name))
+
+
+def _parse_notification_config_raw(raw: str | None) -> list[dict]:
+    """Parse raw notification XML into structured config dicts."""
     if not raw:
         return []
 
@@ -1598,6 +1609,77 @@ def _parse_notification_config(bucket_name: str) -> list[dict]:
             )
 
     return configs
+
+
+def _invalid_notification_config(message: str) -> tuple:
+    return _error("InvalidArgument", message, 400)
+
+
+def _queue_name_from_sqs_arn_spec(spec) -> str | None:
+    if spec.service != "sqs" or not spec.resource or ":" in spec.resource or "/" in spec.resource:
+        return None
+    return spec.resource
+
+
+def _topic_name_from_sns_arn_spec(spec) -> str | None:
+    if spec.service != "sns" or not spec.resource or ":" in spec.resource or "/" in spec.resource:
+        return None
+    return spec.resource
+
+
+def _lambda_name_from_arn_spec(spec) -> str | None:
+    if spec.service != "lambda":
+        return None
+    parts = spec.resource.split(":", 2)
+    if len(parts) < 2 or parts[0] != "function" or not parts[1]:
+        return None
+    return parts[1]
+
+
+def _validate_notification_target_arn(target_type: str, arn: str, bucket_region: str) -> tuple | None:
+    service_for_type = {"sqs": "sqs", "sns": "sns", "lambda": "lambda"}
+    expected_service = service_for_type.get(target_type)
+    try:
+        spec = parse_arn(arn)
+    except ArnParseError:
+        return _invalid_notification_config(
+            "Unable to validate destination configuration: destination ARN is not in the correct format"
+        )
+
+    if spec.service != expected_service:
+        return _invalid_notification_config(
+            f"Unable to validate destination configuration: expected {expected_service} ARN, got {spec.service}"
+        )
+    if not spec.region:
+        return _invalid_notification_config(
+            "Unable to validate destination configuration: destination ARN must include a region"
+        )
+    if spec.region != bucket_region:
+        return _invalid_notification_config(
+            "Unable to validate destination configuration: destination region must match bucket region"
+        )
+
+    if target_type == "sqs" and not _queue_name_from_sqs_arn_spec(spec):
+        return _invalid_notification_config(
+            "Unable to validate destination configuration: invalid SQS queue ARN"
+        )
+    if target_type == "sns" and not _topic_name_from_sns_arn_spec(spec):
+        return _invalid_notification_config(
+            "Unable to validate destination configuration: invalid SNS topic ARN"
+        )
+    if target_type == "lambda" and not _lambda_name_from_arn_spec(spec):
+        return _invalid_notification_config(
+            "Unable to validate destination configuration: invalid Lambda function ARN"
+        )
+    return None
+
+
+def _validate_notification_configs(configs: list[dict], bucket_region: str) -> tuple | None:
+    for cfg in configs:
+        error = _validate_notification_target_arn(cfg["type"], cfg["arn"], bucket_region)
+        if error:
+            return error
+    return None
 
 
 def _event_matches(event_name: str, patterns: list[str]) -> bool:
@@ -1776,8 +1858,8 @@ def _deliver_event_to_sns(arn: str, event_payload: dict) -> None:
 def _deliver_event_to_lambda(arn: str, event_payload: dict) -> None:
     from ministack.services import lambda_svc as _lambda
 
-    func, _config, func_name = _lambda._get_func_record_for_ref(arn)
-    if not func:
+    func, config, func_name = _lambda._get_func_record_for_ref(arn)
+    if not func or not config:
         logger.warning("S3 notification: Lambda function %s not found", func_name)
         return
 
@@ -1785,7 +1867,7 @@ def _deliver_event_to_lambda(arn: str, event_payload: dict) -> None:
     # (MaximumRetryAttempts, default 2) and routing to the function's DLQ /
     # DestinationConfig.OnFailure on final failure. Shared helper keeps the
     # semantics identical to direct Invoke(InvocationType=Event).
-    _lambda.invoke_async_with_retry(func, event_payload)
+    _lambda.invoke_async_with_retry(_lambda._execution_record_for_config(func, config), event_payload)
     logger.info("S3 notification → Lambda %s (async with retry+DLQ)", func_name)
 
 

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -1282,13 +1282,27 @@ def _wait_lambda_invoked(logs_client, function_name, marker, timeout=5.0):
     return False
 
 
-def _create_event_lambda(lam, name):
+def _regional_client(service: str, region: str):
+    import boto3
+    from botocore.config import Config
+
+    return boto3.client(
+        service,
+        endpoint_url=os.environ.get("MINISTACK_ENDPOINT", "http://localhost:4566"),
+        aws_access_key_id="test",
+        aws_secret_access_key="test",
+        region_name=region,
+        config=Config(region_name=region, retries={"mode": "standard"}, max_pool_connections=50),
+    )
+
+
+def _create_event_lambda(lam, name, marker="S3EVT"):
     import io as _io
     import zipfile as _zip
     code = (
         "def handler(event, context):\n"
         "    import json\n"
-        "    print('S3EVT', json.dumps(event))\n"
+        f"    print('{marker}', context.invoked_function_arn, json.dumps(event))\n"
         "    return {'ok': True}\n"
     )
     buf = _io.BytesIO()
@@ -1323,6 +1337,43 @@ def test_s3_event_notification_to_lambda_boto3_default(s3, lam, logs):
     s3.put_object(Bucket="s3-evt-lam-boto3-bkt", Key="boto3.txt", Body=b"hi")
     assert _wait_lambda_invoked(logs, fname, "boto3.txt"), \
         "Lambda was not invoked for boto3-shaped notification config"
+
+
+def test_s3_event_notification_to_lambda_validates_bucket_region(s3, lam):
+    fname = "s3-evt-lam-region"
+    _create_event_lambda(lam, fname, marker="east")
+    west_lam = _regional_client("lambda", "us-west-2")
+    west_logs = _regional_client("logs", "us-west-2")
+    west_arn = _create_event_lambda(west_lam, fname, marker="west")
+
+    s3.create_bucket(Bucket="s3-evt-lam-region-bkt")
+    with pytest.raises(ClientError) as exc:
+        s3.put_bucket_notification_configuration(
+            Bucket="s3-evt-lam-region-bkt",
+            NotificationConfiguration={
+                "LambdaFunctionConfigurations": [
+                    {"LambdaFunctionArn": west_arn, "Events": ["s3:ObjectCreated:*"]},
+                ],
+            },
+        )
+    assert exc.value.response["Error"]["Code"] == "InvalidArgument"
+
+    s3.create_bucket(
+        Bucket="s3-evt-lam-west-bkt",
+        CreateBucketConfiguration={"LocationConstraint": "us-west-2"},
+    )
+    s3.put_bucket_notification_configuration(
+        Bucket="s3-evt-lam-west-bkt",
+        NotificationConfiguration={
+            "LambdaFunctionConfigurations": [
+                {"LambdaFunctionArn": west_arn, "Events": ["s3:ObjectCreated:*"]},
+            ],
+        },
+    )
+    s3.put_object(Bucket="s3-evt-lam-west-bkt", Key="regional.txt", Body=b"hi")
+
+    assert _wait_lambda_invoked(west_logs, fname, "regional.txt"), \
+        "S3 notification did not invoke the Lambda from the ARN's region"
 
 
 def test_s3_event_notification_to_lambda_modern_xml(s3, lam, logs):
@@ -1874,7 +1925,7 @@ def test_s3_post_object_unquoted_field_names(s3):
         f"--{boundary}--\r\n"
     ).encode()
     r = requests.post(
-        f"http://localhost:4566/qa-s3-post-tok",
+        "http://localhost:4566/qa-s3-post-tok",
         data=body,
         headers={"Content-Type": f"multipart/form-data; boundary={boundary}"},
     )
@@ -2438,7 +2489,9 @@ def test_s3_put_object_acl_canned(s3):
 def test_s3_put_object_acl_invalid_canned(s3):
     """Invalid x-amz-acl values are rejected with InvalidArgument (400)."""
     import uuid as _u
+
     from botocore.exceptions import ClientError
+
     bucket = f"acl-bad-{_u.uuid4().hex[:8]}"
     s3.create_bucket(Bucket=bucket)
     s3.put_object(Bucket=bucket, Key="k", Body=b"x")
@@ -2452,7 +2505,9 @@ def test_s3_put_object_acl_invalid_canned(s3):
 def test_s3_get_object_acl_no_such_key(s3):
     """GetObjectAcl on a missing key returns NoSuchKey (404)."""
     import uuid as _u
+
     from botocore.exceptions import ClientError
+
     bucket = f"acl-missing-{_u.uuid4().hex[:8]}"
     s3.create_bucket(Bucket=bucket)
     with pytest.raises(ClientError) as exc:


### PR DESCRIPTION
## Summary

This PR tightens S3 bucket notification validation for the `feat/multi-region` branch.

Changes include:
- Parse S3 notification XML before storing it so destination ARNs can be validated up front.
- Reject SQS, SNS, and Lambda notification destinations when the ARN is malformed, uses the wrong service type, omits a region, or targets a different region than the bucket.
- Preserve successful same-region notification behavior, including buckets created outside the default request region.
- Invoke Lambda notification targets through the Lambda function config scope so ARN-qualified regional functions execute in their configured account+region context.
- Add regression coverage for cross-region Lambda notification rejection and valid same-region regional delivery.

## Testing

- `.venv/bin/ruff check ministack/services/s3.py tests/test_s3.py`
- `AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test AWS_DEFAULT_REGION=us-east-1 MINISTACK_ENDPOINT=http://localhost:4566 .venv/bin/pytest -q tests/test_s3.py`
  - `137 passed, 1 skipped`
