### PR TITLE
Adopt ARN parsing for CodeBuild project identifiers

### DIFF
--- a/ministack/services/codebuild.py
+++ b/ministack/services/codebuild.py
@@ -15,6 +15,7 @@ import logging
 import os
 import time
 
+from ministack.core.arn import ArnParseError, is_arn, parse_arn
 from ministack.core.persistence import PERSIST_STATE, load_state
 from ministack.core.responses import (
     AccountScopedDict,
@@ -74,6 +75,30 @@ def _project_arn(name):
 
 def _build_arn(build_id):
     return f"arn:aws:codebuild:{get_region()}:{get_account_id()}:build/{build_id}"
+
+
+def _project_name_from_identifier(value):
+    """Resolve a project name for BatchGetProjects-style not-found semantics."""
+    if not is_arn(value):
+        return value
+    try:
+        spec = parse_arn(value)
+    except ArnParseError:
+        return None
+
+    if (
+        spec.partition != "aws"
+        or spec.service != "codebuild"
+        or spec.region != get_region()
+        or spec.account_id != get_account_id()
+    ):
+        return None
+
+    prefix = "project/"
+    if not spec.resource.startswith(prefix):
+        return None
+    project_name = spec.resource[len(prefix):]
+    return project_name or None
 
 
 def _build_id(project_name):
@@ -217,8 +242,8 @@ def _batch_get_projects(data):
     found = []
     not_found = []
     for name in names:
-        lookup = name.rsplit("/", 1)[-1] if name.startswith("arn:aws:codebuild:") else name
-        project = _projects.get(lookup)
+        lookup = _project_name_from_identifier(name)
+        project = _projects.get(lookup) if lookup else None
         if project:
             found.append(_project_shape(project))
         else:

--- a/tests/test_codebuild.py
+++ b/tests/test_codebuild.py
@@ -3,6 +3,22 @@ from botocore.exceptions import ClientError
 
 # ========== CodeBuild ==========
 
+def _ensure_codebuild_project(codebuild, name):
+    if codebuild.batch_get_projects(names=[name])["projects"]:
+        return
+    codebuild.create_project(
+        name=name,
+        source={"type": "NO_SOURCE"},
+        artifacts={"type": "NO_ARTIFACTS"},
+        environment={
+            "type": "LINUX_CONTAINER",
+            "image": "aws/codebuild/standard:7.0",
+            "computeType": "BUILD_GENERAL1_SMALL",
+        },
+        serviceRole="arn:aws:iam::000000000000:role/codebuild-role",
+    )
+
+
 def test_codebuild_create_project(codebuild):
     resp = codebuild.create_project(
         name="test-project",
@@ -46,6 +62,30 @@ def test_codebuild_batch_get_projects_by_arn(codebuild):
     assert len(resp["projects"]) == 1
     assert resp["projects"][0]["name"] == "test-project"
     assert resp["projectsNotFound"] == []
+
+
+@pytest.mark.parametrize(
+    "identifier_template",
+    [
+        "arn:aws:codebuild:us-east-1:000000000000:build/{name}",
+        "arn:aws:codebuild:project/{name}",
+        "arn:aws-us-gov:codebuild:us-east-1:000000000000:project/{name}",
+        "arn:aws:lambda:us-east-1:000000000000:project/{name}",
+        "arn:aws:codebuild:us-west-2:000000000000:project/{name}",
+        "arn:aws:codebuild:us-east-1:111111111111:project/{name}",
+    ],
+)
+def test_codebuild_batch_get_projects_does_not_tail_resolve_out_of_scope_arns(
+    codebuild,
+    identifier_template,
+):
+    name = "arn-parser-project"
+    _ensure_codebuild_project(codebuild, name)
+
+    identifier = identifier_template.format(name=name)
+    resp = codebuild.batch_get_projects(names=[identifier])
+    assert resp["projects"] == []
+    assert resp["projectsNotFound"] == [identifier]
 
 
 def test_codebuild_list_projects(codebuild):


### PR DESCRIPTION
Summary
- Adopt shared ARN parsing for CodeBuild `BatchGetProjects` identifiers.
- Preserve plain project-name lookup while validating ARN partition, service, account, Region, and `project/` resource prefix before resolving project names.
- Add regressions so malformed, wrong-service, wrong-account, wrong-Region, wrong-partition, and wrong-resource-type ARNs do not tail-resolve to same-named local projects.

Validation
- `uv run --extra dev ruff check ministack/services/codebuild.py tests/test_codebuild.py`
- Source-backed MiniStack on `GATEWAY_PORT=14564`: `MINISTACK_ENDPOINT=http://localhost:14564 uv run --extra dev pytest tests/test_codebuild.py -q` (`20 passed`)