### PR TITLE
Scope RDS state by region

### DIFF
--- a/ministack/services/rds.py
+++ b/ministack/services/rds.py
@@ -33,6 +33,7 @@ parameters.
 import contextvars
 import copy
 import datetime
+import hashlib
 import json
 import logging
 import os
@@ -44,7 +45,14 @@ from xml.sax.saxutils import escape as _esc
 
 from ministack.core.arn import ArnParseError, parse_arn
 from ministack.core.persistence import load_state
-from ministack.core.responses import AccountScopedDict, apply_image_prefix, get_account_id, get_region, new_uuid
+from ministack.core.responses import (
+    AccountRegionScopedDict,
+    AccountScopedDict,
+    apply_image_prefix,
+    get_account_id,
+    get_region,
+    new_uuid,
+)
 
 logger = logging.getLogger("rds")
 
@@ -54,14 +62,14 @@ RDS_TMPFS_SIZE = os.environ.get("RDS_TMPFS_SIZE", "256m")
 RDS_PERSIST = os.environ.get("RDS_PERSIST", "0").lower() in ("1", "true", "yes")
 DOCKER_NETWORK = os.environ.get("DOCKER_NETWORK", "")
 
-_instances = AccountScopedDict()
-_clusters = AccountScopedDict()
-_subnet_groups = AccountScopedDict()
-_param_groups = AccountScopedDict()
-_snapshots = AccountScopedDict()
-_db_cluster_param_groups = AccountScopedDict()
-_db_cluster_snapshots = AccountScopedDict()
-_option_groups = AccountScopedDict()
+_instances = AccountRegionScopedDict()
+_clusters = AccountRegionScopedDict()
+_subnet_groups = AccountRegionScopedDict()
+_param_groups = AccountRegionScopedDict()
+_snapshots = AccountRegionScopedDict()
+_db_cluster_param_groups = AccountRegionScopedDict()
+_db_cluster_snapshots = AccountRegionScopedDict()
+_option_groups = AccountRegionScopedDict()
 _global_clusters = AccountScopedDict()
 _tags = AccountScopedDict()
 _port_counter = [BASE_PORT]
@@ -109,20 +117,38 @@ def restore_state(data):
         _port_counter[0] = data["port_counter"]
     instances_data = data.get("instances", {})
     to_respawn = []
-    if isinstance(instances_data, AccountScopedDict):
-        # New format: AccountScopedDict with full multi-account data
+    if isinstance(instances_data, AccountRegionScopedDict):
         for key, inst in list(instances_data._data.items()):
+            account_id, region, instance_id = key
             inst["_docker_container_id"] = None
             inst["DBInstanceStatus"] = "creating"
+            if RDS_PERSIST:
+                inst.setdefault("_docker_volume_name", _rds_docker_volume_name(instance_id, account_id, region))
             _instances._data[key] = inst
-            to_respawn.append((key[0], inst.get("DBInstanceIdentifier") or key[1], inst))
+            to_respawn.append((account_id, region, instance_id, inst))
+    elif isinstance(instances_data, AccountScopedDict):
+        # Legacy account-scoped format: preserve the instance ARN region when available.
+        for key, inst in list(instances_data._data.items()):
+            account_id, instance_id = key
+            inst["_docker_container_id"] = None
+            inst["DBInstanceStatus"] = "creating"
+            region = _best_effort_region_from_record_arn(inst, "DBInstanceArn")
+            if RDS_PERSIST:
+                inst.setdefault("_docker_volume_name", _legacy_rds_docker_volume_name(instance_id))
+                inst["_legacy_docker_container_name"] = _legacy_rds_docker_name(instance_id)
+            _instances._data[(account_id, region, instance_id)] = inst
+            to_respawn.append((account_id, region, inst.get("DBInstanceIdentifier") or instance_id, inst))
     else:
         # Legacy format: plain dict keyed by instance name
         for name, inst in instances_data.items():
             inst["_docker_container_id"] = None
             inst["DBInstanceStatus"] = "creating"
-            _instances[name] = inst
-            to_respawn.append((None, name, inst))
+            region = _best_effort_region_from_record_arn(inst, "DBInstanceArn")
+            if RDS_PERSIST:
+                inst.setdefault("_docker_volume_name", _legacy_rds_docker_volume_name(name))
+                inst["_legacy_docker_container_name"] = _legacy_rds_docker_name(name)
+            _instances.set_scoped(get_account_id(), region, name, inst)
+            to_respawn.append((None, region, name, inst))
 
     # Re-spin backing containers for persisted instances. Mirrors the MWAA
     # restore pattern: persistence saves the instance metadata but the Docker
@@ -130,16 +156,54 @@ def restore_state(data):
     # to bring it back. Without this, restored instances stay marked
     # "available" with no running container, and StartDBInstance is
     # metadata-only so it can't recover them either.
-    from ministack.core.responses import _request_account_id
-    for account_id, db_id, inst in to_respawn:
+    from ministack.core.responses import _request_account_id, _request_region
+    for account_id, region, db_id, inst in to_respawn:
         ctx = contextvars.copy_context()
 
-        def _runner(account_id=account_id, db_id=db_id, inst=inst):
+        def _runner(account_id=account_id, region=region, db_id=db_id, inst=inst):
             if account_id is not None:
                 _request_account_id.set(account_id)
+            if region is not None:
+                _request_region.set(region)
             _start_rds_container_for_instance(db_id, inst)
 
         threading.Thread(target=ctx.run, args=(_runner,), daemon=True).start()
+
+
+def _best_effort_region_from_record_arn(record, field):
+    """Return a region while restoring legacy RDS state.
+
+    This is intentionally best-effort persistence migration logic, not request
+    validation.
+    """
+    arn = record.get(field, "") if isinstance(record, dict) else ""
+    try:
+        region = parse_arn(arn).region
+    except ArnParseError:
+        return get_region()
+    return region or get_region()
+
+
+def _rds_docker_scope(account_id=None, region=None):
+    account_id = account_id or get_account_id()
+    region = region or get_region()
+    return hashlib.sha1(f"{account_id}:{region}".encode()).hexdigest()[:12]
+
+
+def _rds_docker_name(db_id, account_id=None, region=None):
+    return f"ministack-rds-{_rds_docker_scope(account_id, region)}-{db_id}"
+
+
+def _rds_docker_volume_name(db_id, account_id=None, region=None):
+    return f"ministack-rds-{_rds_docker_scope(account_id, region)}-{db_id}-data"
+
+
+def _legacy_rds_docker_name(db_id):
+    return f"ministack-rds-{db_id}"
+
+
+def _legacy_rds_docker_volume_name(db_id):
+    return f"ministack-rds-{db_id}-data"
 
 
 def _start_rds_container_for_instance(db_id, instance):
@@ -147,9 +211,9 @@ def _start_rds_container_for_instance(db_id, instance):
 
     Reads engine, credentials, and endpoint info from the persisted instance
     dict instead of CreateDBInstance request params. If a container with the
-    deterministic name ``ministack-rds-{db_id}`` already exists (e.g. host
-    rebooted but Docker preserved stopped containers), it is removed first so
-    a clean run can attach to the persistent named volume. Sets
+    deterministic account+Region scoped name already exists (e.g. host rebooted
+    but Docker preserved stopped containers), it is removed first so a clean run
+    can attach to the persistent named volume. Sets
     ``DBInstanceStatus`` to ``available`` on success, ``failed`` on Docker
     error.
     """
@@ -189,32 +253,37 @@ def _start_rds_container_for_instance(db_id, instance):
         instance["DBInstanceStatus"] = "available"
         return
 
-    container_name = f"ministack-rds-{db_id}"
-    try:
-        existing = docker_client.containers.get(container_name)
-        # `force=True` stops AND removes in one shot, including
-        # half-spawned "Created" containers that didn't fully start
-        # — those still hold port mappings and would collide with
-        # the next `containers.run` (#692 follow-up: doodaz saw
-        # a `Created` container blocking the bind).
+    container_name = _rds_docker_name(db_id)
+    stale_names = [container_name]
+    legacy_container_name = instance.pop("_legacy_docker_container_name", None)
+    if legacy_container_name and legacy_container_name != container_name:
+        stale_names.append(legacy_container_name)
+    for stale_name in stale_names:
         try:
-            existing.remove(force=True, v=False)
-        except Exception as e:
-            logger.warning("RDS: failed to remove stale container %s: %s",
-                           container_name, e)
-        # Verify the name is actually free now; if removal silently
-        # failed, abort respawn rather than crash inside `containers.run`
-        # with a confusing name-conflict error.
-        try:
-            docker_client.containers.get(container_name)
-            logger.warning("RDS: stale container %s still present after "
-                           "force-remove — aborting respawn", container_name)
-            instance["DBInstanceStatus"] = "failed"
-            return
+            existing = docker_client.containers.get(stale_name)
+            # `force=True` stops AND removes in one shot, including
+            # half-spawned "Created" containers that didn't fully start
+            # — those still hold port mappings and would collide with
+            # the next `containers.run` (#692 follow-up: doodaz saw
+            # a `Created` container blocking the bind).
+            try:
+                existing.remove(force=True, v=False)
+            except Exception as e:
+                logger.warning("RDS: failed to remove stale container %s: %s",
+                               stale_name, e)
+            # Verify the name is actually free now; if removal silently
+            # failed, abort respawn rather than crash inside `containers.run`
+            # with a confusing name-conflict error.
+            try:
+                docker_client.containers.get(stale_name)
+                logger.warning("RDS: stale container %s still present after "
+                               "force-remove — aborting respawn", stale_name)
+                instance["DBInstanceStatus"] = "failed"
+                return
+            except Exception:
+                pass  # Good — name is gone.
         except Exception:
-            pass  # Good — name is gone.
-    except Exception:
-        pass  # No existing container with that name — fine
+            pass  # No existing container with that name — fine
 
     ms_network = _get_ministack_network(docker_client)
     container_kwargs = dict(
@@ -222,13 +291,20 @@ def _start_rds_container_for_instance(db_id, instance):
         environment=env_vars,
         ports={f"{container_port}/tcp": host_port},
         name=container_name,
-        labels={"ministack": "rds", "db_id": db_id},
+        labels={
+            "ministack": "rds",
+            "db_id": db_id,
+            "account_id": get_account_id(),
+            "region": get_region(),
+        },
     )
     if ms_network:
         container_kwargs["network"] = ms_network
     if RDS_PERSIST:
+        volume_name = instance.get("_docker_volume_name") or _rds_docker_volume_name(db_id)
+        instance["_docker_volume_name"] = volume_name
         container_kwargs["volumes"] = {
-            f"ministack-rds-{db_id}-data": {"bind": data_path, "mode": "rw"},
+            volume_name: {"bind": data_path, "mode": "rw"},
         }
     else:
         container_kwargs["tmpfs"] = {
@@ -590,6 +666,32 @@ def _parse_rds_arn(value):
     return spec, resource_type, resource_id
 
 
+def _regional_get(store, identifier, resource_type):
+    parsed = _parse_rds_arn(identifier)
+    if parsed:
+        spec, parsed_type, resource_id = parsed
+        if parsed_type != resource_type:
+            return None
+        if spec.account_id != get_account_id():
+            return None
+        return store.get_scoped(spec.account_id, spec.region, resource_id)
+    return store.get(identifier)
+
+
+def _request_region_get(store, identifier, resource_type):
+    parsed = _parse_rds_arn(identifier)
+    if parsed:
+        spec, parsed_type, resource_id = parsed
+        if parsed_type != resource_type:
+            return None
+        if spec.account_id != get_account_id():
+            return None
+        if spec.region != get_region():
+            return None
+        return store.get(resource_id)
+    return store.get(identifier)
+
+
 def _request_region_identifier(identifier, resource_type, store=None, arn_key=None):
     resource_id = _request_region_resource_identifier(identifier, resource_type)
     if resource_id is None:
@@ -689,9 +791,19 @@ def _resource_not_found_error_for_arn(identifier):
 
 
 def _resolve_cluster(cluster_id):
-    """Look up a DB cluster by identifier or same-region ARN."""
-    cluster_id = _request_region_identifier(cluster_id, "cluster", _clusters, "DBClusterArn")
-    return _clusters.get(cluster_id) if cluster_id is not None else None
+    """Look up a DB cluster by identifier in the request Region or by ARN Region.
+
+    Use this only for data-plane or global-topology operations whose AWS
+    semantics intentionally follow same-account member ARNs across Regions.
+    Normal regional control-plane APIs should use
+    ``_resolve_cluster_in_request_region``.
+    """
+    return _regional_get(_clusters, cluster_id, "cluster")
+
+
+def _resolve_cluster_in_request_region(cluster_id):
+    """Look up a DB cluster only in the request Region."""
+    return _request_region_get(_clusters, cluster_id, "cluster")
 
 
 def _resolve_instance(db_id):
@@ -700,8 +812,7 @@ def _resolve_instance(db_id):
     AWS accepts either value for the DBInstanceIdentifier parameter in
     DescribeDBInstances and related APIs.
     """
-    db_id = _request_region_identifier(db_id, "db", _instances, "DBInstanceArn")
-    inst = _instances.get(db_id)
+    inst = _request_region_get(_instances, db_id, "db")
     if inst:
         return inst
     if isinstance(db_id, str) and db_id.startswith("db-"):
@@ -736,7 +847,7 @@ def _register_instance_in_cluster(instance):
     cid = instance.get("DBClusterIdentifier")
     if not cid:
         return
-    cluster = _clusters.get(cid)
+    cluster = _resolve_cluster_in_request_region(cid)
     if not cluster:
         return
     members = cluster.setdefault("DBClusterMembers", [])
@@ -783,7 +894,7 @@ def _create_db_instance(p):
 
     # Inherit credentials from cluster when instance is a cluster member.
     cluster_id_param = _p(p, "DBClusterIdentifier")
-    parent = _resolve_cluster(cluster_id_param) if cluster_id_param else None
+    parent = _resolve_cluster_in_request_region(cluster_id_param) if cluster_id_param else None
     if parent:
         cluster_id_param = parent["DBClusterIdentifier"]
         if not _p(p, "MasterUsername"):
@@ -809,6 +920,7 @@ def _create_db_instance(p):
     endpoint_port = port
     host_port = None
     docker_container_id = None
+    docker_volume_name = None
     internal_host = None
     internal_port = None
     real_container_started = False
@@ -833,8 +945,13 @@ def _create_db_instance(p):
                     image=image, detach=True,
                     environment=env,
                     ports={f"{container_port}/tcp": host_port},
-                    name=f"ministack-rds-{db_id}",
-                    labels={"ministack": "rds", "db_id": db_id},
+                    name=_rds_docker_name(db_id),
+                    labels={
+                        "ministack": "rds",
+                        "db_id": db_id,
+                        "account_id": get_account_id(),
+                        "region": get_region(),
+                    },
                 )
                 if ms_network:
                     container_kwargs["network"] = ms_network
@@ -843,8 +960,9 @@ def _create_db_instance(p):
                 # is harmless but wasteful and complicates the Postgres 18+
                 # layout change (where the path differs from earlier majors).
                 if RDS_PERSIST:
+                    docker_volume_name = _rds_docker_volume_name(db_id)
                     container_kwargs["volumes"] = {
-                        f"ministack-rds-{db_id}-data": {"bind": data_path, "mode": "rw"},
+                        docker_volume_name: {"bind": data_path, "mode": "rw"},
                     }
                 else:
                     container_kwargs["tmpfs"] = {
@@ -980,6 +1098,7 @@ def _create_db_instance(p):
         "IsStorageConfigUpgradeAvailable": False,
         "MultiTenant": False,
         "_docker_container_id": docker_container_id,
+        "_docker_volume_name": docker_volume_name,
         "_internal_address": internal_host,
         "_internal_port": internal_port,
         "_MasterUserPassword": master_pass,
@@ -1502,7 +1621,7 @@ def _create_db_cluster(p):
 
 def _delete_db_cluster(p):
     cluster_id = _p(p, "DBClusterIdentifier")
-    cluster = _resolve_cluster(cluster_id)
+    cluster = _resolve_cluster_in_request_region(cluster_id)
     if not cluster:
         wrong_region = _invalid_cluster_identifier_error(cluster_id)
         if wrong_region:
@@ -1528,7 +1647,7 @@ def _delete_db_cluster(p):
 def _describe_db_clusters(p):
     cluster_id = _p(p, "DBClusterIdentifier")
     if cluster_id:
-        cluster = _resolve_cluster(cluster_id)
+        cluster = _resolve_cluster_in_request_region(cluster_id)
         if not cluster:
             wrong_region = _invalid_region_arn_error(cluster_id, "DBClusterIdentifier")
             if wrong_region:
@@ -1582,7 +1701,7 @@ def _rotate_real_password(cluster, old_pass, new_pass):
 
 def _modify_db_cluster(p):
     cluster_id = _p(p, "DBClusterIdentifier")
-    cluster = _resolve_cluster(cluster_id)
+    cluster = _resolve_cluster_in_request_region(cluster_id)
     if not cluster:
         wrong_region = _invalid_cluster_identifier_error(cluster_id)
         if wrong_region:
@@ -2132,7 +2251,7 @@ def _create_db_cluster_snapshot(p):
         return _error("DBClusterSnapshotAlreadyExistsFault",
             f"DB cluster snapshot {snap_id} already exists.", 400)
 
-    cluster = _resolve_cluster(cluster_id)
+    cluster = _resolve_cluster_in_request_region(cluster_id)
     if not cluster:
         wrong_region = _invalid_region_arn_error(cluster_id, "DBClusterIdentifier")
         if wrong_region:
@@ -2252,7 +2371,7 @@ def _modify_subnet_group(p):
 
 def _start_db_cluster(p):
     cluster_id = _p(p, "DBClusterIdentifier")
-    cluster = _resolve_cluster(cluster_id)
+    cluster = _resolve_cluster_in_request_region(cluster_id)
     if not cluster:
         wrong_region = _invalid_cluster_identifier_error(cluster_id)
         if wrong_region:
@@ -2265,7 +2384,7 @@ def _start_db_cluster(p):
 
 def _stop_db_cluster(p):
     cluster_id = _p(p, "DBClusterIdentifier")
-    cluster = _resolve_cluster(cluster_id)
+    cluster = _resolve_cluster_in_request_region(cluster_id)
     if not cluster:
         wrong_region = _invalid_cluster_identifier_error(cluster_id)
         if wrong_region:
@@ -2499,7 +2618,7 @@ def _create_global_cluster(p):
 
     source_cluster = None
     if source_cluster_id:
-        source_cluster = _resolve_cluster(source_cluster_id)
+        source_cluster = _resolve_cluster_in_request_region(source_cluster_id)
         if not source_cluster:
             wrong_region = _invalid_region_arn_error(
                 source_cluster_id,
@@ -3403,7 +3522,7 @@ _ACTION_MAP = {
 def reset():
     docker_client = _get_docker()
     if docker_client:
-        for instance in _instances.values():
+        for instance in _instances.all_values():
             cid = instance.get("_docker_container_id")
             if cid:
                 try:

--- a/ministack/services/rds_data.py
+++ b/ministack/services/rds_data.py
@@ -11,7 +11,7 @@ import threading
 import uuid
 
 from ministack.core.arn import ArnParseError, parse_arn
-from ministack.core.responses import AccountScopedDict, error_response_json, json_response
+from ministack.core.responses import AccountScopedDict, error_response_json, get_account_id, json_response
 
 logger = logging.getLogger("rds-data")
 
@@ -69,17 +69,14 @@ def _stub_success():
 
 
 def _cluster_id_from_arn(resource_arn):
-    """Extract cluster identifier from an ARN."""
+    """Return a stable, region-qualified key for per-cluster stub state."""
     try:
         spec = parse_arn(resource_arn)
     except ArnParseError:
         return resource_arn
-    if spec.service != "rds":
-        return resource_arn
-    _resource_type, sep, resource_id = spec.resource.partition(":")
-    if not sep:
-        return resource_arn
-    return resource_id
+    if spec.service == "rds":
+        return f"{spec.account_id}:{spec.region}:{spec.resource}"
+    return resource_arn
 
 
 _CREATE_DB_RE = re.compile(
@@ -233,9 +230,11 @@ def _resolve_cluster(resource_arn):
     if not parsed:
         return None, None
 
-    _spec, resource_type, _resource_id = parsed
+    spec, resource_type, resource_id = parsed
     if resource_type == "db":
-        instance = rds._resolve_instance(resource_arn)
+        if spec.account_id != get_account_id():
+            return None, None
+        instance = rds._instances.get_scoped(spec.account_id, spec.region, resource_id)
         if instance:
             return instance, instance.get("Engine", "postgres")
         return None, None
@@ -251,7 +250,7 @@ def _resolve_cluster(resource_arn):
     cluster_id = cluster["DBClusterIdentifier"]
 
     # Find an instance belonging to this cluster
-    for inst in rds._instances.values():
+    for inst in rds._instances.values_scoped(spec.account_id, spec.region):
         if inst.get("DBClusterIdentifier") == cluster_id:
             return inst, engine
 

--- a/tests/test_rds.py
+++ b/tests/test_rds.py
@@ -1478,6 +1478,7 @@ def test_rds_restore_state_respawns_docker_container(monkeypatch):
     running container, and the metadata-only StartDBInstance /
     RebootDBInstance ops can't recover them. Regression test for #692.
     """
+    from ministack.core.responses import get_account_id, get_region
     from ministack.services import rds as m
 
     runs = []
@@ -1533,12 +1534,17 @@ def test_rds_restore_state_respawns_docker_container(monkeypatch):
         time.sleep(0.05)
 
     assert runs, "restore_state did not respawn the Docker container"
-    assert runs[0]["name"] == f"ministack-rds-{db_id}"
+    assert runs[0]["name"] == m._rds_docker_name(db_id)
     assert runs[0]["image"].endswith("postgres:16-alpine")
     assert runs[0]["environment"]["POSTGRES_USER"] == "admin"
     assert runs[0]["environment"]["POSTGRES_PASSWORD"] == "password123"
     assert runs[0]["environment"]["POSTGRES_DB"] == "mydb"
-    assert runs[0]["labels"] == {"ministack": "rds", "db_id": db_id}
+    assert runs[0]["labels"] == {
+        "ministack": "rds",
+        "db_id": db_id,
+        "account_id": get_account_id(),
+        "region": get_region(),
+    }
 
     restored = m._instances.get(db_id)
     assert restored is not None
@@ -1569,7 +1575,8 @@ def test_rds_restore_state_removes_stale_container_before_respawn(monkeypatch):
         def remove(self, **kwargs):
             removed.append(self.name)
 
-    stale = FakeContainer(name="ministack-rds-stale-db", container_id="cid-stale")
+    stale_name = m._rds_docker_name("stale-db")
+    stale = FakeContainer(name=stale_name, container_id="cid-stale")
 
     class FakeContainers:
         def get(self, name):
@@ -1577,7 +1584,7 @@ def test_rds_restore_state_removes_stale_container_before_respawn(monkeypatch):
             # called and `removed` is populated, subsequent .get()s for
             # the same name raise "not found" — mirrors real docker after
             # a successful force-remove.
-            if name == "ministack-rds-stale-db" and "ministack-rds-stale-db" not in removed:
+            if name == stale_name and stale_name not in removed:
                 return stale
             raise Exception("not found")
 
@@ -1616,9 +1623,86 @@ def test_rds_restore_state_removes_stale_container_before_respawn(monkeypatch):
     while time.time() < deadline and not runs:
         time.sleep(0.05)
 
-    assert "ministack-rds-stale-db" in removed, "stale container not removed"
+    assert stale_name in removed, "stale container not removed"
     assert runs, "fresh container not spawned after removing stale one"
-    assert runs[0]["name"] == "ministack-rds-stale-db"
+    assert runs[0]["name"] == stale_name
+
+    m._instances.clear()
+
+
+def test_rds_restore_state_preserves_legacy_persistent_volume_name(monkeypatch):
+    from ministack.services import rds as m
+
+    runs = []
+    removed = []
+
+    class FakeContainer:
+        def __init__(self, name):
+            self.id = "cid-fake"
+            self.name = name
+            self.attrs = {"NetworkSettings": {"Networks": {}}}
+
+        def reload(self): pass
+        def stop(self, timeout=2): pass
+        def remove(self, **kwargs):
+            removed.append(self.name)
+
+    class FakeContainers:
+        def __init__(self, legacy_name):
+            self.legacy_name = legacy_name
+
+        def get(self, name):
+            if name == self.legacy_name and name not in removed:
+                return FakeContainer(name)
+            raise Exception("not found")
+
+        def run(self, **kwargs):
+            runs.append(kwargs)
+            return FakeContainer(kwargs["name"])
+
+    class FakeDocker:
+        def __init__(self, legacy_name):
+            self.containers = FakeContainers(legacy_name)
+
+    monkeypatch.setattr(m, "RDS_PERSIST", True)
+    db_id = "legacy-volume-db"
+    legacy_container_name = m._legacy_rds_docker_name(db_id)
+    monkeypatch.setattr(m, "_get_docker", lambda: FakeDocker(legacy_container_name))
+    monkeypatch.setattr(m, "_get_ministack_network", lambda c: None)
+
+    persisted = {
+        "instances": {db_id: {
+            "DBInstanceIdentifier": db_id,
+            "Engine": "postgres",
+            "EngineVersion": "16.3",
+            "MasterUsername": "admin",
+            "_MasterUserPassword": "pw",
+            "DBName": "db",
+            "DBInstanceStatus": "available",
+            "Endpoint": {"Address": "localhost", "Port": 15501, "HostedZoneId": "Z"},
+        }},
+        "clusters": {}, "subnet_groups": {}, "param_groups": {},
+        "snapshots": {}, "db_cluster_param_groups": {},
+        "db_cluster_snapshots": {}, "option_groups": {},
+        "global_clusters": {}, "tags": {}, "port_counter": 15501,
+    }
+
+    m._instances.clear()
+    m.restore_state(persisted)
+
+    deadline = time.time() + 5
+    while time.time() < deadline and not runs:
+        time.sleep(0.05)
+
+    assert runs, "restore_state did not respawn the Docker container"
+    assert legacy_container_name in removed
+    assert runs[0]["volumes"] == {
+        m._legacy_rds_docker_volume_name(db_id): {
+            "bind": "/var/lib/postgresql/data",
+            "mode": "rw",
+        },
+    }
+    assert m._instances[db_id]["_docker_volume_name"] == m._legacy_rds_docker_volume_name(db_id)
 
     m._instances.clear()
 
@@ -1737,7 +1821,8 @@ def test_rds_respawn_falls_back_when_persisted_host_port_taken(monkeypatch):
 
     class FakeContainer:
         def __init__(self, name):
-            self.id = "cid-fake"; self.name = name
+            self.id = "cid-fake"
+            self.name = name
             self.attrs = {"NetworkSettings": {"Networks": {}}}
         def reload(self): pass
         def stop(self, timeout=2): pass
@@ -1814,7 +1899,8 @@ def test_rds_respawn_force_removes_stale_created_container(monkeypatch):
 
     class FakeContainer:
         def __init__(self, name):
-            self.id = "cid-fake"; self.name = name
+            self.id = "cid-fake"
+            self.name = name
             self.attrs = {"NetworkSettings": {"Networks": {}}}
         def reload(self): pass
         def stop(self, timeout=2): pass

--- a/tests/test_rds_data.py
+++ b/tests/test_rds_data.py
@@ -143,31 +143,58 @@ def test_execute_nonexistent_cluster():
     assert "not found" in body.get("message", body.get("Message", "")).lower()
 
 
-def test_execute_rejects_foreign_region_cluster_arn():
-    """ExecuteStatement should not resolve a cluster ARN from another region."""
-    west = _regional_client("rds", "us-west-2")
-    cluster_id = f"rds-data-foreign-region-{uuid.uuid4().hex[:8]}"
+def test_rds_data_resolves_cluster_arn_by_arn_region(rds, sm):
+    east_rds = _regional_client("rds", "us-east-1")
+    west_rds = _regional_client("rds", "us-west-2")
+    east_data = _regional_client("rds-data", "us-east-1")
+    cluster_id = f"rds-data-region-{uuid.uuid4().hex[:8]}"
+    secret_arn = sm.create_secret(
+        Name=f"rds-data-region-secret-{uuid.uuid4().hex[:8]}",
+        SecretString='{"username":"admin","password":"testpass123"}',
+    )["ARN"]
 
     try:
-        cluster = west.create_db_cluster(
+        east_rds.create_db_cluster(
             DBClusterIdentifier=cluster_id,
             Engine="aurora-mysql",
             MasterUsername="admin",
-            MasterUserPassword="password123",
-        )["DBCluster"]
+            MasterUserPassword="testpass123",
+        )
+        west_rds.create_db_cluster(
+            DBClusterIdentifier=cluster_id,
+            Engine="aurora-mysql",
+            MasterUsername="admin",
+            MasterUserPassword="testpass123",
+        )
+        east_arn = east_rds.describe_db_clusters(DBClusterIdentifier=cluster_id)["DBClusters"][0]["DBClusterArn"]
+        west_arn = west_rds.describe_db_clusters(DBClusterIdentifier=cluster_id)["DBClusters"][0]["DBClusterArn"]
 
-        status, body = _raw_post("/Execute", {
-            "resourceArn": cluster["DBClusterArn"],
-            "secretArn": FAKE_SECRET_ARN,
-            "sql": "SELECT 1",
-        })
-        assert status == 400
-        assert "not found" in body.get("message", body.get("Message", "")).lower()
+        east_data.execute_statement(
+            resourceArn=west_arn,
+            secretArn=secret_arn,
+            sql="CREATE DATABASE west_only_db",
+        )
+        east_resp = east_data.execute_statement(
+            resourceArn=east_arn,
+            secretArn=secret_arn,
+            sql="SHOW DATABASES",
+        )
+        west_resp = east_data.execute_statement(
+            resourceArn=west_arn,
+            secretArn=secret_arn,
+            sql="SHOW DATABASES",
+        )
+
+        east_names = [r[0]["stringValue"] for r in east_resp.get("records", [])]
+        west_names = [r[0]["stringValue"] for r in west_resp.get("records", [])]
+        assert "west_only_db" not in east_names
+        assert "west_only_db" in west_names
     finally:
-        try:
-            west.delete_db_cluster(DBClusterIdentifier=cluster_id, SkipFinalSnapshot=True)
-        except ClientError:
-            pass
+        for client in (east_rds, west_rds):
+            try:
+                client.delete_db_cluster(DBClusterIdentifier=cluster_id, SkipFinalSnapshot=True)
+            except ClientError:
+                pass
 
 
 def test_execute_rejects_foreign_account_cluster_arn():
@@ -199,15 +226,98 @@ def test_execute_rejects_foreign_account_cluster_arn():
             pass
 
 
-def test_cluster_id_from_arn_preserves_colon_resource_tail():
+def test_cluster_id_from_arn_includes_account_region_and_resource_tail():
     from ministack.services import rds_data
 
     assert (
         rds_data._cluster_id_from_arn(
             "arn:aws:rds:us-east-1:000000000000:cluster:cluster-id:tail",
         )
-        == "cluster-id:tail"
+        == "000000000000:us-east-1:cluster:cluster-id:tail"
     )
+
+
+def test_rds_data_member_lookup_uses_resource_arn_region():
+    from ministack.core.responses import (
+        get_account_id,
+        get_region,
+        set_request_account_id,
+        set_request_region,
+    )
+    from ministack.services import rds, rds_data
+
+    original_account = get_account_id()
+    original_region = get_region()
+    cluster_id = f"rds-data-member-{uuid.uuid4().hex[:8]}"
+    east_arn = f"arn:aws:rds:us-east-1:{ACCOUNT_ID}:cluster:{cluster_id}"
+    west_arn = f"arn:aws:rds:us-west-2:{ACCOUNT_ID}:cluster:{cluster_id}"
+    east_instance = {
+        "DBInstanceIdentifier": f"{cluster_id}-east",
+        "DBClusterIdentifier": cluster_id,
+        "Engine": "aurora-mysql",
+        "Endpoint": {"Address": "east.example", "Port": 3306},
+    }
+    west_instance = {
+        "DBInstanceIdentifier": f"{cluster_id}-west",
+        "DBClusterIdentifier": cluster_id,
+        "Engine": "aurora-mysql",
+        "Endpoint": {"Address": "west.example", "Port": 3306},
+    }
+
+    try:
+        set_request_account_id(ACCOUNT_ID)
+        rds.reset()
+        rds._clusters.set_scoped(
+            ACCOUNT_ID,
+            "us-east-1",
+            cluster_id,
+            {"DBClusterIdentifier": cluster_id, "DBClusterArn": east_arn, "Engine": "aurora-mysql"},
+        )
+        rds._clusters.set_scoped(
+            ACCOUNT_ID,
+            "us-west-2",
+            cluster_id,
+            {"DBClusterIdentifier": cluster_id, "DBClusterArn": west_arn, "Engine": "aurora-mysql"},
+        )
+        rds._instances.set_scoped(ACCOUNT_ID, "us-east-1", east_instance["DBInstanceIdentifier"], east_instance)
+        rds._instances.set_scoped(ACCOUNT_ID, "us-west-2", west_instance["DBInstanceIdentifier"], west_instance)
+
+        set_request_region("us-east-1")
+        instance, engine = rds_data._resolve_cluster(west_arn)
+
+        assert instance is west_instance
+        assert engine == "aurora-mysql"
+    finally:
+        rds.reset()
+        set_request_account_id(original_account)
+        set_request_region(original_region)
+
+
+def test_rds_data_db_arn_lookup_rejects_foreign_account():
+    from ministack.core.responses import (
+        get_account_id,
+        set_request_account_id,
+    )
+    from ministack.services import rds, rds_data
+
+    original_account = get_account_id()
+    db_id = f"rds-data-db-{uuid.uuid4().hex[:8]}"
+    db_arn = f"arn:aws:rds:us-east-1:111111111111:db:{db_id}"
+    instance = {
+        "DBInstanceIdentifier": db_id,
+        "Engine": "aurora-mysql",
+        "Endpoint": {"Address": "foreign.example", "Port": 3306},
+    }
+
+    try:
+        rds.reset()
+        rds._instances.set_scoped("111111111111", "us-east-1", db_id, instance)
+        set_request_account_id(ACCOUNT_ID)
+
+        assert rds_data._resolve_cluster(db_arn) == (None, None)
+    finally:
+        rds.reset()
+        set_request_account_id(original_account)
 
 
 def test_begin_transaction_nonexistent_cluster():
@@ -500,7 +610,10 @@ def test_rds_data_non_container_endpoint_keeps_stub_mode(monkeypatch):
 
     assert status == 200
     assert payload["records"] == []
-    assert "stub_user" in rds_data._stub_users.get("stub-cluster", set())
+    assert "stub_user" in rds_data._stub_users.get(
+        rds_data._cluster_id_from_arn(resource_arn),
+        set(),
+    )
 
 
 def test_rds_data_lock_wait_timeout_is_not_connection_error():

--- a/tests/test_rds_regions.py
+++ b/tests/test_rds_regions.py
@@ -1,0 +1,287 @@
+import uuid
+
+import boto3
+import pytest
+from botocore.config import Config
+from botocore.exceptions import ClientError
+from conftest import ENDPOINT
+
+
+def _regional_rds(region, access_key_id="test"):
+    return boto3.client(
+        "rds",
+        endpoint_url=ENDPOINT,
+        aws_access_key_id=access_key_id,
+        aws_secret_access_key="test",
+        region_name=region,
+        config=Config(region_name=region, retries={"mode": "standard"}),
+    )
+
+
+def _delete_cluster(client, cluster_id):
+    try:
+        client.delete_db_cluster(DBClusterIdentifier=cluster_id, SkipFinalSnapshot=True)
+    except ClientError:
+        pass
+
+
+def _delete_instance(client, instance_id):
+    try:
+        client.delete_db_instance(DBInstanceIdentifier=instance_id, SkipFinalSnapshot=True)
+    except ClientError:
+        pass
+
+
+def test_rds_clusters_are_region_scoped():
+    east = _regional_rds("us-east-1")
+    west = _regional_rds("us-west-2")
+    east_only = f"rds-east-only-{uuid.uuid4().hex[:8]}"
+    shared = f"rds-shared-{uuid.uuid4().hex[:8]}"
+
+    try:
+        east.create_db_cluster(
+            DBClusterIdentifier=east_only,
+            Engine="aurora-mysql",
+            MasterUsername="admin",
+            MasterUserPassword="password123",
+        )
+        with pytest.raises(ClientError) as exc:
+            west.describe_db_clusters(DBClusterIdentifier=east_only)
+        assert exc.value.response["Error"]["Code"] == "DBClusterNotFoundFault"
+
+        east.create_db_cluster(
+            DBClusterIdentifier=shared,
+            Engine="aurora-mysql",
+            MasterUsername="admin",
+            MasterUserPassword="password123",
+            DatabaseName="eastdb",
+        )
+        west.create_db_cluster(
+            DBClusterIdentifier=shared,
+            Engine="aurora-mysql",
+            MasterUsername="admin",
+            MasterUserPassword="password123",
+            DatabaseName="westdb",
+        )
+
+        east_cluster = east.describe_db_clusters(DBClusterIdentifier=shared)["DBClusters"][0]
+        west_cluster = west.describe_db_clusters(DBClusterIdentifier=shared)["DBClusters"][0]
+        assert east_cluster["DBClusterArn"] != west_cluster["DBClusterArn"]
+        assert ":us-east-1:" in east_cluster["DBClusterArn"]
+        assert ":us-west-2:" in west_cluster["DBClusterArn"]
+        assert east_cluster["DatabaseName"] == "eastdb"
+        assert west_cluster["DatabaseName"] == "westdb"
+    finally:
+        for client, cluster_id in (
+            (east, east_only),
+            (east, shared),
+            (west, shared),
+        ):
+            _delete_cluster(client, cluster_id)
+
+
+def test_rds_cluster_arn_lookup_rejects_foreign_account():
+    account_a = _regional_rds("us-west-2", access_key_id="111111111111")
+    account_b = _regional_rds("us-west-2", access_key_id="222222222222")
+    cluster_id = f"rds-cross-account-{uuid.uuid4().hex[:8]}"
+
+    try:
+        cluster = account_a.create_db_cluster(
+            DBClusterIdentifier=cluster_id,
+            Engine="aurora-mysql",
+            MasterUsername="admin",
+            MasterUserPassword="password123",
+        )["DBCluster"]
+
+        same_account = account_a.describe_db_clusters(
+            DBClusterIdentifier=cluster["DBClusterArn"],
+        )["DBClusters"][0]
+        assert same_account["DBClusterIdentifier"] == cluster_id
+
+        with pytest.raises(ClientError) as exc:
+            account_b.describe_db_clusters(DBClusterIdentifier=cluster["DBClusterArn"])
+        assert exc.value.response["Error"]["Code"] == "DBClusterNotFoundFault"
+    finally:
+        _delete_cluster(account_a, cluster_id)
+
+
+def test_rds_regional_cluster_apis_reject_foreign_region_arns():
+    east = _regional_rds("us-east-1")
+    west = _regional_rds("us-west-2")
+    cluster_id = f"rds-foreign-region-{uuid.uuid4().hex[:8]}"
+
+    try:
+        cluster = west.create_db_cluster(
+            DBClusterIdentifier=cluster_id,
+            Engine="aurora-mysql",
+            MasterUsername="admin",
+            MasterUserPassword="password123",
+        )["DBCluster"]
+        cluster_arn = cluster["DBClusterArn"]
+
+        same_region = west.describe_db_clusters(
+            DBClusterIdentifier=cluster_arn,
+        )["DBClusters"][0]
+        assert same_region["DBClusterIdentifier"] == cluster_id
+
+        with pytest.raises(ClientError) as exc:
+            east.describe_db_clusters(DBClusterIdentifier=cluster_arn)
+        assert exc.value.response["Error"]["Code"] == "InvalidParameterValue"
+
+        with pytest.raises(ClientError) as exc:
+            east.modify_db_cluster(
+                DBClusterIdentifier=cluster_arn,
+                BackupRetentionPeriod=1,
+                ApplyImmediately=True,
+            )
+        assert exc.value.response["Error"]["Code"] == "InvalidParameterValue"
+
+        with pytest.raises(ClientError) as exc:
+            east.delete_db_cluster(DBClusterIdentifier=cluster_arn, SkipFinalSnapshot=True)
+        assert exc.value.response["Error"]["Code"] == "InvalidParameterValue"
+
+        with pytest.raises(ClientError) as exc:
+            east.enable_http_endpoint(ResourceArn=cluster_arn)
+        assert exc.value.response["Error"]["Code"] == "ResourceNotFoundFault"
+    finally:
+        _delete_cluster(west, cluster_id)
+
+
+def test_rds_instances_are_region_scoped():
+    east = _regional_rds("us-east-1")
+    west = _regional_rds("us-west-2")
+    shared = f"rds-inst-shared-{uuid.uuid4().hex[:8]}"
+
+    try:
+        east.create_db_instance(
+            DBInstanceIdentifier=shared,
+            DBInstanceClass="db.t3.micro",
+            Engine="postgres",
+            MasterUsername="admin",
+            MasterUserPassword="pass",
+            AllocatedStorage=10,
+        )
+        west.create_db_instance(
+            DBInstanceIdentifier=shared,
+            DBInstanceClass="db.t3.small",
+            Engine="postgres",
+            MasterUsername="admin",
+            MasterUserPassword="pass",
+            AllocatedStorage=20,
+        )
+
+        east_instance = east.describe_db_instances(DBInstanceIdentifier=shared)["DBInstances"][0]
+        west_instance = west.describe_db_instances(DBInstanceIdentifier=shared)["DBInstances"][0]
+        assert east_instance["DBInstanceArn"] != west_instance["DBInstanceArn"]
+        assert ":us-east-1:" in east_instance["DBInstanceArn"]
+        assert ":us-west-2:" in west_instance["DBInstanceArn"]
+        assert east_instance["DBInstanceClass"] == "db.t3.micro"
+        assert west_instance["DBInstanceClass"] == "db.t3.small"
+    finally:
+        _delete_instance(east, shared)
+        _delete_instance(west, shared)
+
+
+def test_rds_regional_instance_apis_reject_foreign_region_arns():
+    east = _regional_rds("us-east-1")
+    west = _regional_rds("us-west-2")
+    instance_id = f"rds-inst-arn-{uuid.uuid4().hex[:8]}"
+    snapshot_id = f"rds-inst-arn-snap-{uuid.uuid4().hex[:8]}"
+
+    try:
+        instance = west.create_db_instance(
+            DBInstanceIdentifier=instance_id,
+            DBInstanceClass="db.t3.micro",
+            Engine="postgres",
+            MasterUsername="admin",
+            MasterUserPassword="pass",
+            AllocatedStorage=10,
+        )["DBInstance"]
+        instance_arn = instance["DBInstanceArn"]
+
+        same_region = west.describe_db_instances(DBInstanceIdentifier=instance_arn)["DBInstances"][0]
+        assert same_region["DBInstanceIdentifier"] == instance_id
+
+        with pytest.raises(ClientError) as exc:
+            east.describe_db_instances(DBInstanceIdentifier=instance_arn)
+        assert exc.value.response["Error"]["Code"] == "InvalidParameterValue"
+
+        with pytest.raises(ClientError) as exc:
+            east.modify_db_instance(
+                DBInstanceIdentifier=instance_arn,
+                DBInstanceClass="db.t3.small",
+                ApplyImmediately=True,
+            )
+        assert exc.value.response["Error"]["Code"] == "InvalidParameterValue"
+
+        with pytest.raises(ClientError) as exc:
+            east.create_db_snapshot(
+                DBSnapshotIdentifier=snapshot_id,
+                DBInstanceIdentifier=instance_arn,
+            )
+        assert exc.value.response["Error"]["Code"] == "InvalidParameterValue"
+
+        with pytest.raises(ClientError) as exc:
+            east.delete_db_instance(DBInstanceIdentifier=instance_arn, SkipFinalSnapshot=True)
+        assert exc.value.response["Error"]["Code"] == "InvalidParameterValue"
+    finally:
+        _delete_instance(west, instance_id)
+
+
+def test_rds_legacy_instance_restore_preserves_arn_region(monkeypatch):
+    from ministack.core.responses import AccountScopedDict, get_region, set_request_region
+    from ministack.services import rds
+
+    class ImmediateThread:
+        def __init__(self, target, args=(), daemon=None):
+            self.target = target
+            self.args = args
+
+        def start(self):
+            self.target(*self.args)
+
+    original_region = get_region()
+    instance_id = f"rds-restore-{uuid.uuid4().hex[:8]}"
+    instance = {
+        "DBInstanceIdentifier": instance_id,
+        "DBInstanceArn": f"arn:aws:rds:us-west-2:000000000000:db:{instance_id}",
+    }
+    legacy = AccountScopedDict()
+    legacy.set_scoped("000000000000", "us-east-1", instance_id, instance)
+
+    monkeypatch.setattr(rds, "_get_docker", lambda: None)
+    monkeypatch.setattr(rds.threading, "Thread", ImmediateThread)
+
+    try:
+        rds.reset()
+        rds.restore_state({"instances": legacy})
+
+        assert rds._instances.get_scoped("000000000000", "us-east-1", instance_id) is None
+        restored = rds._instances.get_scoped("000000000000", "us-west-2", instance_id)
+        assert restored["DBInstanceArn"] == instance["DBInstanceArn"]
+        assert restored["DBInstanceStatus"] == "available"
+    finally:
+        rds.reset()
+        set_request_region(original_region)
+
+
+def test_rds_docker_artifact_names_are_region_scoped():
+    from ministack.core.responses import get_region, set_request_region
+    from ministack.services import rds
+
+    original_region = get_region()
+    try:
+        set_request_region("us-east-1")
+        east_name = rds._rds_docker_name("shared-db")
+        east_volume = rds._rds_docker_volume_name("shared-db")
+
+        set_request_region("us-west-2")
+        west_name = rds._rds_docker_name("shared-db")
+        west_volume = rds._rds_docker_volume_name("shared-db")
+
+        assert east_name != west_name
+        assert east_volume != west_volume
+        assert east_name.endswith("-shared-db")
+        assert west_name.endswith("-shared-db")
+    finally:
+        set_request_region(original_region)


### PR DESCRIPTION
## Summary
- convert regional RDS stores to account+Region scoped dictionaries while keeping global clusters account-scoped
- split request-Region RDS lookups from ARN-Region lookups for data-plane/global-topology behavior
- scope RDS Docker container and volume names by account+Region, while preserving legacy persistent volume names during restore
- update RDS Data cluster/member lookup so resource ARNs resolve against the ARN account+Region for the MVP ExecuteStatement path

## Tests
- `uv run --extra dev ruff check ministack/services/rds.py ministack/services/rds_data.py tests/test_rds.py tests/test_rds_data.py tests/test_rds_regions.py`
- source-backed: `MINISTACK_ENDPOINT=http://localhost:4567 uv run --extra dev pytest tests/test_rds.py tests/test_rds_data.py tests/test_rds_regions.py tests/test_persistence.py -q` (`255 passed, 1 skipped`)
- PR image `ministackorg/ministack-preview-build:pr-742-d30ec0ad`: `MINISTACK_ENDPOINT=http://localhost:4567 uv run --extra dev pytest tests/test_rds.py tests/test_rds_data.py tests/test_rds_regions.py tests/test_persistence.py -q` (`255 passed, 1 skipped`)
