### PR TITLE
Scope Cognito pre-token Lambda invocation

### DIFF
--- a/ministack/services/cognito.py
+++ b/ministack/services/cognito.py
@@ -489,10 +489,11 @@ def _apply_pretoken_trigger(pool_id: str, claims: dict, token_type: str,
     try:
         # Lazy import to avoid a circular dependency between cognito and lambda_svc.
         from ministack.services import lambda_svc
-        record, _config, _name = lambda_svc._get_func_record_for_ref(arn)
-        if record is None:
+        record, config, _name = lambda_svc._get_func_record_for_ref(arn)
+        if record is None or config is None:
             raise RuntimeError(f"PreTokenGeneration Lambda not found: {arn}")
-        result = lambda_svc._execute_function(record, event)
+        exec_record = lambda_svc._execution_record_for_config(record, config)
+        result = lambda_svc._execute_function_with_config_scope(exec_record, event)
     except Exception as e:
         logger.warning("PreTokenGeneration Lambda invocation failed for pool %s: %s",
                        pool_id, e)


### PR DESCRIPTION
## Summary

This PR scopes Cognito pre-token generation Lambda triggers to the target Lambda function context on the `feat/multi-region` branch.

Changes include:
- Resolve PreTokenGeneration Lambda trigger ARNs through the config-aware Lambda lookup path.
- Execute pre-token generation handlers inside the target function's account+region context.
- Preserve existing Cognito token override behavior while avoiding ambient request-region Lambda execution.

## Testing

- `.venv/bin/ruff check ministack/services/cognito.py`
- `AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test AWS_DEFAULT_REGION=us-east-1 MINISTACK_ENDPOINT=http://localhost:4566 .venv/bin/pytest -q tests/test_cognito.py`
  - `125 passed`
