### PR TITLE
Scope EventBridge Lambda target invocation

### DIFF
--- a/ministack/services/eventbridge.py
+++ b/ministack/services/eventbridge.py
@@ -1002,12 +1002,13 @@ def _dispatch_to_lambda(arn, payload):
     except (json.JSONDecodeError, TypeError):
         event = {"body": payload}
 
-    func, _config, func_name = lambda_svc._get_func_record_for_ref(arn)
-    if not func:
+    func, config, func_name = lambda_svc._get_func_record_for_ref(arn)
+    if not func or not config:
         logger.warning("EventBridge → Lambda: function %s not found", func_name)
         return
+    exec_record = lambda_svc._execution_record_for_config(func, config)
     threading.Thread(
-        target=lambda_svc._execute_function, args=(func, event), daemon=True
+        target=lambda_svc._execute_function_with_config_scope, args=(exec_record, event), daemon=True
     ).start()
     logger.info("EventBridge → Lambda %s: dispatched", func_name)
 


### PR DESCRIPTION
## Summary

This PR scopes EventBridge Lambda target invocation to the target Lambda function context on the `feat/multi-region` branch.

Changes include:
- Resolve EventBridge Lambda target ARNs through the config-aware Lambda lookup path.
- Execute EventBridge Lambda targets inside the target function's account+region context.
- Preserve existing rule matching and target dispatch behavior while avoiding ambient request-region Lambda execution.

## Testing

- `.venv/bin/ruff check ministack/services/eventbridge.py`
- `AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test AWS_DEFAULT_REGION=us-east-1 MINISTACK_ENDPOINT=http://localhost:4566 .venv/bin/pytest -q tests/test_eventbridge.py`
  - `102 passed`
