### PR TITLE
Scope ALB Lambda region lookup

### DIFF
--- a/ministack/services/alb.py
+++ b/ministack/services/alb.py
@@ -28,6 +28,7 @@ import string
 import time
 from urllib.parse import parse_qs
 
+from ministack.core.arn import ArnParseError, parse_arn
 from ministack.core.persistence import PERSIST_STATE, load_state
 from ministack.core.responses import AccountScopedDict, get_account_id, get_region, new_uuid
 
@@ -1016,23 +1017,34 @@ async def _forward_to_tg(tg_arn, method, path, headers, body, query_params):
     target_type = tg.get("TargetType", "instance")
 
     if target_type == "lambda":
-        func_ref = registered[0]["Id"]
-        return await _invoke_lambda_target(func_ref, tg_arn, method, path,
+        func_id = registered[0]["Id"]
+        return await _invoke_lambda_target(func_id, tg_arn, method, path,
                                            headers, body, query_params)
 
     return (502, {"Content-Type": "application/json"},
             json.dumps({"message": f"Target type '{target_type}' not supported."}).encode())
 
 
-async def _invoke_lambda_target(func_ref, tg_arn, method, path, headers, body, query_params):
+async def _invoke_lambda_target(function_ref, tg_arn, method, path, headers, body, query_params):
     try:
         from ministack.services import lambda_svc
     except ImportError:
         return (502, {"Content-Type": "application/json"},
                 json.dumps({"message": "Lambda service unavailable"}).encode())
 
-    func_data, func_config, func_name = lambda_svc._get_func_record_for_ref(func_ref)
-    if func_data is None:
+    try:
+        tg_spec = parse_arn(tg_arn)
+    except ArnParseError:
+        tg_spec = None
+    owner_account_id = tg_spec.account_id if tg_spec else get_account_id()
+    owner_region = tg_spec.region if tg_spec else get_region()
+
+    func, config, func_name = lambda_svc._get_func_record_for_ref_in_scope(
+        function_ref,
+        account_id=owner_account_id,
+        region=owner_region,
+    )
+    if not func or not config:
         return (502, {"Content-Type": "application/json"},
                 json.dumps({"message": f"Lambda function '{func_name}' not found"}).encode())
 
@@ -1060,18 +1072,23 @@ async def _invoke_lambda_target(func_ref, tg_arn, method, path, headers, body, q
         "isBase64Encoded": is_b64,
     }
 
-    exec_record = lambda_svc._execution_record_for_config(func_data, func_config)
-    started = time.time()
-    exec_result = await asyncio.to_thread(lambda_svc._execute_function, exec_record, event)
-    duration_ms = (time.time() - started) * 1000.0
-    lambda_svc._run_with_function_config_scope(
-        func_config,
-        lambda_svc._emit_lambda_metrics,
-        func_name,
-        duration_ms=duration_ms,
-        error=bool(exec_result.get("error")),
-        throttle=bool(exec_result.get("throttle")),
-    )
+    exec_record = lambda_svc._execution_record_for_config(func, config)
+
+    def _invoke_and_record_metrics():
+        started = time.time()
+        invocation_result = lambda_svc._execute_function_with_config_scope(exec_record, event)
+        duration_ms = (time.time() - started) * 1000.0
+        lambda_svc._run_with_function_config_scope(
+            config,
+            lambda_svc._emit_lambda_metrics,
+            func_name,
+            duration_ms=duration_ms,
+            error=bool(invocation_result.get("error")),
+            throttle=bool(invocation_result.get("throttle")),
+        )
+        return invocation_result
+
+    exec_result = await asyncio.to_thread(_invoke_and_record_metrics)
     lambda_response, _err = lambda_svc.lambda_execute_result_to_api_proxy_response(exec_result)
 
     if exec_result.get("error"):

--- a/tests/test_alb.py
+++ b/tests/test_alb.py
@@ -374,10 +374,12 @@ def _alb_teardown(elbv2, lam, lb_arn, tg_arn, l_arn, fn_name):
     except Exception:
         pass
 
-def test_elbv2_dataplane_forward_lambda(elbv2, lam):
+@pytest.mark.serial
+def test_elbv2_dataplane_forward_lambda(elbv2, lam, cw):
     """ALB forwards request to Lambda via /_alb/{lb-name}/ path prefix."""
     import urllib.request as _req
 
+    fn_name = "dp-alb-fwd-fn"
     fn_code = (
         "import json\n"
         "def handler(event, context):\n"
@@ -387,7 +389,7 @@ def test_elbv2_dataplane_forward_lambda(elbv2, lam):
         "        'body': json.dumps({'method': event['httpMethod'], 'path': event['path']}),\n"
         "    }\n"
     )
-    lb_arn, tg_arn, l_arn, fn_arn = _alb_setup(elbv2, lam, "dp-alb-fwd", "dp-alb-fwd-fn", fn_code)
+    lb_arn, tg_arn, l_arn, fn_arn = _alb_setup(elbv2, lam, "dp-alb-fwd", fn_name, fn_code)
     try:
         url = f"{_endpoint}/_alb/dp-alb-fwd/api/hello"
         resp = _req.urlopen(_req.Request(url, method="GET"))
@@ -395,8 +397,22 @@ def test_elbv2_dataplane_forward_lambda(elbv2, lam):
         body = json.loads(resp.read())
         assert body["method"] == "GET"
         assert body["path"] == "/api/hello"
+
+        end = time.time() + 60
+        start = end - 600
+        invocations = cw.get_metric_statistics(
+            Namespace="AWS/Lambda",
+            MetricName="Invocations",
+            Dimensions=[{"Name": "FunctionName", "Value": fn_name}],
+            StartTime=start,
+            EndTime=end,
+            Period=60,
+            Statistics=["Sum"],
+        )
+        total = sum(p["Sum"] for p in invocations["Datapoints"])
+        assert total >= 1, f"expected ALB Lambda target to emit metrics, got {total}"
     finally:
-        _alb_teardown(elbv2, lam, lb_arn, tg_arn, l_arn, "dp-alb-fwd-fn")
+        _alb_teardown(elbv2, lam, lb_arn, tg_arn, l_arn, fn_name)
 
 
 @pytest.mark.serial

--- a/tests/test_lambda.py
+++ b/tests/test_lambda.py
@@ -3377,6 +3377,81 @@ def test_apigatewayv1_plain_lambda_name_uses_api_owner_region(monkeypatch):
         set_request_region(original_region)
 
 
+def test_alb_plain_lambda_target_uses_target_group_region(monkeypatch):
+    """ALB Lambda target names resolve in the target group's owning Region."""
+    from ministack.services import alb as _alb
+
+    account_id = "000000000000"
+    region = "us-west-2"
+    function_name = f"alb-plain-region-{_uuid_mod.uuid4().hex}"
+    expected_arn = _install_region_scoped_lambda(function_name, region, account_id)
+    target_group_arn = f"arn:aws:elasticloadbalancing:{region}:{account_id}:targetgroup/test/abc123"
+    original_account = get_account_id()
+    original_region = get_region()
+    captured = {}
+
+    def _fake_execute(exec_record, event):
+        captured["arn"] = exec_record["config"]["FunctionArn"]
+        return {"body": {"statusCode": 209, "headers": {}, "body": "alb-ok"}}
+
+    monkeypatch.setattr(lsvc, "_execute_function_with_config_scope", _fake_execute)
+    monkeypatch.setattr(lsvc, "_emit_lambda_metrics", lambda *args, **kwargs: None)
+    set_request_account_id(account_id)
+    set_request_region("us-east-1")
+    try:
+        status, _headers, body = asyncio.run(_alb._invoke_lambda_target(
+            function_name,
+            target_group_arn,
+            "GET",
+            "/test",
+            {},
+            b"",
+            {},
+        ))
+        assert status == 209
+        assert body == b"alb-ok"
+        assert captured["arn"] == expected_arn
+    finally:
+        _remove_region_scoped_lambda(function_name, region, account_id)
+        set_request_account_id(original_account)
+        set_request_region(original_region)
+
+
+def test_alb_lambda_target_preserves_plain_json_payload(monkeypatch):
+    """ALB Lambda targets keep non-proxy JSON returns as response bodies."""
+    from ministack.services import alb as _alb
+
+    account_id = "000000000000"
+    region = "us-west-2"
+    function_name = f"alb-json-payload-{_uuid_mod.uuid4().hex}"
+    _install_region_scoped_lambda(function_name, region, account_id)
+    target_group_arn = f"arn:aws:elasticloadbalancing:{region}:{account_id}:targetgroup/test/abc123"
+    original_account = get_account_id()
+    original_region = get_region()
+
+    monkeypatch.setattr(lsvc, "_execute_function_with_config_scope", lambda _exec_record, _event: {"body": {"ok": True}})
+    monkeypatch.setattr(lsvc, "_emit_lambda_metrics", lambda *args, **kwargs: None)
+    set_request_account_id(account_id)
+    set_request_region("us-east-1")
+    try:
+        status, headers, body = asyncio.run(_alb._invoke_lambda_target(
+            function_name,
+            target_group_arn,
+            "GET",
+            "/test",
+            {},
+            b"",
+            {},
+        ))
+        assert status == 200
+        assert headers == {}
+        assert json.loads(body) == {"ok": True}
+    finally:
+        _remove_region_scoped_lambda(function_name, region, account_id)
+        set_request_account_id(original_account)
+        set_request_region(original_region)
+
+
 # ──────────────────────────────── pool key ──────────────────────────────────
 
 def _pool_config(account_id: str, function_name: str = "fn", **overrides):


### PR DESCRIPTION
## Summary

This PR scopes ALB Lambda target lookup and execution to the owning target group or target Lambda region on the `feat/multi-region` branch.

Changes include:
- Resolve ALB plain-name Lambda targets in the target group's account+region context.
- Preserve ARN-qualified Lambda target behavior by executing against the ARN function's account+region context.
- Execute ALB Lambda requests through the Lambda config-aware execution path so logs and metrics are emitted in the function's configured region.
- Add regression coverage for ALB Lambda target region lookup and Lambda region behavior.

## Testing

- `.venv/bin/ruff check ministack/services/alb.py tests/test_alb.py tests/test_lambda.py`
- `AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test AWS_DEFAULT_REGION=us-east-1 MINISTACK_ENDPOINT=http://localhost:4566 .venv/bin/pytest -q tests/test_alb.py tests/test_lambda.py`
  - `197 passed, 1 skipped`
