### PR TITLE
fix(apigateway): v1 Lambda-proxy overrides case-mismatched default headers

### DIFF
--- a/ministack/services/apigateway_v1.py
+++ b/ministack/services/apigateway_v1.py
@@ -976,7 +976,16 @@ async def _invoke_lambda_proxy_v1(integration, api_id, stage_name, stage, resour
 
     status = lambda_response.get("statusCode", 200)
     resp_headers = {"Content-Type": "application/json"}
-    resp_headers.update(lambda_response.get("headers", {}))
+    # Apply the Lambda's `headers` with case-insensitive override of any seeded
+    # default, the same way the multiValueHeaders merge below already case-folds
+    # collisions (added in #750 by @Nahuel990). HTTP field names are
+    # case-insensitive (RFC 9110 §5.1), so a lowercase `content-type` from the
+    # function must replace the default `Content-Type`, not ship alongside it.
+    for k, v in (lambda_response.get("headers") or {}).items():
+        lower_k = k.lower()
+        for existing in [h for h in resp_headers if h.lower() == lower_k]:
+            del resp_headers[existing]
+        resp_headers[k] = v
     # Payload format 1.0 carries multi-value headers (notably Set-Cookie) in
     # `multiValueHeaders`. AWS docs: "If you specify values for both `headers`
     # and `multiValueHeaders`, API Gateway merges them into a single list. If

--- a/tests/test_apigatewayv1.py
+++ b/tests/test_apigatewayv1.py
@@ -634,6 +634,73 @@ def test_apigwv1_execute_lambda_proxy_mvh_wins_case_insensitive(apigw_v1, lam):
     lam.delete_function(FunctionName=fname)
 
 
+def test_apigwv1_execute_lambda_proxy_header_case_override(apigw_v1, lam):
+    """A lowercase `content-type` overrides the default, not duplicates it.
+
+    Follow-up to #750: the multiValueHeaders merge there case-folds collisions,
+    but a plain-`headers` `content-type` vs the seeded default `Content-Type`
+    was still emitted twice. HTTP field names are case-insensitive (RFC 9110
+    §5.1), so the function's header must win as a single header.
+    """
+    import urllib.request as _urlreq
+    import uuid as _uuid
+
+    fname = f"intg-v1-ctcase-{_uuid.uuid4().hex[:8]}"
+    code = (
+        b"def handler(event, context):\n"
+        b"    return {\n"
+        b"        'statusCode': 200,\n"
+        b"        'headers': {'content-type': 'text/plain'},\n"
+        b"        'body': 'ok',\n"
+        b"    }\n"
+    )
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("index.py", code)
+    lam.create_function(
+        FunctionName=fname,
+        Runtime="python3.12",
+        Role="arn:aws:iam::000000000000:role/test-role",
+        Handler="index.handler",
+        Code={"ZipFile": buf.getvalue()},
+    )
+
+    api_id = apigw_v1.create_rest_api(name=f"v1-ctcase-{fname}")["id"]
+    root = next(r for r in apigw_v1.get_resources(restApiId=api_id)["items"] if r["path"] == "/")
+    resource_id = apigw_v1.create_resource(
+        restApiId=api_id,
+        parentId=root["id"],
+        pathPart="ct",
+    )["id"]
+    apigw_v1.put_method(
+        restApiId=api_id,
+        resourceId=resource_id,
+        httpMethod="GET",
+        authorizationType="NONE",
+    )
+    apigw_v1.put_integration(
+        restApiId=api_id,
+        resourceId=resource_id,
+        httpMethod="GET",
+        type="AWS_PROXY",
+        integrationHttpMethod="POST",
+        uri=f"arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:000000000000:function:{fname}/invocations",
+    )
+    dep_id = apigw_v1.create_deployment(restApiId=api_id)["id"]
+    apigw_v1.create_stage(restApiId=api_id, stageName="test", deploymentId=dep_id)
+
+    url = f"http://{api_id}.execute-api.localhost:{_EXECUTE_PORT}/test/ct"
+    req = _urlreq.Request(url, method="GET")
+    req.add_header("Host", f"{api_id}.execute-api.localhost:{_EXECUTE_PORT}")
+    resp = _urlreq.urlopen(req)
+    assert resp.status == 200
+    # Exactly one Content-Type, and it's the Lambda's value (not the default).
+    assert (resp.headers.get_all("Content-Type") or []) == ["text/plain"]
+
+    apigw_v1.delete_rest_api(restApiId=api_id)
+    lam.delete_function(FunctionName=fname)
+
+
 @pytest.mark.skipif(not shutil.which("curl"), reason="provided bootstrap uses curl for Runtime API")
 def test_apigwv1_execute_lambda_proxy_provided_runtime(apigw_v1, lam):
     """execute-api AWS_PROXY must run provided.* zips via lambda_svc (Go/terraform parity)."""


### PR DESCRIPTION
Follow-up to #750.

## Problem

The `multiValueHeaders` merge added in #750 (by @Nahuel990) case-folds
collisions, but only for keys present in `multiValueHeaders`. A `content-type`
carried in the plain `headers` map still collided with the seeded default
`Content-Type` and shipped **twice**. HTTP field names are case-insensitive
(RFC 9110 §5.1), so the function's header should override the default and be
emitted once.

## Fix (`apigateway_v1.py`)

Apply the same case-folding @Nahuel990 used for the `multiValueHeaders` merge to
the scalar `headers` merge, so a lowercase `content-type` replaces the default
`Content-Type` rather than duplicating it.

## Tests

- lowercase `content-type` → a single overriding `Content-Type`.

Full API Gateway suite green; one-function change to the v1 builder.
