### PR TITLE
feat: region isolation via AccountRegionScopedDict

### DIFF
--- a/ministack/core/responses.py
+++ b/ministack/core/responses.py
@@ -164,6 +164,110 @@ class AccountScopedDict:
         return f"AccountScopedDict({dict(self.items())})"
 
 
+
+class AccountRegionScopedDict:
+    """A dict-like container that namespaces keys by account ID *and* region.
+
+    Stores data as ``(account_id, region, key)`` tuples internally so
+    resources in different regions never collide. All standard dict
+    operations are scoped to the caller's account and the current request
+    region via ``get_account_id()`` and ``get_region()``.
+
+    Use for regional services (EC2, S3, Lambda, DynamoDB, etc.).
+
+    For global services (IAM, STS, Route 53, CloudFront) that have a single
+    namespace independent of region, use ``AccountScopedDict`` instead.
+    """
+
+    __slots__ = ("_data",)
+
+    def __init__(self):
+        self._data: dict = {}
+
+    # -- internal helpers --------------------------------------------------
+
+    def _scoped(self, key):
+        return (get_account_id(), get_region(), key)
+
+    def _unscope(self, scoped_key):
+        return scoped_key[2]
+
+    def _prefix(self):
+        return (get_account_id(), get_region())
+
+    def _is_mine(self, scoped_key):
+        return scoped_key[0] == get_account_id() and scoped_key[1] == get_region()
+
+    # -- dict interface ----------------------------------------------------
+
+    def __setitem__(self, key, value):
+        self._data[self._scoped(key)] = value
+
+    def __getitem__(self, key):
+        return self._data[self._scoped(key)]
+
+    def __delitem__(self, key):
+        del self._data[self._scoped(key)]
+
+    def __contains__(self, key):
+        return self._scoped(key) in self._data
+
+    def __len__(self):
+        return sum(1 for k in self._data if self._is_mine(k))
+
+    def __bool__(self):
+        return any(self._is_mine(k) for k in self._data)
+
+    def __iter__(self):
+        for k in self._data:
+            if self._is_mine(k):
+                yield self._unscope(k)
+
+    def get(self, key, default=None):
+        return self._data.get(self._scoped(key), default)
+
+    def pop(self, key, *args):
+        return self._data.pop(self._scoped(key), *args)
+
+    def setdefault(self, key, default=None):
+        return self._data.setdefault(self._scoped(key), default)
+
+    def keys(self):
+        return [self._unscope(k) for k in self._data if self._is_mine(k)]
+
+    def values(self):
+        return [v for k, v in self._data.items() if self._is_mine(k)]
+
+    def items(self):
+        return [(self._unscope(k), v) for k, v in self._data.items() if self._is_mine(k)]
+
+    def update(self, other):
+        if isinstance(other, AccountRegionScopedDict):
+            self._data.update(other._data)
+        elif isinstance(other, dict):
+            for k, v in other.items():
+                self[k] = v
+
+    def clear(self):
+        """Clear ALL accounts' and regions' data (used by reset)."""
+        self._data.clear()
+
+    def to_dict(self):
+        """Convert ALL data to a plain dict for serialization.
+        Keys are stored as (account_id, region, original_key) tuples."""
+        return dict(self._data)
+
+    @classmethod
+    def from_dict(cls, data):
+        """Restore from a plain dict produced by to_dict()."""
+        obj = cls()
+        obj._data = dict(data)
+        return obj
+
+    def __repr__(self):
+        return f"AccountRegionScopedDict({dict(self.items())})"
+
+
 def xml_response(root_tag: str, namespace: str, children: dict, status: int = 200) -> tuple:
     """Build an AWS-style XML response."""
     root = Element(root_tag, xmlns=namespace)

--- a/ministack/services/alb.py
+++ b/ministack/services/alb.py
@@ -28,7 +28,7 @@ import time
 from urllib.parse import parse_qs
 
 from ministack.core.persistence import PERSIST_STATE, load_state
-from ministack.core.responses import AccountScopedDict, get_account_id, get_region, new_uuid
+from ministack.core.responses import AccountRegionScopedDict, get_account_id, get_region, new_uuid
 
 logger = logging.getLogger("alb")
 
@@ -38,15 +38,15 @@ NS = "http://elasticloadbalancing.amazonaws.com/doc/2015-12-01/"
 # ---------------------------------------------------------------------------
 # State
 # ---------------------------------------------------------------------------
-_lbs = AccountScopedDict()        # lb_arn   -> LB record
-_tgs = AccountScopedDict()        # tg_arn   -> TG record
-_listeners = AccountScopedDict()  # l_arn    -> Listener record
-_rules = AccountScopedDict()      # r_arn    -> Rule record
-_targets = AccountScopedDict()    # tg_arn   -> [target dict]
-_tags = AccountScopedDict()       # res_arn  -> [{Key, Value}]
-_lb_attrs = AccountScopedDict()   # lb_arn   -> [{Key, Value}]
-_tg_attrs = AccountScopedDict()   # tg_arn   -> [{Key, Value}]
-_listener_attrs = AccountScopedDict()  # l_arn -> [{Key, Value}]
+_lbs = AccountRegionScopedDict()        # lb_arn   -> LB record
+_tgs = AccountRegionScopedDict()        # tg_arn   -> TG record
+_listeners = AccountRegionScopedDict()  # l_arn    -> Listener record
+_rules = AccountRegionScopedDict()      # r_arn    -> Rule record
+_targets = AccountRegionScopedDict()    # tg_arn   -> [target dict]
+_tags = AccountRegionScopedDict()       # res_arn  -> [{Key, Value}]
+_lb_attrs = AccountRegionScopedDict()   # lb_arn   -> [{Key, Value}]
+_tg_attrs = AccountRegionScopedDict()   # tg_arn   -> [{Key, Value}]
+_listener_attrs = AccountRegionScopedDict()  # l_arn -> [{Key, Value}]
 
 
 def get_state():

--- a/ministack/services/apigateway.py
+++ b/ministack/services/apigateway.py
@@ -51,7 +51,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 
-from ministack.core.responses import AccountScopedDict, error_response_json, get_account_id, get_region, new_uuid
+from ministack.core.responses import AccountRegionScopedDict, error_response_json, get_account_id, get_region, new_uuid
 
 _HOST = os.environ.get("MINISTACK_HOST", "localhost")
 _PORT = os.environ.get("GATEWAY_PORT", "4566")
@@ -89,19 +89,19 @@ _PROXY_TIMEOUT_SECONDS = _timeout_from_env("MINISTACK_APIGW_PROXY_TIMEOUT_SECOND
 _JWKS_TIMEOUT_SECONDS = _timeout_from_env("MINISTACK_APIGW_JWKS_TIMEOUT_SECONDS", 5.0)
 
 # ---- Module-level state ----
-_apis = AccountScopedDict()          # api_id -> api object
-_routes = AccountScopedDict()        # api_id -> {route_id -> route object}
-_integrations = AccountScopedDict()  # api_id -> {integration_id -> integration object}
-_stages = AccountScopedDict()        # api_id -> {stage_name -> stage object}
-_deployments = AccountScopedDict()   # api_id -> {deployment_id -> deployment object}
-_authorizers = AccountScopedDict()   # api_id -> {authorizer_id -> authorizer object}
-_api_tags = AccountScopedDict()      # resource_arn -> {key -> value}
-_route_responses = AccountScopedDict()         # api_id -> {route_id -> {rr_id -> route_response}}
-_integration_responses = AccountScopedDict()   # api_id -> {integration_id -> {ir_id -> int_response}}
+_apis = AccountRegionScopedDict()          # api_id -> api object
+_routes = AccountRegionScopedDict()        # api_id -> {route_id -> route object}
+_integrations = AccountRegionScopedDict()  # api_id -> {integration_id -> integration object}
+_stages = AccountRegionScopedDict()        # api_id -> {stage_name -> stage object}
+_deployments = AccountRegionScopedDict()   # api_id -> {deployment_id -> deployment object}
+_authorizers = AccountRegionScopedDict()   # api_id -> {authorizer_id -> authorizer object}
+_api_tags = AccountRegionScopedDict()      # resource_arn -> {key -> value}
+_route_responses = AccountRegionScopedDict()         # api_id -> {route_id -> {rr_id -> route_response}}
+_integration_responses = AccountRegionScopedDict()   # api_id -> {integration_id -> {ir_id -> int_response}}
 # JWKS cache is account-scoped because issuer URLs in MiniStack can resolve
 # to per-account local Cognito user pools — the same URL string may legitimately
 # serve different keys in different accounts.
-_jwks_cache = AccountScopedDict()
+_jwks_cache = AccountRegionScopedDict()
 
 # WebSocket connection registry — connections are not per-account-scoped at the store level
 # because the @connections management API may arrive on any host/account; instead we store

--- a/ministack/services/apigateway_v1.py
+++ b/ministack/services/apigateway_v1.py
@@ -79,7 +79,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 
-from ministack.core.responses import AccountScopedDict, get_account_id, get_region, new_uuid
+from ministack.core.responses import AccountRegionScopedDict, get_account_id, get_region, new_uuid
 from ministack.services.apigateway import _timeout_from_env, _urlopen_async
 
 
@@ -97,19 +97,19 @@ REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 # ---- Module-level state ----
 # All per-tenant state uses AccountScopedDict so the same REST API id in two
 # different accounts never collides and list operations don't leak cross-account.
-_rest_apis = AccountScopedDict()           # rest_api_id -> RestApi
-_resources = AccountScopedDict()           # rest_api_id -> {resource_id -> Resource}
-_stages_v1 = AccountScopedDict()           # rest_api_id -> {stage_name -> Stage}
-_deployments_v1 = AccountScopedDict()      # rest_api_id -> {deployment_id -> Deployment}
-_authorizers_v1 = AccountScopedDict()      # rest_api_id -> {authorizer_id -> Authorizer}
-_models = AccountScopedDict()              # rest_api_id -> {model_id -> Model}
-_api_keys = AccountScopedDict()            # key_id -> ApiKey
-_usage_plans = AccountScopedDict()         # plan_id -> UsagePlan
-_usage_plan_keys = AccountScopedDict()     # plan_id -> {key_id -> UsagePlanKey}
-_domain_names = AccountScopedDict()        # domain_name -> DomainName
-_base_path_mappings = AccountScopedDict()  # domain_name -> {base_path -> BasePathMapping}
-_v1_tags = AccountScopedDict()             # resource_arn -> {key -> value}
-_account_settings = AccountScopedDict()    # singleton per account: stores fields set via UpdateAccount
+_rest_apis = AccountRegionScopedDict()           # rest_api_id -> RestApi
+_resources = AccountRegionScopedDict()           # rest_api_id -> {resource_id -> Resource}
+_stages_v1 = AccountRegionScopedDict()           # rest_api_id -> {stage_name -> Stage}
+_deployments_v1 = AccountRegionScopedDict()      # rest_api_id -> {deployment_id -> Deployment}
+_authorizers_v1 = AccountRegionScopedDict()      # rest_api_id -> {authorizer_id -> Authorizer}
+_models = AccountRegionScopedDict()              # rest_api_id -> {model_id -> Model}
+_api_keys = AccountRegionScopedDict()            # key_id -> ApiKey
+_usage_plans = AccountRegionScopedDict()         # plan_id -> UsagePlan
+_usage_plan_keys = AccountRegionScopedDict()     # plan_id -> {key_id -> UsagePlanKey}
+_domain_names = AccountRegionScopedDict()        # domain_name -> DomainName
+_base_path_mappings = AccountRegionScopedDict()  # domain_name -> {base_path -> BasePathMapping}
+_v1_tags = AccountRegionScopedDict()             # resource_arn -> {key -> value}
+_account_settings = AccountRegionScopedDict()    # singleton per account: stores fields set via UpdateAccount
 
 
 # ---- Helpers ----

--- a/ministack/services/appconfig.py
+++ b/ministack/services/appconfig.py
@@ -34,7 +34,7 @@ import time
 import uuid
 
 from ministack.core.persistence import PERSIST_STATE, load_state
-from ministack.core.responses import AccountScopedDict, get_account_id, get_region
+from ministack.core.responses import AccountRegionScopedDict, get_account_id, get_region
 
 logger = logging.getLogger("appconfig")
 
@@ -44,14 +44,14 @@ REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 # State
 # ---------------------------------------------------------------------------
 
-_applications = AccountScopedDict()
-_environments = AccountScopedDict()          # "{app_id}/{env_id}" -> record
-_config_profiles = AccountScopedDict()       # "{app_id}/{profile_id}" -> record
-_hosted_versions = AccountScopedDict()       # "{app_id}/{profile_id}/{version}" -> record
-_deployment_strategies = AccountScopedDict()
-_deployments = AccountScopedDict()           # "{app_id}/{env_id}/{deploy_num}" -> record
-_tags = AccountScopedDict()                  # arn -> {key: value}
-_sessions = AccountScopedDict()              # token -> session record
+_applications = AccountRegionScopedDict()
+_environments = AccountRegionScopedDict()          # "{app_id}/{env_id}" -> record
+_config_profiles = AccountRegionScopedDict()       # "{app_id}/{profile_id}" -> record
+_hosted_versions = AccountRegionScopedDict()       # "{app_id}/{profile_id}/{version}" -> record
+_deployment_strategies = AccountRegionScopedDict()
+_deployments = AccountRegionScopedDict()           # "{app_id}/{env_id}/{deploy_num}" -> record
+_tags = AccountRegionScopedDict()                  # arn -> {key: value}
+_sessions = AccountRegionScopedDict()              # token -> session record
 
 # ---------------------------------------------------------------------------
 # Persistence

--- a/ministack/services/appsync.py
+++ b/ministack/services/appsync.py
@@ -26,6 +26,7 @@ import time
 
 from ministack.core.persistence import PERSIST_STATE, load_state
 from ministack.core.responses import (
+    AccountRegionScopedDict,
     AccountScopedDict,
     error_response_json,
     get_account_id,
@@ -42,12 +43,12 @@ REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 # In-memory state
 # ---------------------------------------------------------------------------
 
-_apis = AccountScopedDict()            # apiId -> api record
-_api_keys = AccountScopedDict()        # apiId -> {keyId -> key record}
-_data_sources = AccountScopedDict()    # apiId -> {name -> data source record}
-_resolvers = AccountScopedDict()       # apiId -> {typeName -> {fieldName -> resolver record}}
-_types = AccountScopedDict()           # apiId -> {typeName -> type record}
-_tags = AccountScopedDict()            # resource_arn -> {key: value}
+_apis = AccountRegionScopedDict()            # apiId -> api record
+_api_keys = AccountRegionScopedDict()        # apiId -> {keyId -> key record}
+_data_sources = AccountRegionScopedDict()    # apiId -> {name -> data source record}
+_resolvers = AccountRegionScopedDict()       # apiId -> {typeName -> {fieldName -> resolver record}}
+_types = AccountRegionScopedDict()           # apiId -> {typeName -> type record}
+_tags = AccountRegionScopedDict()            # resource_arn -> {key: value}
 
 # ---------------------------------------------------------------------------
 # Persistence

--- a/ministack/services/appsync_events.py
+++ b/ministack/services/appsync_events.py
@@ -28,6 +28,7 @@ import time
 
 from ministack.core.persistence import load_state
 from ministack.core.responses import (
+    AccountRegionScopedDict,
     AccountScopedDict,
     error_response_json,
     get_account_id,
@@ -43,11 +44,11 @@ logger = logging.getLogger("appsync_events")
 # ---------------------------------------------------------------------------
 
 # apiId -> api record
-_apis = AccountScopedDict()
+_apis = AccountRegionScopedDict()
 # apiId -> {name -> channel namespace record}
-_channel_namespaces = AccountScopedDict()
+_channel_namespaces = AccountRegionScopedDict()
 # apiId -> {keyId -> api key record}
-_api_keys = AccountScopedDict()
+_api_keys = AccountRegionScopedDict()
 
 # Active realtime connections, keyed by opaque connection id assigned on accept.
 # {connection_id -> {"api_id": str, "account_id": str, "outbox": asyncio.Queue,

--- a/ministack/services/athena.py
+++ b/ministack/services/athena.py
@@ -28,6 +28,7 @@ from urllib.parse import urlparse
 
 from ministack.core.persistence import PERSIST_STATE, load_state
 from ministack.core.responses import (
+    AccountRegionScopedDict,
     AccountScopedDict,
     error_response_json,
     get_account_id,
@@ -54,14 +55,14 @@ def get_athena_engine():
     return engine
 
 
-_executions = AccountScopedDict()
+_executions = AccountRegionScopedDict()
 # Per-account workgroups / data catalogs. AWS's "primary" workgroup and
 # "AwsDataCatalog" exist in every account — we lazily seed them per-tenant
 # on first access so two accounts never share the same workgroup or catalog
 # state (creation times, configs, etc.).
-_workgroups = AccountScopedDict()
-_named_queries = AccountScopedDict()
-_data_catalogs = AccountScopedDict()
+_workgroups = AccountRegionScopedDict()
+_named_queries = AccountRegionScopedDict()
+_data_catalogs = AccountRegionScopedDict()
 
 
 def _ensure_default_workgroup():
@@ -85,8 +86,8 @@ def _ensure_default_data_catalog():
             "Type": "GLUE",
             "Parameters": {},
         }
-_prepared_statements = AccountScopedDict()  # "workgroup/name" -> statement dict
-_tags = AccountScopedDict()  # arn -> {key: value, ...}
+_prepared_statements = AccountRegionScopedDict()  # "workgroup/name" -> statement dict
+_tags = AccountRegionScopedDict()  # arn -> {key: value, ...}
 
 
 def get_state():

--- a/ministack/services/autoscaling.py
+++ b/ministack/services/autoscaling.py
@@ -21,17 +21,17 @@ import time
 from collections import defaultdict
 
 from ministack.core.persistence import load_state
-from ministack.core.responses import AccountScopedDict, get_account_id, get_region, new_uuid, now_iso
+from ministack.core.responses import AccountRegionScopedDict, get_account_id, get_region, new_uuid, now_iso
 
 logger = logging.getLogger("autoscaling")
 REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 
-_asgs = AccountScopedDict()
-_launch_configs = AccountScopedDict()
-_policies = AccountScopedDict()
-_hooks = AccountScopedDict()
-_scheduled_actions = AccountScopedDict()
-_tags = AccountScopedDict()  # asg_name -> [{"Key":..., "Value":...}, ...]
+_asgs = AccountRegionScopedDict()
+_launch_configs = AccountRegionScopedDict()
+_policies = AccountRegionScopedDict()
+_hooks = AccountRegionScopedDict()
+_scheduled_actions = AccountRegionScopedDict()
+_tags = AccountRegionScopedDict()  # asg_name -> [{"Key":..., "Value":...}, ...]
 
 
 def get_state():

--- a/ministack/services/backup.py
+++ b/ministack/services/backup.py
@@ -18,7 +18,7 @@ import logging
 import time
 
 from ministack.core.persistence import load_state
-from ministack.core.responses import AccountScopedDict, get_account_id, get_region, new_uuid
+from ministack.core.responses import AccountRegionScopedDict, get_account_id, get_region, new_uuid
 
 logger = logging.getLogger("backup")
 
@@ -26,10 +26,10 @@ logger = logging.getLogger("backup")
 # State
 # ---------------------------------------------------------------------------
 
-_vaults     = AccountScopedDict()     # vault_name -> vault record
-_plans      = AccountScopedDict()     # plan_id -> plan record
-_selections = AccountScopedDict()     # selection_id -> selection record
-_jobs       = AccountScopedDict()     # job_id -> job record
+_vaults     = AccountRegionScopedDict()     # vault_name -> vault record
+_plans      = AccountRegionScopedDict()     # plan_id -> plan record
+_selections = AccountRegionScopedDict()     # selection_id -> selection record
+_jobs       = AccountRegionScopedDict()     # job_id -> job record
 
 
 def reset():

--- a/ministack/services/batch.py
+++ b/ministack/services/batch.py
@@ -13,6 +13,7 @@ import logging
 import time
 
 from ministack.core.responses import (
+    AccountRegionScopedDict,
     AccountScopedDict,
     error_response_json,
     get_account_id,
@@ -22,10 +23,10 @@ from ministack.core.responses import (
 
 logger = logging.getLogger("batch")
 
-_compute_envs = AccountScopedDict()   # name -> dict
-_job_queues = AccountScopedDict()     # name -> dict
-_job_definitions = AccountScopedDict()  # name -> [revisions]
-_jobs = AccountScopedDict()           # job_id -> dict
+_compute_envs = AccountRegionScopedDict()   # name -> dict
+_job_queues = AccountRegionScopedDict()     # name -> dict
+_job_definitions = AccountRegionScopedDict()  # name -> [revisions]
+_jobs = AccountRegionScopedDict()           # job_id -> dict
 
 
 def reset():

--- a/ministack/services/cloudformation/__init__.py
+++ b/ministack/services/cloudformation/__init__.py
@@ -14,17 +14,17 @@ import logging
 import os
 from urllib.parse import parse_qs
 
-from ministack.core.responses import AccountScopedDict
+from ministack.core.responses import AccountRegionScopedDict
 
 logger = logging.getLogger("cloudformation")
 
 REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 
 # In-memory state (shared across all submodules)
-_stacks = AccountScopedDict()          # stack_name -> stack dict
-_stack_events = AccountScopedDict()    # stack_id -> [event list]
-_exports = AccountScopedDict()         # export_name -> {StackId, Name, Value}
-_change_sets = AccountScopedDict()     # cs_id -> change set dict
+_stacks = AccountRegionScopedDict()          # stack_name -> stack dict
+_stack_events = AccountRegionScopedDict()    # stack_id -> [event list]
+_exports = AccountRegionScopedDict()         # export_name -> {StackId, Name, Value}
+_change_sets = AccountRegionScopedDict()     # cs_id -> change set dict
 
 # Re-exports for compatibility
 from .engine import (  # noqa: E402
@@ -79,6 +79,6 @@ def reset():
 
 
 # Must be last — handlers imports from this module
-from ministack.core.responses import AccountScopedDict, get_account_id
+from ministack.core.responses import AccountRegionScopedDict, get_account_id
 
 from .handlers import _ACTION_HANDLERS, _validate_template  # noqa: E402

--- a/ministack/services/cloudfront_keyvaluestore.py
+++ b/ministack/services/cloudfront_keyvaluestore.py
@@ -17,7 +17,7 @@ from datetime import datetime
 from urllib.parse import unquote
 
 from ministack.core.persistence import load_state
-from ministack.core.responses import AccountScopedDict, json_response, new_uuid
+from ministack.core.responses import AccountRegionScopedDict, json_response, new_uuid
 
 logger = logging.getLogger("cloudfront-keyvaluestore")
 
@@ -33,7 +33,7 @@ _STORE_RE = re.compile(r"^/key-value-stores/(arn:.+)$")
 # ---------------------------------------------------------------------------
 # In-memory state — keyed by KVS ARN
 # ---------------------------------------------------------------------------
-_stores = AccountScopedDict()  # arn -> {"etag": str, "items": {key: value}}
+_stores = AccountRegionScopedDict()  # arn -> {"etag": str, "items": {key: value}}
 
 
 def reset():

--- a/ministack/services/cloudtrail.py
+++ b/ministack/services/cloudtrail.py
@@ -21,17 +21,17 @@ import os
 import time
 
 from ministack.core.persistence import load_state
-from ministack.core.responses import AccountScopedDict, get_account_id, get_region, new_uuid
+from ministack.core.responses import AccountRegionScopedDict, get_account_id, get_region, new_uuid
 
 logger = logging.getLogger("cloudtrail")
 
 _recording_enabled: bool = os.environ.get("CLOUDTRAIL_RECORDING", "0") == "1"
 _MAX_EVENTS: int = int(os.environ.get("CLOUDTRAIL_MAX_EVENTS", "10000"))
 
-_events = AccountScopedDict()           # "events" -> deque[event_dict]
-_trails = AccountScopedDict()           # trail_name -> trail_record
-_event_selectors = AccountScopedDict()  # trail_name -> list[EventSelector]
-_trail_tags = AccountScopedDict()       # trail_arn -> {tag_key: tag_value}
+_events = AccountRegionScopedDict()           # "events" -> deque[event_dict]
+_trails = AccountRegionScopedDict()           # trail_name -> trail_record
+_event_selectors = AccountRegionScopedDict()  # trail_name -> list[EventSelector]
+_trail_tags = AccountRegionScopedDict()       # trail_arn -> {tag_key: tag_value}
 
 _SCRUB_KEYS = frozenset(
     {

--- a/ministack/services/cloudwatch.py
+++ b/ministack/services/cloudwatch.py
@@ -21,7 +21,7 @@ from datetime import datetime, timezone
 from urllib.parse import parse_qs
 
 from ministack.core.persistence import PERSIST_STATE, load_state
-from ministack.core.responses import AccountScopedDict, get_account_id, get_region, new_uuid
+from ministack.core.responses import AccountRegionScopedDict, get_account_id, get_region, new_uuid
 
 logger = logging.getLogger("cloudwatch")
 
@@ -31,15 +31,15 @@ TWO_WEEKS_SECONDS = 14 * 24 * 3600
 # Per-tenant metric store — keyed by (namespace, metric_name, dims_key) per
 # account via AccountScopedDict so GetMetricStatistics / ListMetrics from one
 # account cannot see another account's data points.
-_metrics = AccountScopedDict()
-_alarms = AccountScopedDict()
-_composite_alarms = AccountScopedDict()
+_metrics = AccountRegionScopedDict()
+_alarms = AccountRegionScopedDict()
+_composite_alarms = AccountRegionScopedDict()
 # Alarm state-change history, per-account. Stored as AccountScopedDict under
 # a single key "entries" so the standard list manipulation still applies to
 # the caller's tenant only.
-_alarm_history = AccountScopedDict()
-_resource_tags = AccountScopedDict()
-_dashboards = AccountScopedDict()  # dashboard_name -> {DashboardName, DashboardBody, LastModified}
+_alarm_history = AccountRegionScopedDict()
+_resource_tags = AccountRegionScopedDict()
+_dashboards = AccountRegionScopedDict()  # dashboard_name -> {DashboardName, DashboardBody, LastModified}
 
 
 def _metric_bucket(key: tuple) -> list:

--- a/ministack/services/cloudwatch_logs.py
+++ b/ministack/services/cloudwatch_logs.py
@@ -26,6 +26,7 @@ import os
 import time
 
 from ministack.core.responses import (
+    AccountRegionScopedDict,
     AccountScopedDict,
     error_response_json,
     get_account_id,
@@ -40,7 +41,7 @@ REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 
 from ministack.core.persistence import PERSIST_STATE, load_state
 
-_log_groups = AccountScopedDict()
+_log_groups = AccountRegionScopedDict()
 # group_name -> {
 #   arn, creationTime, retentionInDays (int|None), tags: {str: str},
 #   subscriptionFilters: {filterName: {filterName, logGroupName, filterPattern,
@@ -50,23 +51,23 @@ _log_groups = AccountScopedDict()
 #             firstEventTimestamp, lastEventTimestamp, lastIngestionTime}},
 # }
 
-_destinations = AccountScopedDict()
+_destinations = AccountRegionScopedDict()
 # dest_name -> {destinationName, targetArn, roleArn, accessPolicy, arn, creationTime}
 
-_metric_filters = AccountScopedDict()
+_metric_filters = AccountRegionScopedDict()
 # (log_group_name, filter_name) -> {filterName, logGroupName, filterPattern, metricTransformations, creationTime}
 
-_queries = AccountScopedDict()
+_queries = AccountRegionScopedDict()
 # query_id -> {queryId, logGroupName, startTime, endTime, queryString, status}
 
-_delivery_sources = AccountScopedDict()
+_delivery_sources = AccountRegionScopedDict()
 # source_name -> {name, arn, resourceArns: [str], logType, service, tags}
 
-_delivery_destinations = AccountScopedDict()
+_delivery_destinations = AccountRegionScopedDict()
 # dest_name -> {name, arn, deliveryDestinationType, outputFormat,
 #               deliveryDestinationConfiguration: {destinationResourceArn}, tags}
 
-_deliveries = AccountScopedDict()
+_deliveries = AccountRegionScopedDict()
 # delivery_id -> {id, arn, deliverySourceName, deliveryDestinationArn,
 #                 deliveryDestinationType, recordFields, fieldDelimiter,
 #                 s3DeliveryConfiguration, tags}

--- a/ministack/services/codebuild.py
+++ b/ministack/services/codebuild.py
@@ -17,6 +17,7 @@ import time
 
 from ministack.core.persistence import PERSIST_STATE, load_state
 from ministack.core.responses import (
+    AccountRegionScopedDict,
     AccountScopedDict,
     error_response_json,
     get_account_id,
@@ -32,8 +33,8 @@ REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 # ---------------------------------------------------------------------------
 # In-memory state
 # ---------------------------------------------------------------------------
-_projects = AccountScopedDict()    # project_name -> project record
-_builds = AccountScopedDict()      # build_id -> build record
+_projects = AccountRegionScopedDict()    # project_name -> project record
+_builds = AccountRegionScopedDict()      # build_id -> build record
 
 
 def reset():

--- a/ministack/services/cognito.py
+++ b/ministack/services/cognito.py
@@ -70,6 +70,7 @@ from defusedxml.ElementTree import fromstring as safe_xml_parse
 
 from ministack.core.persistence import PERSIST_STATE, load_state
 from ministack.core.responses import (
+    AccountRegionScopedDict,
     AccountScopedDict,
     error_response_json,
     get_account_id,
@@ -211,7 +212,7 @@ _SAML_NS = {
 # In-memory state — User Pools (cognito-idp)
 # ---------------------------------------------------------------------------
 
-_user_pools = AccountScopedDict()
+_user_pools = AccountRegionScopedDict()
 # pool_id -> {
 #   Id, Name, Arn, CreationDate, LastModifiedDate, Status,
 #   Policies, Schema, AutoVerifiedAttributes, UsernameAttributes,
@@ -224,7 +225,7 @@ _user_pools = AccountScopedDict()
 #   _identity_providers: {provider_name -> provider_dict},
 # }
 
-_pool_domain_map = AccountScopedDict()   # domain -> pool_id
+_pool_domain_map = AccountRegionScopedDict()   # domain -> pool_id
 
 # ---------------------------------------------------------------------------
 # In-memory state — OAuth2 Authorization Codes & Refresh Tokens
@@ -237,7 +238,7 @@ _refresh_tokens: dict[str, dict] = {}        # refresh_token_value -> {pool_id, 
 # In-memory state — Identity Pools (cognito-identity)
 # ---------------------------------------------------------------------------
 
-_identity_pools = AccountScopedDict()
+_identity_pools = AccountRegionScopedDict()
 # identity_pool_id -> {
 #   IdentityPoolId, IdentityPoolName, AllowUnauthenticatedIdentities,
 #   SupportedLoginProviders, DeveloperProviderName,
@@ -247,7 +248,7 @@ _identity_pools = AccountScopedDict()
 #   _identities: {identity_id -> identity_dict},
 # }
 
-_identity_tags = AccountScopedDict()   # identity_pool_id -> {key: value}
+_identity_tags = AccountRegionScopedDict()   # identity_pool_id -> {key: value}
 
 # ---------------------------------------------------------------------------
 # In-memory state — OAuth2 authorization codes

--- a/ministack/services/cur.py
+++ b/ministack/services/cur.py
@@ -17,14 +17,15 @@ import logging
 
 from ministack.core.persistence import load_state
 from ministack.core.responses import (
+    AccountRegionScopedDict,
     AccountScopedDict,
     error_response_json,
 )
 
 logger = logging.getLogger("cur")
 
-_report_definitions = AccountScopedDict()  # report_name -> report_definition
-_report_tags = AccountScopedDict()  # report_name -> {tag_key: tag_value}
+_report_definitions = AccountRegionScopedDict()  # report_name -> report_definition
+_report_tags = AccountRegionScopedDict()  # report_name -> {tag_key: tag_value}
 
 
 def reset():

--- a/ministack/services/dynamodb.py
+++ b/ministack/services/dynamodb.py
@@ -25,6 +25,7 @@ from collections import defaultdict
 from decimal import Decimal, InvalidOperation
 
 from ministack.core.responses import (
+    AccountRegionScopedDict,
     AccountScopedDict,
     error_response_json,
     get_account_id,
@@ -56,28 +57,28 @@ REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 
 from ministack.core.persistence import PERSIST_STATE, load_state
 
-_tables = AccountScopedDict()
-_tags = AccountScopedDict()
-_ttl_settings = AccountScopedDict()
-_pitr_settings = AccountScopedDict()
+_tables = AccountRegionScopedDict()
+_tags = AccountRegionScopedDict()
+_ttl_settings = AccountRegionScopedDict()
+_pitr_settings = AccountRegionScopedDict()
 # Kinesis streaming destinations — TableName -> list of
 # {"StreamArn": str, "DestinationStatus": "ACTIVE"|"DISABLED",
 #  "ApproximateCreationDateTimePrecision": "MILLISECOND"|"MICROSECOND"}.
 # ACTIVE entries get each _emit_stream_event record fanned out via
 # kinesis.put_record_internal; DISABLED entries stay on the describe
 # response (matching the ~24 h AWS retention window for readability).
-_kinesis_destinations = AccountScopedDict()
+_kinesis_destinations = AccountRegionScopedDict()
 # Contributor Insights — key is "TableName" or "TableName/index/IndexName".
 # Value: {"ContributorInsightsStatus": "ENABLED"|"DISABLED",
 #         "LastUpdateDateTime": float epoch, "ContributorInsightsRuleList": [str, ...]}.
-_backups = AccountScopedDict()  # BackupArn -> BackupDescription dict
-_contributor_insights = AccountScopedDict()
+_backups = AccountRegionScopedDict()  # BackupArn -> BackupDescription dict
+_contributor_insights = AccountRegionScopedDict()
 # Resource-based policies — ResourceArn -> {"Policy": str, "RevisionId": str}.
-_resource_policies = AccountScopedDict()
+_resource_policies = AccountRegionScopedDict()
 # Export tasks — ExportArn -> ExportDescription dict.
-_exports = AccountScopedDict()
+_exports = AccountRegionScopedDict()
 # Import tasks — ImportArn -> ImportTableDescription dict.
-_imports = AccountScopedDict()
+_imports = AccountRegionScopedDict()
 _lock = threading.Lock()
 
 
@@ -426,7 +427,7 @@ def _validate_item(item: dict, pk_name: str | None = None, sk_name: str | None =
 
 # DynamoDB Streams: table_name -> list of stream records
 # Each record follows the DynamoDB Streams event format consumed by Lambda ESMs.
-_stream_records = AccountScopedDict()
+_stream_records = AccountRegionScopedDict()
 _stream_seq_counter = 0
 _stream_seq_lock = threading.Lock()
 
@@ -2721,7 +2722,7 @@ def _transact_write_items(data):
     return json_response(result)
 
 
-_txn_idempotency = AccountScopedDict()
+_txn_idempotency = AccountRegionScopedDict()
 
 
 def _transact_get_items(data):

--- a/ministack/services/ec2.py
+++ b/ministack/services/ec2.py
@@ -69,7 +69,7 @@ from urllib.parse import parse_qs
 from xml.sax.saxutils import escape as _esc
 
 from ministack.core.persistence import PERSIST_STATE, load_state
-from ministack.core.responses import AccountScopedDict, get_account_id, get_region, new_uuid
+from ministack.core.responses import AccountRegionScopedDict, get_account_id, get_region, new_uuid
 
 logger = logging.getLogger("ec2")
 
@@ -79,30 +79,30 @@ REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 # State
 # ---------------------------------------------------------------------------
 
-_instances = AccountScopedDict()
-_security_groups = AccountScopedDict()
-_key_pairs = AccountScopedDict()
-_vpcs = AccountScopedDict()
-_subnets = AccountScopedDict()
-_internet_gateways = AccountScopedDict()
-_addresses = AccountScopedDict()       # allocation_id -> address record
-_tags = AccountScopedDict()            # resource_id -> [{"Key": ..., "Value": ...}]
-_route_tables = AccountScopedDict()    # rtb_id -> route table record
-_network_interfaces = AccountScopedDict()  # eni_id -> ENI record
-_vpc_endpoints = AccountScopedDict()   # vpce_id -> endpoint record
-_volumes = AccountScopedDict()         # vol_id -> volume record
-_snapshots = AccountScopedDict()       # snap_id -> snapshot record
-_nat_gateways = AccountScopedDict()    # nat_id -> NAT gateway record
-_network_acls = AccountScopedDict()    # acl_id -> network ACL record
-_flow_logs = AccountScopedDict()       # flow_log_id -> flow log record
-_vpc_peering = AccountScopedDict()     # pcx_id -> peering connection record
-_dhcp_options = AccountScopedDict()    # dopt_id -> DHCP options record
-_egress_igws = AccountScopedDict()     # eigw_id -> egress-only internet gateway record
-_prefix_lists = AccountScopedDict()    # pl_id -> managed prefix list record
-_vpn_gateways = AccountScopedDict()    # vgw_id -> VPN gateway record
-_customer_gateways = AccountScopedDict()  # cgw_id -> customer gateway record
-_vpn_connections = AccountScopedDict()    # vpn_id -> VPN connection record
-_launch_templates = AccountScopedDict()   # lt_id -> launch template record (includes versions list)
+_instances = AccountRegionScopedDict()
+_security_groups = AccountRegionScopedDict()
+_key_pairs = AccountRegionScopedDict()
+_vpcs = AccountRegionScopedDict()
+_subnets = AccountRegionScopedDict()
+_internet_gateways = AccountRegionScopedDict()
+_addresses = AccountRegionScopedDict()       # allocation_id -> address record
+_tags = AccountRegionScopedDict()            # resource_id -> [{"Key": ..., "Value": ...}]
+_route_tables = AccountRegionScopedDict()    # rtb_id -> route table record
+_network_interfaces = AccountRegionScopedDict()  # eni_id -> ENI record
+_vpc_endpoints = AccountRegionScopedDict()   # vpce_id -> endpoint record
+_volumes = AccountRegionScopedDict()         # vol_id -> volume record
+_snapshots = AccountRegionScopedDict()       # snap_id -> snapshot record
+_nat_gateways = AccountRegionScopedDict()    # nat_id -> NAT gateway record
+_network_acls = AccountRegionScopedDict()    # acl_id -> network ACL record
+_flow_logs = AccountRegionScopedDict()       # flow_log_id -> flow log record
+_vpc_peering = AccountRegionScopedDict()     # pcx_id -> peering connection record
+_dhcp_options = AccountRegionScopedDict()    # dopt_id -> DHCP options record
+_egress_igws = AccountRegionScopedDict()     # eigw_id -> egress-only internet gateway record
+_prefix_lists = AccountRegionScopedDict()    # pl_id -> managed prefix list record
+_vpn_gateways = AccountRegionScopedDict()    # vgw_id -> VPN gateway record
+_customer_gateways = AccountRegionScopedDict()  # cgw_id -> customer gateway record
+_vpn_connections = AccountRegionScopedDict()    # vpn_id -> VPN connection record
+_launch_templates = AccountRegionScopedDict()   # lt_id -> launch template record (includes versions list)
 
 
 # ── Persistence ────────────────────────────────────────────

--- a/ministack/services/ecr.py
+++ b/ministack/services/ecr.py
@@ -13,6 +13,7 @@ import time
 
 from ministack.core.persistence import PERSIST_STATE, load_state
 from ministack.core.responses import (
+    AccountRegionScopedDict,
     AccountScopedDict,
     error_response_json,
     get_account_id,
@@ -25,17 +26,17 @@ logger = logging.getLogger("ecr")
 
 REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 
-_repositories = AccountScopedDict()
-_images = AccountScopedDict()
-_lifecycle_policies = AccountScopedDict()
-_repo_policies = AccountScopedDict()
+_repositories = AccountRegionScopedDict()
+_images = AccountRegionScopedDict()
+_lifecycle_policies = AccountRegionScopedDict()
+_repo_policies = AccountRegionScopedDict()
 # Docker Registry HTTP API V2 backing storage.
 # _layer_blobs[repo] = {digest: bytes}     — finalised layer + config bytes addressable by digest.
 # _manifest_blobs[repo] = {digest: bytes}  — raw manifest bytes addressable by digest (for HEAD/GET by digest).
 # _uploads[repo] = {upload_uuid: bytearray} — in-flight chunked uploads (cleared on PUT).
-_layer_blobs = AccountScopedDict()
-_manifest_blobs = AccountScopedDict()
-_uploads = AccountScopedDict()
+_layer_blobs = AccountRegionScopedDict()
+_manifest_blobs = AccountRegionScopedDict()
+_uploads = AccountRegionScopedDict()
 
 
 # ── Persistence ────────────────────────────────────────────

--- a/ministack/services/ecs.py
+++ b/ministack/services/ecs.py
@@ -33,6 +33,7 @@ import time
 
 from ministack.core.persistence import load_state
 from ministack.core.responses import (
+    AccountRegionScopedDict,
     AccountScopedDict,
     error_response_json,
     get_account_id,
@@ -47,20 +48,20 @@ logger = logging.getLogger("ecs")
 
 REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 
-_clusters = AccountScopedDict()
-_task_defs = AccountScopedDict()
-_task_def_latest = AccountScopedDict()
-_services = AccountScopedDict()
-_tasks = AccountScopedDict()
-_tags = AccountScopedDict()
-_account_settings = AccountScopedDict()
-_capacity_providers = AccountScopedDict()
+_clusters = AccountRegionScopedDict()
+_task_defs = AccountRegionScopedDict()
+_task_def_latest = AccountRegionScopedDict()
+_services = AccountRegionScopedDict()
+_tasks = AccountRegionScopedDict()
+_tags = AccountRegionScopedDict()
+_account_settings = AccountRegionScopedDict()
+_capacity_providers = AccountRegionScopedDict()
 # `_attributes` was originally declared next to its handler block much
 # further down the file. Moved up here so the import-time `load_state`
 # block (which calls `restore_state` and references `_attributes`) sees
 # it defined; otherwise warm-boot fires NameError, the surrounding
 # try/except swallows it, and ALL ECS state silently fails to restore.
-_attributes = AccountScopedDict()
+_attributes = AccountRegionScopedDict()
 
 _docker = None
 
@@ -120,8 +121,8 @@ def get_state():
     }
     # Save tasks but strip Docker container IDs.
     # Iterate _data directly to capture ALL accounts.
-    from ministack.core.responses import AccountScopedDict
-    tasks = AccountScopedDict()
+    from ministack.core.responses import AccountRegionScopedDict
+    tasks = AccountRegionScopedDict()
     for scoped_key, task in _tasks._data.items():
         t = copy.deepcopy(task)
         t.pop("_docker_ids", None)
@@ -142,7 +143,7 @@ def restore_state(data):
     _account_settings.update(data.get("account_settings", {}))
     _capacity_providers.update(data.get("capacity_providers", {}))
     _attributes.update(data.get("attributes", {}))
-    from ministack.core.responses import AccountScopedDict
+    from ministack.core.responses import AccountRegionScopedDict
     tasks_data = data.get("tasks", {})
     if isinstance(tasks_data, AccountScopedDict):
         for scoped_key, task in tasks_data._data.items():

--- a/ministack/services/efs.py
+++ b/ministack/services/efs.py
@@ -25,7 +25,7 @@ import string
 import time
 
 from ministack.core.persistence import PERSIST_STATE, load_state
-from ministack.core.responses import AccountScopedDict, get_account_id, get_region
+from ministack.core.responses import AccountRegionScopedDict, get_account_id, get_region
 
 logger = logging.getLogger("efs")
 
@@ -35,9 +35,9 @@ REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 # State
 # ---------------------------------------------------------------------------
 
-_file_systems = AccountScopedDict()    # fs_id -> fs record
-_mount_targets = AccountScopedDict()   # mt_id -> mount target record
-_access_points = AccountScopedDict()   # ap_id -> access point record
+_file_systems = AccountRegionScopedDict()    # fs_id -> fs record
+_mount_targets = AccountRegionScopedDict()   # mt_id -> mount target record
+_access_points = AccountRegionScopedDict()   # ap_id -> access point record
 
 # ---------------------------------------------------------------------------
 # ID generators
@@ -373,8 +373,8 @@ def _find_resource(resource_id):
 # Lifecycle / Backup / Account (stubs)
 # ---------------------------------------------------------------------------
 
-_lifecycle_configs = AccountScopedDict()
-_backup_policies = AccountScopedDict()
+_lifecycle_configs = AccountRegionScopedDict()
+_backup_policies = AccountRegionScopedDict()
 
 
 def get_state():

--- a/ministack/services/eks.py
+++ b/ministack/services/eks.py
@@ -23,6 +23,7 @@ import time
 
 from ministack.core.persistence import load_state
 from ministack.core.responses import (
+    AccountRegionScopedDict,
     AccountScopedDict,
     apply_image_prefix,
     error_response_json,
@@ -50,10 +51,10 @@ except ImportError:
 # State
 # ---------------------------------------------------------------------------
 
-_clusters = AccountScopedDict()       # name -> cluster record
-_nodegroups = AccountScopedDict()     # "cluster/nodegroup" -> nodegroup record
-_addons = AccountScopedDict()         # "cluster/addonName" -> addon record
-_tags = AccountScopedDict()           # arn -> {key: value}
+_clusters = AccountRegionScopedDict()       # name -> cluster record
+_nodegroups = AccountRegionScopedDict()     # "cluster/nodegroup" -> nodegroup record
+_addons = AccountRegionScopedDict()         # "cluster/addonName" -> addon record
+_tags = AccountRegionScopedDict()           # arn -> {key: value}
 _port_counter_lock = threading.Lock()
 _port_counter = [EKS_BASE_PORT]
 

--- a/ministack/services/elasticache.py
+++ b/ministack/services/elasticache.py
@@ -27,7 +27,7 @@ import time
 from urllib.parse import parse_qs
 
 from ministack.core.persistence import load_state
-from ministack.core.responses import AccountScopedDict, apply_image_prefix, get_account_id, get_region, new_uuid
+from ministack.core.responses import AccountRegionScopedDict, apply_image_prefix, get_account_id, get_region, new_uuid
 
 logger = logging.getLogger("elasticache")
 
@@ -44,18 +44,18 @@ DOCKER_NETWORK = os.environ.get("DOCKER_NETWORK", "")
 # CI/dev deterministic; flip to "1" to exercise sharded discovery.
 ELASTICACHE_CLUSTER_MODE_REAL = os.environ.get("ELASTICACHE_CLUSTER_MODE_REAL", "") == "1"
 
-_clusters = AccountScopedDict()
-_replication_groups = AccountScopedDict()
-_subnet_groups = AccountScopedDict()
-_param_groups = AccountScopedDict()
-_param_group_params = AccountScopedDict()  # group_name -> {param_name -> param_dict}
-_tags = AccountScopedDict()  # arn -> [{"Key": ..., "Value": ...}, ...]
-_snapshots = AccountScopedDict()
-_users = AccountScopedDict()
-_user_groups = AccountScopedDict()
+_clusters = AccountRegionScopedDict()
+_replication_groups = AccountRegionScopedDict()
+_subnet_groups = AccountRegionScopedDict()
+_param_groups = AccountRegionScopedDict()
+_param_group_params = AccountRegionScopedDict()  # group_name -> {param_name -> param_dict}
+_tags = AccountRegionScopedDict()  # arn -> [{"Key": ..., "Value": ...}, ...]
+_snapshots = AccountRegionScopedDict()
+_users = AccountRegionScopedDict()
+_user_groups = AccountRegionScopedDict()
 # Per-account event log. AccountScopedDict under key "entries" so the list
 # manipulation stays simple and DescribeEvents never leaks cross-tenant rows.
-_events = AccountScopedDict()
+_events = AccountRegionScopedDict()
 
 
 def _events_list() -> list:

--- a/ministack/services/emr.py
+++ b/ministack/services/emr.py
@@ -24,6 +24,7 @@ import time
 
 from ministack.core.persistence import PERSIST_STATE, load_state
 from ministack.core.responses import (
+    AccountRegionScopedDict,
     AccountScopedDict,
     error_response_json,
     get_account_id,
@@ -40,8 +41,8 @@ REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 # State
 # ---------------------------------------------------------------------------
 
-_clusters = AccountScopedDict()   # cluster_id -> cluster record
-_steps = AccountScopedDict()      # cluster_id -> [step records]
+_clusters = AccountRegionScopedDict()   # cluster_id -> cluster record
+_steps = AccountRegionScopedDict()      # cluster_id -> [step records]
 _block_public_access: dict = {
     "BlockPublicSecurityGroupRules": False,
     "PermittedPublicSecurityGroupRuleRanges": [],

--- a/ministack/services/eventbridge.py
+++ b/ministack/services/eventbridge.py
@@ -33,6 +33,7 @@ import time
 from datetime import datetime, timedelta, timezone
 
 from ministack.core.responses import (
+    AccountRegionScopedDict,
     AccountScopedDict,
     error_response_json,
     get_account_id,
@@ -70,21 +71,21 @@ from ministack.core.persistence import PERSIST_STATE, load_state
 # Per-account bus registry. The "default" bus is lazily created per account
 # on first access so every tenant has its own default bus with an ARN whose
 # account-id segment matches the caller.
-_event_buses = AccountScopedDict()
-_rules = AccountScopedDict()
-_targets = AccountScopedDict()
+_event_buses = AccountRegionScopedDict()
+_rules = AccountRegionScopedDict()
+_targets = AccountRegionScopedDict()
 # Per-account event log — AccountScopedDict under "entries" keeps the list
 # semantics while scoping reads to the caller's account.
-_events_log = AccountScopedDict()
-_tags = AccountScopedDict()
-_archives = AccountScopedDict()
-_event_bus_policies = AccountScopedDict()  # bus_name -> {Statement: [...]}
-_connections = AccountScopedDict()         # connection_name -> {...}
-_api_destinations = AccountScopedDict()    # destination_name -> {...}
-_replays = AccountScopedDict()              # replay_name -> replay record
-_endpoints = AccountScopedDict()            # endpoint name -> endpoint record
+_events_log = AccountRegionScopedDict()
+_tags = AccountRegionScopedDict()
+_archives = AccountRegionScopedDict()
+_event_bus_policies = AccountRegionScopedDict()  # bus_name -> {Statement: [...]}
+_connections = AccountRegionScopedDict()         # connection_name -> {...}
+_api_destinations = AccountRegionScopedDict()    # destination_name -> {...}
+_replays = AccountRegionScopedDict()              # replay_name -> replay record
+_endpoints = AccountRegionScopedDict()            # endpoint name -> endpoint record
 # Partner event sources, per-account (key: "account|name" pattern inside each tenant).
-_partner_event_sources = AccountScopedDict()
+_partner_event_sources = AccountRegionScopedDict()
 
 # Tracks when each scheduled rule last fired: {(account_id, rule_key): timestamp}.
 # Plain dict (not AccountScopedDict) because the scheduler thread owns it globally.

--- a/ministack/services/firehose.py
+++ b/ministack/services/firehose.py
@@ -25,6 +25,7 @@ import time
 
 from ministack.core.persistence import PERSIST_STATE, load_state
 from ministack.core.responses import (
+    AccountRegionScopedDict,
     AccountScopedDict,
     error_response_json,
     get_account_id,
@@ -40,7 +41,7 @@ REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 
 # ─── in-memory state ──────────────────────────────────────────────────────────
 
-_streams = AccountScopedDict()          # name -> stream descriptor
+_streams = AccountRegionScopedDict()          # name -> stream descriptor
 _lock = threading.Lock()
 _dest_counter = 0
 

--- a/ministack/services/glue.py
+++ b/ministack/services/glue.py
@@ -23,6 +23,7 @@ import time
 
 from ministack.core.persistence import PERSIST_STATE, load_state
 from ministack.core.responses import (
+    AccountRegionScopedDict,
     AccountScopedDict,
     error_response_json,
     get_account_id,
@@ -95,20 +96,20 @@ def _is_spark_job(job):
     cmd_name = job.get("Command", {}).get("Name", "")
     return cmd_name in ("glueetl", "gluestreaming")
 
-_databases = AccountScopedDict()
-_tables = AccountScopedDict()       # "db_name/table_name" -> table dict
-_partitions = AccountScopedDict()   # "db_name/table_name" -> [partition, ...]
-_partition_indexes = AccountScopedDict()  # "db_name/table_name" -> [index, ...]
-_connections = AccountScopedDict()
-_crawlers = AccountScopedDict()
-_jobs = AccountScopedDict()
-_job_runs = AccountScopedDict()     # job_name -> [run, ...]
-_tags = AccountScopedDict()         # arn -> {key: value, ...}
-_security_configs = AccountScopedDict()
-_classifiers = AccountScopedDict()
-_triggers = AccountScopedDict()     # trigger_name -> trigger dict
-_workflows = AccountScopedDict()    # workflow_name -> workflow dict
-_workflow_runs = AccountScopedDict() # workflow_name -> [run, ...]
+_databases = AccountRegionScopedDict()
+_tables = AccountRegionScopedDict()       # "db_name/table_name" -> table dict
+_partitions = AccountRegionScopedDict()   # "db_name/table_name" -> [partition, ...]
+_partition_indexes = AccountRegionScopedDict()  # "db_name/table_name" -> [index, ...]
+_connections = AccountRegionScopedDict()
+_crawlers = AccountRegionScopedDict()
+_jobs = AccountRegionScopedDict()
+_job_runs = AccountRegionScopedDict()     # job_name -> [run, ...]
+_tags = AccountRegionScopedDict()         # arn -> {key: value, ...}
+_security_configs = AccountRegionScopedDict()
+_classifiers = AccountRegionScopedDict()
+_triggers = AccountRegionScopedDict()     # trigger_name -> trigger dict
+_workflows = AccountRegionScopedDict()    # workflow_name -> workflow dict
+_workflow_runs = AccountRegionScopedDict() # workflow_name -> [run, ...]
 
 _ALL_STATE = {
     "databases": _databases,

--- a/ministack/services/inspector2.py
+++ b/ministack/services/inspector2.py
@@ -11,6 +11,7 @@ import uuid
 
 from ministack.core.persistence import load_state
 from ministack.core.responses import (
+    AccountRegionScopedDict,
     AccountScopedDict,
     error_response_json,
     get_account_id,
@@ -20,12 +21,12 @@ from ministack.core.responses import (
 
 logger = logging.getLogger("inspector2")
 
-_account_config = AccountScopedDict()
-_findings = AccountScopedDict()
-_coverage = AccountScopedDict()
-_scan_history = AccountScopedDict()
-_tags = AccountScopedDict()
-_filters = AccountScopedDict()
+_account_config = AccountRegionScopedDict()
+_findings = AccountRegionScopedDict()
+_coverage = AccountRegionScopedDict()
+_scan_history = AccountRegionScopedDict()
+_tags = AccountRegionScopedDict()
+_filters = AccountRegionScopedDict()
 
 
 def _now_iso():

--- a/ministack/services/iot.py
+++ b/ministack/services/iot.py
@@ -42,6 +42,7 @@ from typing import Awaitable, Callable
 
 from ministack.core.persistence import load_state
 from ministack.core.responses import (
+    AccountRegionScopedDict,
     AccountScopedDict,
     _request_account_id,
     error_response_json,
@@ -69,11 +70,11 @@ _NAME_RE = re.compile(r"^[a-zA-Z0-9:_-]{1,128}$")
 # Module-level state (account-scoped)
 # ---------------------------------------------------------------------------
 
-_things: AccountScopedDict = AccountScopedDict()  # thingName -> Thing dict
-_thing_types: AccountScopedDict = AccountScopedDict()
-_thing_groups: AccountScopedDict = AccountScopedDict()
-_certificates: AccountScopedDict = AccountScopedDict()  # certificateId -> Certificate dict
-_policies: AccountScopedDict = AccountScopedDict()  # policyName -> Policy dict
+_things: AccountRegionScopedDict = AccountRegionScopedDict()  # thingName -> Thing dict
+_thing_types: AccountRegionScopedDict = AccountRegionScopedDict()
+_thing_groups: AccountRegionScopedDict = AccountRegionScopedDict()
+_certificates: AccountRegionScopedDict = AccountRegionScopedDict()  # certificateId -> Certificate dict
+_policies: AccountRegionScopedDict = AccountRegionScopedDict()  # policyName -> Policy dict
 
 # Local CA state — lazily generated on first use, persisted across restarts.
 import threading

--- a/ministack/services/kinesis.py
+++ b/ministack/services/kinesis.py
@@ -22,6 +22,7 @@ import threading
 import time
 
 from ministack.core.responses import (
+    AccountRegionScopedDict,
     AccountScopedDict,
     error_response_json,
     get_account_id,
@@ -38,9 +39,9 @@ ITERATOR_EXPIRY_SECONDS = 300
 
 from ministack.core.persistence import PERSIST_STATE, load_state
 
-_streams = AccountScopedDict()
-_shard_iterators = AccountScopedDict()
-_consumers = AccountScopedDict()
+_streams = AccountRegionScopedDict()
+_shard_iterators = AccountRegionScopedDict()
+_consumers = AccountRegionScopedDict()
 _sequence_counter = 0
 _sequence_lock = threading.Lock()
 

--- a/ministack/services/kms.py
+++ b/ministack/services/kms.py
@@ -14,6 +14,7 @@ import os
 import time
 
 from ministack.core.responses import (
+    AccountRegionScopedDict,
     AccountScopedDict,
     error_response_json,
     get_account_id,
@@ -42,7 +43,7 @@ REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 
 from ministack.core.persistence import PERSIST_STATE, load_state
 
-_keys = AccountScopedDict()
+_keys = AccountRegionScopedDict()
 # key_id -> {
 #     KeyId, Arn, KeyState, KeyUsage, KeySpec, Description,
 #     CreationDate, Enabled, Origin,
@@ -50,7 +51,7 @@ _keys = AccountScopedDict()
 #     _public_key_der (bytes, RSA/ECC only),
 #     _symmetric_key (bytes, SYMMETRIC_DEFAULT only),
 # }
-_aliases = AccountScopedDict()  # alias_name -> key_id (e.g. "alias/my-key" -> "uuid")
+_aliases = AccountRegionScopedDict()  # alias_name -> key_id (e.g. "alias/my-key" -> "uuid")
 
 
 # ── Persistence ────────────────────────────────────────────
@@ -58,8 +59,8 @@ _aliases = AccountScopedDict()  # alias_name -> key_id (e.g. "alias/my-key" -> "
 def get_state():
     """Return JSON-serializable state. Symmetric keys are base64-encoded;
     RSA private keys are PEM-encoded if cryptography is available."""
-    from ministack.core.responses import AccountScopedDict
-    serializable_keys = AccountScopedDict()
+    from ministack.core.responses import AccountRegionScopedDict
+    serializable_keys = AccountRegionScopedDict()
     # Iterate _data directly to capture ALL accounts
     for scoped_key, rec in _keys._data.items():
         entry = {k: v for k, v in rec.items()
@@ -84,7 +85,7 @@ def get_state():
 
 def restore_state(data):
     if data:
-        from ministack.core.responses import AccountScopedDict
+        from ministack.core.responses import AccountRegionScopedDict
         keys_data = data.get("keys", {})
         def _restore_key_entry(entry):
             if "_symmetric_key_b64" in entry:

--- a/ministack/services/lambda_durable.py
+++ b/ministack/services/lambda_durable.py
@@ -27,6 +27,7 @@ import uuid
 from urllib.parse import unquote
 
 from ministack.core.responses import (
+    AccountRegionScopedDict,
     AccountScopedDict,
     error_response_json,
     get_account_id,
@@ -58,7 +59,7 @@ from ministack.core.persistence import load_state
 #     "History": list[dict],            # append-only event log
 #     "NextEventId": int,
 #   }
-_executions = AccountScopedDict()
+_executions = AccountRegionScopedDict()
 
 # Resume scheduler — heapq of (resume_at_epoch, durable_arn, account_id).
 # When a durable invocation returns Status=PENDING with WAIT operations still

--- a/ministack/services/lambda_svc.py
+++ b/ministack/services/lambda_svc.py
@@ -49,6 +49,7 @@ from urllib.parse import unquote
 from ministack.core.lambda_runtime import get_or_create_worker, invalidate_worker
 from ministack.core.persistence import PERSIST_STATE, load_state
 from ministack.core.responses import (
+    AccountRegionScopedDict,
     _12_DIGIT_RE,
     AccountScopedDict,
     _request_account_id,
@@ -187,10 +188,10 @@ def _get_docker_client():
     except Exception:
         return None
 
-_functions = AccountScopedDict()  # function_name -> FunctionRecord
-_layers = AccountScopedDict()  # layer_name -> {"versions": [...], "next_version": int}
-_esms = AccountScopedDict()  # uuid -> esm dict
-_function_urls = AccountScopedDict()  # function_name -> FunctionUrlConfig dict
+_functions = AccountRegionScopedDict()  # function_name -> FunctionRecord
+_layers = AccountRegionScopedDict()  # layer_name -> {"versions": [...], "next_version": int}
+_esms = AccountRegionScopedDict()  # uuid -> esm dict
+_function_urls = AccountRegionScopedDict()  # function_name -> FunctionUrlConfig dict
 _poller_started = False
 _poller_lock = threading.Lock()
 
@@ -199,8 +200,8 @@ _poller_lock = threading.Lock()
 
 def get_state():
     """Return JSON-serializable state. code_zip bytes are base64-encoded."""
-    from ministack.core.responses import AccountScopedDict
-    funcs = AccountScopedDict()
+    from ministack.core.responses import AccountRegionScopedDict
+    funcs = AccountRegionScopedDict()
     # Iterate _data directly to capture ALL accounts, not just current request context
     for scoped_key, func in _functions._data.items():
         f = copy.deepcopy(func)
@@ -226,7 +227,7 @@ def get_state():
 
 def restore_state(data):
     if data:
-        from ministack.core.responses import AccountScopedDict
+        from ministack.core.responses import AccountRegionScopedDict
         funcs = data.get("functions", {})
         if isinstance(funcs, AccountScopedDict):
             for scoped_key, func in funcs._data.items():
@@ -4342,9 +4343,9 @@ def _delete_esm(esm_id: str):
 # ---------------------------------------------------------------------------
 
 # Per-ESM Kinesis iterator tracking: esm_uuid -> {shard_id: position}
-_kinesis_positions = AccountScopedDict()
+_kinesis_positions = AccountRegionScopedDict()
 # Per-ESM DynamoDB stream tracking: esm_uuid -> {shard_id: position}
-_dynamodb_stream_positions = AccountScopedDict()
+_dynamodb_stream_positions = AccountRegionScopedDict()
 _dynamodb_stream_positions_lock = threading.Lock()
 
 

--- a/ministack/services/mwaa.py
+++ b/ministack/services/mwaa.py
@@ -23,6 +23,7 @@ import time
 
 from ministack.core.persistence import load_state
 from ministack.core.responses import (
+    AccountRegionScopedDict,
     AccountScopedDict,
     apply_image_prefix,
     error_response_json,
@@ -39,7 +40,7 @@ MWAA_PERSIST = os.environ.get("MWAA_PERSIST", "0").lower() in ("1", "true", "yes
 DOCKER_NETWORK = os.environ.get("DOCKER_NETWORK", "")
 DEFAULT_AIRFLOW_IMAGE = os.environ.get("MWAA_AIRFLOW_IMAGE", "apache/airflow:3.0.6")
 
-_environments = AccountScopedDict()
+_environments = AccountRegionScopedDict()
 _port_counter = [BASE_PORT]
 _allocated_ports: set[int] = set()
 _freed_ports: list[int] = []

--- a/ministack/services/opensearch.py
+++ b/ministack/services/opensearch.py
@@ -27,6 +27,7 @@ import threading
 import time
 
 from ministack.core.responses import (
+    AccountRegionScopedDict,
     AccountScopedDict,
     apply_image_prefix,
     get_account_id,
@@ -79,9 +80,9 @@ _NAME_RE = re.compile(r"^[a-z][a-z0-9\-]{2,27}$")
 # State (account-scoped)
 # ---------------------------------------------------------------------------
 
-_domains = AccountScopedDict()        # name -> DomainStatus dict (+ private _* fields)
-_tags = AccountScopedDict()           # arn -> [{Key, Value}, ...]
-_change_progress = AccountScopedDict()  # name -> change progress record
+_domains = AccountRegionScopedDict()        # name -> DomainStatus dict (+ private _* fields)
+_tags = AccountRegionScopedDict()           # arn -> [{Key, Value}, ...]
+_change_progress = AccountRegionScopedDict()  # name -> change progress record
 
 # Port counter and Docker handle are process-global (data plane is shared).
 _port_counter = [BASE_PORT]

--- a/ministack/services/pipes.py
+++ b/ministack/services/pipes.py
@@ -15,14 +15,14 @@ import threading
 import time
 
 from ministack.core.persistence import load_state
-from ministack.core.responses import AccountScopedDict, get_account_id, get_region, new_uuid
+from ministack.core.responses import AccountRegionScopedDict, get_account_id, get_region, new_uuid
 
 logger = logging.getLogger("pipes")
 
 REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 
-_pipes = AccountScopedDict()       # pipe_name -> pipe record
-_positions = AccountScopedDict()   # pipe_arn -> next stream record index
+_pipes = AccountRegionScopedDict()       # pipe_name -> pipe record
+_positions = AccountRegionScopedDict()   # pipe_arn -> next stream record index
 _poller_started = False
 _poller_lock = threading.Lock()
 

--- a/ministack/services/rds.py
+++ b/ministack/services/rds.py
@@ -43,7 +43,7 @@ from urllib.parse import parse_qs
 from xml.sax.saxutils import escape as _esc
 
 from ministack.core.persistence import load_state
-from ministack.core.responses import AccountScopedDict, apply_image_prefix, get_account_id, get_region, new_uuid
+from ministack.core.responses import AccountRegionScopedDict, apply_image_prefix, get_account_id, get_region, new_uuid
 
 logger = logging.getLogger("rds")
 
@@ -53,16 +53,16 @@ RDS_TMPFS_SIZE = os.environ.get("RDS_TMPFS_SIZE", "256m")
 RDS_PERSIST = os.environ.get("RDS_PERSIST", "0").lower() in ("1", "true", "yes")
 DOCKER_NETWORK = os.environ.get("DOCKER_NETWORK", "")
 
-_instances = AccountScopedDict()
-_clusters = AccountScopedDict()
-_subnet_groups = AccountScopedDict()
-_param_groups = AccountScopedDict()
-_snapshots = AccountScopedDict()
-_db_cluster_param_groups = AccountScopedDict()
-_db_cluster_snapshots = AccountScopedDict()
-_option_groups = AccountScopedDict()
-_global_clusters = AccountScopedDict()
-_tags = AccountScopedDict()
+_instances = AccountRegionScopedDict()
+_clusters = AccountRegionScopedDict()
+_subnet_groups = AccountRegionScopedDict()
+_param_groups = AccountRegionScopedDict()
+_snapshots = AccountRegionScopedDict()
+_db_cluster_param_groups = AccountRegionScopedDict()
+_db_cluster_snapshots = AccountRegionScopedDict()
+_option_groups = AccountRegionScopedDict()
+_global_clusters = AccountRegionScopedDict()
+_tags = AccountRegionScopedDict()
 _port_counter = [BASE_PORT]
 
 _docker = None
@@ -109,7 +109,7 @@ def restore_state(data):
     instances_data = data.get("instances", {})
     to_respawn = []
     if isinstance(instances_data, AccountScopedDict):
-        # New format: AccountScopedDict with full multi-account data
+        # New format: AccountRegionScopedDict with full multi-account data
         for key, inst in list(instances_data._data.items()):
             inst["_docker_container_id"] = None
             inst["DBInstanceStatus"] = "creating"

--- a/ministack/services/rds_data.py
+++ b/ministack/services/rds_data.py
@@ -11,7 +11,7 @@ import re
 import threading
 import uuid
 
-from ministack.core.responses import AccountScopedDict, error_response_json, get_account_id, get_region, json_response
+from ministack.core.responses import AccountRegionScopedDict, error_response_json, get_account_id, get_region, json_response
 
 logger = logging.getLogger("rds-data")
 
@@ -23,9 +23,9 @@ _lock = threading.Lock()
 
 # In-memory tracking for stub mode: remember databases/users created via SQL.
 # Keyed by cluster identifier.
-_stub_databases = AccountScopedDict()   # cluster_id -> set of database names
-_stub_users = AccountScopedDict()       # cluster_id -> set of usernames
-_stub_grants = AccountScopedDict()      # cluster_id -> {username -> list of grant strings}
+_stub_databases = AccountRegionScopedDict()   # cluster_id -> set of database names
+_stub_users = AccountRegionScopedDict()       # cluster_id -> set of usernames
+_stub_grants = AccountRegionScopedDict()      # cluster_id -> {username -> list of grant strings}
 
 
 def _error(code, message, status=400):

--- a/ministack/services/resource_groups.py
+++ b/ministack/services/resource_groups.py
@@ -23,6 +23,7 @@ import re
 
 from ministack.core.persistence import load_state
 from ministack.core.responses import (
+    AccountRegionScopedDict,
     AccountScopedDict,
     get_account_id,
     get_region,
@@ -36,12 +37,12 @@ _GROUP_ARN_RE = re.compile(
 )
 _VALID_QUERY_TYPES = {"TAG_FILTERS_1_0", "CLOUDFORMATION_STACK_1_0"}
 
-_groups = AccountScopedDict()           # name -> Group dict
-_group_queries = AccountScopedDict()    # name -> ResourceQuery dict
-_group_configs = AccountScopedDict()    # name -> [GroupConfigurationItem]
-_group_members = AccountScopedDict()    # name -> [resource_arn]
-_group_tags = AccountScopedDict()       # name -> {tag_key: tag_value}
-_account_settings = AccountScopedDict()  # "settings" -> AccountSettings dict
+_groups = AccountRegionScopedDict()           # name -> Group dict
+_group_queries = AccountRegionScopedDict()    # name -> ResourceQuery dict
+_group_configs = AccountRegionScopedDict()    # name -> [GroupConfigurationItem]
+_group_members = AccountRegionScopedDict()    # name -> [resource_arn]
+_group_tags = AccountRegionScopedDict()       # name -> {tag_key: tag_value}
+_account_settings = AccountRegionScopedDict()  # "settings" -> AccountSettings dict
 
 
 def get_state():

--- a/ministack/services/s3.py
+++ b/ministack/services/s3.py
@@ -43,6 +43,7 @@ from defusedxml.ElementTree import fromstring
 
 from ministack.core.persistence import PERSIST_STATE, load_state
 from ministack.core.responses import (
+    AccountRegionScopedDict,
     AccountScopedDict,
     get_account_id,
     iso_to_rfc7231,
@@ -60,31 +61,31 @@ XML_DECL = b'<?xml version="1.0" encoding="UTF-8"?>'
 # ---------------------------------------------------------------------------
 # In-memory storage
 # ---------------------------------------------------------------------------
-_buckets = AccountScopedDict()
+_buckets = AccountRegionScopedDict()
 
-_bucket_policies = AccountScopedDict()
-_bucket_notifications = AccountScopedDict()
-_bucket_tags = AccountScopedDict()
-_bucket_versioning = AccountScopedDict()
-_bucket_encryption = AccountScopedDict()
-_bucket_lifecycle = AccountScopedDict()
-_bucket_cors = AccountScopedDict()
-_bucket_acl = AccountScopedDict()
-_bucket_websites = AccountScopedDict()
-_bucket_logging_config = AccountScopedDict()
-_bucket_accelerate_config = AccountScopedDict()
-_bucket_request_payment_config = AccountScopedDict()
+_bucket_policies = AccountRegionScopedDict()
+_bucket_notifications = AccountRegionScopedDict()
+_bucket_tags = AccountRegionScopedDict()
+_bucket_versioning = AccountRegionScopedDict()
+_bucket_encryption = AccountRegionScopedDict()
+_bucket_lifecycle = AccountRegionScopedDict()
+_bucket_cors = AccountRegionScopedDict()
+_bucket_acl = AccountRegionScopedDict()
+_bucket_websites = AccountRegionScopedDict()
+_bucket_logging_config = AccountRegionScopedDict()
+_bucket_accelerate_config = AccountRegionScopedDict()
+_bucket_request_payment_config = AccountRegionScopedDict()
 
-_object_tags = AccountScopedDict()
-_object_acl = AccountScopedDict()  # (bucket, key) -> stored ACL XML string
-_object_versions = AccountScopedDict()  # (bucket, key) -> [{version_id, obj_record}, ...]
+_object_tags = AccountRegionScopedDict()
+_object_acl = AccountRegionScopedDict()  # (bucket, key) -> stored ACL XML string
+_object_versions = AccountRegionScopedDict()  # (bucket, key) -> [{version_id, obj_record}, ...]
 
-_bucket_object_lock = AccountScopedDict()
-_bucket_replication = AccountScopedDict()
-_object_retention = AccountScopedDict()
-_object_legal_hold = AccountScopedDict()
+_bucket_object_lock = AccountRegionScopedDict()
+_bucket_replication = AccountRegionScopedDict()
+_object_retention = AccountRegionScopedDict()
+_object_legal_hold = AccountRegionScopedDict()
 
-_multipart_uploads = AccountScopedDict()
+_multipart_uploads = AccountRegionScopedDict()
 
 # ── Persistence (metadata only — object bodies are NOT persisted here) ────
 
@@ -116,7 +117,7 @@ _PERSISTED_BUCKET_DICTS = {
 def get_state():
     # Persist bucket metadata without object bodies.
     # Use _data directly to capture ALL accounts, not just the current one.
-    buckets_meta = AccountScopedDict()
+    buckets_meta = AccountRegionScopedDict()
     for scoped_key, bkt in _buckets._data.items():
         meta = {k: v for k, v in bkt.items() if k != "objects"}
         buckets_meta._data[scoped_key] = meta

--- a/ministack/services/s3files.py
+++ b/ministack/services/s3files.py
@@ -22,6 +22,7 @@ from urllib.parse import unquote
 
 from ministack.core.persistence import load_state
 from ministack.core.responses import (
+    AccountRegionScopedDict,
     AccountScopedDict,
     error_response_json,
     get_account_id,
@@ -42,12 +43,12 @@ def _empty_200():
 
 logger = logging.getLogger("s3files")
 
-_file_systems = AccountScopedDict()
-_mount_targets = AccountScopedDict()
-_access_points = AccountScopedDict()
-_policies = AccountScopedDict()
-_sync_configs = AccountScopedDict()
-_tags = AccountScopedDict()
+_file_systems = AccountRegionScopedDict()
+_mount_targets = AccountRegionScopedDict()
+_access_points = AccountRegionScopedDict()
+_policies = AccountRegionScopedDict()
+_sync_configs = AccountRegionScopedDict()
+_tags = AccountRegionScopedDict()
 
 
 def get_state():

--- a/ministack/services/s3tables.py
+++ b/ministack/services/s3tables.py
@@ -36,6 +36,7 @@ from urllib.parse import unquote
 
 from ministack.core.persistence import PERSIST_STATE, load_state
 from ministack.core.responses import (
+    AccountRegionScopedDict,
     AccountScopedDict,
     error_response_json,
     get_account_id,
@@ -49,9 +50,9 @@ logger = logging.getLogger("s3tables")
 
 # ── In-memory state ────────────────────────────────────────
 
-_table_buckets = AccountScopedDict()
-_namespaces = AccountScopedDict()        # "bucket_arn\x00namespace" -> ns dict
-_tables = AccountScopedDict()            # "bucket_arn\x00namespace\x00table" -> table dict
+_table_buckets = AccountRegionScopedDict()
+_namespaces = AccountRegionScopedDict()        # "bucket_arn\x00namespace" -> ns dict
+_tables = AccountRegionScopedDict()            # "bucket_arn\x00namespace\x00table" -> table dict
 
 
 # ── Persistence ────────────────────────────────────────────

--- a/ministack/services/scheduler.py
+++ b/ministack/services/scheduler.py
@@ -18,7 +18,7 @@ import re
 import time
 
 from ministack.core.persistence import load_state
-from ministack.core.responses import AccountScopedDict, get_account_id, get_region
+from ministack.core.responses import AccountRegionScopedDict, get_account_id, get_region
 
 logger = logging.getLogger("scheduler")
 
@@ -28,9 +28,9 @@ REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 # State
 # ---------------------------------------------------------------------------
 
-_schedules = AccountScopedDict()       # (group, name) -> schedule record
-_schedule_groups = AccountScopedDict()  # group_name -> group record
-_tags = AccountScopedDict()            # arn -> {key: value}
+_schedules = AccountRegionScopedDict()       # (group, name) -> schedule record
+_schedule_groups = AccountRegionScopedDict()  # group_name -> group record
+_tags = AccountRegionScopedDict()            # arn -> {key: value}
 
 
 def reset():

--- a/ministack/services/secretsmanager.py
+++ b/ministack/services/secretsmanager.py
@@ -20,6 +20,7 @@ import string
 import time
 
 from ministack.core.responses import (
+    AccountRegionScopedDict,
     AccountScopedDict,
     error_response_json,
     get_account_id,
@@ -34,8 +35,8 @@ REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 
 from ministack.core.persistence import PERSIST_STATE, load_state
 
-_secrets = AccountScopedDict()
-_resource_policies = AccountScopedDict()
+_secrets = AccountRegionScopedDict()
+_resource_policies = AccountRegionScopedDict()
 # name -> {
 #   ARN, Name, Description, Tags: [{Key, Value}],
 #   CreatedDate, LastChangedDate, LastAccessedDate,

--- a/ministack/services/servicediscovery.py
+++ b/ministack/services/servicediscovery.py
@@ -11,6 +11,7 @@ import time
 import xml.etree.ElementTree as ET
 
 from ministack.core.responses import (
+    AccountRegionScopedDict,
     AccountScopedDict,
     error_response_json,
     get_account_id,
@@ -25,14 +26,14 @@ logger = logging.getLogger("servicediscovery")
 REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 
 # In-memory state
-_namespaces = AccountScopedDict()     # ns_id -> namespace dict
-_services = AccountScopedDict()       # svc_id -> service dict
-_instances = AccountScopedDict()      # svc_id -> {instance_id -> instance dict}
-_operations = AccountScopedDict()     # op_id -> operation dict
-_resource_tags = AccountScopedDict()  # resource_arn -> [{"Key": ..., "Value": ...}]
-_service_attributes = AccountScopedDict()      # svc_id -> {key: value}
-_instance_health_status = AccountScopedDict()  # svc_id -> {instance_id: status}
-_instances_revision = AccountScopedDict()      # svc_id -> int
+_namespaces = AccountRegionScopedDict()     # ns_id -> namespace dict
+_services = AccountRegionScopedDict()       # svc_id -> service dict
+_instances = AccountRegionScopedDict()      # svc_id -> {instance_id -> instance dict}
+_operations = AccountRegionScopedDict()     # op_id -> operation dict
+_resource_tags = AccountRegionScopedDict()  # resource_arn -> [{"Key": ..., "Value": ...}]
+_service_attributes = AccountRegionScopedDict()      # svc_id -> {key: value}
+_instance_health_status = AccountRegionScopedDict()  # svc_id -> {instance_id: status}
+_instances_revision = AccountRegionScopedDict()      # svc_id -> int
 
 
 def get_state():

--- a/ministack/services/ses.py
+++ b/ministack/services/ses.py
@@ -39,18 +39,18 @@ from email.policy import default as default_policy
 from urllib.parse import parse_qs, unquote
 
 from ministack.core.persistence import PERSIST_STATE, load_state
-from ministack.core.responses import AccountScopedDict, get_account_id, get_region, new_uuid
+from ministack.core.responses import AccountRegionScopedDict, get_account_id, get_region, new_uuid
 
 logger = logging.getLogger("ses")
 
 REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 
-_identities = AccountScopedDict()
+_identities = AccountRegionScopedDict()
 # Per-account sent-mail record. AccountScopedDict under "entries" so the list
 # manipulation stays simple but GetSendStatistics / inspection is scoped.
-_sent_emails = AccountScopedDict()
-_templates = AccountScopedDict()
-_configuration_sets = AccountScopedDict()
+_sent_emails = AccountRegionScopedDict()
+_templates = AccountRegionScopedDict()
+_configuration_sets = AccountRegionScopedDict()
 
 
 def _sent_emails_list() -> list:

--- a/ministack/services/ses_v2.py
+++ b/ministack/services/ses_v2.py
@@ -16,16 +16,16 @@ import re
 import time
 
 from ministack.core.persistence import PERSIST_STATE, load_state
-from ministack.core.responses import AccountScopedDict, get_account_id, get_region, json_response, new_uuid, now_iso
+from ministack.core.responses import AccountRegionScopedDict, get_account_id, get_region, json_response, new_uuid, now_iso
 from ministack.services.ses import _build_mime_message, _parse_raw_mime, _sent_emails_list, _smtp_relay
 
 logger = logging.getLogger("ses-v2")
 
 REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 
-_identities = AccountScopedDict()        # identity -> dict
-_config_sets = AccountScopedDict()       # name -> dict
-_ses_tags = AccountScopedDict()          # resource_arn -> [tags]
+_identities = AccountRegionScopedDict()        # identity -> dict
+_config_sets = AccountRegionScopedDict()       # name -> dict
+_ses_tags = AccountRegionScopedDict()          # resource_arn -> [tags]
 
 
 def get_state() -> dict:

--- a/ministack/services/sns.py
+++ b/ministack/services/sns.py
@@ -27,7 +27,7 @@ _HOST = os.environ.get("MINISTACK_HOST", "localhost")
 _PORT = os.environ.get("GATEWAY_PORT", "4566")
 
 import ministack.services.lambda_svc as _lambda_svc
-from ministack.core.responses import AccountScopedDict, get_account_id, get_region, new_uuid
+from ministack.core.responses import AccountRegionScopedDict, get_account_id, get_region, new_uuid
 from ministack.services import sqs as _sqs
 
 logger = logging.getLogger("sns")
@@ -49,10 +49,10 @@ def _normalize_arn(arn: str) -> str:
 
 from ministack.core.persistence import PERSIST_STATE, load_state
 
-_topics = AccountScopedDict()
-_sub_arn_to_topic = AccountScopedDict()
-_platform_applications = AccountScopedDict()
-_platform_endpoints = AccountScopedDict()
+_topics = AccountRegionScopedDict()
+_sub_arn_to_topic = AccountRegionScopedDict()
+_platform_applications = AccountRegionScopedDict()
+_platform_endpoints = AccountRegionScopedDict()
 
 
 # ── Persistence ────────────────────────────────────────────

--- a/ministack/services/sqs.py
+++ b/ministack/services/sqs.py
@@ -35,14 +35,14 @@ from urllib.parse import parse_qs
 from xml.sax.saxutils import escape as _esc
 
 from ministack.core.persistence import PERSIST_STATE, load_state
-from ministack.core.responses import AccountScopedDict, get_account_id, get_region, md5_hash, new_uuid, now_iso
+from ministack.core.responses import AccountRegionScopedDict, get_account_id, get_region, md5_hash, new_uuid, now_iso
 
 logger = logging.getLogger("sqs")
 
 # ── Module-level state ──────────────────────────────────────
 
-_queues = AccountScopedDict()
-_queue_name_to_url = AccountScopedDict()
+_queues = AccountRegionScopedDict()
+_queue_name_to_url = AccountRegionScopedDict()
 _queues_lock = threading.Lock()
 
 

--- a/ministack/services/ssm.py
+++ b/ministack/services/ssm.py
@@ -16,6 +16,7 @@ import time
 from datetime import datetime, timezone
 
 from ministack.core.responses import (
+    AccountRegionScopedDict,
     AccountScopedDict,
     error_response_json,
     get_account_id,
@@ -31,9 +32,9 @@ DEFAULT_PAGE_SIZE = 10
 
 from ministack.core.persistence import PERSIST_STATE, load_state
 
-_parameters = AccountScopedDict()
-_parameter_history = AccountScopedDict()
-_tags = AccountScopedDict()
+_parameters = AccountRegionScopedDict()
+_parameter_history = AccountRegionScopedDict()
+_tags = AccountRegionScopedDict()
 
 
 # ── Persistence ────────────────────────────────────────────

--- a/ministack/services/stepfunctions.py
+++ b/ministack/services/stepfunctions.py
@@ -40,6 +40,7 @@ from datetime import datetime, timezone
 
 from ministack.core.persistence import PERSIST_STATE, load_state
 from ministack.core.responses import (
+    AccountRegionScopedDict,
     AccountScopedDict,
     error_response_json,
     get_account_id,
@@ -72,7 +73,7 @@ _SFN_WAIT_SCALE = _parse_wait_scale()
 REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 
 # SFN mock config — compatible with LocalStack's SFN_MOCK_CONFIG / LOCALSTACK_SFN_MOCK_CONFIG
-_sfn_mock_config = AccountScopedDict()
+_sfn_mock_config = AccountRegionScopedDict()
 _sfn_mock_config_path = (
     os.environ.get("SFN_MOCK_CONFIG")
     or os.environ.get("LOCALSTACK_SFN_MOCK_CONFIG")
@@ -119,24 +120,24 @@ def _get_mock_response(sm_name: str, test_case: str, state_name: str, attempt: i
                 continue
     return None
 
-_state_machines = AccountScopedDict()
-_executions = AccountScopedDict()
-_task_tokens = AccountScopedDict()
-_tags = AccountScopedDict()
-_activities = AccountScopedDict()
-_activity_tasks = AccountScopedDict()
+_state_machines = AccountRegionScopedDict()
+_executions = AccountRegionScopedDict()
+_task_tokens = AccountRegionScopedDict()
+_tags = AccountRegionScopedDict()
+_activities = AccountRegionScopedDict()
+_activity_tasks = AccountRegionScopedDict()
 
 # version_arn -> {stateMachineVersionArn, stateMachineRevisionId,
 #                 description, creationDate, definition, roleArn, type,
 #                 loggingConfiguration}
 # Version ARN shape: arn:aws:states:<region>:<acct>:stateMachine:<name>:<N>
-_state_machine_versions = AccountScopedDict()
+_state_machine_versions = AccountRegionScopedDict()
 
 # alias_arn -> {stateMachineAliasArn, name, description,
 #               routingConfiguration: [{stateMachineVersionArn, weight}],
 #               creationDate, updateDate}
 # Alias ARN shape: arn:aws:states:<region>:<acct>:stateMachine:<name>:<aliasName>
-_state_machine_aliases = AccountScopedDict()
+_state_machine_aliases = AccountRegionScopedDict()
 
 # ── Persistence ────────────────────────────────────────────
 

--- a/ministack/services/transfer.py
+++ b/ministack/services/transfer.py
@@ -44,6 +44,7 @@ from typing import AsyncIterator, Optional
 
 from ministack.core.persistence import load_state
 from ministack.core.responses import (
+    AccountRegionScopedDict,
     AccountScopedDict,
     error_response_json,
     get_account_id,
@@ -75,8 +76,8 @@ REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 # ---------------------------------------------------------------------------
 # In-memory state
 # ---------------------------------------------------------------------------
-_servers = AccountScopedDict()  # server_id -> server record
-_users = AccountScopedDict()    # "{server_id}/{user_name}" -> user record
+_servers = AccountRegionScopedDict()  # server_id -> server record
+_users = AccountRegionScopedDict()    # "{server_id}/{user_name}" -> user record
 
 
 def reset():


### PR DESCRIPTION
- Added AccountRegionScopedDict to responses.py: scopes by (account_id, region, key)
- 53 regional services switched from AccountScopedDict to AccountRegionScopedDict
- 6 global services (IAM, STS, Route53, CloudFront, Organizations, WAF, ACM) keep AccountScopedDict — visible across all regions
- Region extracted from SigV4 Authorization header via extract_region()
- Verified: EC2 instances in eu-south-1 invisible from us-east-1 and vice versa