### PR TITLE
Scope SNS Lambda subscription invocation

### DIFF
--- a/ministack/services/sns.py
+++ b/ministack/services/sns.py
@@ -895,8 +895,8 @@ def _deliver_to_lambda(endpoint: str, envelope: str, topic_arn: str, sub_arn: st
                        msg_id: str, raw_message: str, message_attributes: dict):
     """Invoke a Lambda function with the SNS Records envelope (AWS format)."""
     # endpoint is a Lambda ARN: arn:aws:lambda:region:account:function:name
-    func, _config, func_name = _lambda_svc._get_func_record_for_ref(endpoint)
-    if not func:
+    func, config, func_name = _lambda_svc._get_func_record_for_ref(endpoint)
+    if not func or not config:
         logger.warning("SNS fanout: Lambda function %s not found", func_name)
         return
     event = {
@@ -910,7 +910,8 @@ def _deliver_to_lambda(endpoint: str, envelope: str, topic_arn: str, sub_arn: st
         ]
     }
     try:
-        _lambda_svc._execute_function(func, event)
+        exec_record = _lambda_svc._execution_record_for_config(func, config)
+        _lambda_svc._execute_function_with_config_scope(exec_record, event)
         logger.info("SNS fanout → Lambda %s", func_name)
     except Exception as exc:
         logger.error("SNS fanout → Lambda %s failed: %s", func_name, exc)


### PR DESCRIPTION
## Summary

This PR scopes SNS Lambda subscription fanout to the target Lambda function context on the `feat/multi-region` branch.

Changes include:
- Resolve Lambda subscription endpoints through the config-aware Lambda lookup path.
- Execute SNS Lambda fanout inside the subscribed function's account+region context.
- Preserve existing SNS delivery behavior while avoiding ambient request-region Lambda execution.

## Testing

- `.venv/bin/ruff check ministack/services/sns.py`
- `AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test AWS_DEFAULT_REGION=us-east-1 MINISTACK_ENDPOINT=http://localhost:4566 .venv/bin/pytest -q tests/test_sns.py`
  - `56 passed`
