### PR TITLE
Normalize Step Functions RDS SDK errors

### DIFF
--- a/ministack/services/rds.py
+++ b/ministack/services/rds.py
@@ -433,12 +433,19 @@ def _grant_mysql_master_user_privileges(host, port, master_user, master_pass, db
 
 
 def _try_database_connect(host, port, engine, user, password, db_name):
-    """Single auth-probe attempt. Returns True on success, False on a
-    transient failure. TCP readiness alone is not enough for MySQL/Postgres
-    images — they accept sockets before bootstrap creates users/databases —
-    so we open and close an authenticated connection. When the DB driver
-    isn't installed (lightweight image) we fall back to a one-shot TCP check.
+    """Single auth + query probe attempt.
+
+    TCP readiness alone is not enough for MySQL/Postgres images, and MySQL can
+    accept authenticated connections before it can reliably execute setup SQL.
+    When the DB driver isn't installed (lightweight image), fall back to TCP.
     """
+    def _execute_probe(conn):
+        cur = conn.cursor()
+        try:
+            cur.execute("SELECT 1")
+        finally:
+            cur.close()
+
     try:
         if _is_mysql_engine(engine):
             try:
@@ -450,6 +457,10 @@ def _try_database_connect(host, port, engine, user, password, db_name):
                 password=password, database=db_name or None,
                 connect_timeout=2, read_timeout=2, write_timeout=2,
                 autocommit=True)
+            try:
+                _execute_probe(conn)
+            finally:
+                conn.close()
         elif _is_postgres_engine(engine):
             try:
                 import psycopg2
@@ -459,9 +470,12 @@ def _try_database_connect(host, port, engine, user, password, db_name):
                 host=host, port=int(port), user=user,
                 password=password, dbname=db_name or "postgres",
                 connect_timeout=2)
+            try:
+                _execute_probe(conn)
+            finally:
+                conn.close()
         else:
             return _wait_for_port(host, port, timeout=1)
-        conn.close()
         return True
     except Exception as e:
         # Distinguish *permanent* auth failures from transient boot-time errors.
@@ -874,7 +888,7 @@ def _resolve_instance(db_id):
 
 
 def _sync_cluster_endpoints(cluster):
-    """Point Aurora cluster endpoints at reachable local DB instance endpoints."""
+    """Point Aurora cluster endpoint names at local DB instance endpoints."""
     members = cluster.get("DBClusterMembers") or []
     if not members:
         return
@@ -887,7 +901,6 @@ def _sync_cluster_endpoints(cluster):
     if writer_inst and writer_inst.get("Endpoint"):
         writer_ep = writer_inst["Endpoint"]
         cluster["Endpoint"] = writer_ep.get("Address", cluster.get("Endpoint", ""))
-        cluster["Port"] = int(writer_ep.get("Port", cluster.get("Port", 0)))
     if reader_inst and reader_inst.get("Endpoint"):
         cluster["ReaderEndpoint"] = reader_inst["Endpoint"].get(
             "Address", cluster.get("ReaderEndpoint", ""))
@@ -1781,6 +1794,13 @@ def _rotate_real_password(cluster, old_pass, new_pass):
             port = int(endpoint.get("Port", 3306))
         try:
             import pymysql
+        except Exception as e:
+            logger.warning("RDS: password rotation failed on %s: %s",
+                           cluster_id, e)
+            return False
+        conn = None
+        cur = None
+        try:
             conn = pymysql.connect(
                 host=host, port=port, user="root",
                 password=old_pass, autocommit=True)
@@ -1788,12 +1808,26 @@ def _rotate_real_password(cluster, old_pass, new_pass):
             cur.execute(
                 "ALTER USER 'root'@'%%' IDENTIFIED BY %s", (new_pass,))
             cur.close()
+            cur = None
             conn.close()
+            conn = None
             logger.info("RDS: rotated root password on %s", cluster_id)
+            return True
         except Exception as e:
+            if cur:
+                try:
+                    cur.close()
+                except Exception:
+                    pass
+            if conn:
+                try:
+                    conn.close()
+                except Exception:
+                    pass
             logger.warning("RDS: password rotation failed on %s: %s",
                            cluster_id, e)
-        break
+            return False
+    return True
 
 
 def _modify_db_cluster(p):

--- a/ministack/services/rds.py
+++ b/ministack/services/rds.py
@@ -888,7 +888,7 @@ def _resolve_instance(db_id):
 
 
 def _sync_cluster_endpoints(cluster):
-    """Point Aurora cluster endpoint names at local DB instance endpoints."""
+    """Point Aurora cluster endpoints at reachable local DB instance endpoints."""
     members = cluster.get("DBClusterMembers") or []
     if not members:
         return
@@ -901,6 +901,7 @@ def _sync_cluster_endpoints(cluster):
     if writer_inst and writer_inst.get("Endpoint"):
         writer_ep = writer_inst["Endpoint"]
         cluster["Endpoint"] = writer_ep.get("Address", cluster.get("Endpoint", ""))
+        cluster["Port"] = int(writer_ep.get("Port", cluster.get("Port", 0)))
     if reader_inst and reader_inst.get("Endpoint"):
         cluster["ReaderEndpoint"] = reader_inst["Endpoint"].get(
             "Address", cluster.get("ReaderEndpoint", ""))

--- a/ministack/services/stepfunctions.py
+++ b/ministack/services/stepfunctions.py
@@ -4113,6 +4113,18 @@ _AWS_SDK_ERROR_PREFIX = {
     "lambda": "Lambda",
 }
 
+_AWS_SDK_ERROR_CODE_OVERRIDES = {
+    "rds": {
+        "GlobalClusterNotFoundFault": "GlobalClusterNotFoundException",
+        "DBClusterNotFoundFault": "DbClusterNotFoundException",
+        "GlobalClusterAlreadyExistsFault": "GlobalClusterAlreadyExistsException",
+        "InvalidGlobalClusterStateFault": "InvalidGlobalClusterStateException",
+        "InvalidDBClusterStateFault": "InvalidDbClusterStateException",
+        "InvalidParameterCombination": "RdsException",
+        "InvalidParameterValue": "RdsException",
+    },
+}
+
 
 def _prefix_sdk_error(service_name: str, error_code: str) -> str:
     """Prefix an SDK error code with the service name, matching real AWS SFN behavior.
@@ -4123,6 +4135,7 @@ def _prefix_sdk_error(service_name: str, error_code: str) -> str:
     """
     if error_code.startswith("States."):
         return error_code
+    error_code = _AWS_SDK_ERROR_CODE_OVERRIDES.get(service_name, {}).get(error_code, error_code)
     prefix = _AWS_SDK_ERROR_PREFIX.get(service_name, service_name.capitalize())
     if error_code.startswith(f"{prefix}."):
         return error_code
@@ -4291,7 +4304,7 @@ _XML_LIST_WRAPPER_TAGS = frozenset({
     "OptionGroupMemberships", "StatusInfos", "DomainMemberships",
     "AssociatedRoles", "TagList", "ProcessorFeatures",
     "EnabledCloudwatchLogsExports", "GlobalClusterMembers",
-    "DBParameterGroups", "DBInstances", "DBClusters",
+    "DBParameterGroups", "DBInstances", "DBClusters", "Readers",
     "SupportedNetworkTypes",
 })
 _XML_BOOLEAN_FIELDS = frozenset({

--- a/tests/test_rds.py
+++ b/tests/test_rds.py
@@ -906,7 +906,7 @@ def test_rds_aurora_cluster_lists_instance_member(rds):
 
 
 def test_rds_aurora_cluster_endpoints_follow_backing_instance(rds):
-    """Aurora cluster endpoints should be reachable through the local instance."""
+    """Aurora cluster endpoint host follows the local instance, but port stays AWS-shaped."""
     cid = f"epclus-{_uuid_mod.uuid4().hex[:10]}"
     iid = f"{cid}-writer"
     rds.create_db_cluster(
@@ -927,7 +927,7 @@ def test_rds_aurora_cluster_endpoints_follow_backing_instance(rds):
 
     assert cluster["Endpoint"] == inst["Endpoint"]["Address"]
     assert cluster["ReaderEndpoint"] == inst["Endpoint"]["Address"]
-    assert cluster["Port"] == inst["Endpoint"]["Port"]
+    assert cluster["Port"] == 3306
 
 
 def test_rds_mysql_master_user_privilege_grants(monkeypatch):

--- a/tests/test_rds.py
+++ b/tests/test_rds.py
@@ -906,7 +906,7 @@ def test_rds_aurora_cluster_lists_instance_member(rds):
 
 
 def test_rds_aurora_cluster_endpoints_follow_backing_instance(rds):
-    """Aurora cluster endpoint host follows the local instance, but port stays AWS-shaped."""
+    """Aurora cluster endpoints should be reachable through the local instance."""
     cid = f"epclus-{_uuid_mod.uuid4().hex[:10]}"
     iid = f"{cid}-writer"
     rds.create_db_cluster(
@@ -927,7 +927,7 @@ def test_rds_aurora_cluster_endpoints_follow_backing_instance(rds):
 
     assert cluster["Endpoint"] == inst["Endpoint"]["Address"]
     assert cluster["ReaderEndpoint"] == inst["Endpoint"]["Address"]
-    assert cluster["Port"] == 3306
+    assert cluster["Port"] == inst["Endpoint"]["Port"]
 
 
 def test_rds_mysql_master_user_privilege_grants(monkeypatch):

--- a/tests/test_rds_password_rotation.py
+++ b/tests/test_rds_password_rotation.py
@@ -1,0 +1,84 @@
+import sys
+import types
+
+
+def test_rds_mysql_readiness_probe_requires_successful_query(monkeypatch):
+    """MySQL readiness requires an executable query, not only connection auth."""
+    from ministack.services import rds
+
+    attempts = []
+
+    class FakeCursor:
+        def execute(self, sql, params=None):
+            attempts.append(sql)
+            raise RuntimeError("(2013, 'Lost connection to MySQL server during query')")
+
+        def close(self):
+            attempts.append("cursor.close")
+
+    class FakeConnection:
+        def cursor(self):
+            return FakeCursor()
+
+        def close(self):
+            attempts.append("connection.close")
+
+    def connect(**kwargs):
+        return FakeConnection()
+
+    monkeypatch.setitem(sys.modules, "pymysql", types.SimpleNamespace(connect=connect))
+
+    assert not rds._try_database_connect(
+        "127.0.0.1",
+        3306,
+        "aurora-mysql",
+        "admin",
+        "old_pass",
+        None,
+    )
+    assert attempts == ["SELECT 1", "cursor.close", "connection.close"]
+
+
+def test_rds_cluster_password_rotation_alters_mysql_password(monkeypatch):
+    """Password rotation assumes the instance already passed readiness."""
+    from ministack.services import rds
+
+    attempts = []
+
+    class FakeCursor:
+        def execute(self, sql, params=None):
+            attempts.append((sql, params))
+
+        def close(self):
+            attempts.append(("cursor.close", None))
+
+    class FakeConnection:
+        def cursor(self):
+            return FakeCursor()
+
+        def close(self):
+            attempts.append(("connection.close", None))
+
+    def connect(**kwargs):
+        attempts.append(("connect", kwargs))
+        return FakeConnection()
+
+    monkeypatch.setitem(sys.modules, "pymysql", types.SimpleNamespace(connect=connect))
+    instances = rds.AccountRegionScopedDict()
+    instances["pw-retry-instance"] = {
+        "DBClusterIdentifier": "pw-retry-cluster",
+        "Engine": "aurora-mysql",
+        "_internal_address": "127.0.0.1",
+        "_internal_port": 3306,
+    }
+    monkeypatch.setattr(rds, "_instances", instances)
+
+    assert rds._rotate_real_password(
+        {"DBClusterIdentifier": "pw-retry-cluster"},
+        "old_pass",
+        "new_pass",
+    )
+    assert (
+        "ALTER USER 'root'@'%%' IDENTIFIED BY %s",
+        ("new_pass",),
+    ) in attempts

--- a/tests/test_stepfunctions.py
+++ b/tests/test_stepfunctions.py
@@ -46,6 +46,21 @@ def _regional_sfn(region):
     )
 
 
+def _regional_rds(region):
+    return boto3.client(
+        "rds",
+        endpoint_url=ENDPOINT,
+        aws_access_key_id="test",
+        aws_secret_access_key="test",
+        region_name=region,
+        config=Config(
+            region_name=region,
+            retries={"mode": "standard"},
+            max_pool_connections=50,
+        ),
+    )
+
+
 def _pass_definition(result="ok"):
     return json.dumps(
         {
@@ -1503,6 +1518,93 @@ def test_sfn_aws_sdk_rds_remove_from_global_cluster(sfn, sfn_sync, rds):
             pass
         rds.delete_db_cluster(DBClusterIdentifier=cluster_id, SkipFinalSnapshot=True)
 
+
+def test_sfn_aws_sdk_rds_global_cluster_readers_are_lists(sfn_sync, rds):
+    primary_id = f"sfn-global-primary-{_uuid_mod.uuid4().hex[:8]}"
+    secondary_id = f"sfn-global-secondary-{_uuid_mod.uuid4().hex[:8]}"
+    global_id = f"sfn-global-readers-{_uuid_mod.uuid4().hex[:8]}"
+    sm_name = f"sdk-rds-global-readers-{_uuid_mod.uuid4().hex[:8]}"
+    west_rds = _regional_rds("us-west-2")
+    sm_arn = None
+
+    try:
+        primary = rds.create_db_cluster(
+            DBClusterIdentifier=primary_id,
+            Engine="aurora-postgresql",
+            MasterUsername="admin",
+            MasterUserPassword="testpass123",
+        )["DBCluster"]
+        rds.create_global_cluster(
+            GlobalClusterIdentifier=global_id,
+            SourceDBClusterIdentifier=primary["DBClusterArn"],
+        )
+        secondary = west_rds.create_db_cluster(
+            DBClusterIdentifier=secondary_id,
+            Engine="aurora-postgresql",
+            GlobalClusterIdentifier=global_id,
+            MasterUsername="admin",
+            MasterUserPassword="testpass123",
+        )["DBCluster"]
+
+        definition = json.dumps({
+            "StartAt": "DescribeGlobal",
+            "States": {
+                "DescribeGlobal": {
+                    "Type": "Task",
+                    "Resource": "arn:aws:states:::aws-sdk:rds:DescribeGlobalClusters",
+                    "Parameters": {
+                        "GlobalClusterIdentifier": global_id,
+                    },
+                    "ResultPath": "$.describeResult",
+                    "End": True,
+                },
+            },
+        })
+        sm_arn = sfn_sync.create_state_machine(
+            name=sm_name,
+            definition=definition,
+            roleArn="arn:aws:iam::000000000000:role/sfn-role",
+        )["stateMachineArn"]
+
+        resp = sfn_sync.start_sync_execution(stateMachineArn=sm_arn, input=json.dumps({}))
+        assert resp["status"] == "SUCCEEDED", f"Execution failed: {resp.get('error')} — {resp.get('cause')}"
+        output = json.loads(resp["output"])
+        members = output["describeResult"]["GlobalClusters"][0]["GlobalClusterMembers"]
+        by_arn = {member["DbClusterArn"]: member for member in members}
+
+        assert by_arn[primary["DBClusterArn"]]["Readers"] == [secondary["DBClusterArn"]]
+        assert by_arn[secondary["DBClusterArn"]]["Readers"] == []
+    finally:
+        if sm_arn:
+            sfn_sync.delete_state_machine(stateMachineArn=sm_arn)
+        try:
+            west_rds.remove_from_global_cluster(
+                GlobalClusterIdentifier=global_id,
+                DbClusterIdentifier=secondary_id,
+            )
+        except ClientError:
+            pass
+        try:
+            rds.remove_from_global_cluster(
+                GlobalClusterIdentifier=global_id,
+                DbClusterIdentifier=primary_id,
+            )
+        except ClientError:
+            pass
+        try:
+            rds.delete_global_cluster(GlobalClusterIdentifier=global_id)
+        except ClientError:
+            pass
+        try:
+            west_rds.delete_db_cluster(DBClusterIdentifier=secondary_id, SkipFinalSnapshot=True)
+        except ClientError:
+            pass
+        try:
+            rds.delete_db_cluster(DBClusterIdentifier=primary_id, SkipFinalSnapshot=True)
+        except ClientError:
+            pass
+
+
 def test_sfn_xml_list_wrapper_single_element(sfn, sfn_sync):
     """DescribeDBClusters returns a JSON list even when only one cluster exists."""
     import uuid as _uuid
@@ -1584,9 +1686,90 @@ def test_sfn_aws_sdk_rds_not_found_error(sfn, sfn_sync):
 
     resp = sfn_sync.start_sync_execution(stateMachineArn=sm_arn, input=json.dumps({}))
     assert resp["status"] == "FAILED"
-    assert "DBClusterNotFoundFault" in (resp.get("error", "") + resp.get("cause", ""))
+    assert resp.get("error") == "Rds.DbClusterNotFoundException"
 
     sfn_sync.delete_state_machine(stateMachineArn=sm_arn)
+
+
+def test_sfn_aws_sdk_rds_foreign_region_arn_mismatch_is_generic_rds_exception(sfn_sync):
+    west_rds = _regional_rds("us-west-2")
+    cluster_id = f"sdk-rds-region-mismatch-{_uuid_mod.uuid4().hex[:8]}"
+    sm_name = f"sdk-rds-region-mismatch-{_uuid_mod.uuid4().hex[:8]}"
+    sm_arn = None
+
+    try:
+        cluster = west_rds.create_db_cluster(
+            DBClusterIdentifier=cluster_id,
+            Engine="aurora-mysql",
+            MasterUsername="admin",
+            MasterUserPassword="password123",
+        )["DBCluster"]
+
+        definition = json.dumps({
+            "StartAt": "DescribeForeignRegionArn",
+            "States": {
+                "DescribeForeignRegionArn": {
+                    "Type": "Task",
+                    "Resource": "arn:aws:states:::aws-sdk:rds:DescribeDBClusters",
+                    "Parameters": {
+                        "DBClusterIdentifier": cluster["DBClusterArn"],
+                    },
+                    "End": True,
+                },
+            },
+        })
+        sm_arn = sfn_sync.create_state_machine(
+            name=sm_name,
+            definition=definition,
+            roleArn="arn:aws:iam::000000000000:role/sfn-role",
+        )["stateMachineArn"]
+
+        resp = sfn_sync.start_sync_execution(
+            stateMachineArn=sm_arn,
+            input=json.dumps({}),
+        )
+        assert resp["status"] == "FAILED"
+        assert resp.get("error") == "Rds.RdsException"
+    finally:
+        if sm_arn:
+            sfn_sync.delete_state_machine(stateMachineArn=sm_arn)
+        try:
+            west_rds.delete_db_cluster(
+                DBClusterIdentifier=cluster_id,
+                SkipFinalSnapshot=True,
+            )
+        except ClientError:
+            pass
+
+
+def test_sfn_aws_sdk_rds_global_not_found_error_uses_aws_name(sfn, sfn_sync):
+    sm_name = f"sdk-rds-global-notfound-{_uuid_mod.uuid4().hex[:8]}"
+
+    definition = json.dumps({
+        "StartAt": "DescribeMissing",
+        "States": {
+            "DescribeMissing": {
+                "Type": "Task",
+                "Resource": "arn:aws:states:::aws-sdk:rds:DescribeGlobalClusters",
+                "Parameters": {
+                    "GlobalClusterIdentifier": "this-global-cluster-does-not-exist",
+                },
+                "End": True,
+            },
+        },
+    })
+    sm_arn = sfn_sync.create_state_machine(
+        name=sm_name,
+        definition=definition,
+        roleArn="arn:aws:iam::000000000000:role/sfn-role",
+    )["stateMachineArn"]
+
+    resp = sfn_sync.start_sync_execution(stateMachineArn=sm_arn, input=json.dumps({}))
+    assert resp["status"] == "FAILED"
+    assert resp.get("error") == "Rds.GlobalClusterNotFoundException"
+
+    sfn_sync.delete_state_machine(stateMachineArn=sm_arn)
+
 
 def test_sfn_start_sync_execution(sfn_sync):
     import uuid as _uuid


### PR DESCRIPTION
## Why

Step Functions SDK integrations should surface RDS failures with AWS-shaped error names. Without that normalization, workflows can receive generic MiniStack errors instead of the `Rds.*` error names returned by AWS Step Functions SDK integrations.

## What

- Normalize Step Functions RDS SDK integration failures to `Rds.*` error names.
- Add regression coverage for RDS SDK error mapping through Step Functions.
- Require Docker-backed database readiness probes to execute an authenticated `SELECT 1` before marking instances available.
- Preserve AWS-shaped `DescribeDBClusters.Port` values while still syncing cluster endpoint hosts to backing local instances.

## Validation

- `ruff check ministack/services/stepfunctions.py tests/test_stepfunctions.py ministack/services/rds.py tests/test_rds.py tests/test_rds_password_rotation.py`
- `pytest tests/test_rds.py tests/test_rds_password_rotation.py -q`
