### PR TITLE
Adopt ARN parsing in EventBridge

### DIFF
--- a/ministack/services/eventbridge.py
+++ b/ministack/services/eventbridge.py
@@ -47,6 +47,30 @@ from ministack.core.responses import (
 logger = logging.getLogger("events")
 
 REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
+_SUPPORTED_TARGET_SERVICES = {
+    "appsync",
+    "batch",
+    "codebuild",
+    "codepipeline",
+    "ecs",
+    "events",
+    "execute-api",
+    "firehose",
+    "glue",
+    "imagebuilder",
+    "inspector",
+    "kinesis",
+    "lambda",
+    "logs",
+    "redshift",
+    "redshift-serverless",
+    "sagemaker",
+    "sns",
+    "sqs",
+    "ssm",
+    "ssm-incidents",
+    "states",
+}
 
 
 def _now_ts() -> float:
@@ -584,6 +608,11 @@ def _put_targets(data):
     if key not in _rules:
         return error_response_json("ResourceNotFoundException", f"Rule {rule_name} does not exist.", 400)
 
+    for target in targets:
+        error = _validate_target_arn(target)
+        if error:
+            return error
+
     if key not in _targets:
         _targets[key] = []
     existing_ids = {t["Id"] for t in _targets[key]}
@@ -592,6 +621,35 @@ def _put_targets(data):
             _targets[key] = [x for x in _targets[key] if x["Id"] != t["Id"]]
         _targets[key].append(t)
     return json_response({"FailedEntryCount": 0, "FailedEntries": []})
+
+
+def _validate_target_arn(target):
+    arn = target.get("Arn", "")
+    try:
+        spec = parse_arn(arn)
+    except ArnParseError:
+        return error_response_json(
+            "ValidationException",
+            f"Parameter {arn} is not valid. Reason: Provided Arn is not in correct format.",
+            400,
+        )
+
+    if spec.service not in _SUPPORTED_TARGET_SERVICES:
+        return error_response_json(
+            "ValidationException",
+            f"{spec.service} is not a supported service for a target.",
+            400,
+        )
+
+    if (
+        spec.service == "events"
+        and spec.resource.startswith("event-bus/")
+        and (spec.account_id != get_account_id() or spec.region != get_region())
+        and not target.get("RoleArn")
+    ):
+        return error_response_json("ValidationException", "RoleArn is required", 400)
+
+    return None
 
 
 def _remove_targets(data):
@@ -685,10 +743,40 @@ def _test_event_pattern(data):
 # PutEvents + event pattern matching + target dispatch
 # ---------------------------------------------------------------------------
 
-def _normalize_bus_name(name):
-    if name and name.startswith("arn:"):
-        return name.split("/")[-1]
-    return name
+def _events_resource_name_from_ref(value, prefix, label):
+    if not value or not value.startswith("arn:"):
+        return value, None
+    try:
+        spec = parse_arn(value)
+    except ArnParseError:
+        return "", (
+            "ValidationException",
+            f"Parameter {label} is not valid. Reason: Provided Arn is not in correct format.",
+        )
+    if spec.service != "events" or not spec.resource.startswith(prefix):
+        return "", (
+            "ValidationException",
+            f"Parameter {label} is not valid. Reason: Provided Arn is not an EventBridge {label}.",
+        )
+    if spec.account_id != get_account_id() or spec.region != get_region():
+        return "", (
+            "ResourceNotFoundException",
+            f"EventBridge {label} {value} does not exist.",
+        )
+    return spec.resource.split("/", 1)[1], None
+
+
+def _event_bus_name_from_ref(name):
+    return _events_resource_name_from_ref(name, "event-bus/", "EventBusName")
+
+
+def _archive_name_from_ref(source_arn):
+    if not source_arn or not source_arn.startswith("arn:"):
+        return "", (
+            "ValidationException",
+            "Parameter EventSourceArn is not valid. Reason: Provided Arn is not in correct format.",
+        )
+    return _events_resource_name_from_ref(source_arn, "archive/", "EventSourceArn")
 
 
 def _put_events(data):
@@ -703,9 +791,15 @@ def _put_events(data):
             400,
         )
     results = []
+    failed = 0
     for entry in entries:
         event_id = new_uuid()
-        bus_name = _normalize_bus_name(entry.get("EventBusName", "default"))
+        bus_name, bus_error = _event_bus_name_from_ref(entry.get("EventBusName", "default"))
+        if bus_error:
+            code, message = bus_error
+            results.append({"ErrorCode": code, "ErrorMessage": message})
+            failed += 1
+            continue
         # AWS Time is a timestamp shape; ministack convention is int epoch seconds
         # (Java SDK v2 chokes on floats). Persisted in the event_record so
         # archive replay also dispatches the int form.
@@ -729,7 +823,7 @@ def _put_events(data):
         _dispatch_event(event_record)
         _archive_event(event_record)
 
-    return json_response({"FailedEntryCount": 0, "Entries": results})
+    return json_response({"FailedEntryCount": failed, "Entries": results})
 
 
 def _archive_event(event):
@@ -747,9 +841,13 @@ def _archive_event(event):
 
 def _dispatch_event(event):
     bus_name = event.get("EventBusName", "default")
+    event_path = set(event.get("_DispatchPath") or [])
 
     for key, rule in _rules.items():
         if rule.get("EventBusName", "default") != bus_name:
+            continue
+        if key in event_path:
+            logger.warning("EventBridge: recursive rule dispatch skipped for %s", key)
             continue
         if rule.get("State") != "ENABLED":
             continue
@@ -904,6 +1002,7 @@ def _matches_content_filter(value, filter_rule):
 
 def _invoke_target(target, event, rule):
     arn = target.get("Arn", "")
+    event_path = set(event.get("_DispatchPath") or [])
 
     raw_time = event["Time"]
     if isinstance(raw_time, (int, float)):
@@ -923,11 +1022,14 @@ def _invoke_target(target, event, rule):
         "detail": json.loads(event["Detail"]) if isinstance(event["Detail"], str) else event["Detail"],
     })
 
+    target_input_payload = None
     input_transformer = target.get("InputTransformer")
     if input_transformer:
         event_payload = _apply_input_transformer(input_transformer, event)
+        target_input_payload = event_payload
     elif target.get("Input"):
         event_payload = target["Input"]
+        target_input_payload = event_payload
     elif target.get("InputPath"):
         try:
             full = json.loads(event_payload)
@@ -937,22 +1039,67 @@ def _invoke_target(target, event, rule):
                 if p:
                     val = val[p]
             event_payload = json.dumps(val)
+            target_input_payload = event_payload
         except Exception:
             pass
 
     try:
-        if ":lambda:" in arn or ":function:" in arn:
-            _dispatch_to_lambda(arn, event_payload)
-        elif ":sqs:" in arn:
-            _dispatch_to_sqs(arn, event_payload, target.get("SqsParameters") or {})
-        elif ":sns:" in arn:
-            _dispatch_to_sns(arn, event_payload)
-        elif ":states:" in arn:
+        try:
+            spec = parse_arn(arn)
+        except ArnParseError:
+            logger.warning("EventBridge: invalid target ARN %s", arn)
+            return
+
+        if spec.service == "events":
+            _dispatch_to_event_bus(spec, event, rule, event_path, target_input_payload)
+        elif spec.service == "states":
             _dispatch_to_stepfunctions(arn, event_payload)
+        elif not _target_matches_request_scope(spec):
+            logger.warning("EventBridge: target %s is outside the current account/region scope", arn)
+        elif spec.service == "lambda":
+            _dispatch_to_lambda(arn, event_payload)
+        elif spec.service == "sqs":
+            _dispatch_to_sqs(spec, event_payload, target.get("SqsParameters") or {})
+        elif spec.service == "sns":
+            _dispatch_to_sns(arn, event_payload)
         else:
             logger.warning("EventBridge: unsupported target type for ARN %s", arn)
     except Exception as e:
         logger.error("EventBridge target dispatch error for %s: %s", arn, e)
+
+
+def _target_matches_request_scope(spec) -> bool:
+    return spec.account_id == get_account_id() and spec.region == get_region()
+
+
+def _dispatch_to_event_bus(spec, event, rule, event_path, target_input_payload=None):
+    if spec.service != "events" or not spec.resource.startswith("event-bus/"):
+        logger.warning("EventBridge -> Event bus: unsupported event target ARN %s", spec)
+        return
+
+    if spec.account_id != get_account_id() or spec.region != get_region():
+        logger.warning("EventBridge -> Event bus: event bus %s not found", spec)
+        return
+
+    bus_name = spec.resource.split("/", 1)[1]
+    if bus_name not in _event_buses:
+        logger.warning("EventBridge -> Event bus: event bus %s not found", spec)
+        return
+    source_rule_key = _rule_key(rule.get("Name"), rule.get("EventBusName", "default"))
+    if source_rule_key in event_path:
+        logger.warning("EventBridge -> Event bus: recursive target dispatch skipped for %s", spec)
+        return
+    forwarded = dict(event)
+    forwarded["EventBusName"] = bus_name
+    forwarded["Region"] = spec.region
+    forwarded["_DispatchPath"] = [*event_path, source_rule_key]
+    if target_input_payload is not None:
+        forwarded["Detail"] = target_input_payload
+    _dispatch_event(forwarded)
+    archived = dict(forwarded)
+    archived.pop("_DispatchPath", None)
+    _archive_event(archived)
+    logger.info("EventBridge -> Event bus %s: dispatched", spec)
 
 
 def _apply_input_transformer(transformer, event):
@@ -1013,7 +1160,7 @@ def _dispatch_to_lambda(arn, payload):
     logger.info("EventBridge → Lambda %s: dispatched", func_name)
 
 
-def _dispatch_to_sqs(arn, payload, sqs_parameters=None):
+def _dispatch_to_sqs(spec, payload, sqs_parameters=None):
     """Dispatch an EventBridge event to an SQS queue.
 
     ``sqs_parameters`` carries the target's ``SqsParameters`` block from the
@@ -1025,7 +1172,7 @@ def _dispatch_to_sqs(arn, payload, sqs_parameters=None):
     """
     from ministack.services import sqs as _sqs
 
-    queue_name = arn.split(":")[-1]
+    queue_name = spec.resource
     queue_url = _sqs._queue_url(queue_name)
     queue = _sqs._queues.get(queue_url)
     if not queue:
@@ -1258,13 +1405,25 @@ def _start_replay(data):
         )
 
     source_arn = data.get("EventSourceArn", "")
-    # source_arn format: arn:aws:events:{region}:{account}:archive/{name}
-    archive_name = source_arn.split("/")[-1] if "/" in source_arn else ""
+    archive_name, source_error = _archive_name_from_ref(source_arn)
+    if source_error:
+        code, message = source_error
+        return error_response_json(code, message, 400)
     archive = _archives.get(archive_name)
     if not archive:
         return error_response_json(
             "ResourceNotFoundException",
             f"Archive {archive_name} does not exist.",
+            400,
+        )
+    dest_bus_name, dest_error = _event_bus_name_from_ref(dest.get("Arn", ""))
+    if dest_error:
+        code, message = dest_error
+        return error_response_json(code, message, 400)
+    if dest.get("Arn") != archive.get("EventSourceArn"):
+        return error_response_json(
+            "ValidationException",
+            "Destination.Arn must match the archive event source.",
             400,
         )
 
@@ -1284,8 +1443,6 @@ def _start_replay(data):
         "ReplayStartTime": now,
     }
     _replays[name] = replay
-
-    dest_bus_name = _normalize_bus_name(dest.get("Arn", ""))
 
     def _run():
         replay["State"] = "RUNNING"

--- a/tests/test_eventbridge.py
+++ b/tests/test_eventbridge.py
@@ -56,6 +56,360 @@ def test_eventbridge_targets(eb):
     assert len(resp["Targets"]) == 1
 
 
+def test_eventbridge_put_targets_rejects_malformed_target_arn(eb):
+    rule_name = f"target-malformed-{_uuid_mod.uuid4().hex[:8]}"
+    eb.put_rule(Name=rule_name, ScheduleExpression="rate(1 minute)", State="ENABLED")
+
+    with pytest.raises(ClientError) as exc:
+        eb.put_targets(
+            Rule=rule_name,
+            Targets=[{"Id": "bad", "Arn": "not-an-arn"}],
+        )
+
+    assert exc.value.response["Error"]["Code"] == "ValidationException"
+    assert "Provided Arn is not in correct format" in exc.value.response["Error"]["Message"]
+    assert eb.list_targets_by_rule(Rule=rule_name)["Targets"] == []
+
+
+def test_eventbridge_put_targets_rejects_unsupported_target_service(eb):
+    rule_name = f"target-wrong-service-{_uuid_mod.uuid4().hex[:8]}"
+    eb.put_rule(Name=rule_name, ScheduleExpression="rate(1 minute)", State="ENABLED")
+
+    with pytest.raises(ClientError) as exc:
+        eb.put_targets(
+            Rule=rule_name,
+            Targets=[
+                {
+                    "Id": "rds",
+                    "Arn": "arn:aws:rds:us-east-1:000000000000:db:not-a-target",
+                }
+            ],
+        )
+
+    assert exc.value.response["Error"]["Code"] == "ValidationException"
+    assert "rds is not a supported service for a target" in exc.value.response["Error"]["Message"]
+    assert eb.list_targets_by_rule(Rule=rule_name)["Targets"] == []
+
+
+def test_eventbridge_put_targets_accepts_foreign_region_non_bus_target_arns(eb):
+    rule_name = f"target-foreign-{_uuid_mod.uuid4().hex[:8]}"
+    eb.put_rule(Name=rule_name, ScheduleExpression="rate(1 minute)", State="ENABLED")
+
+    resp = eb.put_targets(
+        Rule=rule_name,
+        Targets=[
+            {
+                "Id": "lambda-west",
+                "Arn": "arn:aws:lambda:us-west-2:000000000000:function:foreign-fn",
+            },
+            {
+                "Id": "sqs-west",
+                "Arn": "arn:aws:sqs:us-west-2:000000000000:foreign-q",
+            },
+            {
+                "Id": "sns-west",
+                "Arn": "arn:aws:sns:us-west-2:000000000000:foreign-topic",
+            },
+            {
+                "Id": "sfn-west",
+                "Arn": "arn:aws:states:us-west-2:000000000000:stateMachine:foreign-sm",
+            },
+        ],
+    )
+
+    assert resp["FailedEntryCount"] == 0
+    ids = {target["Id"] for target in eb.list_targets_by_rule(Rule=rule_name)["Targets"]}
+    assert ids == {"lambda-west", "sqs-west", "sns-west", "sfn-west"}
+
+
+def test_eventbridge_put_targets_accepts_supported_non_delivery_target_services(eb):
+    rule_name = f"target-services-{_uuid_mod.uuid4().hex[:8]}"
+    eb.put_rule(Name=rule_name, ScheduleExpression="rate(1 minute)", State="ENABLED")
+
+    resp = eb.put_targets(
+        Rule=rule_name,
+        Targets=[
+            {
+                "Id": "logs",
+                "Arn": "arn:aws:logs:us-east-1:000000000000:log-group:/aws/events/test",
+            },
+            {
+                "Id": "kinesis",
+                "Arn": "arn:aws:kinesis:us-east-1:000000000000:stream/test-stream",
+            },
+            {
+                "Id": "firehose",
+                "Arn": "arn:aws:firehose:us-east-1:000000000000:deliverystream/test-stream",
+            },
+            {
+                "Id": "batch",
+                "Arn": "arn:aws:batch:us-east-1:000000000000:job-queue/test-queue",
+            },
+            {
+                "Id": "ecs",
+                "Arn": "arn:aws:ecs:us-east-1:000000000000:cluster/test-cluster",
+            },
+            {
+                "Id": "apigw",
+                "Arn": "arn:aws:execute-api:us-east-1:000000000000:api-id/stage/GET/path",
+            },
+            {
+                "Id": "appsync",
+                "Arn": "arn:aws:appsync:us-east-1:000000000000:apis/api-id",
+            },
+            {
+                "Id": "ssm",
+                "Arn": "arn:aws:ssm:us-east-1:000000000000:document/AWS-RunShellScript",
+            },
+        ],
+    )
+
+    assert resp["FailedEntryCount"] == 0
+    ids = {target["Id"] for target in eb.list_targets_by_rule(Rule=rule_name)["Targets"]}
+    assert ids == {"logs", "kinesis", "firehose", "batch", "ecs", "apigw", "appsync", "ssm"}
+
+
+def test_eventbridge_put_targets_requires_role_for_foreign_region_event_bus(eb):
+    rule_name = f"target-foreign-bus-{_uuid_mod.uuid4().hex[:8]}"
+    eb.put_rule(Name=rule_name, ScheduleExpression="rate(1 minute)", State="ENABLED")
+
+    with pytest.raises(ClientError) as exc:
+        eb.put_targets(
+            Rule=rule_name,
+            Targets=[
+                {
+                    "Id": "bus-west",
+                    "Arn": "arn:aws:events:us-west-2:000000000000:event-bus/foreign-bus",
+                }
+            ],
+        )
+
+    assert exc.value.response["Error"]["Code"] == "ValidationException"
+    assert "RoleArn is required" in exc.value.response["Error"]["Message"]
+
+
+def test_eventbridge_foreign_region_sqs_target_does_not_deliver_to_same_name_queue(eb, sqs):
+    queue_name = f"target-foreign-sqs-{_uuid_mod.uuid4().hex[:8]}"
+    rule_name = f"target-foreign-sqs-{_uuid_mod.uuid4().hex[:8]}"
+    q_url = sqs.create_queue(QueueName=queue_name)["QueueUrl"]
+    west_arn = f"arn:aws:sqs:us-west-2:000000000000:{queue_name}"
+    eb.put_rule(
+        Name=rule_name,
+        EventPattern=json.dumps({"source": ["foreign.sqs"]}),
+        State="ENABLED",
+    )
+    eb.put_targets(
+        Rule=rule_name,
+        Targets=[{"Id": "foreign-sqs", "Arn": west_arn}],
+    )
+
+    eb.put_events(
+        Entries=[
+            {
+                "Source": "foreign.sqs",
+                "DetailType": "ForeignRegionSqs",
+                "Detail": json.dumps({"should": "not-deliver"}),
+                "EventBusName": "default",
+            }
+        ]
+    )
+
+    msgs = sqs.receive_message(QueueUrl=q_url, MaxNumberOfMessages=1, WaitTimeSeconds=1)
+    assert msgs.get("Messages", []) == []
+
+
+def test_eventbridge_foreign_region_bus_target_does_not_deliver_to_same_name_bus(eb, sqs):
+    bus_name = f"target-foreign-bus-{_uuid_mod.uuid4().hex[:8]}"
+    source_rule = f"source-foreign-bus-{_uuid_mod.uuid4().hex[:8]}"
+    local_rule = f"local-foreign-bus-{_uuid_mod.uuid4().hex[:8]}"
+    queue_name = f"target-foreign-bus-{_uuid_mod.uuid4().hex[:8]}"
+    q_url = sqs.create_queue(QueueName=queue_name)["QueueUrl"]
+    q_arn = sqs.get_queue_attributes(
+        QueueUrl=q_url,
+        AttributeNames=["QueueArn"],
+    )["Attributes"]["QueueArn"]
+
+    eb.create_event_bus(Name=bus_name)
+    eb.put_rule(
+        Name=local_rule,
+        EventBusName=bus_name,
+        EventPattern=json.dumps({"source": ["foreign.bus"]}),
+        State="ENABLED",
+    )
+    eb.put_targets(
+        Rule=local_rule,
+        EventBusName=bus_name,
+        Targets=[{"Id": "local-q", "Arn": q_arn}],
+    )
+    eb.put_rule(
+        Name=source_rule,
+        EventPattern=json.dumps({"source": ["foreign.bus"]}),
+        State="ENABLED",
+    )
+    eb.put_targets(
+        Rule=source_rule,
+        Targets=[
+            {
+                "Id": "foreign-bus",
+                "Arn": f"arn:aws:events:us-west-2:000000000000:event-bus/{bus_name}",
+                "RoleArn": "arn:aws:iam::000000000000:role/eb-cross-region",
+            },
+        ],
+    )
+
+    eb.put_events(
+        Entries=[
+            {
+                "Source": "foreign.bus",
+                "DetailType": "ForeignRegionBus",
+                "Detail": json.dumps({"should": "not-deliver"}),
+                "EventBusName": "default",
+            }
+        ]
+    )
+
+    msgs = sqs.receive_message(QueueUrl=q_url, MaxNumberOfMessages=1, WaitTimeSeconds=1)
+    assert msgs.get("Messages", []) == []
+
+
+def test_eventbridge_same_bus_target_does_not_recursively_dispatch(eb, sqs):
+    rule_name = f"target-self-bus-{_uuid_mod.uuid4().hex[:8]}"
+    queue_name = f"target-self-bus-{_uuid_mod.uuid4().hex[:8]}"
+    q_url = sqs.create_queue(QueueName=queue_name)["QueueUrl"]
+    q_arn = sqs.get_queue_attributes(QueueUrl=q_url, AttributeNames=["QueueArn"])["Attributes"]["QueueArn"]
+    eb.put_rule(
+        Name=rule_name,
+        EventPattern=json.dumps({"source": ["self.bus"]}),
+        State="ENABLED",
+    )
+    eb.put_targets(
+        Rule=rule_name,
+        Targets=[
+            {
+                "Id": "same-bus",
+                "Arn": "arn:aws:events:us-east-1:000000000000:event-bus/default",
+            },
+            {
+                "Id": "local-q",
+                "Arn": q_arn,
+            },
+        ],
+    )
+
+    resp = eb.put_events(
+        Entries=[
+            {
+                "Source": "self.bus",
+                "DetailType": "SelfBus",
+                "Detail": json.dumps({"ok": True}),
+                "EventBusName": "default",
+            }
+        ]
+    )
+
+    assert resp["FailedEntryCount"] == 0
+    msgs = sqs.receive_message(QueueUrl=q_url, MaxNumberOfMessages=10, WaitTimeSeconds=1)
+    assert len(msgs.get("Messages", [])) == 1
+
+
+def test_eventbridge_event_bus_target_archives_forwarded_event(eb):
+    source_bus = f"target-archive-source-{_uuid_mod.uuid4().hex[:8]}"
+    dest_bus = f"target-archive-dest-{_uuid_mod.uuid4().hex[:8]}"
+    source_rule = f"target-archive-rule-{_uuid_mod.uuid4().hex[:8]}"
+    archive_name = f"target-archive-{_uuid_mod.uuid4().hex[:8]}"
+    dest_bus_arn = f"arn:aws:events:us-east-1:000000000000:event-bus/{dest_bus}"
+    eb.create_event_bus(Name=source_bus)
+    eb.create_event_bus(Name=dest_bus)
+    eb.create_archive(ArchiveName=archive_name, EventSourceArn=dest_bus_arn)
+    eb.put_rule(
+        Name=source_rule,
+        EventBusName=source_bus,
+        EventPattern=json.dumps({"source": ["archive.forward"]}),
+        State="ENABLED",
+    )
+    eb.put_targets(
+        Rule=source_rule,
+        EventBusName=source_bus,
+        Targets=[
+            {
+                "Id": "dest-bus",
+                "Arn": dest_bus_arn,
+            },
+        ],
+    )
+
+    eb.put_events(
+        Entries=[
+            {
+                "Source": "archive.forward",
+                "DetailType": "ArchiveForward",
+                "Detail": json.dumps({"ok": True}),
+                "EventBusName": source_bus,
+            }
+        ]
+    )
+
+    assert eb.describe_archive(ArchiveName=archive_name)["EventCount"] == 1
+    eb.delete_archive(ArchiveName=archive_name)
+
+
+def test_eventbridge_event_bus_target_honors_input_override(eb, sqs):
+    source_bus = f"target-input-source-{_uuid_mod.uuid4().hex[:8]}"
+    dest_bus = f"target-input-dest-{_uuid_mod.uuid4().hex[:8]}"
+    source_rule = f"target-input-source-rule-{_uuid_mod.uuid4().hex[:8]}"
+    dest_rule = f"target-input-dest-rule-{_uuid_mod.uuid4().hex[:8]}"
+    queue_name = f"target-input-q-{_uuid_mod.uuid4().hex[:8]}"
+    dest_bus_arn = f"arn:aws:events:us-east-1:000000000000:event-bus/{dest_bus}"
+    q_url = sqs.create_queue(QueueName=queue_name)["QueueUrl"]
+    q_arn = sqs.get_queue_attributes(QueueUrl=q_url, AttributeNames=["QueueArn"])["Attributes"]["QueueArn"]
+    eb.create_event_bus(Name=source_bus)
+    eb.create_event_bus(Name=dest_bus)
+    eb.put_rule(
+        Name=dest_rule,
+        EventBusName=dest_bus,
+        EventPattern=json.dumps({"source": ["bus.input"]}),
+        State="ENABLED",
+    )
+    eb.put_targets(
+        Rule=dest_rule,
+        EventBusName=dest_bus,
+        Targets=[{"Id": "local-q", "Arn": q_arn}],
+    )
+    eb.put_rule(
+        Name=source_rule,
+        EventBusName=source_bus,
+        EventPattern=json.dumps({"source": ["bus.input"]}),
+        State="ENABLED",
+    )
+    eb.put_targets(
+        Rule=source_rule,
+        EventBusName=source_bus,
+        Targets=[
+            {
+                "Id": "dest-bus",
+                "Arn": dest_bus_arn,
+                "Input": json.dumps({"rewritten": True}),
+            },
+        ],
+    )
+
+    eb.put_events(
+        Entries=[
+            {
+                "Source": "bus.input",
+                "DetailType": "BusInput",
+                "Detail": json.dumps({"original": True}),
+                "EventBusName": source_bus,
+            }
+        ]
+    )
+
+    msgs = sqs.receive_message(QueueUrl=q_url, MaxNumberOfMessages=1, WaitTimeSeconds=1)
+    assert len(msgs.get("Messages", [])) == 1
+    body = json.loads(msgs["Messages"][0]["Body"])
+    assert body["detail"] == {"rewritten": True}
+
+
 def test_eventbridge_list_rule_names_by_target(eb):
     fn_arn = "arn:aws:lambda:us-east-1:000000000000:function:list-by-tgt-fn"
     eb.create_event_bus(Name="lrt-bus")
@@ -885,6 +1239,74 @@ def test_eventbridge_put_events_with_arn_as_bus_name(eb, sqs):
     assert len(msgs.get("Messages", [])) == 1
 
 
+def test_eventbridge_put_events_rejects_bad_bus_arn_without_local_fallback(eb, sqs):
+    bus_name = f"qa-eb-bad-bus-{_uuid_mod.uuid4().hex[:8]}"
+    eb.create_event_bus(Name=bus_name)
+    q_url = sqs.create_queue(QueueName=f"qa-eb-bad-bus-q-{_uuid_mod.uuid4().hex[:8]}")["QueueUrl"]
+    q_arn = sqs.get_queue_attributes(QueueUrl=q_url, AttributeNames=["QueueArn"])["Attributes"]["QueueArn"]
+    eb.put_rule(
+        Name="qa-eb-bad-bus-rule",
+        EventBusName=bus_name,
+        EventPattern=json.dumps({"source": ["myapp"]}),
+        State="ENABLED",
+    )
+    eb.put_targets(
+        Rule="qa-eb-bad-bus-rule",
+        EventBusName=bus_name,
+        Targets=[{"Id": "t1", "Arn": q_arn}],
+    )
+
+    response = eb.put_events(
+        Entries=[
+            {
+                "Source": "myapp",
+                "DetailType": "test",
+                "Detail": json.dumps({"key": "value"}),
+                "EventBusName": f"arn:aws:sqs:us-east-1:000000000000:event-bus/{bus_name}",
+            }
+        ]
+    )
+
+    assert response["FailedEntryCount"] == 1
+    assert response["Entries"][0]["ErrorCode"] == "ValidationException"
+    msgs = sqs.receive_message(QueueUrl=q_url, MaxNumberOfMessages=1, WaitTimeSeconds=1)
+    assert msgs.get("Messages", []) == []
+
+
+def test_eventbridge_put_events_rejects_foreign_region_bus_arn_without_local_fallback(eb, sqs):
+    bus_name = f"qa-eb-region-bus-{_uuid_mod.uuid4().hex[:8]}"
+    eb.create_event_bus(Name=bus_name)
+    q_url = sqs.create_queue(QueueName=f"qa-eb-region-bus-q-{_uuid_mod.uuid4().hex[:8]}")["QueueUrl"]
+    q_arn = sqs.get_queue_attributes(QueueUrl=q_url, AttributeNames=["QueueArn"])["Attributes"]["QueueArn"]
+    eb.put_rule(
+        Name="qa-eb-region-bus-rule",
+        EventBusName=bus_name,
+        EventPattern=json.dumps({"source": ["myapp"]}),
+        State="ENABLED",
+    )
+    eb.put_targets(
+        Rule="qa-eb-region-bus-rule",
+        EventBusName=bus_name,
+        Targets=[{"Id": "t1", "Arn": q_arn}],
+    )
+
+    response = eb.put_events(
+        Entries=[
+            {
+                "Source": "myapp",
+                "DetailType": "test",
+                "Detail": json.dumps({"key": "value"}),
+                "EventBusName": f"arn:aws:events:us-west-2:000000000000:event-bus/{bus_name}",
+            }
+        ]
+    )
+
+    assert response["FailedEntryCount"] == 1
+    assert response["Entries"][0]["ErrorCode"] == "ResourceNotFoundException"
+    msgs = sqs.receive_message(QueueUrl=q_url, MaxNumberOfMessages=1, WaitTimeSeconds=1)
+    assert msgs.get("Messages", []) == []
+
+
 def test_eventbridge_cfn_rule_accessible_via_api(eb, sqs, cfn):
     """Rules created via CloudFormation should be accessible via the EventBridge API."""
     bus_name = "qa-eb-cfn-bus"
@@ -1028,7 +1450,6 @@ def test_eventbridge_replay_completes(eb):
 
 def test_eventbridge_replay_not_found(eb):
     """StartReplay with a nonexistent archive returns ResourceNotFoundException."""
-    from botocore.exceptions import ClientError
     nonexistent_arn = "arn:aws:events:us-east-1:000000000000:archive/does-not-exist"
     rep_name = f"rep-nf-{_uuid_mod.uuid4().hex[:8]}"
     with pytest.raises(ClientError) as exc:
@@ -1040,6 +1461,92 @@ def test_eventbridge_replay_not_found(eb):
             Destination={"Arn": "arn:aws:events:us-east-1:000000000000:event-bus/default"},
         )
     assert exc.value.response["Error"]["Code"] == "ResourceNotFoundException"
+
+
+def test_eventbridge_replay_rejects_wrong_service_source_arn_without_local_fallback(eb):
+    arch_name = f"replay-bad-src-{_uuid_mod.uuid4().hex[:8]}"
+    eb.create_archive(
+        ArchiveName=arch_name,
+        EventSourceArn="arn:aws:events:us-east-1:000000000000:event-bus/default",
+    )
+
+    with pytest.raises(ClientError) as exc:
+        eb.start_replay(
+            ReplayName=f"rep-bad-src-{_uuid_mod.uuid4().hex[:8]}",
+            EventSourceArn=f"arn:aws:sqs:us-east-1:000000000000:archive/{arch_name}",
+            EventStartTime=0,
+            EventEndTime=time.time() + 3600,
+            Destination={"Arn": "arn:aws:events:us-east-1:000000000000:event-bus/default"},
+        )
+
+    assert exc.value.response["Error"]["Code"] == "ValidationException"
+    eb.delete_archive(ArchiveName=arch_name)
+
+
+def test_eventbridge_replay_rejects_foreign_region_destination_without_local_fallback(eb):
+    arch_name = f"replay-bad-dest-{_uuid_mod.uuid4().hex[:8]}"
+    eb.create_archive(
+        ArchiveName=arch_name,
+        EventSourceArn="arn:aws:events:us-east-1:000000000000:event-bus/default",
+    )
+    archive_arn = eb.describe_archive(ArchiveName=arch_name)["ArchiveArn"]
+
+    with pytest.raises(ClientError) as exc:
+        eb.start_replay(
+            ReplayName=f"rep-bad-dest-{_uuid_mod.uuid4().hex[:8]}",
+            EventSourceArn=archive_arn,
+            EventStartTime=0,
+            EventEndTime=time.time() + 3600,
+            Destination={"Arn": "arn:aws:events:us-west-2:000000000000:event-bus/default"},
+        )
+
+    assert exc.value.response["Error"]["Code"] == "ResourceNotFoundException"
+    eb.delete_archive(ArchiveName=arch_name)
+
+
+def test_eventbridge_replay_rejects_non_source_destination(eb):
+    arch_name = f"replay-wrong-dest-{_uuid_mod.uuid4().hex[:8]}"
+    replay_name = f"rep-wrong-dest-{_uuid_mod.uuid4().hex[:8]}"
+    other_bus = f"replay-other-{_uuid_mod.uuid4().hex[:8]}"
+    source_bus_arn = "arn:aws:events:us-east-1:000000000000:event-bus/default"
+    other_bus_arn = f"arn:aws:events:us-east-1:000000000000:event-bus/{other_bus}"
+    eb.create_event_bus(Name=other_bus)
+    eb.create_archive(ArchiveName=arch_name, EventSourceArn=source_bus_arn)
+    archive_arn = eb.describe_archive(ArchiveName=arch_name)["ArchiveArn"]
+
+    with pytest.raises(ClientError) as exc:
+        eb.start_replay(
+            ReplayName=replay_name,
+            EventSourceArn=archive_arn,
+            EventStartTime=0,
+            EventEndTime=time.time() + 3600,
+            Destination={"Arn": other_bus_arn},
+        )
+
+    assert exc.value.response["Error"]["Code"] == "ValidationException"
+    with pytest.raises(ClientError) as nf:
+        eb.describe_replay(ReplayName=replay_name)
+    assert nf.value.response["Error"]["Code"] == "ResourceNotFoundException"
+    eb.delete_archive(ArchiveName=arch_name)
+    eb.delete_event_bus(Name=other_bus)
+
+
+def test_eventbridge_replay_rejects_plain_name_source(eb):
+    arch_name = f"replay-plain-src-{_uuid_mod.uuid4().hex[:8]}"
+    source_bus_arn = "arn:aws:events:us-east-1:000000000000:event-bus/default"
+    eb.create_archive(ArchiveName=arch_name, EventSourceArn=source_bus_arn)
+
+    with pytest.raises(ClientError) as exc:
+        eb.start_replay(
+            ReplayName=f"rep-plain-src-{_uuid_mod.uuid4().hex[:8]}",
+            EventSourceArn=arch_name,
+            EventStartTime=0,
+            EventEndTime=time.time() + 3600,
+            Destination={"Arn": source_bus_arn},
+        )
+
+    assert exc.value.response["Error"]["Code"] == "ValidationException"
+    eb.delete_archive(ArchiveName=arch_name)
 
 
 def test_eventbridge_archive_event_count_accumulation(eb):
@@ -1140,22 +1647,24 @@ def test_eventbridge_replay_time_range_filtering(eb, sqs):
         Targets=[{"Id": "t1", "Arn": q_arn}],
     )
 
-    src_bus_arn = "arn:aws:events:us-east-1:000000000000:event-bus/default"
     arch_name = f"trange-arch-{_uuid_mod.uuid4().hex[:8]}"
-    eb.create_archive(ArchiveName=arch_name, EventSourceArn=src_bus_arn)
+    eb.create_archive(ArchiveName=arch_name, EventSourceArn=bus_arn)
 
-    # Put one event now — its Time will be approximately now (float)
+    # Put one event now; its Time will be approximately now.
     eb.put_events(
         Entries=[
             {
                 "Source": "trange.src",
                 "DetailType": "InRange",
                 "Detail": json.dumps({"marker": "in"}),
-                "EventBusName": "default",
+                "EventBusName": bus_name,
             }
         ]
     )
     now = time.time()
+    # Drain the live delivery from PutEvents so the assertion below isolates
+    # whether StartReplay dispatched anything outside the requested window.
+    sqs.receive_message(QueueUrl=q_url, MaxNumberOfMessages=10, WaitTimeSeconds=1)
 
     archive_arn = eb.describe_archive(ArchiveName=arch_name)["ArchiveArn"]
     rep_name = f"rep-trange-{_uuid_mod.uuid4().hex[:8]}"
@@ -1215,21 +1724,23 @@ def test_eventbridge_replay_destination_receives_events(eb, sqs):
         Targets=[{"Id": "t1", "Arn": q_arn}],
     )
 
-    src_bus_arn = "arn:aws:events:us-east-1:000000000000:event-bus/default"
     arch_name = f"dest-arch-{_uuid_mod.uuid4().hex[:8]}"
-    eb.create_archive(ArchiveName=arch_name, EventSourceArn=src_bus_arn)
+    eb.create_archive(ArchiveName=arch_name, EventSourceArn=bus_arn)
     eb.put_events(
         Entries=[
             {
                 "Source": "dest.replay",
                 "DetailType": "ReplayDelivery",
                 "Detail": json.dumps({"check": "delivered"}),
-                "EventBusName": "default",
+                "EventBusName": bus_name,
             }
         ]
     )
     archive_arn = eb.describe_archive(ArchiveName=arch_name)["ArchiveArn"]
     rep_name = f"rep-dest-{_uuid_mod.uuid4().hex[:8]}"
+    # Drain live delivery from the seed PutEvents call so the final assertion
+    # proves StartReplay delivered a fresh event.
+    sqs.receive_message(QueueUrl=q_url, MaxNumberOfMessages=10, WaitTimeSeconds=1)
     eb.start_replay(
         ReplayName=rep_name,
         EventSourceArn=archive_arn,


### PR DESCRIPTION
## Why
Bring EventBridge ARN handling into alignment with the shared parser-adoption rules so malformed, wrong-service, wrong-account, and wrong-Region ARNs cannot fall back to same-named local resources.

## What
- Validate EventBridge target ARNs with the shared ARN parser before storing targets
- Parse event bus and archive references for `PutEvents` and replay paths
- Preserve accepted EventBridge target services while preventing unsupported service fallback
- Prevent wrong-scope target delivery for SQS, event bus forwarding, and replay source/destination handling
- Preserve event-bus target behavior for input overrides, recursion prevention, and destination-bus archiving
- Add focused EventBridge regression coverage for parser failures, cross-region exceptions, replay validation, and event-bus target forwarding

## Risk Assessment
Medium within the feature branch because this tightens EventBridge validation and dispatch behavior. The change is scoped to EventBridge parser adoption and covered by focused EventBridge regression tests.

## References
Validation:
- `uv run --extra dev ruff check ministack/services/eventbridge.py tests/test_eventbridge.py`
- `uv run --extra dev pytest tests/test_eventbridge.py -q` (`118 passed`)
- `codex review --base Areson/resource-groups-tagging-arn-parser`
