### PR TITLE
Scope API Gateway Lambda region lookup

### DIFF
--- a/ministack/services/apigateway.py
+++ b/ministack/services/apigateway.py
@@ -90,6 +90,7 @@ _JWKS_TIMEOUT_SECONDS = _timeout_from_env("MINISTACK_APIGW_JWKS_TIMEOUT_SECONDS"
 
 # ---- Module-level state ----
 _apis = AccountScopedDict()          # api_id -> api object
+_api_regions = AccountScopedDict()   # api_id -> owning region
 _routes = AccountScopedDict()        # api_id -> {route_id -> route object}
 _integrations = AccountScopedDict()  # api_id -> {integration_id -> integration object}
 _stages = AccountScopedDict()        # api_id -> {stage_name -> stage object}
@@ -203,6 +204,7 @@ def get_state() -> dict:
     import copy
     return {
         "apis": copy.deepcopy(_apis),
+        "api_regions": copy.deepcopy(_api_regions),
         "routes": copy.deepcopy(_routes),
         "integrations": copy.deepcopy(_integrations),
         "stages": copy.deepcopy(_stages),
@@ -217,6 +219,7 @@ def get_state() -> dict:
 def load_persisted_state(data: dict) -> None:
     """Restore module state from a previously persisted snapshot."""
     _apis.update(data.get("apis", {}))
+    _api_regions.update(data.get("api_regions", {}))
     _routes.update(data.get("routes", {}))
     _integrations.update(data.get("integrations", {}))
     _stages.update(data.get("stages", {}))
@@ -836,6 +839,8 @@ async def handle_execute(api_id, stage, path, method, headers, body, query_param
             (path_params or None),
             authorizer_claims=authorizer_claims,
             authorizer_scopes=authorizer_scopes,
+            owner_account_id=get_account_id(),
+            owner_region=_api_regions.get(api_id, get_region()),
         )
     elif integration_type == "HTTP_PROXY":
         mapped_headers, mapped_query, mapped_path = _apply_request_parameter_mappings(
@@ -935,6 +940,8 @@ async def _invoke_lambda_proxy(
     *,
     authorizer_claims=None,
     authorizer_scopes=None,
+    owner_account_id=None,
+    owner_region=None,
 ):
     """Invoke a Lambda function using the API Gateway v2 proxy event format."""
     from ministack.services import lambda_svc
@@ -944,13 +951,14 @@ async def _invoke_lambda_proxy(
     # Unwrap to the inner Lambda ARN before parsing name + qualifier (#409).
     # Bare Lambda ARNs and plain function names keep working via the fallback.
     lambda_ref = _extract_lambda_ref_from_integration_uri(integration.get("integrationUri", ""))
-    func_name, qualifier = lambda_svc._resolve_name_and_qualifier(lambda_ref)
-    func_data, func_config, func_name = lambda_svc._get_func_record_for_ref(lambda_ref)
-    if func_data is None:
+    func_data, func_config, func_name = lambda_svc._get_func_record_for_ref_in_scope(
+        lambda_ref,
+        account_id=owner_account_id,
+        region=owner_region,
+    )
+    if func_data is None or func_config is None:
         return 502, {"Content-Type": "application/json"}, json.dumps({
-            "message": f"Lambda function '{func_name}'" +
-                       (f" (qualifier '{qualifier}')" if qualifier else "") +
-                       " not found"
+            "message": f"Lambda function '{lambda_ref or func_name}' not found"
         }).encode()
 
     # Build API Gateway v2 proxy event (payload format 2.0)
@@ -999,7 +1007,7 @@ async def _invoke_lambda_proxy(
     # the shared helper so v1/v2 stay consistent and we get 429s on
     # ConcurrentInvocationLimitExceeded.
     exec_record = lambda_svc._execution_record_for_config(func_data, func_config)
-    result = await asyncio.to_thread(lambda_svc._execute_function, exec_record, event)
+    result = await asyncio.to_thread(lambda_svc._execute_function_with_config_scope, exec_record, event)
     lambda_response, _ = lambda_svc.lambda_execute_result_to_api_proxy_response(result)
 
     status = lambda_response.get("statusCode", 200)
@@ -1102,6 +1110,7 @@ def _create_api(data):
     if data.get("corsConfiguration"):
         api["corsConfiguration"] = data["corsConfiguration"]
     _apis[api_id] = api
+    _api_regions[api_id] = get_region()
     _routes[api_id] = {}
     _integrations[api_id] = {}
     _stages[api_id] = {}
@@ -1123,6 +1132,7 @@ def _get_apis():
 
 def _delete_api(api_id):
     _apis.pop(api_id, None)
+    _api_regions.pop(api_id, None)
     _routes.pop(api_id, None)
     _integrations.pop(api_id, None)
     _stages.pop(api_id, None)
@@ -1449,6 +1459,7 @@ def _delete_authorizer(api_id, auth_id):
 
 def reset():
     _apis.clear()
+    _api_regions.clear()
     _routes.clear()
     _integrations.clear()
     _stages.clear()
@@ -1575,19 +1586,23 @@ def _api_protocol(api_id: str) -> str | None:
 
     WebSocket connections arrive on the execute-api host before we've resolved
     which account owns the api. We scan every AccountScopedDict bucket to find
-    the owning account, then return (protocol, account_id).
+    the owning account and region.
     """
     info = _api_owner(api_id)
     return info[0] if info else None
 
 
 def _api_owner(api_id: str):
-    """Return (protocolType, owner_account_id) for an API or None if unknown."""
+    """Return (protocolType, owner_account_id, owner_region) for an API or None."""
     # AccountScopedDict stores keys as (account_id, original_key). Walk internals
     # so we can find the owning account without knowing it up front.
     for (acct, key), api in _apis._data.items():
         if key == api_id:
-            return (api.get("protocolType", "HTTP"), acct)
+            return (
+                api.get("protocolType", "HTTP"),
+                acct,
+                _api_regions.get_scoped(acct, None, api_id, get_region()),
+            )
     return None
 
 
@@ -1629,7 +1644,7 @@ def _evaluate_route_selection(expr: str, payload_text: str) -> str:
     return "$default"
 
 
-async def _invoke_ws_lambda(api_id: str, account_id: str, route: dict, stage: str,
+async def _invoke_ws_lambda(api_id: str, account_id: str, region: str, route: dict, stage: str,
                             connection_id: str, event_type: str, message_id: str,
                             body_text: str, source_ip: str, headers: dict,
                             query_params: dict | None = None, **kwargs) -> dict | None:
@@ -1687,9 +1702,13 @@ async def _invoke_ws_lambda(api_id: str, account_id: str, route: dict, stage: st
     # Same unwrap path as HTTP (#409): APIGW integrationUri is the wrapper form
     # that nests the Lambda ARN between /functions/ and /invocations.
     lambda_ref = _extract_lambda_ref_from_integration_uri(integration.get("integrationUri", ""))
-    func_name, qualifier = lambda_svc._resolve_name_and_qualifier(lambda_ref)
-    func_data, func_config, func_name = lambda_svc._get_func_record_for_ref(lambda_ref)
-    if func_data is None:
+    _parsed_name, qualifier = lambda_svc._resolve_name_and_qualifier(lambda_ref)
+    func_data, func_config, func_name = lambda_svc._get_func_record_for_ref_in_scope(
+        lambda_ref,
+        account_id=account_id,
+        region=region,
+    )
+    if func_data is None or func_config is None:
         return None
 
     request_context = {
@@ -1788,7 +1807,7 @@ async def handle_websocket(scope, receive, send, api_id: str, path_override: str
         await send({"type": "websocket.close", "code": 1008})
         return
 
-    protocol, account_id = owner
+    protocol, account_id, owner_region = owner
 
     # Stage parsing: Host-based URLs look like wss://{apiId}.execute-api.../stage;
     # path-based compat URLs (#401) use path_override with the rewritten path.
@@ -1827,14 +1846,15 @@ async def handle_websocket(scope, receive, send, api_id: str, path_override: str
     connection_id = new_uuid().replace("-", "")[:16]
 
     # Set account context so downstream Lambda invocations see the right tenant.
-    from ministack.core.responses import _request_account_id
-    token = _request_account_id.set(account_id)
+    from ministack.core.responses import _request_account_id, _request_region
+    account_token = _request_account_id.set(account_id)
+    region_token = _request_region.set(owner_region)
     try:
         # $connect hook
         connect_route = _match_ws_route(api_id, "$connect")
         if connect_route is not None:
             resp = await _invoke_ws_lambda(
-                api_id, account_id, connect_route, stage, connection_id,
+                api_id, account_id, owner_region, connect_route, stage, connection_id,
                 "CONNECT", new_uuid(), "", source_ip, headers,
                 query_params=query_params,
             )
@@ -1910,7 +1930,7 @@ async def handle_websocket(scope, receive, send, api_id: str, path_override: str
                     continue
                 msg_id = new_uuid()
                 resp = await _invoke_ws_lambda(
-                    api_id, account_id, route, stage, connection_id, "MESSAGE",
+                    api_id, account_id, owner_region, route, stage, connection_id, "MESSAGE",
                     msg_id, payload, source_ip, headers,
                 )
                 if resp is None:
@@ -1935,7 +1955,7 @@ async def handle_websocket(scope, receive, send, api_id: str, path_override: str
             if disconnect_route is not None:
                 try:
                     await _invoke_ws_lambda(
-                        api_id, account_id, disconnect_route, stage, connection_id,
+                        api_id, account_id, owner_region, disconnect_route, stage, connection_id,
                         "DISCONNECT", new_uuid(), "", source_ip, headers,
                         disconnect_code=disconnect_code,
                         disconnect_reason=disconnect_reason,
@@ -1948,7 +1968,8 @@ async def handle_websocket(scope, receive, send, api_id: str, path_override: str
                 pass
     finally:
         try:
-            _request_account_id.reset(token)
+            _request_region.reset(region_token)
+            _request_account_id.reset(account_token)
         except Exception:
             pass
 

--- a/ministack/services/apigateway_v1.py
+++ b/ministack/services/apigateway_v1.py
@@ -98,6 +98,7 @@ REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 # All per-tenant state uses AccountScopedDict so the same REST API id in two
 # different accounts never collides and list operations don't leak cross-account.
 _rest_apis = AccountScopedDict()           # rest_api_id -> RestApi
+_rest_api_regions = AccountScopedDict()    # rest_api_id -> owning region
 _resources = AccountScopedDict()           # rest_api_id -> {resource_id -> Resource}
 _stages_v1 = AccountScopedDict()           # rest_api_id -> {stage_name -> Stage}
 _deployments_v1 = AccountScopedDict()      # rest_api_id -> {deployment_id -> Deployment}
@@ -514,18 +515,21 @@ def _extract_lambda_ref_from_integration_uri(uri: str) -> str:
     return uri
 
 
-async def _call_lambda(function_ref, event):
+async def _call_lambda(function_ref, event, *, account_id=None, region=None):
     """Invoke a Lambda function and return the parsed response dict.
 
-    ``function_ref`` may be a function name, qualified name, or full ARN.
-    Full ARNs resolve in their ARN region so API Gateway integrations keep
-    working after Lambda state became region-scoped."""
+    ``function_ref`` may be a name, partial ARN, or full ARN. Full ARNs are
+    resolved through Lambda's scoped lookup so region-qualified integration URIs
+    invoke the function named in the ARN instead of the request/default region."""
     from ministack.services import lambda_svc
 
-    func_name, qualifier = lambda_svc._resolve_name_and_qualifier(function_ref)
-    func_data, func_config, func_name = lambda_svc._get_func_record_for_ref(function_ref)
-    if func_data is None:
-        label = f"{func_name}:{qualifier}" if qualifier else func_name
+    func_data, func_config, func_name = lambda_svc._get_func_record_for_ref_in_scope(
+        function_ref,
+        account_id=account_id,
+        region=region,
+    )
+    if func_data is None or func_config is None:
+        label = function_ref or func_name
         return None, f"Lambda function '{label}' not found"
 
     # Route through the central _execute_function dispatcher so CloudWatch
@@ -533,7 +537,7 @@ async def _call_lambda(function_ref, event):
     # Response shaping (throttle→429, error→502, body→envelope) goes through
     # the shared helper so v1/v2 stay consistent.
     exec_record = lambda_svc._execution_record_for_config(func_data, func_config)
-    result = await asyncio.to_thread(lambda_svc._execute_function, exec_record, event)
+    result = await asyncio.to_thread(lambda_svc._execute_function_with_config_scope, exec_record, event)
     lambda_response, _ = lambda_svc.lambda_execute_result_to_api_proxy_response(result)
     # On error the helper returns {statusCode: 502, body: <msg>}; preserve
     # the _call_lambda contract of (None, error_msg) so callers that check
@@ -556,6 +560,7 @@ def get_state():
     import copy
     return {
         "rest_apis": copy.deepcopy(_rest_apis),
+        "rest_api_regions": copy.deepcopy(_rest_api_regions),
         "resources": copy.deepcopy(_resources),
         "stages_v1": copy.deepcopy(_stages_v1),
         "deployments_v1": copy.deepcopy(_deployments_v1),
@@ -574,6 +579,7 @@ def get_state():
 def load_persisted_state(data):
     """Restore module state from a previously persisted snapshot."""
     _rest_apis.update(data.get("rest_apis", {}))
+    _rest_api_regions.update(data.get("rest_api_regions", {}))
     _resources.update(data.get("resources", {}))
     _stages_v1.update(data.get("stages_v1", {}))
     _deployments_v1.update(data.get("deployments_v1", {}))
@@ -591,6 +597,7 @@ def load_persisted_state(data):
 def reset():
     """Clear all module state."""
     _rest_apis.clear()
+    _rest_api_regions.clear()
     _resources.clear()
     _stages_v1.clear()
     _deployments_v1.clear()
@@ -910,7 +917,9 @@ async def handle_execute(api_id, stage_name, method, path, headers, body, query_
     if int_type in ("AWS_PROXY", "AWS"):
         return await _invoke_lambda_proxy_v1(
             integration, api_id, stage_name, stage, resource, path, method,
-            headers, body, query_params, path_params
+            headers, body, query_params, path_params,
+            owner_account_id=get_account_id(),
+            owner_region=_rest_api_regions.get(api_id, get_region()),
         )
     elif int_type in ("HTTP_PROXY", "HTTP"):
         return await _invoke_http_proxy_v1(
@@ -922,7 +931,22 @@ async def handle_execute(api_id, stage_name, method, path, headers, body, query_
         return 500, {"Content-Type": "application/json"}, json.dumps({"message": f"Unsupported integration type: {int_type}"}).encode()
 
 
-async def _invoke_lambda_proxy_v1(integration, api_id, stage_name, stage, resource, request_path, method, headers, body, query_params, path_params):
+async def _invoke_lambda_proxy_v1(
+    integration,
+    api_id,
+    stage_name,
+    stage,
+    resource,
+    request_path,
+    method,
+    headers,
+    body,
+    query_params,
+    path_params,
+    *,
+    owner_account_id=None,
+    owner_region=None,
+):
     """Invoke Lambda with API Gateway v1 payload format 1.0."""
     uri = integration.get("uri", "")
     # Supported URI formats:
@@ -977,7 +1001,12 @@ async def _invoke_lambda_proxy_v1(integration, api_id, stage_name, stage, resour
         "isBase64Encoded": False,
     }
 
-    lambda_response, err = await _call_lambda(lambda_ref, event)
+    lambda_response, err = await _call_lambda(
+        lambda_ref,
+        event,
+        account_id=owner_account_id,
+        region=owner_region,
+    )
     if err:
         return 502, {"Content-Type": "application/json"}, json.dumps({"message": err}).encode()
 
@@ -1137,6 +1166,7 @@ def _create_rest_api(data):
         "disableExecuteApiEndpoint": data.get("disableExecuteApiEndpoint", False),
     }
     _rest_apis[api_id] = api
+    _rest_api_regions[api_id] = get_region()
     _resources[api_id] = {}
     _stages_v1[api_id] = {}
     _deployments_v1[api_id] = {}
@@ -1182,6 +1212,7 @@ def _delete_rest_api(api_id):
     if api_id not in _rest_apis:
         return _v1_error("NotFoundException", "Invalid API identifier specified", 404)
     _rest_apis.pop(api_id, None)
+    _rest_api_regions.pop(api_id, None)
     _resources.pop(api_id, None)
     _stages_v1.pop(api_id, None)
     _deployments_v1.pop(api_id, None)

--- a/ministack/services/cloudformation/provisioners.py
+++ b/ministack/services/cloudformation/provisioners.py
@@ -1065,13 +1065,18 @@ def _cfn_nested_stack_deploy(logical_id, props, parent_stack_name, *,
     sub-attribute form CDK and console-built templates emit.
     """
     import copy
+
     from ministack.core.responses import get_account_id, get_region, new_uuid
     from ministack.services.cloudformation import (
-        _stack_events, _stacks,
+        _stack_events,
+        _stacks,
     )
     from ministack.services.cloudformation.engine import (
-        _evaluate_conditions, _parse_template, _resolve_parameters,
-        _resolve_refs, _topological_sort,
+        _evaluate_conditions,
+        _parse_template,
+        _resolve_parameters,
+        _resolve_refs,
+        _topological_sort,
     )
     from ministack.services.cloudformation.helpers import _resolve_template
     from ministack.services.cloudformation.stacks import _add_event
@@ -3246,6 +3251,7 @@ def _apigw_v2_api_create(logical_id, props, stack_name):
     if props.get("CorsConfiguration"):
         api["corsConfiguration"] = props["CorsConfiguration"]
     _apigw_v2._apis[api_id] = api
+    _apigw_v2._api_regions[api_id] = get_region()
     _apigw_v2._routes[api_id] = {}
     _apigw_v2._integrations[api_id] = {}
     _apigw_v2._stages[api_id] = {}
@@ -3255,6 +3261,7 @@ def _apigw_v2_api_create(logical_id, props, stack_name):
 
 def _apigw_v2_api_delete(physical_id, props):
     _apigw_v2._apis.pop(physical_id, None)
+    _apigw_v2._api_regions.pop(physical_id, None)
     _apigw_v2._routes.pop(physical_id, None)
     _apigw_v2._integrations.pop(physical_id, None)
     _apigw_v2._stages.pop(physical_id, None)

--- a/tests/test_apigatewayv2.py
+++ b/tests/test_apigatewayv2.py
@@ -113,6 +113,31 @@ def test_apigw_delete_api(apigw):
         apigw.get_api(ApiId=api_id)
     assert exc.value.response["ResponseMetadata"]["HTTPStatusCode"] == 404
 
+def test_apigw_cfn_api_tracks_owner_region():
+    from ministack.core.responses import get_region, set_request_region
+    from ministack.services import apigateway as _apigw
+    from ministack.services.cloudformation import provisioners as _provisioners
+
+    original_region = get_region()
+    api_id = None
+    try:
+        set_request_region("us-west-2")
+        api_id, _attrs = _provisioners._apigw_v2_api_create(
+            "HttpApi",
+            {"Name": "cfn-apigwv2-region-owner", "ProtocolType": "HTTP"},
+            "cfn-apigwv2-region",
+        )
+
+        assert _apigw._api_regions[api_id] == "us-west-2"
+
+        _provisioners._apigw_v2_api_delete(api_id, {})
+        assert api_id not in _apigw._api_regions
+        api_id = None
+    finally:
+        if api_id is not None:
+            _provisioners._apigw_v2_api_delete(api_id, {})
+        set_request_region(original_region)
+
 def test_apigw_create_route(apigw):
     api_id = apigw.create_api(Name="route-api", ProtocolType="HTTP")["ApiId"]
     resp = apigw.create_route(ApiId=api_id, RouteKey="GET /items")
@@ -1133,6 +1158,7 @@ def test_apigw_websocket_lambda_worker_uses_function_region(monkeypatch):
         result = asyncio.run(apigw_mod._invoke_ws_lambda(
             api_id,
             "000000000000",
+            "us-east-1",
             route,
             "$default",
             "conn-1",
@@ -1140,6 +1166,7 @@ def test_apigw_websocket_lambda_worker_uses_function_region(monkeypatch):
             "msg-1",
             "{}",
             "127.0.0.1",
+            {},
             {},
         ))
     finally:
@@ -2063,6 +2090,108 @@ def test_apigwv2_named_stage_still_requires_prefix(apigw, lam):
 def _wrapped_uri(fn_arn: str) -> str:
     """Build the APIGW integration URI Terraform/AWS actually send."""
     return f"arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/{fn_arn}/invocations"
+
+
+def _lambda_client(region: str):
+    import boto3
+
+    return boto3.client(
+        "lambda",
+        endpoint_url=_endpoint,
+        aws_access_key_id="test",
+        aws_secret_access_key="test",
+        region_name=region,
+    )
+
+
+def _regional_marker_code(marker: str) -> str:
+    return f"""
+def handler(event, context):
+    return {{
+        'statusCode': 200,
+        'body': '{marker}:' + context.invoked_function_arn,
+    }}
+"""
+
+
+def _make_regional_fn(lam, name: str, marker: str) -> str:
+    created = lam.create_function(
+        FunctionName=name,
+        Runtime="python3.12",
+        Role=_LAMBDA_ROLE,
+        Handler="index.handler",
+        Code={"ZipFile": _make_zip(_regional_marker_code(marker))},
+    )
+    lam.invoke(
+        FunctionName=name,
+        InvocationType="RequestResponse",
+        Payload=b'{"_ministack_warmup": true}',
+    )
+    return created["FunctionArn"]
+
+
+def test_apigwv2_lambda_integration_uses_function_arn_region(apigw, lam):
+    import urllib.request
+
+    west_lam = _lambda_client("us-west-2")
+    fn_name = f"apigw-region-{uuid.uuid4().hex[:6]}"
+    _make_regional_fn(lam, fn_name, "east")
+    west_arn = _make_regional_fn(west_lam, fn_name, "west")
+
+    api_id = apigw.create_api(Name="regional-lambda-api", ProtocolType="HTTP")["ApiId"]
+    integ = apigw.create_integration(
+        ApiId=api_id,
+        IntegrationType="AWS_PROXY",
+        IntegrationUri=_wrapped_uri(west_arn),
+        IntegrationMethod="POST",
+    )
+    apigw.create_route(ApiId=api_id, RouteKey="GET /hello", Target=f"integrations/{integ['IntegrationId']}")
+    apigw.create_stage(ApiId=api_id, StageName="$default", AutoDeploy=True)
+
+    req = urllib.request.Request(f"http://{api_id}.execute-api.localhost:{_EXECUTE_PORT}/hello")
+    req.add_header("Host", f"{api_id}.execute-api.localhost:{_EXECUTE_PORT}")
+    resp = urllib.request.urlopen(req, timeout=30)
+
+    assert resp.status == 200
+    body = resp.read().decode()
+    assert body.startswith("west:")
+    assert ":us-west-2:" in body
+
+
+def test_apigwv1_lambda_integration_uses_function_arn_region(apigw_v1, lam):
+    import urllib.request
+
+    west_lam = _lambda_client("us-west-2")
+    fn_name = f"apigwv1-region-{uuid.uuid4().hex[:6]}"
+    _make_regional_fn(lam, fn_name, "east")
+    west_arn = _make_regional_fn(west_lam, fn_name, "west")
+
+    api_id = apigw_v1.create_rest_api(name="regional-v1-api")["id"]
+    root = apigw_v1.get_resources(restApiId=api_id)["items"][0]["id"]
+    res_id = apigw_v1.create_resource(restApiId=api_id, parentId=root, pathPart="hello")["id"]
+    apigw_v1.put_method(
+        restApiId=api_id,
+        resourceId=res_id,
+        httpMethod="GET",
+        authorizationType="NONE",
+    )
+    apigw_v1.put_integration(
+        restApiId=api_id,
+        resourceId=res_id,
+        httpMethod="GET",
+        type="AWS_PROXY",
+        integrationHttpMethod="POST",
+        uri=_wrapped_uri(west_arn),
+    )
+    apigw_v1.create_deployment(restApiId=api_id, stageName="prod")
+
+    url = f"http://localhost:{_EXECUTE_PORT}/restapis/{api_id}/prod/_user_request_/hello"
+    resp = urllib.request.urlopen(url, timeout=30)
+
+    assert resp.status == 200
+    body = resp.read().decode()
+    assert body.startswith("west:")
+    assert ":us-west-2:" in body
 
 
 def test_apigwv2_integration_wrapped_function_arn(apigw, lam):

--- a/tests/test_lambda.py
+++ b/tests/test_lambda.py
@@ -1,3 +1,4 @@
+import asyncio
 import io
 import json
 import os
@@ -3263,6 +3264,115 @@ def test_lambda_update_esm_rejects_unresolved_function_arn():
         lsvc._functions._data.update(original_functions)
         lsvc._esms.clear()
         lsvc._esms._data.update(original_esms)
+        set_request_account_id(original_account)
+        set_request_region(original_region)
+
+
+def _install_region_scoped_lambda(function_name, region, account_id="000000000000"):
+    function_arn = f"arn:aws:lambda:{region}:{account_id}:function:{function_name}"
+    config = {
+        "FunctionName": function_name,
+        "FunctionArn": function_arn,
+        "Runtime": "python3.12",
+        "Handler": "index.handler",
+        "Timeout": 3,
+        "MemorySize": 128,
+        "CodeSha256": "test",
+    }
+    func = {
+        "config": config,
+        "versions": {},
+        "aliases": {},
+    }
+    lsvc._functions.set_scoped(account_id, region, function_name, func)
+    return function_arn
+
+
+def _remove_region_scoped_lambda(function_name, region, account_id="000000000000"):
+    lsvc._functions.pop_scoped(account_id, region, function_name, None)
+
+
+def test_apigatewayv2_plain_lambda_name_uses_api_owner_region(monkeypatch):
+    """HTTP API plain-name integrations resolve in the API's owning Region."""
+    from ministack.services import apigateway as _apigw
+
+    account_id = "000000000000"
+    region = "us-west-2"
+    function_name = f"apigw-v2-plain-region-{_uuid_mod.uuid4().hex}"
+    expected_arn = _install_region_scoped_lambda(function_name, region, account_id)
+    original_account = get_account_id()
+    original_region = get_region()
+    captured = {}
+
+    def _fake_execute(exec_record, event):
+        captured["arn"] = exec_record["config"]["FunctionArn"]
+        return {"body": {"statusCode": 207, "headers": {}, "body": "v2-ok"}}
+
+    monkeypatch.setattr(lsvc, "_execute_function_with_config_scope", _fake_execute)
+    set_request_account_id(account_id)
+    set_request_region("us-east-1")
+    try:
+        status, _headers, body = asyncio.run(_apigw._invoke_lambda_proxy(
+            {"integrationUri": function_name},
+            "api123",
+            "$default",
+            "/test",
+            "GET",
+            {},
+            b"",
+            {},
+            owner_account_id=account_id,
+            owner_region=region,
+        ))
+        assert status == 207
+        assert body == b"v2-ok"
+        assert captured["arn"] == expected_arn
+    finally:
+        _remove_region_scoped_lambda(function_name, region, account_id)
+        set_request_account_id(original_account)
+        set_request_region(original_region)
+
+
+def test_apigatewayv1_plain_lambda_name_uses_api_owner_region(monkeypatch):
+    """REST API plain-name integrations resolve in the API's owning Region."""
+    from ministack.services import apigateway_v1 as _apigw_v1
+
+    account_id = "000000000000"
+    region = "us-west-2"
+    function_name = f"apigw-v1-plain-region-{_uuid_mod.uuid4().hex}"
+    expected_arn = _install_region_scoped_lambda(function_name, region, account_id)
+    original_account = get_account_id()
+    original_region = get_region()
+    captured = {}
+
+    def _fake_execute(exec_record, event):
+        captured["arn"] = exec_record["config"]["FunctionArn"]
+        return {"body": {"statusCode": 208, "headers": {}, "body": "v1-ok"}}
+
+    monkeypatch.setattr(lsvc, "_execute_function_with_config_scope", _fake_execute)
+    set_request_account_id(account_id)
+    set_request_region("us-east-1")
+    try:
+        status, _headers, body = asyncio.run(_apigw_v1._invoke_lambda_proxy_v1(
+            {"uri": function_name},
+            "rest123",
+            "prod",
+            {"variables": {}},
+            {"id": "resource123", "path": "/test"},
+            "/test",
+            "GET",
+            {},
+            b"",
+            {},
+            {},
+            owner_account_id=account_id,
+            owner_region=region,
+        ))
+        assert status == 208
+        assert body == b"v1-ok"
+        assert captured["arn"] == expected_arn
+    finally:
+        _remove_region_scoped_lambda(function_name, region, account_id)
         set_request_account_id(original_account)
         set_request_region(original_region)
 


### PR DESCRIPTION
## Summary

This PR scopes API Gateway Lambda integration lookup and execution to the owning API or target Lambda region on the `feat/multi-region` branch.

Changes include:
- Resolve API Gateway v2 and v1 plain-name Lambda integrations in the API owner's account+region context.
- Preserve ARN-qualified Lambda integration behavior by executing against the ARN function's account+region context.
- Apply the same region-aware lookup to WebSocket Lambda integrations.
- Keep CloudFormation API Gateway integration provisioning aligned with the scoped Lambda lookup behavior.
- Add regression coverage for API Gateway v1, API Gateway v2, WebSocket, and Lambda integration region behavior.

## Testing

- `.venv/bin/ruff check ministack/services/apigateway.py ministack/services/apigateway_v1.py ministack/services/cloudformation/provisioners.py tests/test_apigatewayv2.py tests/test_lambda.py`
- `AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test AWS_DEFAULT_REGION=us-east-1 MINISTACK_ENDPOINT=http://localhost:4566 .venv/bin/pytest -q tests/test_apigatewayv2.py tests/test_apigatewayv1.py tests/test_lambda.py`
  - `335 passed, 1 skipped, 1 warning`
