### PR TITLE
Scope AppSync Lambda region lookup

### DIFF
--- a/ministack/services/appsync.py
+++ b/ministack/services/appsync.py
@@ -1004,11 +1004,12 @@ def _resolve_lambda(data_source, args):
         return args
 
     import ministack.services.lambda_svc as _lambda_svc
-    func, _config, _func_name = _lambda_svc._get_func_record_for_ref(func_arn)
-    if not func:
+    func, func_config, _func_name = _lambda_svc._get_func_record_for_ref(func_arn)
+    if not func or not func_config:
         return args
 
-    result = _lambda_svc._execute_function(func, args)
+    exec_record = _lambda_svc._execution_record_for_config(func, func_config)
+    result = _lambda_svc._execute_function_with_config_scope(exec_record, args)
     body = result.get("body")
     if isinstance(body, dict):
         return body

--- a/ministack/services/appsync_events.py
+++ b/ministack/services/appsync_events.py
@@ -448,15 +448,16 @@ def _events_authorizer_invoke(
     }
     try:
         from ministack.services import lambda_svc
-        fn, _cfg, _name = lambda_svc._get_func_record_for_ref(arn)  # noqa: SLF001
+        fn, cfg, _name = lambda_svc._get_func_record_for_ref(arn)  # noqa: SLF001
     except Exception as e:
         logger.error("AppSync Events authorizer resolve %s: %s", arn, e)
         return False, None
-    if not fn:
+    if not fn or not cfg:
         logger.error("AppSync Events authorizer Lambda not registered: %s", arn)
         return False, None
     try:
-        res = lambda_svc._execute_function(fn, payload)  # noqa: SLF001
+        exec_record = lambda_svc._execution_record_for_config(fn, cfg)  # noqa: SLF001
+        res = lambda_svc._execute_function_with_config_scope(exec_record, payload)  # noqa: SLF001
     except Exception as e:
         logger.error("AppSync Events authorizer invoke: %s", e)
         return False, None


### PR DESCRIPTION
## Summary

This PR scopes AppSync Lambda integrations to the Lambda function config region on the `feat/multi-region` branch.

Changes include:
- Resolve AppSync GraphQL Lambda data sources through the Lambda ARN-aware lookup helper.
- Execute AppSync GraphQL Lambda resolvers inside the target function's account+region context instead of the ambient request context.
- Resolve AppSync Events Lambda authorizers through the same config-aware Lambda path.
- Execute AppSync Events authorizers inside the target function's account+region context.

## Testing

- `.venv/bin/ruff check ministack/services/appsync.py ministack/services/appsync_events.py`
- `AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test AWS_DEFAULT_REGION=us-east-1 MINISTACK_ENDPOINT=http://localhost:4566 .venv/bin/pytest -q tests/test_appsync.py tests/test_appsync_events.py`
  - `41 passed, 1 skipped`
