### PR TITLE
Adopt ARN parsing for S3 notification targets

### DIFF
--- a/ministack/services/s3.py
+++ b/ministack/services/s3.py
@@ -1333,7 +1333,7 @@ def _put_bucket_notification(name: str, body: bytes):
         return _no_such_bucket(name)
     raw = body.decode("utf-8", errors="replace")
     configs = _parse_notification_config_raw(raw)
-    bucket_region = _buckets[name].get("region") or os.environ.get("MINISTACK_REGION", "us-east-1")
+    bucket_region = _notification_bucket_region(name)
     validation_error = _validate_notification_configs(configs, bucket_region)
     if validation_error:
         return validation_error
@@ -1615,6 +1615,18 @@ def _invalid_notification_config(message: str) -> tuple:
     return _error("InvalidArgument", message, 400)
 
 
+def _notification_bucket_region(bucket_name: str) -> str:
+    bucket = _buckets.get(bucket_name, {})
+    return bucket.get("region") or os.environ.get("MINISTACK_REGION", "us-east-1")
+
+
+_NOTIFICATION_TARGET_SERVICES = {
+    "sqs": "sqs",
+    "sns": "sns",
+    "lambda": "lambda",
+}
+
+
 def _queue_name_from_sqs_arn_spec(spec) -> str | None:
     if spec.service != "sqs" or not spec.resource or ":" in spec.resource or "/" in spec.resource:
         return None
@@ -1636,27 +1648,31 @@ def _lambda_name_from_arn_spec(spec) -> str | None:
     return parts[1]
 
 
-def _validate_notification_target_arn(target_type: str, arn: str, bucket_region: str) -> tuple | None:
-    service_for_type = {"sqs": "sqs", "sns": "sns", "lambda": "lambda"}
-    expected_service = service_for_type.get(target_type)
+def _parse_notification_target_arn(target_type: str, arn: str, bucket_region: str):
+    expected_service = _NOTIFICATION_TARGET_SERVICES.get(target_type)
     try:
         spec = parse_arn(arn)
     except ArnParseError:
-        return _invalid_notification_config(
-            "Unable to validate destination configuration: destination ARN is not in the correct format"
-        )
+        return None, "destination ARN is not in the correct format"
 
     if spec.service != expected_service:
-        return _invalid_notification_config(
-            f"Unable to validate destination configuration: expected {expected_service} ARN, got {spec.service}"
-        )
+        return spec, f"expected {expected_service} ARN, got {spec.service}"
+    if not spec.account_id:
+        return spec, "destination ARN must include an account ID"
+    if spec.account_id != get_account_id():
+        return spec, "destination account must match bucket owner account"
     if not spec.region:
-        return _invalid_notification_config(
-            "Unable to validate destination configuration: destination ARN must include a region"
-        )
+        return spec, "destination ARN must include a region"
     if spec.region != bucket_region:
+        return spec, "destination region must match bucket region"
+    return spec, None
+
+
+def _validate_notification_target_arn(target_type: str, arn: str, bucket_region: str) -> tuple | None:
+    spec, error = _parse_notification_target_arn(target_type, arn, bucket_region)
+    if error:
         return _invalid_notification_config(
-            "Unable to validate destination configuration: destination region must match bucket region"
+            f"Unable to validate destination configuration: {error}"
         )
 
     if target_type == "sqs" and not _queue_name_from_sqs_arn_spec(spec):
@@ -1717,6 +1733,7 @@ def _fire_s3_event(
         has_eventbridge = "EventBridgeConfiguration" in raw_xml
         if not configs and not has_eventbridge:
             return
+        bucket_region = _notification_bucket_region(bucket_name)
 
         short_event = event_name.replace("s3:", "", 1)
         event_time = now_iso()
@@ -1771,11 +1788,11 @@ def _fire_s3_event(
                 payload["Records"][0]["s3"]["configurationId"] = cfg["id"]
 
                 if cfg["type"] == "sqs":
-                    _deliver_event_to_sqs(cfg["arn"], payload)
+                    _deliver_event_to_sqs(cfg["arn"], payload, bucket_region)
                 elif cfg["type"] == "sns":
-                    _deliver_event_to_sns(cfg["arn"], payload)
+                    _deliver_event_to_sns(cfg["arn"], payload, bucket_region)
                 elif cfg["type"] == "lambda":
-                    _deliver_event_to_lambda(cfg["arn"], payload)
+                    _deliver_event_to_lambda(cfg["arn"], payload, bucket_region)
             except Exception:
                 logger.exception(
                     "S3 notification delivery failed for config %s", cfg.get("id")
@@ -1815,10 +1832,29 @@ def _fire_s3_event(
         )
 
 
-def _deliver_event_to_sqs(arn: str, event_payload: dict) -> None:
+def _parse_delivery_notification_target(target_type: str, arn: str, bucket_region: str):
+    spec, error = _parse_notification_target_arn(target_type, arn, bucket_region)
+    if error:
+        logger.warning(
+            "S3 notification: invalid %s target ARN %s: %s",
+            target_type.upper(),
+            arn,
+            error,
+        )
+        return None
+    return spec
+
+
+def _deliver_event_to_sqs(arn: str, event_payload: dict, bucket_region: str) -> None:
     from ministack.services import sqs as _sqs
 
-    queue_name = arn.rsplit(":", 1)[-1]
+    spec = _parse_delivery_notification_target("sqs", arn, bucket_region)
+    if not spec:
+        return
+    queue_name = _queue_name_from_sqs_arn_spec(spec)
+    if not queue_name:
+        logger.warning("S3 notification: invalid SQS queue ARN %s", arn)
+        return
     queue_url = _sqs._queue_url(queue_name)
     queue = _sqs._queues.get(queue_url)
     if not queue:
@@ -1841,9 +1877,15 @@ def _deliver_event_to_sqs(arn: str, event_payload: dict) -> None:
     logger.info("S3 notification → SQS %s", queue_name)
 
 
-def _deliver_event_to_sns(arn: str, event_payload: dict) -> None:
+def _deliver_event_to_sns(arn: str, event_payload: dict, bucket_region: str) -> None:
     from ministack.services import sns as _sns
 
+    spec = _parse_delivery_notification_target("sns", arn, bucket_region)
+    if not spec:
+        return
+    if not _topic_name_from_sns_arn_spec(spec):
+        logger.warning("S3 notification: invalid SNS topic ARN %s", arn)
+        return
     topic = _sns._topics.get(arn)
     if not topic:
         logger.warning("S3 notification: SNS topic %s not found", arn)
@@ -1855,9 +1897,15 @@ def _deliver_event_to_sns(arn: str, event_payload: dict) -> None:
     logger.info("S3 notification → SNS %s", arn)
 
 
-def _deliver_event_to_lambda(arn: str, event_payload: dict) -> None:
+def _deliver_event_to_lambda(arn: str, event_payload: dict, bucket_region: str) -> None:
     from ministack.services import lambda_svc as _lambda
 
+    spec = _parse_delivery_notification_target("lambda", arn, bucket_region)
+    if not spec:
+        return
+    if not _lambda_name_from_arn_spec(spec):
+        logger.warning("S3 notification: invalid Lambda function ARN %s", arn)
+        return
     func, config, func_name = _lambda._get_func_record_for_ref(arn)
     if not func or not config:
         logger.warning("S3 notification: Lambda function %s not found", func_name)
@@ -1891,6 +1939,7 @@ def _fire_s3_test_event(bucket_name: str) -> None:
         configs = _parse_notification_config(bucket_name)
         if not configs:
             return
+        bucket_region = _notification_bucket_region(bucket_name)
         payload = {
             "Service": "Amazon S3",
             "Event": "s3:TestEvent",
@@ -1902,11 +1951,11 @@ def _fire_s3_test_event(bucket_name: str) -> None:
         for cfg in configs:
             try:
                 if cfg["type"] == "sqs":
-                    _deliver_event_to_sqs(cfg["arn"], payload)
+                    _deliver_event_to_sqs(cfg["arn"], payload, bucket_region)
                 elif cfg["type"] == "sns":
-                    _deliver_event_to_sns(cfg["arn"], payload)
+                    _deliver_event_to_sns(cfg["arn"], payload, bucket_region)
                 elif cfg["type"] == "lambda":
-                    _deliver_event_to_lambda(cfg["arn"], payload)
+                    _deliver_event_to_lambda(cfg["arn"], payload, bucket_region)
             except Exception:
                 logger.exception(
                     "S3 test-event delivery failed for config %s", cfg.get("id")

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -2,6 +2,7 @@ import json
 import os
 import re
 import time
+import uuid as _uuid_mod
 from datetime import datetime
 from urllib.parse import urlparse
 
@@ -1304,6 +1305,161 @@ def test_s3_put_notification_sends_test_event(s3, sqs):
     assert "Records" not in body
 
 
+@pytest.mark.parametrize(
+    ("config_key", "arn_key", "target_arn"),
+    [
+        ("QueueConfigurations", "QueueArn", "not-an-arn"),
+        ("QueueConfigurations", "QueueArn", "arn:aws:rds:us-east-1:000000000000:db:wrong-service"),
+        ("TopicConfigurations", "TopicArn", "arn:aws:sqs:us-east-1:000000000000:wrong-service"),
+        (
+            "LambdaFunctionConfigurations",
+            "LambdaFunctionArn",
+            "arn:aws:sns:us-east-1:000000000000:wrong-service",
+        ),
+        ("QueueConfigurations", "QueueArn", "arn:aws:sqs:us-east-1:000000000001:s3-foreign-account-q"),
+        ("TopicConfigurations", "TopicArn", "arn:aws:sns:us-east-1:000000000001:s3-foreign-account-topic"),
+        (
+            "LambdaFunctionConfigurations",
+            "LambdaFunctionArn",
+            "arn:aws:lambda:us-east-1:000000000001:function:s3-foreign-account-fn",
+        ),
+        ("QueueConfigurations", "QueueArn", "arn:aws:sqs:us-west-2:000000000000:s3-foreign-region-q"),
+        ("TopicConfigurations", "TopicArn", "arn:aws:sns:us-west-2:000000000000:s3-foreign-region-topic"),
+        (
+            "LambdaFunctionConfigurations",
+            "LambdaFunctionArn",
+            "arn:aws:lambda:us-west-2:000000000000:function:s3-foreign-region-fn",
+        ),
+    ],
+)
+def test_s3_notification_rejects_invalid_or_out_of_scope_target_arns(
+    s3, config_key, arn_key, target_arn,
+):
+    bkt = f"s3-evt-invalid-arn-{_uuid_mod.uuid4().hex[:8]}"
+    s3.create_bucket(Bucket=bkt)
+
+    with pytest.raises(ClientError) as exc:
+        s3.put_bucket_notification_configuration(
+            Bucket=bkt,
+            NotificationConfiguration={
+                config_key: [
+                    {
+                        arn_key: target_arn,
+                        "Events": ["s3:ObjectCreated:*"],
+                    }
+                ],
+            },
+        )
+    assert exc.value.response["Error"]["Code"] == "InvalidArgument"
+
+
+def test_s3_notification_validates_target_region_against_bucket_region(s3):
+    bkt = f"s3-evt-bucket-region-{_uuid_mod.uuid4().hex[:8]}"
+    s3.create_bucket(
+        Bucket=bkt,
+        CreateBucketConfiguration={"LocationConstraint": "us-west-2"},
+    )
+
+    s3.put_bucket_notification_configuration(
+        Bucket=bkt,
+        NotificationConfiguration={
+            "QueueConfigurations": [
+                {
+                    "QueueArn": "arn:aws:sqs:us-west-2:000000000000:s3-west-region-q",
+                    "Events": ["s3:ObjectCreated:*"],
+                }
+            ],
+        },
+    )
+
+    with pytest.raises(ClientError) as exc:
+        s3.put_bucket_notification_configuration(
+            Bucket=bkt,
+            NotificationConfiguration={
+                "QueueConfigurations": [
+                    {
+                        "QueueArn": "arn:aws:sqs:us-east-1:000000000000:s3-east-region-q",
+                        "Events": ["s3:ObjectCreated:*"],
+                    }
+                ],
+            },
+        )
+    assert exc.value.response["Error"]["Code"] == "InvalidArgument"
+
+
+@pytest.mark.parametrize(
+    "target_arn",
+    [
+        "arn:aws:sqs:us-east-1:000000000001:shared-q",
+        "arn:aws:sqs:us-west-2:000000000000:shared-q",
+    ],
+)
+def test_s3_notification_sqs_delivery_rejects_out_of_scope_arns_without_name_fallback(
+    monkeypatch, target_arn,
+):
+    from ministack.services import s3 as s3mod
+    from ministack.services import sqs as sqsmod
+
+    messages = []
+    monkeypatch.setattr(s3mod, "get_account_id", lambda: "000000000000")
+    monkeypatch.setattr(sqsmod, "_queue_url", lambda name: f"url/{name}")
+    monkeypatch.setattr(sqsmod, "_queues", {"url/shared-q": {"messages": messages}})
+    monkeypatch.setattr(sqsmod, "_ensure_msg_fields", lambda msg: None)
+
+    s3mod._deliver_event_to_sqs(target_arn, {"Records": []}, "us-east-1")
+
+    assert messages == []
+
+
+@pytest.mark.parametrize(
+    "target_arn",
+    [
+        "arn:aws:sns:us-east-1:000000000001:shared-topic",
+        "arn:aws:sns:us-west-2:000000000000:shared-topic",
+    ],
+)
+def test_s3_notification_sns_delivery_rejects_out_of_scope_arns_before_fanout(
+    monkeypatch, target_arn,
+):
+    from ministack.services import s3 as s3mod
+    from ministack.services import sns as snsmod
+
+    fanouts = []
+    monkeypatch.setattr(s3mod, "get_account_id", lambda: "000000000000")
+    monkeypatch.setattr(snsmod, "_topics", {target_arn: {"subscriptions": []}})
+    monkeypatch.setattr(snsmod, "_fanout", lambda *args, **kwargs: fanouts.append(args))
+
+    s3mod._deliver_event_to_sns(target_arn, {"Records": []}, "us-east-1")
+
+    assert fanouts == []
+
+
+@pytest.mark.parametrize(
+    "target_arn",
+    [
+        "arn:aws:lambda:us-east-1:000000000001:function:shared-fn",
+        "arn:aws:lambda:us-west-2:000000000000:function:shared-fn",
+    ],
+)
+def test_s3_notification_lambda_delivery_rejects_out_of_scope_arns_before_lookup(
+    monkeypatch, target_arn,
+):
+    from ministack.services import lambda_svc as lambdamod
+    from ministack.services import s3 as s3mod
+
+    lookups = []
+    monkeypatch.setattr(s3mod, "get_account_id", lambda: "000000000000")
+    monkeypatch.setattr(
+        lambdamod,
+        "_get_func_record_for_ref",
+        lambda ref: lookups.append(ref) or ({}, {}, "shared-fn"),
+    )
+
+    s3mod._deliver_event_to_lambda(target_arn, {"Records": []}, "us-east-1")
+
+    assert lookups == []
+
+
 def _wait_lambda_invoked(logs_client, function_name, marker, timeout=5.0):
     """Poll the function's log group for a marker substring. Returns True on
     first match, False after timeout."""
@@ -1444,7 +1600,7 @@ def test_s3_event_notification_to_lambda_modern_xml(s3, lam, logs):
         '</NotificationConfiguration>'
     )
     req = _urlreq.Request(
-        "http://localhost:4566/s3-evt-lam-modern-bkt?notification",
+        f"{os.environ.get('MINISTACK_ENDPOINT', 'http://localhost:4566')}/s3-evt-lam-modern-bkt?notification",
         data=modern_xml.encode(),
         method="PUT",
         headers={"Content-Type": "application/xml", "Authorization": "AWS test:test"},
@@ -1475,7 +1631,7 @@ def test_s3_event_notification_to_lambda_with_filter(s3, lam, logs):
         '</NotificationConfiguration>'
     )
     req = _urlreq.Request(
-        "http://localhost:4566/s3-evt-lam-filter-bkt?notification",
+        f"{os.environ.get('MINISTACK_ENDPOINT', 'http://localhost:4566')}/s3-evt-lam-filter-bkt?notification",
         data=modern_xml.encode(), method="PUT",
         headers={"Content-Type": "application/xml", "Authorization": "AWS test:test"},
     )


### PR DESCRIPTION
Summary
- Adopt shared ARN parsing for S3 bucket notification SQS, SNS, and Lambda target ARNs.
- Validate destination service, account, and bucket Region at configuration time, then revalidate targets during normal event and `s3:TestEvent` delivery.
- Add regressions that prevent malformed or out-of-scope target ARNs from falling back to same-named local resources.

Validation
- `python3 -m py_compile ministack/services/s3.py tests/test_s3.py`
- `uv run --extra dev ruff check ministack/services/s3.py tests/test_s3.py`
- Source-backed MiniStack on `GATEWAY_PORT=14562` with focused S3 notification tests: `21 passed`
- Source-backed MiniStack on `GATEWAY_PORT=14562` with Lambda notification regressions: `4 passed`
- Source-backed MiniStack on `GATEWAY_PORT=14562` with delivery-boundary regressions: `6 passed`