### PR TITLE
fix(apigateway): v2 Lambda-proxy honors isBase64Encoded in both directions

### DIFF
--- a/ministack/services/apigateway.py
+++ b/ministack/services/apigateway.py
@@ -921,6 +921,22 @@ def _path_matches(route_path: str, request_path: str) -> bool:
     return _extract_path_params(route_path, request_path) is not None
 
 
+def _v2_request_body_is_text(content_type: str | None) -> bool:
+    """Whether an HTTP API (v2) request body is delivered as a UTF-8 string.
+
+    Real AWS delivers the body as text (``isBase64Encoded`` false) only for a
+    whitelist of content types; everything else — including a missing content
+    type and ``application/x-www-form-urlencoded`` — is base64-encoded. The docs
+    don't enumerate this, so the set below was verified against live AWS.
+    """
+    ct = (content_type or "").split(";", 1)[0].strip().lower()
+    return ct.startswith("text/") or ct in (
+        "application/json",
+        "application/xml",
+        "application/javascript",
+    )
+
+
 async def _invoke_lambda_proxy(
     integration,
     api_id,
@@ -957,6 +973,15 @@ async def _invoke_lambda_proxy(
     # AWS API Gateway v2 joins multi-value query params with commas
     qs = {k: ",".join(v) for k, v in query_params.items()} if query_params else None
     raw_qs = "&".join(f"{k}={val}" for k, vals in query_params.items() for val in vals)
+    # Binary request bodies are base64-encoded with isBase64Encoded=true; only
+    # the text content types AWS recognizes are passed through as UTF-8 strings.
+    if body:
+        if _v2_request_body_is_text(headers.get("content-type")):
+            req_body, req_is_base64 = body.decode("utf-8", errors="replace"), False
+        else:
+            req_body, req_is_base64 = base64.b64encode(body).decode("ascii"), True
+    else:
+        req_body, req_is_base64 = None, False
     event = {
         "version": "2.0",
         "routeKey": route_key,
@@ -982,8 +1007,8 @@ async def _invoke_lambda_proxy(
             "timeEpoch": int(time.time() * 1000),
         },
         "pathParameters": path_params,
-        "body": body.decode("utf-8", errors="replace") if body else None,
-        "isBase64Encoded": False,
+        "body": req_body,
+        "isBase64Encoded": req_is_base64,
     }
     if authorizer_claims is not None:
         event["requestContext"]["authorizer"] = {
@@ -1027,7 +1052,13 @@ async def _invoke_lambda_proxy(
             del resp_headers[existing]
         resp_headers["Set-Cookie"] = list(cookies)
     resp_body = lambda_response.get("body", "")
-    if isinstance(resp_body, str):
+    # A base64-encoded body (isBase64Encoded=true) is decoded to its raw bytes
+    # before sending. HTTP APIs (v2) honor this unconditionally — there is no
+    # binaryMediaTypes negotiation as in REST (v1) — so a true flag always means
+    # "the body string is base64; emit the decoded bytes."
+    if lambda_response.get("isBase64Encoded") and isinstance(resp_body, str):
+        resp_body = base64.b64decode(resp_body)
+    elif isinstance(resp_body, str):
         resp_body = resp_body.encode("utf-8")
     elif isinstance(resp_body, dict):
         resp_body = json.dumps(resp_body, ensure_ascii=False).encode("utf-8")

--- a/tests/test_apigatewayv2.py
+++ b/tests/test_apigatewayv2.py
@@ -570,6 +570,132 @@ def test_apigw_execute_lambda_proxy_header_case_override(apigw, lam):
     apigw.delete_api(ApiId=api_id)
     lam.delete_function(FunctionName=fname)
 
+def test_apigw_execute_lambda_proxy_base64_body(apigw, lam):
+    """A base64 response body (isBase64Encoded) is decoded to raw bytes.
+
+    HTTP API (v2) honors isBase64Encoded unconditionally. The response must
+    carry the decoded binary, not the literal base64 string.
+    """
+    import urllib.request as _urlreq
+    import uuid as _uuid
+
+    fname = f"intg-apigw-b64-{_uuid.uuid4().hex[:8]}"
+    # All 256 byte values — definitely not valid UTF-8, so a literal-base64
+    # regression would not compare equal.
+    code = (
+        b"import base64\n"
+        b"def handler(event, context):\n"
+        b"    raw = bytes(range(256))\n"
+        b"    return {\n"
+        b"        'statusCode': 200,\n"
+        b"        'headers': {'Content-Type': 'application/octet-stream'},\n"
+        b"        'isBase64Encoded': True,\n"
+        b"        'body': base64.b64encode(raw).decode('ascii'),\n"
+        b"    }\n"
+    )
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("index.py", code)
+    lam.create_function(
+        FunctionName=fname, Runtime="python3.12",
+        Role="arn:aws:iam::000000000000:role/test-role",
+        Handler="index.handler", Code={"ZipFile": buf.getvalue()},
+    )
+
+    api_id = apigw.create_api(Name=f"b64-api-{fname}", ProtocolType="HTTP")["ApiId"]
+    int_id = apigw.create_integration(
+        ApiId=api_id, IntegrationType="AWS_PROXY",
+        IntegrationUri=f"arn:aws:lambda:us-east-1:000000000000:function:{fname}",
+        PayloadFormatVersion="2.0",
+    )["IntegrationId"]
+    route_id = apigw.create_route(
+        ApiId=api_id, RouteKey="GET /bin", Target=f"integrations/{int_id}",
+    )["RouteId"]
+    apigw.create_stage(ApiId=api_id, StageName="$default")
+
+    url = f"http://{api_id}.execute-api.localhost:{_EXECUTE_PORT}/$default/bin"
+    req = _urlreq.Request(url, method="GET")
+    req.add_header("Host", f"{api_id}.execute-api.localhost:{_EXECUTE_PORT}")
+    resp = _urlreq.urlopen(req)
+    assert resp.status == 200
+    assert resp.read() == bytes(range(256))
+
+    apigw.delete_route(ApiId=api_id, RouteId=route_id)
+    apigw.delete_integration(ApiId=api_id, IntegrationId=int_id)
+    apigw.delete_api(ApiId=api_id)
+    lam.delete_function(FunctionName=fname)
+
+def test_apigw_execute_lambda_proxy_binary_request_body(apigw, lam):
+    """A binary request body is base64-encoded into the event.
+
+    Verified against real AWS (HTTP API v2): the inbound body is delivered as
+    base64 with isBase64Encoded=true for non-text content types (e.g.
+    application/octet-stream), and as a UTF-8 string for text types (e.g.
+    application/json).
+    """
+    import hashlib
+    import json as _json
+    import urllib.request as _urlreq
+    import uuid as _uuid
+
+    fname = f"intg-apigw-binreq-{_uuid.uuid4().hex[:8]}"
+    # Echo back what the function actually received in the event.
+    code = (
+        b"import json, base64, hashlib\n"
+        b"def handler(event, context):\n"
+        b"    b = event.get('body'); isb = bool(event.get('isBase64Encoded'))\n"
+        b"    if b is None: raw = b''\n"
+        b"    elif isb: raw = base64.b64decode(b)\n"
+        b"    else: raw = b.encode('utf-8', 'surrogateescape')\n"
+        b"    return {'statusCode': 200, 'headers': {'content-type': 'application/json'},\n"
+        b"            'body': json.dumps({'isB64': isb, 'sha': hashlib.sha256(raw).hexdigest()})}\n"
+    )
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("index.py", code)
+    lam.create_function(
+        FunctionName=fname, Runtime="python3.12",
+        Role="arn:aws:iam::000000000000:role/test-role",
+        Handler="index.handler", Code={"ZipFile": buf.getvalue()},
+    )
+
+    api_id = apigw.create_api(Name=f"binreq-api-{fname}", ProtocolType="HTTP")["ApiId"]
+    int_id = apigw.create_integration(
+        ApiId=api_id, IntegrationType="AWS_PROXY",
+        IntegrationUri=f"arn:aws:lambda:us-east-1:000000000000:function:{fname}",
+        PayloadFormatVersion="2.0",
+    )["IntegrationId"]
+    route_id = apigw.create_route(
+        ApiId=api_id, RouteKey="POST /echo", Target=f"integrations/{int_id}",
+    )["RouteId"]
+    apigw.create_stage(ApiId=api_id, StageName="$default")
+
+    url = f"http://{api_id}.execute-api.localhost:{_EXECUTE_PORT}/$default/echo"
+    host = f"{api_id}.execute-api.localhost:{_EXECUTE_PORT}"
+
+    # Binary content type -> base64-encoded body, round-tripping the raw bytes.
+    payload = bytes(range(256))
+    expected_sha = hashlib.sha256(payload).hexdigest()
+    req = _urlreq.Request(url, data=payload, method="POST")
+    req.add_header("Host", host)
+    req.add_header("Content-Type", "application/octet-stream")
+    got = _json.loads(_urlreq.urlopen(req).read())
+    assert got["isB64"] is True
+    assert got["sha"] == expected_sha
+
+    # Text content type (application/json) -> passed through as a UTF-8 string.
+    req2 = _urlreq.Request(url, data=b'{"x":1}', method="POST")
+    req2.add_header("Host", host)
+    req2.add_header("Content-Type", "application/json")
+    got2 = _json.loads(_urlreq.urlopen(req2).read())
+    assert got2["isB64"] is False
+    assert got2["sha"] == hashlib.sha256(b'{"x":1}').hexdigest()
+
+    apigw.delete_route(ApiId=api_id, RouteId=route_id)
+    apigw.delete_integration(ApiId=api_id, IntegrationId=int_id)
+    apigw.delete_api(ApiId=api_id)
+    lam.delete_function(FunctionName=fname)
+
 def test_apigw_execute_no_route(apigw):
     """execute-api returns 404 when no matching route exists."""
     import urllib.error as _urlerr


### PR DESCRIPTION
HTTP API (v2) Lambda-proxy ignored binary payloads on both sides. This adds `isBase64Encoded` handling in both directions.

## Response
A body with `isBase64Encoded: true` was emitted as the literal base64 string. It's now decoded to raw bytes before sending. `isBase64Encoded` is part of the documented v2 response payload format (refs below), and HTTP APIs honor it unconditionally — there is no `binaryMediaTypes` negotiation like REST/v1.

## Request
The inbound body was always `body.decode("utf-8")` with `isBase64Encoded: false`, corrupting binary uploads. It's now base64-encoded with `isBase64Encoded: true` for non-text content types.

The docs establish the mechanism — *"the body of the request. If the content type of the request is binary, the body is base64-encoded"* / *"`isBase64Encoded`: TRUE if the body is a binary payload and base64-encoded"* — but they **don't enumerate which content types count as binary**. So I **verified the split against real AWS** (HTTP API v2, payload 2.0, AWS_PROXY). The body is delivered as a UTF-8 string (`isBase64Encoded: false`) only for `text/*` and `application/json` / `application/xml` / `application/javascript`; everything else — including a missing `Content-Type` and (surprisingly) `application/x-www-form-urlencoded` — is base64-encoded.

| Content-Type sent | `isBase64Encoded` observed |
|---|---|
| `application/json`, `text/plain`, `text/html`, `application/xml`, `application/javascript` | **false** (UTF-8 string) |
| `application/octet-stream`, `image/png`, `image/jpeg`, `application/pdf`, `application/x-www-form-urlencoded`, *(no Content-Type)* | **true** (base64) |

<details><summary>Live-AWS verification (reproducible, self-cleaning)</summary>

```bash
#!/usr/bin/env bash
set -euo pipefail; export AWS_PAGER=""
REGION=us-east-1; SFX=$(date +%s); FN="b64req-$SFX"; ROLE="b64req-role-$SFX"
ACCT=$(aws sts get-caller-identity --query Account --output text)
TRUST='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
ROLE_ARN=$(aws iam create-role --role-name "$ROLE" --assume-role-policy-document "$TRUST" --query Role.Arn --output text)
aws iam attach-role-policy --role-name "$ROLE" --policy-arn arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
sleep 12
cat > /tmp/echo.py <<'PY'
import json, base64, hashlib
def handler(event, context):
    b=event.get("body"); isb=bool(event.get("isBase64Encoded"))
    raw=base64.b64decode(b) if (isb and b) else (b.encode("utf-8","surrogateescape") if b else b"")
    return {"statusCode":200,"headers":{"content-type":"application/json"},
            "body":json.dumps({"isB64":isb,"sha":hashlib.sha256(raw).hexdigest()[:12]})}
PY
(cd /tmp && zip -q echo.zip echo.py)
ARN=$(aws lambda create-function --function-name "$FN" --runtime python3.12 --role "$ROLE_ARN" \
  --handler echo.handler --zip-file fileb:///tmp/echo.zip --region "$REGION" --query FunctionArn --output text)
aws lambda wait function-active-v2 --function-name "$FN" --region "$REGION"
read API EP < <(aws apigatewayv2 create-api --name "$FN-api" --protocol-type HTTP --target "$ARN" \
  --region "$REGION" --query '[ApiId,ApiEndpoint]' --output text)
aws lambda add-permission --function-name "$FN" --statement-id "agw-$SFX" --action lambda:InvokeFunction \
  --principal apigateway.amazonaws.com --source-arn "arn:aws:execute-api:$REGION:$ACCT:$API/*/*" --region "$REGION" >/dev/null
sleep 5; printf '\x00\x01\x02\xfe\xff' > /tmp/p.bin
for CT in application/json text/plain application/xml application/javascript \
          application/x-www-form-urlencoded application/octet-stream image/png application/pdf; do
  printf '%-36s ' "$CT"; curl -s -X POST -H "Content-Type: $CT" --data-binary @/tmp/p.bin "$EP/"; echo
done
printf '%-36s ' "(no content-type)"; curl -s -X POST --data-binary @/tmp/p.bin "$EP/"; echo
# cleanup
aws apigatewayv2 delete-api --api-id "$API" --region "$REGION"
aws lambda delete-function --function-name "$FN" --region "$REGION"
aws iam detach-role-policy --role-name "$ROLE" --policy-arn arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
aws iam delete-role --role-name "$ROLE"
```
</details>

## References (AWS docs)
- [Create AWS Lambda proxy integrations for HTTP APIs](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html) — the payload-format-2.0 request and response shapes both include `isBase64Encoded`.
- [Invoking Lambda function URLs](https://docs.aws.amazon.com/lambda/latest/dg/urls-invocation.html) — same v2 payload schema; documents that a binary request body is base64-encoded and `isBase64Encoded` is set, and that the response `isBase64Encoded` flag is honored. (Neither page enumerates the text-vs-binary content types, hence the live test.)

## Tests
- base64 response body → decoded to raw bytes on the wire
- binary request body (`application/octet-stream`) → delivered as base64, round-tripping the raw bytes; a text body (`application/json`) → passed through as a UTF-8 string

Scope is v2 only; the REST (v1) binary path (`binaryMediaTypes`-driven) is a separate PR.
