### PR TITLE
Adopt ARN parsing in Resource Groups Tagging API

### DIFF
--- a/ministack/services/tagging.py
+++ b/ministack/services/tagging.py
@@ -12,7 +12,7 @@ Architecture:
   given ARN. Used by TagResources. Writers raise ``_ResourceNotFound`` when
   the ARN points at a resource that does not exist in the caller's account;
   the entry point catches it and surfaces the ARN in ``FailedResourcesMap``
-  with ``InvalidParameterException``, matching AWS.
+  with ``ResourceNotFound``, matching AWS.
 - **Removers** do the inverse for UntagResources.
 
 Each service keeps its own tag format (S3 flat dict, DynamoDB key/value list,
@@ -23,19 +23,33 @@ denormalise on write.
 
 import json
 import logging
-import os
 
+from ministack.core.arn import Arn, ArnParseError, parse_arn
 from ministack.core.responses import get_region
 
 logger = logging.getLogger("tagging")
-REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
+
+
+_GLOBAL_RESOURCE_SERVICES = {"cloudfront", "s3"}
 
 
 class _ResourceNotFound(Exception):
     """Raised by a writer/remover when the target ARN refers to a resource
     that does not exist in the caller's account. Caught by the TagResources /
     UntagResources entry points and surfaced in ``FailedResourcesMap`` with
-    ``InvalidParameterException`` (matches real AWS behaviour)."""
+    ``ResourceNotFound`` (matches real AWS behaviour)."""
+
+
+class _InvalidResourceArn(Exception):
+    """Raised when an ARN cannot be parsed or is not valid for this operation."""
+
+
+class _WrongAccountArn(Exception):
+    """Raised when a parsed ARN belongs to a different account."""
+
+
+class _WrongRegionArn(Exception):
+    """Raised when a parsed ARN belongs to a different region."""
 
 
 # ── Tag format normalisation ──────────────────────────────────────────────────
@@ -221,9 +235,13 @@ def _account():
 def _matches_type_filters(arn, type_filters):
     if not type_filters:
         return True
+    try:
+        spec = parse_arn(arn)
+    except ArnParseError:
+        return False
     for tf in type_filters:
         svc_prefix = tf.split(":")[0]
-        if f"::{svc_prefix}:" in arn or f":{svc_prefix}:" in arn:
+        if spec.service == svc_prefix:
             return True
     return False
 
@@ -243,33 +261,205 @@ def _matches_tag_filters(tags, tag_filters):
     return True
 
 
-def _service_key_from_arn(arn):
-    """Extract service segment from ARN (e.g. 'arn:aws:s3:::...' → 's3')."""
-    parts = arn.split(":")
-    return parts[2] if len(parts) >= 3 else ""
+def _parse_resource_arn(arn):
+    try:
+        spec = parse_arn(arn)
+    except ArnParseError as exc:
+        raise _InvalidResourceArn(f"{arn} is not a valid AmazonResourceName (ARN)") from exc
+    if (
+        spec.service in _COLLECTORS
+        and spec.service not in _GLOBAL_RESOURCE_SERVICES
+        and (not spec.region or not spec.account_id)
+    ):
+        raise _InvalidResourceArn(f"{arn} is not a valid AmazonResourceName (ARN)")
+    return spec
+
+
+def _parse_resource_arn_list(arn_list):
+    return [(arn, _parse_resource_arn(arn)) for arn in arn_list]
+
+
+def _resource_tail(spec: Arn, arn: str, prefix: str) -> str:
+    if not spec.resource.startswith(prefix):
+        raise _ResourceNotFound(arn)
+    tail = spec.resource[len(prefix):]
+    if not tail:
+        raise _ResourceNotFound(arn)
+    return tail
+
+
+def _s3_bucket_name(spec: Arn, arn: str) -> str:
+    if spec.region or spec.account_id or not spec.resource or "/" in spec.resource:
+        raise _ResourceNotFound(arn)
+    return spec.resource
+
+
+def _require_resource_scope(spec: Arn, arn: str) -> None:
+    if spec.service == "s3":
+        if spec.region or spec.account_id:
+            raise _ResourceNotFound(arn)
+        return
+    if spec.service == "cloudfront":
+        if spec.region or spec.account_id != _account():
+            raise _WrongAccountArn(arn)
+        return
+    if spec.region and spec.region != get_region():
+        raise _WrongRegionArn(arn)
+    if spec.account_id != _account():
+        raise _WrongAccountArn(arn)
+
+
+def _reject_foreign_region_arn(spec: Arn, arn: str, action: str) -> None:
+    if spec.service in _COLLECTORS and spec.region and spec.region != get_region():
+        raise _WrongRegionArn(
+            f"Region in the ARN {arn} does not match with the region in which {action} API is invoked"
+        )
+
+
+def _json(data, status=200):
+    return status, {"Content-Type": "application/x-amz-json-1.1"}, json.dumps(data).encode()
+
+
+def _invalid_parameter(message):
+    return 400, {
+        "Content-Type": "application/x-amz-json-1.1",
+        "x-amzn-errortype": "InvalidParameterException",
+    }, json.dumps({
+        "__type": "InvalidParameterException",
+        "message": message,
+    }).encode()
+
+
+def _failed_resource(error_code, message, status_code):
+    return {
+        "ErrorCode": error_code,
+        "ErrorMessage": message,
+        "StatusCode": status_code,
+    }
+
+
+def _dynamodb_table_name(spec: Arn, arn: str) -> str:
+    return _resource_tail(spec, arn, "table/")
+
+
+def _eventbridge_resource_exists(spec: Arn, arn: str) -> bool:
+    import ministack.services.eventbridge as svc
+    resource = spec.resource
+    if resource.startswith("event-bus/"):
+        name = _resource_tail(spec, arn, "event-bus/")
+        if name == "default":
+            svc._ensure_default_bus()
+        return name in svc._event_buses
+    if resource.startswith("rule/"):
+        tail = _resource_tail(spec, arn, "rule/")
+        if "/" in tail:
+            bus, name = tail.rsplit("/", 1)
+        else:
+            bus, name = "default", tail
+        return svc._rule_key(name, bus) in svc._rules
+    if resource.startswith("archive/"):
+        return _resource_tail(spec, arn, "archive/") in svc._archives
+    if resource.startswith("replay/"):
+        return _resource_tail(spec, arn, "replay/") in svc._replays
+    if resource.startswith("endpoint/"):
+        return _resource_tail(spec, arn, "endpoint/") in svc._endpoints
+    if resource.startswith("connection/"):
+        return _resource_tail(spec, arn, "connection/") in svc._connections
+    if resource.startswith("api-destination/"):
+        return _resource_tail(spec, arn, "api-destination/") in svc._api_destinations
+    return False
+
+
+def _ecs_resource_exists(arn: str) -> bool:
+    import ministack.services.ecs as svc
+    return (
+        any(c.get("clusterArn") == arn for c in svc._clusters.values())
+        or any(td.get("taskDefinitionArn") == arn for td in svc._task_defs.values())
+        or any(s.get("serviceArn") == arn for s in svc._services.values())
+        or any(t.get("taskArn") == arn for t in svc._tasks.values())
+        or any(cp.get("capacityProviderArn") == arn for cp in svc._capacity_providers.values())
+    )
+
+
+def _glue_resource_exists(spec: Arn, arn: str) -> bool:
+    import ministack.services.glue as svc
+    resource = spec.resource
+    if resource.startswith("database/"):
+        return _resource_tail(spec, arn, "database/") in svc._databases
+    if resource.startswith("table/"):
+        return _resource_tail(spec, arn, "table/") in svc._tables
+    if resource.startswith("crawler/"):
+        return _resource_tail(spec, arn, "crawler/") in svc._crawlers
+    if resource.startswith("job/"):
+        return _resource_tail(spec, arn, "job/") in svc._jobs
+    if resource.startswith("connection/"):
+        return _resource_tail(spec, arn, "connection/") in svc._connections
+    if resource.startswith("trigger/"):
+        return _resource_tail(spec, arn, "trigger/") in svc._triggers
+    if resource.startswith("workflow/"):
+        return _resource_tail(spec, arn, "workflow/") in svc._workflows
+    return arn in svc._tags
+
+
+def _appsync_resource_exists(spec: Arn, arn: str) -> bool:
+    import ministack.services.appsync as svc
+    if not spec.resource.startswith("apis/"):
+        return False
+    return _resource_tail(spec, arn, "apis/") in svc._apis
+
+
+def _scheduler_resource_exists(spec: Arn, arn: str) -> bool:
+    import ministack.services.scheduler as svc
+    if spec.resource.startswith("schedule/"):
+        tail = _resource_tail(spec, arn, "schedule/")
+        parts = tail.split("/", 1)
+        if len(parts) != 2:
+            return False
+        return f"{parts[0]}/{parts[1]}" in svc._schedules
+    if spec.resource.startswith("schedule-group/"):
+        name = _resource_tail(spec, arn, "schedule-group/")
+        if name == "default":
+            svc._ensure_default_group()
+        return name in svc._schedule_groups
+    return False
+
+
+def _cloudfront_resource_exists(spec: Arn, arn: str) -> bool:
+    import ministack.services.cloudfront as svc
+    if spec.resource.startswith("distribution/"):
+        return _resource_tail(spec, arn, "distribution/") in svc._distributions
+    if spec.resource.startswith("function/"):
+        return _resource_tail(spec, arn, "function/") in svc._functions
+    if spec.resource.startswith("key-value-store/"):
+        return _resource_tail(spec, arn, "key-value-store/") in svc._kvstores
+    return arn in svc._tags
 
 
 # ── Per-service tag writers ───────────────────────────────────────────────────
 
-def _write_s3(arn, tags):
+def _write_s3(spec, arn, tags):
     import ministack.services.s3 as svc
-    name = arn.split(":::")[-1]
+    name = _s3_bucket_name(spec, arn)
+    if name not in svc._buckets:
+        raise _ResourceNotFound(arn)
     svc._bucket_tags.setdefault(name, {}).update(tags)
 
 
-def _write_lambda(arn, tags):
+def _write_lambda(spec, arn, tags):
     """Merge ``tags`` into the Lambda function's ``tags`` field.
 
     Raises ``_ResourceNotFound`` if the function does not exist in the caller's
     account (AWS returns InvalidParameterException in that case)."""
     import ministack.services.lambda_svc as svc
-    func, _config, _name = svc._get_base_func_record_for_ref(arn)
+    name = _resource_tail(spec, arn, "function:")
+    base_name = name.split(":", 1)[0]
+    func = svc._functions.get(base_name)
     if func is None:
         raise _ResourceNotFound(arn)
     func.setdefault("tags", {}).update(tags)
 
 
-def _write_sqs(arn, tags):
+def _write_sqs(_spec, arn, tags):
     """Merge ``tags`` into the SQS queue keyed by ``QueueArn``.
 
     Raises ``_ResourceNotFound`` if no queue in the caller's account matches."""
@@ -281,7 +471,7 @@ def _write_sqs(arn, tags):
     raise _ResourceNotFound(arn)
 
 
-def _write_sns(arn, tags):
+def _write_sns(_spec, arn, tags):
     """Merge ``tags`` into the SNS topic at ``arn``.
 
     Raises ``_ResourceNotFound`` if the topic does not exist in the caller's
@@ -292,105 +482,126 @@ def _write_sns(arn, tags):
     svc._topics[arn].setdefault("tags", {}).update(tags)
 
 
-def _write_dynamodb(arn, tags):
+def _write_dynamodb(spec, arn, tags):
     import ministack.services.dynamodb as svc
+    table_name = _dynamodb_table_name(spec, arn)
+    if table_name not in svc._tables:
+        raise _ResourceNotFound(arn)
     existing = {t["Key"]: t["Value"] for t in svc._tags.get(arn, [])}
     existing.update(tags)
     svc._tags[arn] = [{"Key": k, "Value": v} for k, v in existing.items()]
 
 
-def _write_eventbridge(arn, tags):
+def _write_eventbridge(spec, arn, tags):
     import ministack.services.eventbridge as svc
+    if not _eventbridge_resource_exists(spec, arn):
+        raise _ResourceNotFound(arn)
     svc._tags.setdefault(arn, {}).update(tags)
 
 
-def _write_kms(arn, tags):
+def _write_kms(spec, arn, tags):
     import ministack.services.kms as svc
-    key_id = arn.split("/")[-1]
-    if key_id in svc._keys:
-        existing = {t["TagKey"]: t["TagValue"] for t in svc._keys[key_id].get("Tags", [])}
-        existing.update(tags)
-        svc._keys[key_id]["Tags"] = [{"TagKey": k, "TagValue": v} for k, v in existing.items()]
+    _resource_tail(spec, arn, "key/")
+    key = svc._resolve_key(arn)
+    if key is None:
+        raise _ResourceNotFound(arn)
+    existing = {t["TagKey"]: t["TagValue"] for t in key.get("Tags", [])}
+    existing.update(tags)
+    key["Tags"] = [{"TagKey": k, "TagValue": v} for k, v in existing.items()]
 
 
-def _write_ecr(arn, tags):
+def _write_ecr(spec, arn, tags):
     import ministack.services.ecr as svc
-    name = arn.split("repository/")[-1]
-    if name in svc._repositories:
-        existing = {t["Key"]: t["Value"] for t in svc._repositories[name].get("tags", [])}
-        existing.update(tags)
-        svc._repositories[name]["tags"] = [{"Key": k, "Value": v} for k, v in existing.items()]
+    name = _resource_tail(spec, arn, "repository/")
+    if name not in svc._repositories:
+        raise _ResourceNotFound(arn)
+    existing = {t["Key"]: t["Value"] for t in svc._repositories[name].get("tags", [])}
+    existing.update(tags)
+    svc._repositories[name]["tags"] = [{"Key": k, "Value": v} for k, v in existing.items()]
 
 
-def _write_ecs(arn, tags):
+def _write_ecs(_spec, arn, tags):
     import ministack.services.ecs as svc
+    if not _ecs_resource_exists(arn):
+        raise _ResourceNotFound(arn)
     existing = {t["key"]: t["value"] for t in svc._tags.get(arn, [])}
     existing.update(tags)
     svc._tags[arn] = [{"key": k, "value": v} for k, v in existing.items()]
 
 
-def _write_glue(arn, tags):
+def _write_glue(spec, arn, tags):
     import ministack.services.glue as svc
+    if not _glue_resource_exists(spec, arn):
+        raise _ResourceNotFound(arn)
     svc._tags.setdefault(arn, {}).update(tags)
 
 
-def _write_cognito_idp(arn, tags):
+def _write_cognito_idp(spec, arn, tags):
     """Merge ``tags`` into the Cognito user pool's ``UserPoolTags`` field.
 
     Raises ``_ResourceNotFound`` if the pool does not exist in the caller's
     account."""
     import ministack.services.cognito as svc
-    pool_id = arn.split("userpool/")[-1]
+    pool_id = _resource_tail(spec, arn, "userpool/")
     if pool_id not in svc._user_pools:
         raise _ResourceNotFound(arn)
     svc._user_pools[pool_id].setdefault("UserPoolTags", {}).update(tags)
 
 
-def _write_cognito_identity(arn, tags):
+def _write_cognito_identity(spec, arn, tags):
     import ministack.services.cognito as svc
-    pool_id = arn.split("identitypool/")[-1]
+    pool_id = _resource_tail(spec, arn, "identitypool/")
+    if pool_id not in svc._identity_pools:
+        raise _ResourceNotFound(arn)
     svc._identity_tags.setdefault(pool_id, {}).update(tags)
 
 
-def _write_appsync(arn, tags):
+def _write_appsync(spec, arn, tags):
     import ministack.services.appsync as svc
+    if not _appsync_resource_exists(spec, arn):
+        raise _ResourceNotFound(arn)
     svc._tags.setdefault(arn, {}).update(tags)
 
 
-def _write_scheduler(arn, tags):
+def _write_scheduler(spec, arn, tags):
     import ministack.services.scheduler as svc
+    if not _scheduler_resource_exists(spec, arn):
+        raise _ResourceNotFound(arn)
     svc._tags.setdefault(arn, {}).update(tags)
 
 
-def _write_cloudfront(arn, tags):
+def _write_cloudfront(spec, arn, tags):
     import ministack.services.cloudfront as svc
+    if not _cloudfront_resource_exists(spec, arn):
+        raise _ResourceNotFound(arn)
     existing = {t["Key"]: t["Value"] for t in svc._tags.get(arn, [])}
     existing.update(tags)
     svc._tags[arn] = [{"Key": k, "Value": v} for k, v in existing.items()]
 
 
-def _write_efs(arn, tags):
+def _write_efs(spec, arn, tags):
     import ministack.services.efs as svc
-    if ":file-system/" in arn:
-        resource = svc._file_systems.get(arn.split("file-system/")[-1])
+    if spec.resource.startswith("file-system/"):
+        resource = svc._file_systems.get(_resource_tail(spec, arn, "file-system/"))
     else:
-        resource = svc._access_points.get(arn.split("access-point/")[-1])
-    if resource is not None:
-        existing = {t["Key"]: t["Value"] for t in resource.get("Tags", [])}
-        existing.update(tags)
-        resource["Tags"] = [{"Key": k, "Value": v} for k, v in existing.items()]
+        resource = svc._access_points.get(_resource_tail(spec, arn, "access-point/"))
+    if resource is None:
+        raise _ResourceNotFound(arn)
+    existing = {t["Key"]: t["Value"] for t in resource.get("Tags", [])}
+    existing.update(tags)
+    resource["Tags"] = [{"Key": k, "Value": v} for k, v in existing.items()]
 
 
-def _write_backup(arn, tags):
+def _write_backup(spec, arn, tags):
     import ministack.services.backup as svc
-    if ":backup-vault:" in arn:
-        name = arn.split(":")[-1]
+    if spec.resource.startswith("backup-vault:"):
+        name = _resource_tail(spec, arn, "backup-vault:")
         v = svc._vaults.get(name)
         if v is None:
             raise _ResourceNotFound(arn)
         v.setdefault("BackupVaultTags", {}).update(tags)
-    elif ":backup-plan:" in arn:
-        pid = arn.split(":")[-1]
+    elif spec.resource.startswith("backup-plan:"):
+        pid = _resource_tail(spec, arn, "backup-plan:")
         p = svc._plans.get(pid)
         if p is None:
             raise _ResourceNotFound(arn)
@@ -412,19 +623,24 @@ _WRITERS = {
 
 # ── Per-service tag removers ──────────────────────────────────────────────────
 
-def _remove_s3(arn, keys):
+def _remove_s3(spec, arn, keys):
     import ministack.services.s3 as svc
-    tags = svc._bucket_tags.get(arn.split(":::")[-1], {})
+    name = _s3_bucket_name(spec, arn)
+    if name not in svc._buckets:
+        raise _ResourceNotFound(arn)
+    tags = svc._bucket_tags.get(name, {})
     for k in keys:
         tags.pop(k, None)
 
 
-def _remove_lambda(arn, keys):
+def _remove_lambda(spec, arn, keys):
     """Remove ``keys`` from the Lambda function's ``tags`` field.
 
     Raises ``_ResourceNotFound`` if the function does not exist."""
     import ministack.services.lambda_svc as svc
-    func, _config, _name = svc._get_base_func_record_for_ref(arn)
+    name = _resource_tail(spec, arn, "function:")
+    base_name = name.split(":", 1)[0]
+    func = svc._functions.get(base_name)
     if func is None:
         raise _ResourceNotFound(arn)
     tags = func.get("tags", {})
@@ -432,7 +648,7 @@ def _remove_lambda(arn, keys):
         tags.pop(k, None)
 
 
-def _remove_sqs(arn, keys):
+def _remove_sqs(_spec, arn, keys):
     """Remove ``keys`` from the SQS queue's tags. Raises ``_ResourceNotFound``."""
     import ministack.services.sqs as svc
     for q in svc._queues.values():
@@ -444,7 +660,7 @@ def _remove_sqs(arn, keys):
     raise _ResourceNotFound(arn)
 
 
-def _remove_sns(arn, keys):
+def _remove_sns(_spec, arn, keys):
     """Remove ``keys`` from the SNS topic's tags. Raises ``_ResourceNotFound``."""
     import ministack.services.sns as svc
     if arn not in svc._topics:
@@ -454,52 +670,62 @@ def _remove_sns(arn, keys):
         tags.pop(k, None)
 
 
-def _remove_dynamodb(arn, keys):
+def _remove_dynamodb(spec, arn, keys):
     import ministack.services.dynamodb as svc
+    table_name = _dynamodb_table_name(spec, arn)
+    if table_name not in svc._tables:
+        raise _ResourceNotFound(arn)
     svc._tags[arn] = [t for t in svc._tags.get(arn, []) if t["Key"] not in keys]
 
 
-def _remove_eventbridge(arn, keys):
+def _remove_eventbridge(spec, arn, keys):
     import ministack.services.eventbridge as svc
+    if not _eventbridge_resource_exists(spec, arn):
+        raise _ResourceNotFound(arn)
     tags = svc._tags.get(arn, {})
     for k in keys:
         tags.pop(k, None)
 
 
-def _remove_kms(arn, keys):
+def _remove_kms(spec, arn, keys):
     import ministack.services.kms as svc
-    key_id = arn.split("/")[-1]
-    if key_id in svc._keys:
-        svc._keys[key_id]["Tags"] = [
-            t for t in svc._keys[key_id].get("Tags", []) if t["TagKey"] not in keys
-        ]
+    _resource_tail(spec, arn, "key/")
+    key = svc._resolve_key(arn)
+    if key is None:
+        raise _ResourceNotFound(arn)
+    key["Tags"] = [t for t in key.get("Tags", []) if t["TagKey"] not in keys]
 
 
-def _remove_ecr(arn, keys):
+def _remove_ecr(spec, arn, keys):
     import ministack.services.ecr as svc
-    name = arn.split("repository/")[-1]
-    if name in svc._repositories:
-        svc._repositories[name]["tags"] = [
-            t for t in svc._repositories[name].get("tags", []) if t["Key"] not in keys
-        ]
+    name = _resource_tail(spec, arn, "repository/")
+    if name not in svc._repositories:
+        raise _ResourceNotFound(arn)
+    svc._repositories[name]["tags"] = [
+        t for t in svc._repositories[name].get("tags", []) if t["Key"] not in keys
+    ]
 
 
-def _remove_ecs(arn, keys):
+def _remove_ecs(_spec, arn, keys):
     import ministack.services.ecs as svc
+    if not _ecs_resource_exists(arn):
+        raise _ResourceNotFound(arn)
     svc._tags[arn] = [t for t in svc._tags.get(arn, []) if t["key"] not in keys]
 
 
-def _remove_glue(arn, keys):
+def _remove_glue(spec, arn, keys):
     import ministack.services.glue as svc
+    if not _glue_resource_exists(spec, arn):
+        raise _ResourceNotFound(arn)
     tags = svc._tags.get(arn, {})
     for k in keys:
         tags.pop(k, None)
 
 
-def _remove_cognito_idp(arn, keys):
+def _remove_cognito_idp(spec, arn, keys):
     """Remove ``keys`` from a Cognito user pool's tags. Raises ``_ResourceNotFound``."""
     import ministack.services.cognito as svc
-    pool_id = arn.split("userpool/")[-1]
+    pool_id = _resource_tail(spec, arn, "userpool/")
     if pool_id not in svc._user_pools:
         raise _ResourceNotFound(arn)
     tags = svc._user_pools[pool_id].get("UserPoolTags", {})
@@ -507,51 +733,66 @@ def _remove_cognito_idp(arn, keys):
         tags.pop(k, None)
 
 
-def _remove_cognito_identity(arn, keys):
+def _remove_cognito_identity(spec, arn, keys):
     import ministack.services.cognito as svc
-    pool_id = arn.split("identitypool/")[-1]
+    pool_id = _resource_tail(spec, arn, "identitypool/")
+    if pool_id not in svc._identity_pools:
+        raise _ResourceNotFound(arn)
     tags = svc._identity_tags.get(pool_id, {})
     for k in keys:
         tags.pop(k, None)
 
 
-def _remove_appsync(arn, keys):
+def _remove_appsync(spec, arn, keys):
     import ministack.services.appsync as svc
+    if not _appsync_resource_exists(spec, arn):
+        raise _ResourceNotFound(arn)
     tags = svc._tags.get(arn, {})
     for k in keys:
         tags.pop(k, None)
 
 
-def _remove_scheduler(arn, keys):
+def _remove_scheduler(spec, arn, keys):
     import ministack.services.scheduler as svc
+    if not _scheduler_resource_exists(spec, arn):
+        raise _ResourceNotFound(arn)
     tags = svc._tags.get(arn, {})
     for k in keys:
         tags.pop(k, None)
 
 
-def _remove_cloudfront(arn, keys):
+def _remove_cloudfront(spec, arn, keys):
     import ministack.services.cloudfront as svc
+    if not _cloudfront_resource_exists(spec, arn):
+        raise _ResourceNotFound(arn)
     svc._tags[arn] = [t for t in svc._tags.get(arn, []) if t["Key"] not in keys]
 
 
-def _remove_efs(arn, keys):
+def _remove_efs(spec, arn, keys):
     import ministack.services.efs as svc
-    if ":file-system/" in arn:
-        resource = svc._file_systems.get(arn.split("file-system/")[-1])
+    if spec.resource.startswith("file-system/"):
+        resource = svc._file_systems.get(_resource_tail(spec, arn, "file-system/"))
     else:
-        resource = svc._access_points.get(arn.split("access-point/")[-1])
-    if resource is not None:
-        resource["Tags"] = [t for t in resource.get("Tags", []) if t["Key"] not in keys]
+        resource = svc._access_points.get(_resource_tail(spec, arn, "access-point/"))
+    if resource is None:
+        raise _ResourceNotFound(arn)
+    resource["Tags"] = [t for t in resource.get("Tags", []) if t["Key"] not in keys]
 
 
-def _remove_backup(arn, keys):
+def _remove_backup(spec, arn, keys):
     import ministack.services.backup as svc
-    if ":backup-vault:" in arn:
-        tags = svc._vaults.get(arn.split(":")[-1], {}).get("BackupVaultTags", {})
-    elif ":backup-plan:" in arn:
-        tags = svc._plans.get(arn.split(":")[-1], {}).get("Tags", {})
+    if spec.resource.startswith("backup-vault:"):
+        vault = svc._vaults.get(_resource_tail(spec, arn, "backup-vault:"))
+        if vault is None:
+            raise _ResourceNotFound(arn)
+        tags = vault.get("BackupVaultTags", {})
+    elif spec.resource.startswith("backup-plan:"):
+        plan = svc._plans.get(_resource_tail(spec, arn, "backup-plan:"))
+        if plan is None:
+            raise _ResourceNotFound(arn)
+        tags = plan.get("Tags", {})
     else:
-        return
+        raise _ResourceNotFound(arn)
     for k in keys:
         tags.pop(k, None)
 
@@ -572,6 +813,25 @@ _REMOVERS = {
 def _get_resources(data):
     tag_filters = data.get("TagFilters", [])
     type_filters = data.get("ResourceTypeFilters", [])
+    arn_list = data.get("ResourceARNList", [])
+    if arn_list:
+        exclusive_params = {
+            "ExcludeCompliantResources",
+            "IncludeComplianceDetails",
+            "PaginationToken",
+            "ResourceTypeFilters",
+            "ResourcesPerPage",
+            "TagFilters",
+            "TagsPerPage",
+        }
+        if any(param in data for param in exclusive_params):
+            return _invalid_parameter(
+                "ResourceARNList cannot be specified with filters, compliance details, or pagination parameters"
+            )
+    try:
+        requested_arns = {arn for arn, _spec in _parse_resource_arn_list(arn_list)} if arn_list else None
+    except _InvalidResourceArn as exc:
+        return _invalid_parameter(str(exc))
 
     if type_filters:
         type_prefixes = {tf.split(":")[0] for tf in type_filters}
@@ -586,6 +846,8 @@ def _get_resources(data):
     for collector in dict.fromkeys(active.values()):
         try:
             for arn, tags in collector():
+                if requested_arns is not None and arn not in requested_arns:
+                    continue
                 if not _matches_type_filters(arn, type_filters):
                     continue
                 if not _matches_tag_filters(tags, tag_filters):
@@ -594,10 +856,10 @@ def _get_resources(data):
         except Exception:
             pass  # service not yet initialised — skip silently
 
-    return 200, {"Content-Type": "application/x-amz-json-1.1"}, json.dumps({
+    return _json({
         "ResourceTagMappingList": results,
         "PaginationToken": "",
-    }).encode()
+    })
 
 
 def _get_tag_keys(data):
@@ -609,10 +871,10 @@ def _get_tag_keys(data):
                     keys.add(t["Key"])
         except Exception:
             pass
-    return 200, {"Content-Type": "application/x-amz-json-1.1"}, json.dumps({
+    return _json({
         "TagKeys": sorted(keys),
         "PaginationToken": "",
-    }).encode()
+    })
 
 
 def _get_tag_values(data):
@@ -626,10 +888,10 @@ def _get_tag_values(data):
                         values.add(t["Value"])
         except Exception:
             pass
-    return 200, {"Content-Type": "application/x-amz-json-1.1"}, json.dumps({
+    return _json({
         "TagValues": sorted(values),
         "PaginationToken": "",
-    }).encode()
+    })
 
 
 # ── Entry point ───────────────────────────────────────────────────────────────
@@ -639,41 +901,51 @@ def _tag_resources(data):
 
     Per ARN, failures are reported in ``FailedResourcesMap``:
       - Unknown service segment → ``InvalidParameterException`` (400).
-      - Resource not found in caller's account → ``InvalidParameterException`` (400).
+      - Resource not found in caller's account → ``ResourceNotFound`` (404).
       - Anything else raised by the writer → ``InternalServiceException`` (500).
     The top-level response is always 200 with a (possibly empty) map, matching AWS."""
     arn_list = data.get("ResourceARNList", [])
     tags = data.get("Tags", {})
     failed = {}
 
-    for arn in arn_list:
-        svc_key = _service_key_from_arn(arn)
+    try:
+        parsed_arns = _parse_resource_arn_list(arn_list)
+        for arn, spec in parsed_arns:
+            _reject_foreign_region_arn(spec, arn, "TagResources")
+    except (_InvalidResourceArn, _WrongRegionArn) as exc:
+        return _invalid_parameter(str(exc))
+
+    for arn, spec in parsed_arns:
+        svc_key = spec.service
         writer = _WRITERS.get(svc_key)
         if writer is None:
-            failed[arn] = {
-                "ErrorCode": "InvalidParameterException",
-                "ErrorMessage": f"Unsupported resource type: {svc_key}",
-                "StatusCode": 400,
-            }
+            failed[arn] = _failed_resource(
+                "InvalidParameterException",
+                "Unrecognized service or resource type for tagging",
+                400,
+            )
             continue
         try:
-            writer(arn, tags)
+            _require_resource_scope(spec, arn)
+            writer(spec, arn, tags)
+        except _WrongAccountArn:
+            failed[arn] = _failed_resource(
+                "InvalidClientTokenId",
+                "No account found for the given parameters",
+                403,
+            )
+        except _WrongRegionArn as exc:
+            return _invalid_parameter(str(exc))
         except _ResourceNotFound:
-            failed[arn] = {
-                "ErrorCode": "InvalidParameterException",
-                "ErrorMessage": f"Resource not found: {arn}",
-                "StatusCode": 400,
-            }
+            # AWS RGTA returns this literal failed-resource shape for well-formed
+            # same-service ARNs whose target resource does not exist.
+            failed[arn] = _failed_resource("ResourceNotFound", "Resource does not exist", 404)
         except Exception as exc:
-            failed[arn] = {
-                "ErrorCode": "InternalServiceException",
-                "ErrorMessage": str(exc),
-                "StatusCode": 500,
-            }
+            failed[arn] = _failed_resource("InternalServiceException", str(exc), 500)
 
-    return 200, {"Content-Type": "application/x-amz-json-1.1"}, json.dumps({
+    return _json({
         "FailedResourcesMap": failed,
-    }).encode()
+    })
 
 
 def _untag_resources(data):
@@ -685,34 +957,44 @@ def _untag_resources(data):
     tag_keys = data.get("TagKeys", [])
     failed = {}
 
-    for arn in arn_list:
-        svc_key = _service_key_from_arn(arn)
+    try:
+        parsed_arns = _parse_resource_arn_list(arn_list)
+        for arn, spec in parsed_arns:
+            _reject_foreign_region_arn(spec, arn, "UntagResources")
+    except (_InvalidResourceArn, _WrongRegionArn) as exc:
+        return _invalid_parameter(str(exc))
+
+    for arn, spec in parsed_arns:
+        svc_key = spec.service
         remover = _REMOVERS.get(svc_key)
         if remover is None:
-            failed[arn] = {
-                "ErrorCode": "InvalidParameterException",
-                "ErrorMessage": f"Unsupported resource type: {svc_key}",
-                "StatusCode": 400,
-            }
+            failed[arn] = _failed_resource(
+                "InvalidParameterException",
+                "Unrecognized service or resource type for tagging",
+                400,
+            )
             continue
         try:
-            remover(arn, tag_keys)
+            _require_resource_scope(spec, arn)
+            remover(spec, arn, tag_keys)
+        except _WrongAccountArn:
+            failed[arn] = _failed_resource(
+                "InvalidClientTokenId",
+                "No account found for the given parameters",
+                403,
+            )
+        except _WrongRegionArn as exc:
+            return _invalid_parameter(str(exc))
         except _ResourceNotFound:
-            failed[arn] = {
-                "ErrorCode": "InvalidParameterException",
-                "ErrorMessage": f"Resource not found: {arn}",
-                "StatusCode": 400,
-            }
+            # AWS RGTA returns this literal failed-resource shape for well-formed
+            # same-service ARNs whose target resource does not exist.
+            failed[arn] = _failed_resource("ResourceNotFound", "Resource does not exist", 404)
         except Exception as exc:
-            failed[arn] = {
-                "ErrorCode": "InternalServiceException",
-                "ErrorMessage": str(exc),
-                "StatusCode": 500,
-            }
+            failed[arn] = _failed_resource("InternalServiceException", str(exc), 500)
 
-    return 200, {"Content-Type": "application/x-amz-json-1.1"}, json.dumps({
+    return _json({
         "FailedResourcesMap": failed,
-    }).encode()
+    })
 
 
 _HANDLERS = {

--- a/tests/test_tagging.py
+++ b/tests/test_tagging.py
@@ -25,6 +25,17 @@ def _regional_client(service, region):
     )
 
 
+def _account_client(service, account, region="us-east-1"):
+    return boto3.client(
+        service,
+        endpoint_url=os.environ.get("MINISTACK_ENDPOINT", "http://localhost:4566"),
+        region_name=region,
+        aws_access_key_id=account,
+        aws_secret_access_key="test",
+        config=Config(region_name=region, retries={"mode": "standard"}),
+    )
+
+
 def _lambda_zip():
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, "w") as zf:
@@ -194,6 +205,53 @@ def test_tagging_get_resources_no_match(tagging):
 def test_tagging_get_resources_pagination_token_empty(tagging):
     resp = tagging.get_resources()
     assert resp.get("PaginationToken", "") == ""
+
+
+def test_tagging_get_resources_resource_arn_list_filters_to_requested_resources(tagging, s3):
+    s3.create_bucket(Bucket="tg-get-arn-list-a")
+    s3.create_bucket(Bucket="tg-get-arn-list-b")
+    s3.put_bucket_tagging(Bucket="tg-get-arn-list-a", Tagging={
+        "TagSet": [{"Key": _TAG_KEY, "Value": "arn-list"}]
+    })
+    s3.put_bucket_tagging(Bucket="tg-get-arn-list-b", Tagging={
+        "TagSet": [{"Key": _TAG_KEY, "Value": "arn-list"}]
+    })
+
+    arn = "arn:aws:s3:::tg-get-arn-list-a"
+    resp = tagging.get_resources(ResourceARNList=[arn])
+
+    assert [r["ResourceARN"] for r in resp["ResourceTagMappingList"]] == [arn]
+
+
+def test_tagging_get_resources_resource_arn_list_malformed_arn_fails_request(tagging):
+    with pytest.raises(ClientError) as exc:
+        tagging.get_resources(ResourceARNList=["not-an-arn"])
+
+    assert exc.value.response["Error"]["Code"] == "InvalidParameterException"
+
+
+def test_tagging_get_resources_resource_arn_list_rejects_filters(tagging, s3):
+    s3.create_bucket(Bucket="tg-get-arn-list-filter")
+    arn = "arn:aws:s3:::tg-get-arn-list-filter"
+
+    with pytest.raises(ClientError) as exc:
+        tagging.get_resources(
+            ResourceARNList=[arn],
+            TagFilters=[{"Key": _TAG_KEY, "Values": ["invalid-combination"]}],
+        )
+
+    assert exc.value.response["Error"]["Code"] == "InvalidParameterException"
+
+
+def test_tagging_get_resources_resource_arn_list_omits_unresolved_well_formed_arns(tagging):
+    resp = tagging.get_resources(ResourceARNList=[
+        "arn:aws:sns:us-west-2:000000000000:foreign-region-topic",
+        "arn:aws:sns:us-east-1:999999999999:bogus-account-topic",
+        "arn:aws:notaservice:us-east-1:000000000000:thing/missing",
+        "arn:aws:sns:us-east-1:000000000000:missing-topic",
+    ])
+
+    assert resp["ResourceTagMappingList"] == []
 
 
 # ========== Phase 2: New service collectors ==========
@@ -564,10 +622,10 @@ def test_tagging_tag_resources_multiple_arns(tagging, s3):
 def test_tagging_tag_resources_unknown_service(tagging):
     """Unknown service segment appears in FailedResourcesMap, not an exception."""
     resp = tagging.tag_resources(
-        ResourceARNList=["arn:aws:unknownsvc:::no-such-resource"],
+        ResourceARNList=["arn:aws:unknownsvc:us-east-1:000000000000:no-such-resource"],
         Tags={_TAG_KEY: "fail"},
     )
-    assert "arn:aws:unknownsvc:::no-such-resource" in resp["FailedResourcesMap"]
+    assert "arn:aws:unknownsvc:us-east-1:000000000000:no-such-resource" in resp["FailedResourcesMap"]
 
 
 # ========== UntagResources ==========
@@ -620,10 +678,10 @@ def test_tagging_untag_resources_nonexistent_key_is_noop(tagging, s3):
 def test_tagging_untag_resources_unknown_service(tagging):
     """Unknown service segment appears in FailedResourcesMap."""
     resp = tagging.untag_resources(
-        ResourceARNList=["arn:aws:unknownsvc:::no-such-resource"],
+        ResourceARNList=["arn:aws:unknownsvc:us-east-1:000000000000:no-such-resource"],
         TagKeys=[_TAG_KEY],
     )
-    assert "arn:aws:unknownsvc:::no-such-resource" in resp["FailedResourcesMap"]
+    assert "arn:aws:unknownsvc:us-east-1:000000000000:no-such-resource" in resp["FailedResourcesMap"]
 
 
 # ========== Cross-operation roundtrips ==========
@@ -662,26 +720,162 @@ def test_tagging_tag_resources_unknown_service_returns_invalid_parameter(tagging
     """Unknown ARN service segment returns InvalidParameterException/400, not
     InternalServiceException/501 — matches real AWS."""
     resp = tagging.tag_resources(
-        ResourceARNList=["arn:aws:unknownsvc:::no-such"],
+        ResourceARNList=["arn:aws:unknownsvc:us-east-1:000000000000:no-such"],
         Tags={"k": "v"},
     )
-    entry = resp["FailedResourcesMap"]["arn:aws:unknownsvc:::no-such"]
+    entry = resp["FailedResourcesMap"]["arn:aws:unknownsvc:us-east-1:000000000000:no-such"]
     assert entry["ErrorCode"] == "InvalidParameterException"
     assert entry["StatusCode"] == 400
+
+
+def test_tagging_tag_resources_malformed_arn_returns_invalid_parameter(tagging):
+    with pytest.raises(ClientError) as exc:
+        tagging.tag_resources(
+            ResourceARNList=["arn:nope"],
+            Tags={"k": "v"},
+        )
+
+    assert exc.value.response["Error"]["Code"] == "InvalidParameterException"
+
+
+def test_tagging_tag_resources_foreign_region_arn_fails_request_without_mutating_local_resource(tagging, kms_client):
+    key_id = kms_client.create_key(Description="tg-tr-kms-foreign-region")["KeyMetadata"]["KeyId"]
+    foreign_region_arn = f"arn:aws:kms:us-west-2:000000000000:key/{key_id}"
+
+    with pytest.raises(ClientError) as exc:
+        tagging.tag_resources(
+            ResourceARNList=[foreign_region_arn],
+            Tags={_TAG_KEY: "wrong-region"},
+        )
+
+    assert exc.value.response["Error"]["Code"] == "InvalidParameterException"
+    check = tagging.get_resources(TagFilters=[{"Key": _TAG_KEY, "Values": ["wrong-region"]}])
+    assert not any(key_id in r["ResourceARN"] for r in check["ResourceTagMappingList"])
+
+
+def test_tagging_tag_resources_kms_forged_region_arn_does_not_mutate_key(kms_client):
+    key_id = kms_client.create_key(Description="tg-tr-kms-forged-region")["KeyMetadata"]["KeyId"]
+    forged_region_arn = f"arn:aws:kms:us-west-2:000000000000:key/{key_id}"
+    west_tagging = _regional_client("resourcegroupstaggingapi", "us-west-2")
+
+    resp = west_tagging.tag_resources(
+        ResourceARNList=[forged_region_arn],
+        Tags={_TAG_KEY: "forged-region"},
+    )
+
+    entry = resp["FailedResourcesMap"][forged_region_arn]
+    assert entry["ErrorCode"] == "ResourceNotFound"
+    assert entry["StatusCode"] == 404
+    assert _TAG_KEY not in {t["TagKey"] for t in kms_client.list_resource_tags(KeyId=key_id)["Tags"]}
+
+
+def test_tagging_tag_resources_malformed_arn_in_mixed_list_fails_request_before_mutation(tagging, s3):
+    s3.create_bucket(Bucket="tg-tr-mixed-malformed")
+    arn = "arn:aws:s3:::tg-tr-mixed-malformed"
+
+    with pytest.raises(ClientError) as exc:
+        tagging.tag_resources(
+            ResourceARNList=[arn, "not-an-arn"],
+            Tags={_TAG_KEY: "should-not-apply"},
+        )
+
+    assert exc.value.response["Error"]["Code"] == "InvalidParameterException"
+    check = tagging.get_resources(ResourceARNList=[arn])
+    assert check["ResourceTagMappingList"] == []
+
+
+def test_tagging_tag_resources_unsupported_global_arn_does_not_block_valid_resources(tagging, s3):
+    s3.create_bucket(Bucket="tg-tr-mixed-unsupported-global")
+    s3_arn = "arn:aws:s3:::tg-tr-mixed-unsupported-global"
+    iam_arn = "arn:aws:iam::000000000000:role/tg-unsupported-role"
+
+    resp = tagging.tag_resources(ResourceARNList=[iam_arn, s3_arn], Tags={_TAG_KEY: "mixed-global"})
+
+    entry = resp["FailedResourcesMap"][iam_arn]
+    assert entry["ErrorCode"] == "InvalidParameterException"
+    assert entry["StatusCode"] == 400
+    check = tagging.get_resources(ResourceARNList=[s3_arn])
+    matched = next(r for r in check["ResourceTagMappingList"] if r["ResourceARN"] == s3_arn)
+    assert {t["Key"]: t["Value"] for t in matched["Tags"]}[_TAG_KEY] == "mixed-global"
+
+
+def test_tagging_tag_resources_unsupported_foreign_region_arn_does_not_block_valid_resources(tagging, s3):
+    s3.create_bucket(Bucket="tg-tr-mixed-unsupported-foreign")
+    s3_arn = "arn:aws:s3:::tg-tr-mixed-unsupported-foreign"
+    unknown_arn = "arn:aws:unknownsvc:us-west-2:000000000000:no-such-resource"
+
+    resp = tagging.tag_resources(ResourceARNList=[unknown_arn, s3_arn], Tags={_TAG_KEY: "mixed-foreign"})
+
+    entry = resp["FailedResourcesMap"][unknown_arn]
+    assert entry["ErrorCode"] == "InvalidParameterException"
+    assert entry["StatusCode"] == 400
+    check = tagging.get_resources(ResourceARNList=[s3_arn])
+    matched = next(r for r in check["ResourceTagMappingList"] if r["ResourceARN"] == s3_arn)
+    assert {t["Key"]: t["Value"] for t in matched["Tags"]}[_TAG_KEY] == "mixed-foreign"
+
+
+def test_tagging_tag_resources_missing_region_arn_fails_request_before_mutation(lam, tagging):
+    fname = f"tg-lambda-missing-region-{uuid.uuid4().hex[:8]}"
+    base_arn = None
+    try:
+        base_arn = lam.create_function(
+            FunctionName=fname,
+            Runtime="python3.12",
+            Role="arn:aws:iam::000000000000:role/test-role",
+            Handler="index.handler",
+            Code={"ZipFile": _lambda_zip()},
+        )["FunctionArn"]
+        malformed_arn = base_arn.replace(":us-east-1:", "::")
+
+        with pytest.raises(ClientError) as exc:
+            tagging.tag_resources(ResourceARNList=[malformed_arn], Tags={"missing-region": "bad"})
+
+        assert exc.value.response["Error"]["Code"] == "InvalidParameterException"
+        assert "missing-region" not in lam.list_tags(Resource=base_arn)["Tags"]
+    finally:
+        if base_arn:
+            lam.delete_function(FunctionName=fname)
+
+
+def test_tagging_tag_resources_missing_account_arn_fails_request_before_mutation(lam, tagging, s3):
+    fname = f"tg-lambda-missing-account-{uuid.uuid4().hex[:8]}"
+    bucket = "tg-tr-missing-account"
+    base_arn = None
+    try:
+        s3.create_bucket(Bucket=bucket)
+        base_arn = lam.create_function(
+            FunctionName=fname,
+            Runtime="python3.12",
+            Role="arn:aws:iam::000000000000:role/test-role",
+            Handler="index.handler",
+            Code={"ZipFile": _lambda_zip()},
+        )["FunctionArn"]
+        malformed_arn = base_arn.replace(":000000000000:", "::")
+        s3_arn = f"arn:aws:s3:::{bucket}"
+
+        with pytest.raises(ClientError) as exc:
+            tagging.tag_resources(ResourceARNList=[s3_arn, malformed_arn], Tags={"missing-account": "bad"})
+
+        assert exc.value.response["Error"]["Code"] == "InvalidParameterException"
+        assert tagging.get_resources(ResourceARNList=[s3_arn])["ResourceTagMappingList"] == []
+        assert "missing-account" not in lam.list_tags(Resource=base_arn)["Tags"]
+    finally:
+        if base_arn:
+            lam.delete_function(FunctionName=fname)
 
 
 def test_tagging_tag_resources_missing_lambda_surfaces_in_failed_map(tagging):
     """Tagging a Lambda that does not exist in the caller's account surfaces
-    InvalidParameterException in FailedResourcesMap instead of silently no-op'ing."""
+    ResourceNotFound in FailedResourcesMap instead of silently no-op'ing."""
     arn = "arn:aws:lambda:us-east-1:000000000000:function:no-such-fn-tag-missing"
     resp = tagging.tag_resources(ResourceARNList=[arn], Tags={"k": "v"})
     assert arn in resp["FailedResourcesMap"]
     entry = resp["FailedResourcesMap"][arn]
-    assert entry["ErrorCode"] == "InvalidParameterException"
-    assert entry["StatusCode"] == 400
+    assert entry["ErrorCode"] == "ResourceNotFound"
+    assert entry["StatusCode"] == 404
 
 
-def test_tagging_tag_resources_lambda_arn_uses_resource_region(lam, tagging):
+def test_tagging_tag_resources_foreign_region_lambda_arn_fails_request_without_mutating_functions(lam, tagging):
     west_lam = _regional_client("lambda", "us-west-2")
     fname = f"tg-lambda-region-{uuid.uuid4().hex[:8]}"
     code = _lambda_zip()
@@ -705,12 +899,11 @@ def test_tagging_tag_resources_lambda_arn_uses_resource_region(lam, tagging):
         )["FunctionArn"]
 
         lam.tag_resource(Resource=east_arn, Tags={"region": "east"})
-        tagging.tag_resources(ResourceARNList=[west_arn], Tags={"region": "west"})
 
-        assert lam.list_tags(Resource=east_arn)["Tags"]["region"] == "east"
-        assert west_lam.list_tags(Resource=west_arn)["Tags"]["region"] == "west"
+        with pytest.raises(ClientError) as exc:
+            tagging.tag_resources(ResourceARNList=[west_arn], Tags={"region": "west"})
 
-        tagging.untag_resources(ResourceARNList=[west_arn], TagKeys=["region"])
+        assert exc.value.response["Error"]["Code"] == "InvalidParameterException"
         assert lam.list_tags(Resource=east_arn)["Tags"]["region"] == "east"
         assert "region" not in west_lam.list_tags(Resource=west_arn)["Tags"]
     finally:
@@ -743,12 +936,86 @@ def test_tagging_tag_resources_qualified_lambda_arn_tags_base_function(lam, tagg
             lam.delete_function(FunctionName=fname)
 
 
+def test_tagging_tag_resources_glue_connection_roundtrip(tagging, glue):
+    name = f"tg-glue-conn-{uuid.uuid4().hex[:8]}"
+    arn = f"arn:aws:glue:us-east-1:000000000000:connection/{name}"
+    glue.create_connection(
+        ConnectionInput={
+            "Name": name,
+            "ConnectionType": "JDBC",
+            "ConnectionProperties": {
+                "JDBC_CONNECTION_URL": "jdbc:postgresql://host/db",
+                "USERNAME": "user",
+                "PASSWORD": "pass",
+            },
+        }
+    )
+
+    resp = tagging.tag_resources(ResourceARNList=[arn], Tags={_TAG_KEY: "glue-conn"})
+    assert resp["FailedResourcesMap"] == {}
+    check = tagging.get_resources(TagFilters=[{"Key": _TAG_KEY, "Values": ["glue-conn"]}])
+    assert any(r["ResourceARN"] == arn for r in check["ResourceTagMappingList"])
+
+    resp = tagging.untag_resources(ResourceARNList=[arn], TagKeys=[_TAG_KEY])
+    assert resp["FailedResourcesMap"] == {}
+    check = tagging.get_resources(ResourceARNList=[arn])
+    matched = [r for r in check["ResourceTagMappingList"] if r["ResourceARN"] == arn]
+    assert matched
+    assert _TAG_KEY not in {t["Key"] for t in matched[0]["Tags"]}
+
+
+def test_tagging_tag_resources_default_eventbridge_and_scheduler_resources_exist_before_service_touch():
+    account = "111122223333"
+    scoped_tagging = _account_client("resourcegroupstaggingapi", account)
+    arns = [
+        f"arn:aws:events:us-east-1:{account}:event-bus/default",
+        f"arn:aws:scheduler:us-east-1:{account}:schedule-group/default",
+    ]
+
+    resp = scoped_tagging.tag_resources(ResourceARNList=arns, Tags={_TAG_KEY: "default-resource"})
+    assert resp["FailedResourcesMap"] == {}
+    check = scoped_tagging.get_resources(ResourceARNList=arns)
+    result_arns = [r["ResourceARN"] for r in check["ResourceTagMappingList"]]
+    assert result_arns == arns
+
+
+def test_tagging_tag_resources_eventbridge_rule_arn_with_slash_bus_name(tagging, eb):
+    bus_name = f"aws.partner/example.com/tg-{uuid.uuid4().hex[:8]}"
+    eb.create_event_bus(Name=bus_name)
+    rule_arn = eb.put_rule(
+        Name=f"tg-rule-{uuid.uuid4().hex[:8]}",
+        EventBusName=bus_name,
+        EventPattern='{"source":["unit"]}',
+    )["RuleArn"]
+
+    resp = tagging.tag_resources(ResourceARNList=[rule_arn], Tags={_TAG_KEY: "event-rule"})
+    assert resp["FailedResourcesMap"] == {}
+    check = tagging.get_resources(ResourceARNList=[rule_arn])
+    matched = next(r for r in check["ResourceTagMappingList"] if r["ResourceARN"] == rule_arn)
+    assert {t["Key"]: t["Value"] for t in matched["Tags"]}[_TAG_KEY] == "event-rule"
+
+
 def test_tagging_untag_missing_sns_surfaces_in_failed_map(tagging):
     arn = "arn:aws:sns:us-east-1:000000000000:no-such-topic-untag-missing"
     resp = tagging.untag_resources(ResourceARNList=[arn], TagKeys=["k"])
     assert arn in resp["FailedResourcesMap"]
     entry = resp["FailedResourcesMap"][arn]
-    assert entry["ErrorCode"] == "InvalidParameterException"
+    assert entry["ErrorCode"] == "ResourceNotFound"
+    assert entry["StatusCode"] == 404
+
+
+def test_tagging_untag_missing_backup_resources_surface_in_failed_map(tagging):
+    arns = [
+        "arn:aws:backup:us-east-1:000000000000:backup-vault:no-such-vault",
+        "arn:aws:backup:us-east-1:000000000000:backup-plan:no-such-plan",
+    ]
+
+    resp = tagging.untag_resources(ResourceARNList=arns, TagKeys=["k"])
+
+    for arn in arns:
+        entry = resp["FailedResourcesMap"][arn]
+        assert entry["ErrorCode"] == "ResourceNotFound"
+        assert entry["StatusCode"] == 404
 
 
 def test_tagging_tag_resources_cross_account_isolation(s3):


### PR DESCRIPTION
## Why
Resource Groups Tagging API should classify ARN inputs through the shared parser so request-wide and per-resource failures align with AWS behavior. This continues ARN parsing adoption on the multi-region feature branch.

## What
- Parse `ResourceARNList`, `TagResources`, and `UntagResources` ARNs with the shared ARN parser
- Enforce malformed, foreign-region, missing region/account, wrong-account, unknown-service, and missing-resource handling
- Add resource existence checks for supported taggable services, including Lambda qualifiers, KMS full ARN matching, Glue connections, Backup resources, and default EventBridge/Scheduler resources
- Add regression coverage for ARN list filtering, request-wide failures, per-resource failures, and supported edge cases

## Risk Assessment
Medium within the feature branch because this tightens Resource Groups Tagging API validation behavior. The blast radius is scoped to tagging API ARN handling and covered by focused service tests.

## References
Validation:
- `uv run --extra dev ruff check ministack/services/tagging.py tests/test_tagging.py`
- `uv run --extra dev pytest tests/test_tagging.py -q` (`72 passed`)
