### PR TITLE
Adopt ARN parsing for SNS subscription endpoints

### DIFF
--- a/ministack/services/sns.py
+++ b/ministack/services/sns.py
@@ -27,6 +27,7 @@ _HOST = os.environ.get("MINISTACK_HOST", "localhost")
 _PORT = os.environ.get("GATEWAY_PORT", "4566")
 
 import ministack.services.lambda_svc as _lambda_svc
+from ministack.core.arn import ArnParseError, parse_arn
 from ministack.core.responses import AccountScopedDict, get_account_id, get_region, new_uuid
 from ministack.services import sqs as _sqs
 
@@ -46,6 +47,46 @@ def _normalize_arn(arn: str) -> str:
     if arn and _re.match(r"arn:aws:sns:[^:]+::[^:]+", arn):
         return _re.sub(r"(arn:aws:sns:[^:]+)::", rf"\1:{get_account_id()}:", arn)
     return arn
+
+
+def _sqs_queue_name_from_arn_spec(spec) -> str | None:
+    if spec.service != "sqs" or not spec.resource or ":" in spec.resource or "/" in spec.resource:
+        return None
+    return spec.resource
+
+
+def _lambda_function_name_from_arn_spec(spec) -> str | None:
+    if spec.service != "lambda":
+        return None
+    parts = spec.resource.split(":", 2)
+    if len(parts) < 2 or parts[0] != "function" or not parts[1]:
+        return None
+    return parts[1]
+
+
+def _invalid_subscription_endpoint(protocol: str, endpoint: str):
+    return _error(
+        "InvalidParameterException",
+        f"Invalid parameter: Endpoint {endpoint} is not a valid {protocol.upper()} ARN",
+        400,
+    )
+
+
+def _validate_subscription_endpoint(protocol: str, endpoint: str):
+    if protocol not in {"sqs", "lambda"}:
+        return None
+    try:
+        spec = parse_arn(endpoint)
+    except ArnParseError:
+        return _invalid_subscription_endpoint(protocol, endpoint)
+
+    if not spec.region or not spec.account_id:
+        return _invalid_subscription_endpoint(protocol, endpoint)
+    if protocol == "sqs" and not _sqs_queue_name_from_arn_spec(spec):
+        return _invalid_subscription_endpoint(protocol, endpoint)
+    if protocol == "lambda" and not _lambda_function_name_from_arn_spec(spec):
+        return _invalid_subscription_endpoint(protocol, endpoint)
+    return None
 
 from ministack.core.persistence import PERSIST_STATE, load_state
 
@@ -293,6 +334,9 @@ def _subscribe(params):
 
     if not protocol:
         return _error("InvalidParameterException", "Protocol is required", 400)
+    endpoint_error = _validate_subscription_endpoint(protocol, endpoint)
+    if endpoint_error:
+        return endpoint_error
 
     for existing in topic["subscriptions"]:
         if existing["protocol"] == protocol and existing["endpoint"] == endpoint:
@@ -857,9 +901,26 @@ def _fanout(topic_arn: str, msg_id: str, message: str, subject: str,
 def _deliver_to_sqs(endpoint: str, envelope: str, raw: bool, raw_message: str,
                     message_group_id: str = "", message_dedup_id: str = "",
                     message_attributes: dict | None = None):
-    queue_name = endpoint.split(":")[-1]
-    queue_url = _sqs._queue_url(queue_name)
-    queue = _sqs._queues.get(queue_url)
+    try:
+        spec = parse_arn(endpoint)
+    except ArnParseError:
+        logger.warning("SNS fanout: invalid SQS endpoint ARN %s", endpoint)
+        return
+    queue_name = _sqs_queue_name_from_arn_spec(spec)
+    if not queue_name:
+        logger.warning("SNS fanout: invalid SQS endpoint ARN %s", endpoint)
+        return
+    if spec.account_id != get_account_id():
+        logger.warning("SNS fanout: SQS queue %s is outside the current account scope", queue_name)
+        return
+    queue = next(
+        (
+            q
+            for q in _sqs._queues.values()
+            if q.get("attributes", {}).get("QueueArn") == str(spec)
+        ),
+        None,
+    )
     if not queue:
         logger.warning("SNS fanout: SQS queue %s not found", queue_name)
         return

--- a/tests/test_sns.py
+++ b/tests/test_sns.py
@@ -7,10 +7,24 @@ import uuid as _uuid_mod
 import zipfile
 from urllib.parse import urlencode, urlparse
 
+import boto3
 import pytest
+from botocore.config import Config
 from botocore.exceptions import ClientError
 
 ENDPOINT = os.environ.get("MINISTACK_ENDPOINT", "http://localhost:4566")
+
+
+def _regional_client(service: str, region: str):
+    return boto3.client(
+        service,
+        endpoint_url=ENDPOINT,
+        aws_access_key_id="test",
+        aws_secret_access_key="test",
+        region_name=region,
+        config=Config(region_name=region, retries={"mode": "standard"}),
+    )
+
 
 def _make_zip(code: str) -> bytes:
     buf = io.BytesIO()
@@ -144,6 +158,75 @@ def test_sns_sqs_fanout(sns, sqs):
     body = json.loads(msgs["Messages"][0]["Body"])
     assert body["Message"] == "fanout msg"
     assert body["TopicArn"] == topic_arn
+
+
+@pytest.mark.parametrize("protocol, endpoint", [
+    ("sqs", "not-an-arn"),
+    ("sqs", "arn:aws:rds:us-east-1:000000000000:db:wrong-service"),
+    ("lambda", "arn:aws:sqs:us-east-1:000000000000:wrong-service-q"),
+    ("lambda", "arn:aws:lambda:us-east-1:000000000000:not-function-resource"),
+])
+def test_sns_subscribe_rejects_invalid_sqs_and_lambda_endpoint_arns(sns, protocol, endpoint):
+    topic_arn = sns.create_topic(Name=f"intg-sns-invalid-endpoint-{_uuid_mod.uuid4().hex[:8]}")["TopicArn"]
+
+    with pytest.raises(ClientError) as exc:
+        sns.subscribe(TopicArn=topic_arn, Protocol=protocol, Endpoint=endpoint)
+    assert exc.value.response["Error"]["Code"] == "InvalidParameterException"
+
+
+def test_sns_sqs_fanout_does_not_tail_match_foreign_account_endpoint(sns, sqs):
+    queue_name = f"intg-sns-foreign-tail-{_uuid_mod.uuid4().hex[:8]}"
+    q_url = sqs.create_queue(QueueName=queue_name)["QueueUrl"]
+    topic_arn = sns.create_topic(Name=f"intg-sns-foreign-tail-{_uuid_mod.uuid4().hex[:8]}")["TopicArn"]
+
+    sns.subscribe(
+        TopicArn=topic_arn,
+        Protocol="sqs",
+        Endpoint=f"arn:aws:sqs:us-east-1:111111111111:{queue_name}",
+    )
+    sns.publish(TopicArn=topic_arn, Message="must-not-tail-match")
+
+    msgs = sqs.receive_message(QueueUrl=q_url, MaxNumberOfMessages=1, WaitTimeSeconds=1)
+    assert "Messages" not in msgs
+
+
+def test_sns_sqs_fanout_delivers_to_matching_cross_region_queue_arn(sns):
+    west_sqs = _regional_client("sqs", "us-west-2")
+    queue_name = f"intg-sns-cross-region-ok-{_uuid_mod.uuid4().hex[:8]}"
+    q_url = west_sqs.create_queue(QueueName=queue_name)["QueueUrl"]
+    q_arn = west_sqs.get_queue_attributes(
+        QueueUrl=q_url,
+        AttributeNames=["QueueArn"],
+    )["Attributes"]["QueueArn"]
+    assert ":us-west-2:" in q_arn
+    topic_arn = sns.create_topic(Name=f"intg-sns-cross-region-ok-{_uuid_mod.uuid4().hex[:8]}")["TopicArn"]
+
+    sns.subscribe(TopicArn=topic_arn, Protocol="sqs", Endpoint=q_arn)
+    sns.publish(TopicArn=topic_arn, Message="cross-region-delivery")
+
+    msgs = west_sqs.receive_message(QueueUrl=q_url, MaxNumberOfMessages=1, WaitTimeSeconds=1)
+    assert len(msgs.get("Messages", [])) == 1
+    body = json.loads(msgs["Messages"][0]["Body"])
+    assert body["Message"] == "cross-region-delivery"
+    assert body["TopicArn"] == topic_arn
+
+
+def test_sns_sqs_fanout_does_not_tail_match_foreign_region_endpoint(sns, sqs):
+    queue_name = f"intg-sns-cross-region-{_uuid_mod.uuid4().hex[:8]}"
+    q_url = sqs.create_queue(QueueName=queue_name)["QueueUrl"]
+    q_arn = sqs.get_queue_attributes(
+        QueueUrl=q_url,
+        AttributeNames=["QueueArn"],
+    )["Attributes"]["QueueArn"]
+    west_q_arn = q_arn.replace(":us-east-1:", ":us-west-2:")
+    topic_arn = sns.create_topic(Name=f"intg-sns-cross-region-{_uuid_mod.uuid4().hex[:8]}")["TopicArn"]
+
+    sns.subscribe(TopicArn=topic_arn, Protocol="sqs", Endpoint=west_q_arn)
+    sns.publish(TopicArn=topic_arn, Message="must-not-tail-match-region")
+
+    msgs = sqs.receive_message(QueueUrl=q_url, MaxNumberOfMessages=1, WaitTimeSeconds=1)
+    assert "Messages" not in msgs
+
 
 def test_sns_tags(sns):
     arn = sns.create_topic(Name="intg-sns-tags")["TopicArn"]


### PR DESCRIPTION
Summary
- Adopt shared ARN parsing for SNS SQS and Lambda subscription endpoints.
- Reject malformed or wrong-service SQS/Lambda endpoint ARNs at subscribe time.
- Resolve SNS-to-SQS fanout by exact stored `QueueArn` so foreign-account or wrong-Region same-name ARNs do not tail-match local queues, while preserving matching cross-Region SQS delivery.

Validation
- `uvx ruff check ministack/services/sns.py tests/test_sns.py`
- `git diff --check`
- Source-backed MiniStack on `GATEWAY_PORT=14563` with focused SNS regression tests: `11 passed`
- Source-backed MiniStack on `GATEWAY_PORT=14563`: `MINISTACK_ENDPOINT=http://localhost:14563 uv run --extra dev pytest tests/test_sns.py -q` (`63 passed`)