### PR TITLE
fix(apigateway): v2 Lambda-proxy emits both header and array cookies, overrides case-mismatched headers

### DIFF
--- a/ministack/services/apigateway.py
+++ b/ministack/services/apigateway.py
@@ -1004,12 +1004,27 @@ async def _invoke_lambda_proxy(
 
     status = lambda_response.get("statusCode", 200)
     resp_headers = {"Content-Type": "application/json"}
-    resp_headers.update(lambda_response.get("headers", {}))
-    # Payload format 2.0 emits multiple Set-Cookie headers via the top-level
-    # `cookies` array, not the headers map. The list value is expanded into one
-    # Set-Cookie line per entry by _send_response.
+    # Apply the Lambda's headers, letting each override any case-insensitive
+    # default already present. HTTP field names are case-insensitive (RFC 9110
+    # §5.1), so a lowercase `content-type` from the function must replace the
+    # seeded `Content-Type`, not ship alongside it — the same case-insensitive
+    # handling #750 applied to the v1 multiValueHeaders merge.
+    for k, v in (lambda_response.get("headers") or {}).items():
+        lower_k = k.lower()
+        for existing in [h for h in resp_headers if h.lower() == lower_k]:
+            del resp_headers[existing]
+        resp_headers[k] = v
+    # Payload format 2.0 delivers cookies via the top-level `cookies` array,
+    # which AWS turns into one Set-Cookie header per entry. The array is the
+    # documented cookie mechanism — AWS guidance is "don't manually add
+    # set-cookie headers; use the cookies array" (Lambda Function URLs / HTTP
+    # API v2 docs) — so when it is present it supersedes any Set-Cookie carried
+    # in `headers` (the structured source wins, as in #750's v1 collision rule).
+    # _send_response expands the list into one Set-Cookie line per entry.
     cookies = lambda_response.get("cookies")
     if cookies:
+        for existing in [h for h in resp_headers if h.lower() == "set-cookie"]:
+            del resp_headers[existing]
         resp_headers["Set-Cookie"] = list(cookies)
     resp_body = lambda_response.get("body", "")
     if isinstance(resp_body, str):

--- a/tests/test_apigatewayv2.py
+++ b/tests/test_apigatewayv2.py
@@ -461,6 +461,115 @@ def test_apigw_execute_lambda_proxy_empty_cookies(apigw, lam):
     apigw.delete_api(ApiId=api_id)
     lam.delete_function(FunctionName=fname)
 
+def test_apigw_execute_lambda_proxy_cookies_supersede_header_set_cookie(apigw, lam):
+    """The `cookies` array supersedes a `Set-Cookie` carried in `headers`.
+
+    Follow-up to #750. For v2 the `cookies` array is the documented cookie
+    mechanism ("don't manually add set-cookie headers" — AWS Lambda Function
+    URLs / HTTP API v2 docs), so when both are returned only the array's cookies
+    ship — mirroring #759's v1 rule where the structured source wins on a
+    case-insensitive collision.
+    """
+    import urllib.request as _urlreq
+    import uuid as _uuid
+
+    fname = f"intg-apigw-cookiewin-{_uuid.uuid4().hex[:8]}"
+    code = (
+        b"def handler(event, context):\n"
+        b"    return {\n"
+        b"        'statusCode': 200,\n"
+        b"        'headers': {'set-cookie': 'should-be-dropped=1; Path=/'},\n"
+        b"        'cookies': ['a=1; Path=/', 'b=2; Path=/'],\n"
+        b"        'body': 'x',\n"
+        b"    }\n"
+    )
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("index.py", code)
+    lam.create_function(
+        FunctionName=fname, Runtime="python3.12",
+        Role="arn:aws:iam::000000000000:role/test-role",
+        Handler="index.handler", Code={"ZipFile": buf.getvalue()},
+    )
+
+    api_id = apigw.create_api(Name=f"cookiewin-api-{fname}", ProtocolType="HTTP")["ApiId"]
+    int_id = apigw.create_integration(
+        ApiId=api_id, IntegrationType="AWS_PROXY",
+        IntegrationUri=f"arn:aws:lambda:us-east-1:000000000000:function:{fname}",
+        PayloadFormatVersion="2.0",
+    )["IntegrationId"]
+    route_id = apigw.create_route(
+        ApiId=api_id, RouteKey="GET /cookiewin", Target=f"integrations/{int_id}",
+    )["RouteId"]
+    apigw.create_stage(ApiId=api_id, StageName="$default")
+
+    url = f"http://{api_id}.execute-api.localhost:{_EXECUTE_PORT}/$default/cookiewin"
+    req = _urlreq.Request(url, method="GET")
+    req.add_header("Host", f"{api_id}.execute-api.localhost:{_EXECUTE_PORT}")
+    resp = _urlreq.urlopen(req)
+    assert resp.status == 200
+    set_cookies = resp.headers.get_all("Set-Cookie") or []
+    # Only the array's cookies ship; the header `Set-Cookie` is superseded.
+    assert set_cookies == ["a=1; Path=/", "b=2; Path=/"]
+    assert all("should-be-dropped" not in c for c in set_cookies)
+
+    apigw.delete_route(ApiId=api_id, RouteId=route_id)
+    apigw.delete_integration(ApiId=api_id, IntegrationId=int_id)
+    apigw.delete_api(ApiId=api_id)
+    lam.delete_function(FunctionName=fname)
+
+def test_apigw_execute_lambda_proxy_header_case_override(apigw, lam):
+    """A lowercase `content-type` overrides the default, not duplicates it.
+
+    Follow-up to #750: HTTP field names are case-insensitive (RFC 9110 §5.1),
+    so a Lambda's `content-type` must replace MiniStack's seeded default
+    `Content-Type` rather than ship as a second header.
+    """
+    import urllib.request as _urlreq
+    import uuid as _uuid
+
+    fname = f"intg-apigw-ctcase-{_uuid.uuid4().hex[:8]}"
+    code = (
+        b"def handler(event, context):\n"
+        b"    return {\n"
+        b"        'statusCode': 200,\n"
+        b"        'headers': {'content-type': 'text/plain'},\n"
+        b"        'body': 'x',\n"
+        b"    }\n"
+    )
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("index.py", code)
+    lam.create_function(
+        FunctionName=fname, Runtime="python3.12",
+        Role="arn:aws:iam::000000000000:role/test-role",
+        Handler="index.handler", Code={"ZipFile": buf.getvalue()},
+    )
+
+    api_id = apigw.create_api(Name=f"ctcase-api-{fname}", ProtocolType="HTTP")["ApiId"]
+    int_id = apigw.create_integration(
+        ApiId=api_id, IntegrationType="AWS_PROXY",
+        IntegrationUri=f"arn:aws:lambda:us-east-1:000000000000:function:{fname}",
+        PayloadFormatVersion="2.0",
+    )["IntegrationId"]
+    route_id = apigw.create_route(
+        ApiId=api_id, RouteKey="GET /ct", Target=f"integrations/{int_id}",
+    )["RouteId"]
+    apigw.create_stage(ApiId=api_id, StageName="$default")
+
+    url = f"http://{api_id}.execute-api.localhost:{_EXECUTE_PORT}/$default/ct"
+    req = _urlreq.Request(url, method="GET")
+    req.add_header("Host", f"{api_id}.execute-api.localhost:{_EXECUTE_PORT}")
+    resp = _urlreq.urlopen(req)
+    assert resp.status == 200
+    # Exactly one Content-Type, and it's the Lambda's value (not the default).
+    assert (resp.headers.get_all("Content-Type") or []) == ["text/plain"]
+
+    apigw.delete_route(ApiId=api_id, RouteId=route_id)
+    apigw.delete_integration(ApiId=api_id, IntegrationId=int_id)
+    apigw.delete_api(ApiId=api_id)
+    lam.delete_function(FunctionName=fname)
+
 def test_apigw_execute_no_route(apigw):
     """execute-api returns 404 when no matching route exists."""
     import urllib.error as _urlerr


### PR DESCRIPTION
Follow-up to #750 — addresses the two v2 observations from that PR's review.

## Problem

Two parity gaps remained in the HTTP API (v2) Lambda-proxy response-header
assembly:

1. ~~A `Set-Cookie` carried in the response `headers` map was **overwritten** by the `cookies` array (`resp_headers["Set-Cookie"] = list(cookies)`). Per the AWS docs, both are sent — so the header cookie was silently dropped.~~

   **Correction (thanks @Nahuel990):** the docs don't support "both are sent." For v2 the `cookies` array is the documented cookie mechanism — *"don't manually add set-cookie headers; use the cookies array"* ([Lambda Function URLs](https://docs.aws.amazon.com/lambda/latest/dg/urls-invocation.html#urls-cookies) / [HTTP API v2](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html) docs, same payload schema). So the `cookies` array should **supersede** any `Set-Cookie` carried in `headers` (case-insensitive), matching #759's v1 rule where the structured source wins on collision.
2. A header returned in different letter-case than a seeded default — notably a
   lowercase `content-type` vs MiniStack's default `Content-Type` — produced
   two dict keys and shipped **twice**, default first. HTTP field names are
   case-insensitive (RFC 9110 §5.1); the function's value should win as one
   header.

## Fix (`apigateway.py`)

- Apply the Lambda's `headers` with case-insensitive override of any seeded
  default, mirroring the `multiValueHeaders` merge introduced for v1 in #750.
- When a `cookies` array is present, case-insensitively drop any `Set-Cookie`
  from `headers`, then emit the array — the array **supersedes** a hand-set
  `Set-Cookie`.

## Tests

- `headers` `Set-Cookie` + `cookies` array → only the array's cookies ship
  (the header `Set-Cookie` is superseded).
- lowercase `content-type` → a single overriding `Content-Type`.

Full API Gateway suite green; scope limited to the v2 builder.
