### PR TITLE
Add Aurora Global metadata support

### DIFF
--- a/ministack/services/rds.py
+++ b/ministack/services/rds.py
@@ -806,6 +806,57 @@ def _resolve_cluster_in_request_region(cluster_id):
     return _request_region_get(_clusters, cluster_id, "cluster")
 
 
+def _resolve_global_cluster(global_id):
+    """Look up a global cluster by identifier."""
+    if _parse_rds_arn(global_id):
+        return None
+    return _global_clusters.get(global_id)
+
+
+def _global_cluster_member(cluster, is_writer):
+    return {
+        "DBClusterArn": cluster["DBClusterArn"],
+        "Readers": [],
+        "IsWriter": is_writer,
+        "GlobalWriteForwardingStatus": cluster.get("GlobalWriteForwardingStatus", "disabled"),
+        "SynchronizationStatus": "connected",
+    }
+
+
+def _global_cluster_member_in_request_region(global_cluster):
+    for member in global_cluster.get("GlobalClusterMembers", []):
+        parsed = _parse_rds_arn(member.get("DBClusterArn", ""))
+        if not parsed:
+            continue
+        spec, resource_type, _resource_id = parsed
+        if (
+            resource_type == "cluster"
+            and spec.account_id == get_account_id()
+            and spec.region == get_region()
+        ):
+            return member
+    return None
+
+
+def _refresh_global_cluster_readers(global_cluster):
+    members = global_cluster.get("GlobalClusterMembers", [])
+    reader_arns = [m["DBClusterArn"] for m in members if not m.get("IsWriter")]
+    for member in members:
+        member["Readers"] = reader_arns if member.get("IsWriter") else []
+
+
+def _attach_cluster_to_global(global_cluster, cluster, is_writer):
+    members = [
+        m for m in global_cluster.setdefault("GlobalClusterMembers", [])
+        if m.get("DBClusterArn") != cluster["DBClusterArn"]
+    ]
+    members.append(_global_cluster_member(cluster, is_writer))
+    global_cluster["GlobalClusterMembers"] = members
+    _refresh_global_cluster_readers(global_cluster)
+    cluster["GlobalClusterIdentifier"] = global_cluster["GlobalClusterIdentifier"]
+    cluster["GlobalWriteForwardingStatus"] = "disabled"
+
+
 def _resolve_instance(db_id):
     """Look up an instance by DBInstanceIdentifier or DbiResourceId.
 
@@ -1548,8 +1599,47 @@ def _create_db_cluster(p):
         return _error("DBClusterAlreadyExistsFault",
             f"DB cluster {cluster_id} already exists.", 400)
 
+    global_cluster_id = _p(p, "GlobalClusterIdentifier")
+    invalid_global_id = _invalid_global_cluster_identifier_error(global_cluster_id)
+    if invalid_global_id:
+        return invalid_global_id
+    global_cluster = _resolve_global_cluster(global_cluster_id) if global_cluster_id else None
+    if global_cluster_id and not global_cluster:
+        return _error("GlobalClusterNotFoundFault",
+            f"Global cluster {global_cluster_id} not found.", 404)
+    if global_cluster and _global_cluster_member_in_request_region(global_cluster):
+        return _error(
+            "InvalidParameterValue",
+            f"Global cluster {global_cluster_id} already has a member in {get_region()}.",
+            400,
+        )
+
     engine = _p(p, "Engine") or "aurora-postgresql"
+    if global_cluster:
+        expected_engine = global_cluster.get("Engine")
+        if _p(p, "Engine") and expected_engine and engine != expected_engine:
+            return _error(
+                "InvalidParameterValue",
+                f"Engine {engine} is incompatible with global cluster "
+                f"{global_cluster_id} engine {expected_engine}.",
+                400,
+            )
+        engine = expected_engine or engine
     engine_version = _p(p, "EngineVersion") or _default_engine_version(engine)
+    if global_cluster:
+        expected_engine_version = global_cluster.get("EngineVersion")
+        if (
+            _p(p, "EngineVersion")
+            and expected_engine_version
+            and engine_version != expected_engine_version
+        ):
+            return _error(
+                "InvalidParameterValue",
+                f"EngineVersion {engine_version} is incompatible with global "
+                f"cluster {global_cluster_id} engine version {expected_engine_version}.",
+                400,
+            )
+        engine_version = expected_engine_version or engine_version
     port = int(_p(p, "Port") or _default_port(engine))
     master_user = _p(p, "MasterUsername") or "admin"
     arn = f"arn:aws:rds:{get_region()}:{get_account_id()}:cluster:{cluster_id}"
@@ -1609,6 +1699,9 @@ def _create_db_cluster(p):
         "ClusterScalabilityType": "standard",
     }
     _clusters[cluster_id] = cluster
+    if global_cluster:
+        is_first_member = not global_cluster.get("GlobalClusterMembers")
+        _attach_cluster_to_global(global_cluster, cluster, is_writer=is_first_member)
 
     req_tags = _parse_tags(p)
     if req_tags:
@@ -1631,6 +1724,10 @@ def _delete_db_cluster(p):
     if cluster.get("DeletionProtection"):
         return _error("InvalidParameterCombination",
             "Cannot delete a DB cluster when DeletionProtection is enabled.", 400)
+
+    if cluster.get("GlobalClusterIdentifier"):
+        return _error("InvalidDBClusterStateFault",
+            "Cannot delete a DB cluster while it is a member of a global cluster.", 400)
 
     skip_snapshot = _p(p, "SkipFinalSnapshot") == "true"
     final_snap_id = _p(p, "FinalDBSnapshotIdentifier")
@@ -2589,11 +2686,10 @@ def _invalid_global_cluster_identifier_error(global_id):
 # ---------------------------------------------------------------------------
 # Global Clusters
 #
-# Emulation scope: single-member global clusters only.  A global cluster can
-# be created standalone or attached to one existing DB cluster via
-# SourceDBClusterIdentifier.  Multi-member membership (secondary clusters
-# in other regions), FailoverGlobalCluster, and SwitchoverGlobalCluster are
-# not supported — MiniStack is a single-region emulator.
+# Emulation scope: metadata-level Aurora Global Database membership.  This
+# supports the create/read/update/delete control-plane path needed by local
+# acceptance tests, without simulating storage replication, failover, or
+# switchover.
 # ---------------------------------------------------------------------------
 
 def _create_global_cluster(p):
@@ -2628,6 +2724,14 @@ def _create_global_cluster(p):
                 return wrong_region
             return _error("DBClusterNotFoundFault",
                 f"DBCluster {source_cluster_id} not found.", 404)
+        existing_global_id = source_cluster.get("GlobalClusterIdentifier")
+        if existing_global_id:
+            return _error(
+                "InvalidDBClusterStateFault",
+                f"DBCluster {source_cluster_id} is already a member of "
+                f"global cluster {existing_global_id}.",
+                400,
+            )
         engine = source_cluster["Engine"]
         engine_version = source_cluster["EngineVersion"]
 
@@ -2644,11 +2748,7 @@ def _create_global_cluster(p):
         "DatabaseName": _p(p, "DatabaseName") or "",
     }
     if source_cluster:
-        gc["GlobalClusterMembers"].append({
-            "DBClusterArn": source_cluster["DBClusterArn"],
-            "IsWriter": True,
-            "GlobalWriteForwardingStatus": "disabled",
-        })
+        _attach_cluster_to_global(gc, source_cluster, is_writer=True)
     _global_clusters[gc_id] = gc
     return _xml(200, "CreateGlobalClusterResponse",
         f"<CreateGlobalClusterResult><GlobalCluster>{_global_cluster_xml(gc)}</GlobalCluster></CreateGlobalClusterResult>")
@@ -2657,10 +2757,10 @@ def _create_global_cluster(p):
 def _describe_global_clusters(p):
     gc_id = _p(p, "GlobalClusterIdentifier")
     if gc_id:
-        invalid_arn = _invalid_global_cluster_identifier_error(gc_id)
-        if invalid_arn:
-            return invalid_arn
-        gc = _global_clusters.get(gc_id)
+        invalid_id = _invalid_global_cluster_identifier_error(gc_id)
+        if invalid_id:
+            return invalid_id
+        gc = _resolve_global_cluster(gc_id)
         if not gc:
             return _error("GlobalClusterNotFoundFault",
                 f"Global cluster {gc_id} not found.", 404)
@@ -2677,10 +2777,10 @@ def _describe_global_clusters(p):
 
 def _delete_global_cluster(p):
     gc_id = _p(p, "GlobalClusterIdentifier")
-    invalid_arn = _invalid_global_cluster_identifier_error(gc_id)
-    if invalid_arn:
-        return invalid_arn
-    gc = _global_clusters.get(gc_id)
+    invalid_id = _invalid_global_cluster_identifier_error(gc_id)
+    if invalid_id:
+        return invalid_id
+    gc = _resolve_global_cluster(gc_id)
     if not gc:
         return _error("GlobalClusterNotFoundFault",
             f"Global cluster {gc_id} not found.", 404)
@@ -2689,13 +2789,12 @@ def _delete_global_cluster(p):
         return _error("InvalidParameterCombination",
             "Cannot delete a global cluster when DeletionProtection is enabled.", 400)
 
-    writer_members = [m for m in gc.get("GlobalClusterMembers", []) if m.get("IsWriter")]
-    if writer_members:
+    if gc.get("GlobalClusterMembers"):
         return _error("InvalidGlobalClusterStateFault",
             "Global cluster still has member clusters. Remove them before deleting.", 400)
 
     gc["Status"] = "deleting"
-    del _global_clusters[gc_id]
+    del _global_clusters[gc["GlobalClusterIdentifier"]]
     return _xml(200, "DeleteGlobalClusterResponse",
         f"<DeleteGlobalClusterResult><GlobalCluster>{_global_cluster_xml(gc)}</GlobalCluster></DeleteGlobalClusterResult>")
 
@@ -2703,34 +2802,43 @@ def _delete_global_cluster(p):
 def _remove_from_global_cluster(p):
     gc_id = _p(p, "GlobalClusterIdentifier")
     db_cluster_id = _p(p, "DbClusterIdentifier")
-    invalid_arn = _invalid_global_cluster_identifier_error(gc_id)
-    if invalid_arn:
-        return invalid_arn
-    gc = _global_clusters.get(gc_id)
+    invalid_id = _invalid_global_cluster_identifier_error(gc_id)
+    if invalid_id:
+        return invalid_id
+    gc = _resolve_global_cluster(gc_id)
     if not gc:
         return _error("GlobalClusterNotFoundFault",
             f"Global cluster {gc_id} not found.", 404)
 
     members = gc.get("GlobalClusterMembers", [])
-    new_members = [m for m in members if m["DBClusterArn"] != db_cluster_id]
-    if len(new_members) == len(members):
-        for cl in _clusters.values():
-            if cl["DBClusterIdentifier"] == db_cluster_id:
-                db_cluster_id = cl["DBClusterArn"]
-                break
-        new_members = [m for m in members if m["DBClusterArn"] != db_cluster_id]
+    cluster = _resolve_cluster(db_cluster_id)
+    db_cluster_arn = cluster["DBClusterArn"] if cluster else db_cluster_id
+    member = next((m for m in members if m["DBClusterArn"] == db_cluster_arn), None)
+    if not member:
+        return _error("DBClusterNotFoundFault",
+            f"DBCluster {db_cluster_id} is not a member of global cluster {gc_id}.", 404)
+    if member.get("IsWriter") and len(members) > 1:
+        return _error("InvalidGlobalClusterStateFault",
+            "Cannot remove the writer DB cluster while reader members remain.", 400)
 
+    new_members = [m for m in members if m["DBClusterArn"] != db_cluster_arn]
     gc["GlobalClusterMembers"] = new_members
+    _refresh_global_cluster_readers(gc)
+    if not cluster:
+        cluster = _resolve_cluster(db_cluster_arn)
+    if cluster:
+        cluster.pop("GlobalClusterIdentifier", None)
+        cluster.pop("GlobalWriteForwardingStatus", None)
     return _xml(200, "RemoveFromGlobalClusterResponse",
         f"<RemoveFromGlobalClusterResult><GlobalCluster>{_global_cluster_xml(gc)}</GlobalCluster></RemoveFromGlobalClusterResult>")
 
 
 def _modify_global_cluster(p):
     gc_id = _p(p, "GlobalClusterIdentifier")
-    invalid_arn = _invalid_global_cluster_identifier_error(gc_id)
-    if invalid_arn:
-        return invalid_arn
-    gc = _global_clusters.get(gc_id)
+    invalid_id = _invalid_global_cluster_identifier_error(gc_id)
+    if invalid_id:
+        return invalid_id
+    gc = _resolve_global_cluster(gc_id)
     if not gc:
         return _error("GlobalClusterNotFoundFault",
             f"Global cluster {gc_id} not found.", 404)
@@ -2743,10 +2851,15 @@ def _modify_global_cluster(p):
         if new_id in _global_clusters:
             return _error("GlobalClusterAlreadyExistsFault",
                 f"Global cluster {new_id} already exists.", 400)
+        old_id = gc["GlobalClusterIdentifier"]
         gc["GlobalClusterIdentifier"] = new_id
         gc["GlobalClusterArn"] = f"arn:aws:rds::{get_account_id()}:global-cluster:{new_id}"
         _global_clusters[new_id] = gc
-        del _global_clusters[gc_id]
+        del _global_clusters[old_id]
+        for member in gc.get("GlobalClusterMembers", []):
+            cluster = _resolve_cluster(member["DBClusterArn"])
+            if cluster:
+                cluster["GlobalClusterIdentifier"] = new_id
 
     if _p(p, "DeletionProtection"):
         gc["DeletionProtection"] = _p(p, "DeletionProtection") == "true"
@@ -2774,12 +2887,16 @@ def _enable_http_endpoint(p):
 
 
 def _global_cluster_xml(gc):
+    _refresh_global_cluster_readers(gc)
     member_xml = ""
     for m in gc.get("GlobalClusterMembers", []):
+        readers_xml = "".join(f"<member>{_esc(reader)}</member>" for reader in m.get("Readers", []))
         member_xml += f"""<GlobalClusterMember>
             <DBClusterArn>{m['DBClusterArn']}</DBClusterArn>
+            <Readers>{readers_xml}</Readers>
             <IsWriter>{str(m.get('IsWriter', False)).lower()}</IsWriter>
             <GlobalWriteForwardingStatus>{m.get('GlobalWriteForwardingStatus', 'disabled')}</GlobalWriteForwardingStatus>
+            <SynchronizationStatus>{m.get('SynchronizationStatus', 'connected')}</SynchronizationStatus>
         </GlobalClusterMember>"""
     return f"""<GlobalClusterIdentifier>{gc['GlobalClusterIdentifier']}</GlobalClusterIdentifier>
         <GlobalClusterArn>{gc['GlobalClusterArn']}</GlobalClusterArn>
@@ -2822,6 +2939,7 @@ def _describe_engine_versions(p):
     }
     versions = versions_map.get(engine, [("15.3", "15")])
     members = ""
+    supports_global = engine in ("aurora-mysql", "aurora-postgresql")
     for ver, family in versions:
         if version_filter and ver != version_filter:
             continue
@@ -2838,7 +2956,7 @@ def _describe_engine_versions(p):
             <SupportedFeatureNames/>
             <Status>available</Status>
             <SupportsParallelQuery>false</SupportsParallelQuery>
-            <SupportsGlobalDatabases>false</SupportsGlobalDatabases>
+            <SupportsGlobalDatabases>{str(supports_global).lower()}</SupportsGlobalDatabases>
             <SupportsBabelfish>false</SupportsBabelfish>
             <SupportsCertificateRotationWithoutRestart>true</SupportsCertificateRotationWithoutRestart>
         </DBEngineVersion>"""
@@ -3067,6 +3185,16 @@ def _cluster_xml(c):
     # emitting an empty element would surface as "" instead of None to clients.
     db_name = c.get("DatabaseName")
     db_name_xml = f"<DatabaseName>{db_name}</DatabaseName>" if db_name else ""
+    global_cluster_id = c.get("GlobalClusterIdentifier")
+    global_cluster_xml = (
+        f"<GlobalClusterIdentifier>{global_cluster_id}</GlobalClusterIdentifier>"
+        if global_cluster_id else ""
+    )
+    global_write_forwarding = c.get("GlobalWriteForwardingStatus")
+    global_write_forwarding_xml = (
+        f"<GlobalWriteForwardingStatus>{global_write_forwarding}</GlobalWriteForwardingStatus>"
+        if global_write_forwarding else ""
+    )
 
     return f"""<DBClusterIdentifier>{c['DBClusterIdentifier']}</DBClusterIdentifier>
         <DBClusterArn>{c['DBClusterArn']}</DBClusterArn>
@@ -3105,6 +3233,8 @@ def _cluster_xml(c):
         <AllocatedStorage>{c.get('AllocatedStorage',1)}</AllocatedStorage>
         <ActivityStreamStatus>{c.get('ActivityStreamStatus','stopped')}</ActivityStreamStatus>
         <NetworkType>{c.get('NetworkType','IPV4')}</NetworkType>
+        {global_cluster_xml}
+        {global_write_forwarding_xml}
         <EngineLifecycleSupport>{c.get('EngineLifecycleSupport','open-source-rds-extended-support')}</EngineLifecycleSupport>"""
 
 

--- a/tests/test_rds_regions.py
+++ b/tests/test_rds_regions.py
@@ -32,6 +32,30 @@ def _delete_instance(client, instance_id):
         pass
 
 
+def _remove_global_member(client, global_id, cluster_id):
+    try:
+        client.remove_from_global_cluster(
+            GlobalClusterIdentifier=global_id,
+            DbClusterIdentifier=cluster_id,
+        )
+    except ClientError:
+        pass
+
+
+def _delete_global_cluster(client, global_id):
+    try:
+        client.modify_global_cluster(
+            GlobalClusterIdentifier=global_id,
+            DeletionProtection=False,
+        )
+    except ClientError:
+        pass
+    try:
+        client.delete_global_cluster(GlobalClusterIdentifier=global_id)
+    except ClientError:
+        pass
+
+
 def test_rds_clusters_are_region_scoped():
     east = _regional_rds("us-east-1")
     west = _regional_rds("us-west-2")
@@ -285,3 +309,263 @@ def test_rds_docker_artifact_names_are_region_scoped():
         assert west_name.endswith("-shared-db")
     finally:
         set_request_region(original_region)
+
+
+def test_create_db_cluster_first_global_member_is_writer():
+    east = _regional_rds("us-east-1")
+    suffix = uuid.uuid4().hex[:8]
+    global_id = f"global-empty-{suffix}"
+    cluster_id = f"global-first-{suffix}"
+
+    try:
+        east.create_global_cluster(
+            GlobalClusterIdentifier=global_id,
+            Engine="aurora-mysql",
+        )
+        cluster = east.create_db_cluster(
+            DBClusterIdentifier=cluster_id,
+            Engine="aurora-mysql",
+            GlobalClusterIdentifier=global_id,
+            MasterUsername="admin",
+            MasterUserPassword="password123",
+        )["DBCluster"]
+
+        global_cluster = east.describe_global_clusters(
+            GlobalClusterIdentifier=global_id,
+        )["GlobalClusters"][0]
+        members = {m["DBClusterArn"]: m for m in global_cluster["GlobalClusterMembers"]}
+        assert members[cluster["DBClusterArn"]]["IsWriter"] is True
+    finally:
+        _remove_global_member(east, global_id, cluster_id)
+        _delete_cluster(east, cluster_id)
+        _delete_global_cluster(east, global_id)
+
+
+def test_create_db_cluster_validates_global_cluster_identifier_and_engine():
+    east = _regional_rds("us-east-1")
+    suffix = uuid.uuid4().hex[:8]
+    global_id = f"global-validate-{suffix}"
+    global_arn_id = f"arn:aws:rds::000000000000:global-cluster:{global_id}"
+    cluster_id = f"global-validate-member-{suffix}"
+
+    try:
+        global_cluster = east.create_global_cluster(
+            GlobalClusterIdentifier=global_id,
+            Engine="aurora-postgresql",
+            EngineVersion="15.3",
+        )["GlobalCluster"]
+
+        with pytest.raises(ClientError) as exc:
+            east.create_db_cluster(
+                DBClusterIdentifier=f"{cluster_id}-arn",
+                Engine="aurora-postgresql",
+                GlobalClusterIdentifier=global_arn_id,
+                MasterUsername="admin",
+                MasterUserPassword="password123",
+            )
+        assert exc.value.response["Error"]["Code"] == "InvalidParameterValue"
+
+        with pytest.raises(ClientError) as exc:
+            east.create_db_cluster(
+                DBClusterIdentifier=f"{cluster_id}-engine",
+                Engine="aurora-mysql",
+                GlobalClusterIdentifier=global_id,
+                MasterUsername="admin",
+                MasterUserPassword="password123",
+            )
+        assert exc.value.response["Error"]["Code"] == "InvalidParameterValue"
+
+        with pytest.raises(ClientError) as exc:
+            east.create_db_cluster(
+                DBClusterIdentifier=f"{cluster_id}-version",
+                Engine="aurora-postgresql",
+                EngineVersion="14.8",
+                GlobalClusterIdentifier=global_id,
+                MasterUsername="admin",
+                MasterUserPassword="password123",
+            )
+        assert exc.value.response["Error"]["Code"] == "InvalidParameterValue"
+
+        member = east.create_db_cluster(
+            DBClusterIdentifier=cluster_id,
+            Engine="aurora-postgresql",
+            GlobalClusterIdentifier=global_id,
+            MasterUsername="admin",
+            MasterUserPassword="password123",
+        )["DBCluster"]
+        assert member["Engine"] == global_cluster["Engine"]
+        assert member["EngineVersion"] == global_cluster["EngineVersion"]
+
+        with pytest.raises(ClientError) as exc:
+            east.create_db_cluster(
+                DBClusterIdentifier=f"{cluster_id}-same-region",
+                Engine="aurora-postgresql",
+                GlobalClusterIdentifier=global_id,
+                MasterUsername="admin",
+                MasterUserPassword="password123",
+            )
+        assert exc.value.response["Error"]["Code"] == "InvalidParameterValue"
+    finally:
+        _remove_global_member(east, global_id, cluster_id)
+        _delete_cluster(east, cluster_id)
+        _delete_global_cluster(east, global_id)
+
+
+def test_aurora_global_metadata_spans_regions():
+    east = _regional_rds("us-east-1")
+    west = _regional_rds("us-west-2")
+    suffix = uuid.uuid4().hex[:8]
+    primary_id = f"global-primary-{suffix}"
+    secondary_id = f"global-secondary-{suffix}"
+    global_id = f"global-metadata-{suffix}"
+
+    try:
+        primary = east.create_db_cluster(
+            DBClusterIdentifier=primary_id,
+            Engine="aurora-mysql",
+            MasterUsername="admin",
+            MasterUserPassword="password123",
+        )["DBCluster"]
+        east.create_global_cluster(
+            GlobalClusterIdentifier=global_id,
+            SourceDBClusterIdentifier=primary["DBClusterArn"],
+            DeletionProtection=True,
+        )
+
+        primary_after_attach = east.describe_db_clusters(
+            DBClusterIdentifier=primary_id,
+        )["DBClusters"][0]
+        assert primary_after_attach["GlobalClusterIdentifier"] == global_id
+
+        west.create_db_cluster(
+            DBClusterIdentifier=secondary_id,
+            Engine="aurora-mysql",
+            GlobalClusterIdentifier=global_id,
+            KmsKeyId="alias/aws/rds",
+            MasterUsername="admin",
+            MasterUserPassword="password123",
+        )
+        secondary = west.describe_db_clusters(
+            DBClusterIdentifier=secondary_id,
+        )["DBClusters"][0]
+        assert secondary["GlobalClusterIdentifier"] == global_id
+        assert secondary["KmsKeyId"] == "alias/aws/rds"
+
+        east_global = east.describe_global_clusters(
+            GlobalClusterIdentifier=global_id,
+        )["GlobalClusters"][0]
+        west_global = west.describe_global_clusters(
+            GlobalClusterIdentifier=global_id,
+        )["GlobalClusters"][0]
+        assert east_global == west_global
+        assert east_global["DeletionProtection"] is True
+
+        by_arn = {m["DBClusterArn"]: m for m in east_global["GlobalClusterMembers"]}
+        assert set(by_arn) == {primary["DBClusterArn"], secondary["DBClusterArn"]}
+        assert by_arn[primary["DBClusterArn"]]["IsWriter"] is True
+        assert by_arn[secondary["DBClusterArn"]]["IsWriter"] is False
+        assert by_arn[secondary["DBClusterArn"]]["SynchronizationStatus"] == "connected"
+        assert by_arn[secondary["DBClusterArn"]]["GlobalWriteForwardingStatus"] == "disabled"
+
+        with pytest.raises(ClientError) as exc:
+            west.delete_db_cluster(DBClusterIdentifier=secondary_id, SkipFinalSnapshot=True)
+        assert exc.value.response["Error"]["Code"] == "InvalidDBClusterStateFault"
+
+        east.modify_global_cluster(GlobalClusterIdentifier=global_id, DeletionProtection=False)
+        east.modify_db_cluster(DBClusterIdentifier=primary_id, DeletionProtection=True)
+        primary_modified = east.describe_db_clusters(
+            DBClusterIdentifier=primary_id,
+        )["DBClusters"][0]
+        assert primary_modified["DeletionProtection"] is True
+        east.modify_db_cluster(DBClusterIdentifier=primary_id, DeletionProtection=False)
+
+        with pytest.raises(ClientError) as exc:
+            east.delete_global_cluster(GlobalClusterIdentifier=global_id)
+        assert exc.value.response["Error"]["Code"] == "InvalidGlobalClusterStateFault"
+
+        with pytest.raises(ClientError) as exc:
+            west.remove_from_global_cluster(
+                GlobalClusterIdentifier=global_id,
+                DbClusterIdentifier=primary["DBClusterArn"],
+            )
+        assert exc.value.response["Error"]["Code"] == "InvalidGlobalClusterStateFault"
+
+        east.remove_from_global_cluster(
+            GlobalClusterIdentifier=global_id,
+            DbClusterIdentifier=secondary["DBClusterArn"],
+        )
+        secondary_after_detach = west.describe_db_clusters(
+            DBClusterIdentifier=secondary_id,
+        )["DBClusters"][0]
+        assert "GlobalClusterIdentifier" not in secondary_after_detach
+        remaining = east.describe_global_clusters(
+            GlobalClusterIdentifier=global_id,
+        )["GlobalClusters"][0]["GlobalClusterMembers"]
+        assert len(remaining) == 1
+        west.delete_db_cluster(DBClusterIdentifier=secondary_id, SkipFinalSnapshot=True)
+
+        east.remove_from_global_cluster(
+            GlobalClusterIdentifier=global_id,
+            DbClusterIdentifier=primary["DBClusterArn"],
+        )
+        empty_global = east.describe_global_clusters(
+            GlobalClusterIdentifier=global_id,
+        )["GlobalClusters"][0]
+        assert empty_global["GlobalClusterMembers"] == []
+        east.delete_global_cluster(GlobalClusterIdentifier=global_id)
+        east.delete_db_cluster(DBClusterIdentifier=primary_id, SkipFinalSnapshot=True)
+    finally:
+        _remove_global_member(west, global_id, secondary_id)
+        _remove_global_member(east, global_id, primary_id)
+        _delete_global_cluster(east, global_id)
+        _delete_cluster(west, secondary_id)
+        _delete_cluster(east, primary_id)
+
+
+def test_create_global_cluster_rejects_already_attached_source_cluster():
+    east = _regional_rds("us-east-1")
+    suffix = uuid.uuid4().hex[:8]
+    cluster_id = f"global-reuse-source-{suffix}"
+    first_global_id = f"global-reuse-first-{suffix}"
+    second_global_id = f"global-reuse-second-{suffix}"
+
+    try:
+        cluster = east.create_db_cluster(
+            DBClusterIdentifier=cluster_id,
+            Engine="aurora-mysql",
+            MasterUsername="admin",
+            MasterUserPassword="password123",
+        )["DBCluster"]
+        east.create_global_cluster(
+            GlobalClusterIdentifier=first_global_id,
+            SourceDBClusterIdentifier=cluster["DBClusterArn"],
+        )
+
+        with pytest.raises(ClientError) as exc:
+            east.create_global_cluster(
+                GlobalClusterIdentifier=second_global_id,
+                SourceDBClusterIdentifier=cluster["DBClusterArn"],
+            )
+        assert exc.value.response["Error"]["Code"] == "InvalidDBClusterStateFault"
+
+        first_global = east.describe_global_clusters(
+            GlobalClusterIdentifier=first_global_id,
+        )["GlobalClusters"][0]
+        assert [m["DBClusterArn"] for m in first_global["GlobalClusterMembers"]] == [
+            cluster["DBClusterArn"],
+        ]
+        with pytest.raises(ClientError):
+            east.describe_global_clusters(GlobalClusterIdentifier=second_global_id)
+    finally:
+        _remove_global_member(east, first_global_id, cluster_id)
+        _delete_global_cluster(east, first_global_id)
+        _delete_global_cluster(east, second_global_id)
+        _delete_cluster(east, cluster_id)
+
+
+def test_aurora_engine_versions_advertise_global_database_support():
+    rds = _regional_rds("us-east-1")
+
+    resp = rds.describe_db_engine_versions(Engine="aurora-mysql")
+    assert resp["DBEngineVersions"]
+    assert all(v["SupportsGlobalDatabases"] is True for v in resp["DBEngineVersions"])


### PR DESCRIPTION
## Summary
- Add Aurora Global cluster membership metadata for RDS DB clusters.
- Keep global cluster members consistent when clusters are attached, detached, renamed, or deleted.
- Reject invalid global-cluster attachments, including ARN identifiers, engine/version mismatches, and duplicate same-region members.

## Validation
- uv run --extra dev ruff check ministack/services/rds.py tests/test_rds_regions.py
- MINISTACK_ENDPOINT=http://localhost:4567 uv run --extra dev pytest tests/test_rds.py tests/test_rds_data.py tests/test_rds_regions.py tests/test_persistence.py -q
  - 260 passed, 1 skipped