### PR TITLE
Adopt ARN parsing for Firehose S3 destinations

### DIFF
--- a/ministack/services/firehose.py
+++ b/ministack/services/firehose.py
@@ -20,9 +20,11 @@ import copy
 import json
 import logging
 import os
+import re
 import threading
 import time
 
+from ministack.core.arn import ArnParseError, parse_arn
 from ministack.core.persistence import PERSIST_STATE, load_state
 from ministack.core.responses import (
     AccountScopedDict,
@@ -37,6 +39,9 @@ from ministack.core.responses import (
 logger = logging.getLogger("firehose")
 
 REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
+_S3_BUCKET_NAME_RE = re.compile(
+    r"^(?!\d+\.\d+\.\d+\.\d+$)(?!.*\.\.)[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$",
+)
 
 # ─── in-memory state ──────────────────────────────────────────────────────────
 
@@ -77,6 +82,34 @@ except Exception:
 
 def _stream_arn(name: str) -> str:
     return f"arn:aws:firehose:{get_region()}:{get_account_id()}:deliverystream/{name}"
+
+
+def _s3_bucket_from_arn(bucket_arn: str) -> str:
+    try:
+        spec = parse_arn(bucket_arn)
+    except ArnParseError as exc:
+        raise ValueError("BucketARN must be an S3 bucket ARN.") from exc
+
+    if (
+        spec.service != "s3"
+        or spec.region
+        or spec.account_id
+        or not spec.resource
+        or "/" in spec.resource
+        or not _S3_BUCKET_NAME_RE.fullmatch(spec.resource)
+    ):
+        raise ValueError("BucketARN must be an S3 bucket ARN.")
+    return spec.resource
+
+
+def _validate_s3_destination_config(dtype: str, cfg: dict):
+    if dtype not in ("ExtendedS3", "S3") or "BucketARN" not in cfg:
+        return None
+    try:
+        _s3_bucket_from_arn(cfg.get("BucketARN", ""))
+    except ValueError as exc:
+        return _invalid(str(exc))
+    return None
 
 
 def _next_dest_id() -> str:
@@ -321,7 +354,7 @@ def _deliver_to_s3(stream: dict, dest: dict, record_data: bytes):
 
         cfg = dest["config"]
         bucket_arn = cfg.get("BucketARN", "")
-        bucket = bucket_arn.split(":::")[-1] if ":::" in bucket_arn else bucket_arn
+        bucket = _s3_bucket_from_arn(bucket_arn)
         prefix = cfg.get("Prefix", "")
         ts = time.strftime("%Y/%m/%d/%H", time.gmtime())
         key = f"{prefix}{ts}/{stream['name']}-{new_uuid()}"
@@ -430,6 +463,9 @@ def _create_delivery_stream(data: dict):
         # A stream with no destination is valid (destination added later via UpdateDestination)
         destinations = []
         if dtype and cfg is not None:
+            validation_error = _validate_s3_destination_config(dtype, cfg)
+            if validation_error:
+                return validation_error
             destinations.append({
                 "id": _next_dest_id(),
                 "type": dtype,
@@ -626,6 +662,9 @@ def _update_destination(data: dict):
 
         dtype, cfg = _resolve_dest_update_config(data)
         if dtype and cfg is not None:
+            validation_error = _validate_s3_destination_config(dtype, cfg)
+            if validation_error:
+                return validation_error
             if dtype == dest["type"]:
                 # Same destination type — merge fields (AWS behaviour)
                 dest["config"] = {**dest["config"], **cfg}

--- a/tests/test_firehose.py
+++ b/tests/test_firehose.py
@@ -31,6 +31,38 @@ def test_firehose_create_and_describe(fh):
     assert "ExtendedS3DestinationDescription" in desc["Destinations"][0]
     assert desc["VersionId"] == "1"
 
+
+@pytest.mark.parametrize(
+    "config_key",
+    ("ExtendedS3DestinationConfiguration", "S3DestinationConfiguration"),
+)
+@pytest.mark.parametrize(
+    "bucket_arn",
+    (
+        "not-an-arn",
+        "arn:aws:sns:us-east-1:000000000000:topic-name",
+        "arn:aws:s3:us-east-1::my-bucket",
+        "arn:aws:s3::000000000000:my-bucket",
+        "arn:aws:s3:::my-bucket/path/to/object",
+        "arn:aws:s3:::my-bucket:extra",
+        "arn:aws:s3:::bad*bucket",
+    ),
+)
+def test_firehose_rejects_invalid_s3_bucket_arns(fh, config_key, bucket_arn):
+    with pytest.raises(ClientError) as exc:
+        fh.create_delivery_stream(
+            DeliveryStreamName=f"intg-fh-bad-bucket-arn-{_uuid_mod.uuid4().hex[:8]}",
+            DeliveryStreamType="DirectPut",
+            **{
+                config_key: {
+                    "BucketARN": bucket_arn,
+                    "RoleARN": "arn:aws:iam::000000000000:role/firehose-role",
+                },
+            },
+        )
+    assert exc.value.response["Error"]["Code"] == "InvalidArgumentException"
+
+
 def test_firehose_list_streams(fh):
     fh.create_delivery_stream(DeliveryStreamName="intg-fh-list-a", DeliveryStreamType="DirectPut")
     fh.create_delivery_stream(DeliveryStreamName="intg-fh-list-b", DeliveryStreamType="DirectPut")
@@ -300,6 +332,37 @@ def test_firehose_update_destination_version_mismatch(fh):
         )
     assert exc.value.response["Error"]["Code"] == "ConcurrentModificationException"
 
+
+def test_firehose_update_destination_rejects_invalid_s3_bucket_arn(fh):
+    name = f"qa-fh-update-bad-bucket-arn-{_uuid_mod.uuid4().hex[:8]}"
+    fh.create_delivery_stream(
+        DeliveryStreamName=name,
+        ExtendedS3DestinationConfiguration={
+            "BucketARN": "arn:aws:s3:::qa-fh-bucket3",
+            "RoleARN": "arn:aws:iam::000000000000:role/r",
+        },
+    )
+    desc = fh.describe_delivery_stream(DeliveryStreamName=name)["DeliveryStreamDescription"]
+    dest_id = desc["Destinations"][0]["DestinationId"]
+    version_id = desc["VersionId"]
+
+    with pytest.raises(ClientError) as exc:
+        fh.update_destination(
+            DeliveryStreamName=name,
+            CurrentDeliveryStreamVersionId=version_id,
+            DestinationId=dest_id,
+            ExtendedS3DestinationUpdate={
+                "BucketARN": "arn:aws:s3:::qa-fh-bucket3/object",
+            },
+        )
+
+    assert exc.value.response["Error"]["Code"] == "InvalidArgumentException"
+    after = fh.describe_delivery_stream(DeliveryStreamName=name)["DeliveryStreamDescription"]
+    s3 = after["Destinations"][0]["ExtendedS3DestinationDescription"]
+    assert after["VersionId"] == version_id
+    assert s3["BucketARN"] == "arn:aws:s3:::qa-fh-bucket3"
+
+
 def test_firehose_s3_destination_writes(s3, fh):
     """PutRecord with S3 destination actually writes data to the S3 bucket."""
     import base64
@@ -337,7 +400,9 @@ def test_firehose_describe_nonexistent_carries_errortype(fh):
 def test_firehose_kinesis_stream_as_source_fans_out_to_s3(fh, kin, s3):
     """KinesisStreamAsSource: records put into the source Kinesis stream
     must reach the configured S3 destination. Issue #744."""
-    import base64 as _b64, time as _time, uuid as _uuid
+    import time as _time
+    import uuid as _uuid
+
     stream_name = f"src-stream-{_uuid.uuid4().hex[:8]}"
     delivery_name = f"fh-{_uuid.uuid4().hex[:8]}"
     bucket = f"fh-src-bucket-{_uuid.uuid4().hex[:8]}"
@@ -381,10 +446,14 @@ def test_firehose_kinesis_stream_as_source_fans_out_to_s3(fh, kin, s3):
         )
         assert bodies == [b'{"a":1}', b'{"a":2}', b'{"a":3}']
     finally:
-        try: fh.delete_delivery_stream(DeliveryStreamName=delivery_name)
-        except Exception: pass
-        try: kin.delete_stream(StreamName=stream_name)
-        except Exception: pass
+        try:
+            fh.delete_delivery_stream(DeliveryStreamName=delivery_name)
+        except Exception:
+            pass
+        try:
+            kin.delete_stream(StreamName=stream_name)
+        except Exception:
+            pass
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
🤖

Summary
- Parse Firehose S3 and ExtendedS3 destination `BucketARN` values with the shared ARN parser.
- Accept only valid global S3 bucket ARNs and reject malformed, wrong-service, regional, account-scoped, object-style, colon-tail, and invalid bucket-name ARNs.
- Apply the same validation on create and update paths, and remove delivery-time bucket tail matching.

Validation
- `git -c core.fsmonitor=false diff --check`
- Source-backed MiniStack on `GATEWAY_PORT=14581`: `MINISTACK_ENDPOINT=http://localhost:14581 uv run --extra dev pytest tests/test_firehose.py -q` (`40 passed`)
- Note: after rebasing over the latest `feat/multi-region`, targeted Firehose `ruff check` is blocked by pre-existing `E701` issues in upstream Firehose processor tests outside this PR parser diff.
- `codex review --base upstream/feat/multi-region` previously reported one valid bucket-tail issue; fixed and reran clean before the rebase.