### PR TITLE
Adopt ARN parsing in CloudWatch Logs delivery

### DIFF
--- a/ministack/services/cloudwatch_logs.py
+++ b/ministack/services/cloudwatch_logs.py
@@ -25,6 +25,7 @@ import logging
 import os
 import time
 
+from ministack.core.arn import ArnParseError, parse_arn
 from ministack.core.responses import (
     AccountRegionScopedDict,
     AccountScopedDict,
@@ -1015,8 +1016,10 @@ def _make_delivery_arn(delivery_id):
 # not supply it; any value in the request is ignored. The field is
 # always server-computed so it stays stable across describe calls.
 def _derive_service_from_arn(arn):
-    parts = arn.split(":", 5)
-    return parts[2] if len(parts) >= 3 else ""
+    try:
+        return parse_arn(arn).service
+    except ArnParseError:
+        return ""
 
 
 # AWS derives deliveryDestinationType from the destination resource ARN
@@ -1025,10 +1028,10 @@ def _derive_destination_type_from_arn(arn):
     """Parse arn:aws:<svc>:region:acct:<resource>/... and map to the
     deliveryDestinationType label AWS returns. Returns None if the ARN
     doesn't match a supported target service."""
-    parts = arn.split(":", 5)
-    if len(parts) < 3:
+    try:
+        svc = parse_arn(arn).service
+    except ArnParseError:
         return None
-    svc = parts[2]
     if svc == "s3":
         return "S3"
     if svc == "logs":
@@ -1039,6 +1042,61 @@ def _derive_destination_type_from_arn(arn):
 
 
 _VALID_OUTPUT_FORMATS = {"json", "plain", "w3c", "raw", "parquet"}
+_DELIVERY_SOURCE_NON_SOURCES = {"firehose", "lambda", "logs", "s3", "sns", "sqs"}
+
+
+def _validation_error(message):
+    return error_response_json("ValidationException", message, 400)
+
+
+def _delivery_source_spec(resource_arn):
+    try:
+        spec = parse_arn(resource_arn)
+    except ArnParseError:
+        return None, _validation_error("Invalid ARN provided.")
+    if spec.region and spec.region != get_region():
+        return None, _validation_error("Cross-region Delivery Source is not supported. Please use a different region.")
+    if spec.account_id and spec.account_id != get_account_id():
+        return None, _validation_error("Account id from identity does not match the resourceArn.")
+    if spec.service in _DELIVERY_SOURCE_NON_SOURCES:
+        return None, error_response_json("ResourceNotFoundException", "Cannot access provided service.", 400)
+    return spec, None
+
+
+def _delivery_destination_resource_spec(destination_resource_arn):
+    try:
+        spec = parse_arn(destination_resource_arn)
+    except ArnParseError:
+        return None, _validation_error("Invalid ARN provided.")
+    if spec.service not in ("firehose", "logs", "s3"):
+        return None, _validation_error("Delivery Destination Resource ARN is of unsupported service.")
+    if spec.service == "s3":
+        if spec.region or spec.account_id:
+            return None, _validation_error("Invalid ARN provided.")
+        return spec, None
+    if spec.region != get_region():
+        return None, _validation_error("Region from identity does not match the Destination Resource ARN.")
+    if spec.account_id != get_account_id():
+        return None, _validation_error("Account id from identity does not match the Destination Resource ARN.")
+    return spec, None
+
+
+def _delivery_destination_spec(delivery_destination_arn):
+    try:
+        spec = parse_arn(delivery_destination_arn)
+    except ArnParseError:
+        return None, _validation_error("Invalid ARN provided.")
+    if spec.service != "logs" or not spec.resource.startswith("delivery-destination:"):
+        return None, _validation_error("Action logs:CreateDelivery should have a valid resource ARN to authorize against.")
+    if spec.region != get_region():
+        return None, _validation_error("Cross-region Delivery Destination is not supported. Please use a different region.")
+    if spec.account_id != get_account_id():
+        return None, error_response_json(
+            "AccessDeniedException",
+            f"User is not authorized to perform: logs:CreateDelivery on resource: {delivery_destination_arn}",
+            400,
+        )
+    return spec, None
 
 
 def _put_delivery_source(data):
@@ -1054,7 +1112,10 @@ def _put_delivery_source(data):
 
     # AWS derives the service label from the resource ARN; ignore any
     # caller-supplied value.
-    derived_service = _derive_service_from_arn(resource_arn)
+    resource_spec, err = _delivery_source_spec(resource_arn)
+    if err:
+        return err
+    derived_service = resource_spec.service
 
     existing = _delivery_sources.get(name)
     if existing:
@@ -1130,6 +1191,9 @@ def _put_delivery_destination(data):
     # AWS derives deliveryDestinationType from the destination resource
     # ARN (s3 -> S3, logs -> CWL, firehose -> FH); callers cannot
     # override it.
+    _dest_resource_spec, err = _delivery_destination_resource_spec(destination_resource_arn)
+    if err:
+        return err
     derived_type = _derive_destination_type_from_arn(destination_resource_arn)
     if derived_type is None:
         return error_response_json(
@@ -1216,11 +1280,10 @@ def _create_delivery(data):
         return error_response_json("ValidationException", "deliverySourceName is required.", 400)
     if not dest_arn:
         return error_response_json("ValidationException", "deliveryDestinationArn is required.", 400)
-    if source_name not in _delivery_sources:
-        return error_response_json(
-            "ResourceNotFoundException",
-            f"Delivery source does not exist: {source_name}", 400,
-        )
+
+    _dest_spec, err = _delivery_destination_spec(dest_arn)
+    if err:
+        return err
 
     # AWS rejects CreateDelivery unless the destination ARN resolves to a
     # destination we've previously recorded via PutDeliveryDestination —
@@ -1233,7 +1296,12 @@ def _create_delivery(data):
     if dest_type is None:
         return error_response_json(
             "ResourceNotFoundException",
-            f"Delivery destination does not exist: {dest_arn}", 400,
+            "Requested Delivery Destination does not exist in this account.", 400,
+        )
+    if source_name not in _delivery_sources:
+        return error_response_json(
+            "ResourceNotFoundException",
+            f"Delivery source does not exist: {source_name}", 400,
         )
 
     # AWS allows at most one Delivery per (deliverySourceName,

--- a/tests/test_cloudwatch_logs.py
+++ b/tests/test_cloudwatch_logs.py
@@ -658,6 +658,37 @@ def test_logs_delivery_source_service_derived_from_resource_arn(logs):
     logs.delete_delivery_source(name=src_name)
 
 
+def test_logs_delivery_source_rejects_malformed_resource_arn(logs):
+    """Malformed delivery source ARNs fail before any source is stored."""
+    uid = _uuid_mod.uuid4().hex[:8]
+    with pytest.raises(ClientError) as exc:
+        logs.put_delivery_source(
+            name=f"intg-svc-malformed-{uid}",
+            resourceArn="not-an-arn",
+            logType="APPLICATION_LOGS",
+        )
+    assert exc.value.response["Error"]["Code"] == "ValidationException"
+
+
+@pytest.mark.parametrize(
+    ("resource_arn", "expected_code"),
+    [
+        ("arn:aws:bedrock:us-west-2:000000000000:knowledge-base/test", "ValidationException"),
+        ("arn:aws:bedrock:us-east-1:111111111111:knowledge-base/test", "ValidationException"),
+        ("arn:aws:sns:us-east-1:000000000000:test", "ResourceNotFoundException"),
+    ],
+)
+def test_logs_delivery_source_rejects_wrong_scope_resource_arns(logs, resource_arn, expected_code):
+    uid = _uuid_mod.uuid4().hex[:8]
+    with pytest.raises(ClientError) as exc:
+        logs.put_delivery_source(
+            name=f"intg-svc-scope-{uid}",
+            resourceArn=resource_arn,
+            logType="APPLICATION_LOGS",
+        )
+    assert exc.value.response["Error"]["Code"] == expected_code
+
+
 def test_logs_delivery_destination_type_derived_from_arn(logs):
     """PutDeliveryDestination must compute ``deliveryDestinationType`` from
     the destinationResourceArn (S3 / CWL / FH)."""
@@ -677,6 +708,26 @@ def test_logs_delivery_destination_type_derived_from_arn(logs):
         logs.delete_delivery_destination(name=dest_name)
 
 
+@pytest.mark.parametrize(
+    "destination_resource_arn",
+    [
+        "arn:aws:logs:us-west-2:000000000000:log-group:/intg/foreign:*",
+        "arn:aws:logs:us-east-1:111111111111:log-group:/intg/bogus:*",
+        "arn:aws:firehose:us-west-2:000000000000:deliverystream/foreign",
+        "arn:aws:firehose:us-east-1:111111111111:deliverystream/bogus",
+        "arn:aws:s3:us-east-1:000000000000:bucket-with-region",
+    ],
+)
+def test_logs_delivery_destination_rejects_wrong_scope_target_arns(logs, destination_resource_arn):
+    uid = _uuid_mod.uuid4().hex[:8]
+    with pytest.raises(ClientError) as exc:
+        logs.put_delivery_destination(
+            name=f"intg-dest-scope-{uid}",
+            deliveryDestinationConfiguration={"destinationResourceArn": destination_resource_arn},
+        )
+    assert exc.value.response["Error"]["Code"] == "ValidationException"
+
+
 def test_logs_delivery_destination_rejects_unknown_output_format(logs):
     """outputFormat outside the AWS-allowed set is rejected."""
     uid = _uuid_mod.uuid4().hex[:8]
@@ -694,14 +745,19 @@ def test_logs_delivery_destination_rejects_unknown_output_format(logs):
 def test_logs_delivery_destination_rejects_unsupported_target(logs):
     """destinationResourceArn that isn't S3/CWL/FH is rejected upfront."""
     uid = _uuid_mod.uuid4().hex[:8]
-    with pytest.raises(ClientError) as exc:
-        logs.put_delivery_destination(
-            name=f"intg-bad-target-{uid}",
-            deliveryDestinationConfiguration={
-                "destinationResourceArn": f"arn:aws:lambda:us-east-1:000000000000:function:anything-{uid}",
-            },
-        )
-    assert exc.value.response["Error"]["Code"] == "ValidationException"
+    cases = [
+        "not-an-arn",
+        f"arn:aws:lambda:us-east-1:000000000000:function:anything-{uid}",
+    ]
+    for i, arn in enumerate(cases):
+        with pytest.raises(ClientError) as exc:
+            logs.put_delivery_destination(
+                name=f"intg-bad-target-{uid}-{i}",
+                deliveryDestinationConfiguration={
+                    "destinationResourceArn": arn,
+                },
+            )
+        assert exc.value.response["Error"]["Code"] == "ValidationException"
 
 
 def test_logs_create_delivery_requires_destination_to_exist(logs):
@@ -723,6 +779,25 @@ def test_logs_create_delivery_requires_destination_to_exist(logs):
         assert exc.value.response["Error"]["Code"] == "ResourceNotFoundException"
     finally:
         logs.delete_delivery_source(name=src_name)
+
+
+@pytest.mark.parametrize(
+    ("delivery_destination_arn", "expected_code"),
+    [
+        ("arn:aws:logs:us-west-2:000000000000:delivery-destination:foreign", "ValidationException"),
+        ("arn:aws:logs:us-east-1:111111111111:delivery-destination:bogus", "AccessDeniedException"),
+        ("not-an-arn", "ValidationException"),
+        ("arn:aws:sns:us-east-1:000000000000:not-a-delivery-destination", "ValidationException"),
+    ],
+)
+def test_logs_create_delivery_rejects_invalid_destination_arn_before_source(logs, delivery_destination_arn, expected_code):
+    uid = _uuid_mod.uuid4().hex[:8]
+    with pytest.raises(ClientError) as exc:
+        logs.create_delivery(
+            deliverySourceName=f"missing-src-{uid}",
+            deliveryDestinationArn=delivery_destination_arn,
+        )
+    assert exc.value.response["Error"]["Code"] == expected_code
 
 
 def test_logs_create_delivery_rejects_duplicate_pair(logs):


### PR DESCRIPTION
Summary
- Adopt shared ARN parsing for CloudWatch Logs delivery source and destination request paths.
- Reject malformed, wrong-service, wrong-account, and wrong-Region ARNs before delivery resources can fall back to same-named local resources.
- Add regressions for delivery source and destination ARN validation behavior.

Validation
- `uv run --extra dev ruff check ministack/services/cloudwatch_logs.py tests/test_cloudwatch_logs.py`
- `git -c core.fsmonitor=false diff --check`
- Docker-backed unit validation was not completed because `docker compose up -d` failed locally: Docker daemon is not running.