### PR TITLE
Adopt ARN parsing for Batch job queues

### DIFF
--- a/ministack/services/batch.py
+++ b/ministack/services/batch.py
@@ -10,8 +10,10 @@ here, not a real container runner.
 import copy
 import json
 import logging
+import re
 import time
 
+from ministack.core.arn import ArnParseError, parse_arn
 from ministack.core.responses import (
     AccountScopedDict,
     error_response_json,
@@ -26,6 +28,8 @@ _compute_envs = AccountScopedDict()   # name -> dict
 _job_queues = AccountScopedDict()     # name -> dict
 _job_definitions = AccountScopedDict()  # name -> [revisions]
 _jobs = AccountScopedDict()           # job_id -> dict
+
+_JOB_QUEUE_NAME_RE = re.compile(r"^[A-Za-z0-9_-]{1,128}$")
 
 
 def reset():
@@ -76,6 +80,39 @@ def _jd_arn(name, revision):
 
 def _job_arn(job_id):
     return f"arn:aws:batch:{get_region()}:{get_account_id()}:job/{job_id}"
+
+
+def _job_queue_name_from_ref(ref):
+    if not ref or not ref.startswith("arn:"):
+        return ref, None
+    try:
+        spec = parse_arn(ref)
+    except ArnParseError:
+        return "", _batch_client_exception(ref)
+    if spec.service != "batch" or spec.account_id != get_account_id():
+        return "", _batch_client_exception(ref)
+    if spec.region != get_region():
+        return None, None
+    if not spec.resource.startswith("job-queue/"):
+        return "", _batch_client_exception(ref)
+    name = spec.resource.split("/", 1)[1]
+    if not _JOB_QUEUE_NAME_RE.fullmatch(name):
+        return "", _batch_client_exception(ref)
+    return name, None
+
+
+def _batch_client_exception(identifier):
+    return error_response_json(
+        "ClientException",
+        f"Invalid job queue identifier: {identifier}",
+        400,
+    )
+
+
+def _job_queue_matches(stored_ref, query_ref, queue_name):
+    if not queue_name:
+        return False
+    return stored_ref in {query_ref, queue_name, _jq_arn(queue_name)}
 
 
 def _now_ms():
@@ -144,7 +181,9 @@ def _describe_job_queues(p):
         out = []
         for n in names:
             # Accept both name and ARN per AWS behaviour.
-            short = n.split("/")[-1]
+            short, error = _job_queue_name_from_ref(n)
+            if error:
+                return error
             if short in _job_queues:
                 out.append(_job_queues[short])
     else:
@@ -217,10 +256,13 @@ def _describe_jobs(p):
 
 def _list_jobs(p):
     queue = p.get("jobQueue", "")
+    queue_name, queue_error = _job_queue_name_from_ref(queue) if queue else ("", None)
+    if queue_error:
+        return queue_error
     status_filter = p.get("jobStatus")
     out = []
     for j in _jobs.values():
-        if queue and j.get("jobQueue") not in (queue, _jq_arn(queue.split("/")[-1])):
+        if queue and not _job_queue_matches(j.get("jobQueue"), queue, queue_name):
             continue
         if status_filter and j.get("status") != status_filter:
             continue

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -1,5 +1,6 @@
 import boto3
 import pytest
+from botocore.exceptions import ClientError
 
 ENDPOINT = "http://localhost:4566"
 REGION = "us-east-1"
@@ -87,6 +88,66 @@ def test_batch_describe_job_queue_by_name_or_arn(batch):
     arn = by_name[0]["jobQueueArn"]
     by_arn = batch.describe_job_queues(jobQueues=[arn])["jobQueues"]
     assert any(q["jobQueueName"] == name for q in by_arn)
+
+
+def test_batch_list_jobs_by_job_queue_arn(batch):
+    jq_name = f"jq-arn-{_uid()}"
+    jd_name = f"jd-arn-{_uid()}"
+    job_name = f"j-arn-{_uid()}"
+    jq = batch.create_job_queue(jobQueueName=jq_name, priority=1, computeEnvironmentOrder=[])
+    jd = batch.register_job_definition(
+        jobDefinitionName=jd_name,
+        type="container",
+        containerProperties={"image": "busybox", "memory": 128, "vcpus": 1},
+    )
+    submitted = batch.submit_job(
+        jobName=job_name,
+        jobQueue=jq["jobQueueArn"],
+        jobDefinition=jd["jobDefinitionArn"],
+    )
+
+    listed = batch.list_jobs(jobQueue=jq["jobQueueArn"])["jobSummaryList"]
+
+    assert any(j["jobId"] == submitted["jobId"] for j in listed)
+
+
+def test_batch_job_queue_arn_inputs_do_not_tail_match(batch):
+    jq_name = f"jq-bad-arn-{_uid()}"
+    jd_name = f"jd-bad-arn-{_uid()}"
+    job_name = f"j-bad-arn-{_uid()}"
+    jq = batch.create_job_queue(jobQueueName=jq_name, priority=1, computeEnvironmentOrder=[])
+    jd = batch.register_job_definition(
+        jobDefinitionName=jd_name,
+        type="container",
+        containerProperties={"image": "busybox", "memory": 128, "vcpus": 1},
+    )
+    submitted = batch.submit_job(
+        jobName=job_name,
+        jobQueue=jq["jobQueueArn"],
+        jobDefinition=jd["jobDefinitionArn"],
+    )
+
+    wrong_service = f"arn:aws:sqs:us-east-1:000000000000:job-queue/{jq_name}"
+    wrong_account = f"arn:aws:batch:us-east-1:111111111111:job-queue/{jq_name}"
+    wrong_resource = f"arn:aws:batch:us-east-1:000000000000:compute-environment/{jq_name}"
+    malformed = f"arn:aws:batch:us-east-1:000000000000:job-queue/{jq_name}/extra"
+    foreign_region = f"arn:aws:batch:us-west-2:000000000000:job-queue/{jq_name}"
+
+    def _assert_client_exception(call):
+        with pytest.raises(ClientError) as exc:
+            call()
+        assert exc.value.response["Error"]["Code"] == "ClientException"
+
+    for bad_ref in [wrong_service, wrong_account, wrong_resource, malformed]:
+        _assert_client_exception(
+            lambda bad_ref=bad_ref: batch.describe_job_queues(jobQueues=[bad_ref])
+        )
+        _assert_client_exception(lambda bad_ref=bad_ref: batch.list_jobs(jobQueue=bad_ref))
+
+    assert batch.describe_job_queues(jobQueues=[foreign_region])["jobQueues"] == []
+    assert batch.list_jobs(jobQueue=foreign_region)["jobSummaryList"] == []
+    listed_by_name = batch.list_jobs(jobQueue=jq_name)["jobSummaryList"]
+    assert any(j["jobId"] == submitted["jobId"] for j in listed_by_name)
 
 
 def test_batch_account_isolation():


### PR DESCRIPTION
Summary
- Parse Batch job queue ARN request inputs with the shared ARN parser.
- Keep valid same-account, same-Region job queue ARNs working for describe/list paths.
- Reject malformed, wrong-service, wrong-account, and wrong-resource ARNs, while treating foreign-Region job queue ARNs as non-local instead of tail-matching local queues.

Validation
- `uv run --extra dev ruff check ministack/services/batch.py tests/test_batch.py`
- `git -c core.fsmonitor=false diff --check`
- Source-backed MiniStack on port 4566 with `uv run --extra dev pytest tests/test_batch.py -q` (`7 passed`)
- `codex review --base upstream/feat/multi-region` reported no actionable correctness issues.