### PR TITLE
Adopt ARN parsing for DynamoDB Streams and Pipes

### DIFF
--- a/ministack/services/dynamodb_streams.py
+++ b/ministack/services/dynamodb_streams.py
@@ -11,6 +11,7 @@ import base64
 import json
 import logging
 
+from ministack.core.arn import ArnParseError, parse_arn
 from ministack.core.responses import error_response_json, json_response
 from ministack.services import dynamodb as _ddb
 
@@ -77,13 +78,27 @@ def _decode_iterator(token: str) -> dict | None:
 
 def _table_from_stream_arn(stream_arn: str) -> str | None:
     """Extract the table name from a stream ARN of the form
-    ``arn:aws:dynamodb:{region}:{account}:table/{name}/stream/{label}``."""
-    if not stream_arn or "/stream/" not in stream_arn:
+    ``arn:aws:dynamodb:{region}:{account}:table/{name}/stream/{label}``.
+
+    Invalid or out-of-shape stream ARNs map to ``None`` so describe/list paths
+    keep DynamoDB Streams' not-found behavior.
+    """
+    try:
+        spec = parse_arn(stream_arn)
+    except ArnParseError:
         return None
-    table_part = stream_arn.split("/stream/", 1)[0]
-    if ":table/" in table_part:
-        return table_part.split(":table/", 1)[1]
-    return None
+    if spec.service != "dynamodb":
+        return None
+    parts = spec.resource.split("/")
+    if (
+        len(parts) < 4
+        or parts[0] != "table"
+        or parts[2] != "stream"
+        or not parts[1]
+        or not parts[3]
+    ):
+        return None
+    return parts[1]
 
 
 def _records_for(table_name: str) -> list:

--- a/ministack/services/pipes.py
+++ b/ministack/services/pipes.py
@@ -14,6 +14,7 @@ import os
 import threading
 import time
 
+from ministack.core.arn import ArnParseError, parse_arn
 from ministack.core.persistence import load_state
 from ministack.core.responses import AccountScopedDict, get_account_id, get_region, new_uuid
 
@@ -130,9 +131,7 @@ def _poll_once():
 
         source_arn = pipe.get("Source", "")
         target_arn = pipe.get("Target", "")
-        if ":dynamodb:" not in source_arn or "/stream/" not in source_arn:
-            continue
-        if ":sns:" not in target_arn:
+        if _arn_service(source_arn) != "dynamodb" or _arn_service(target_arn) != "sns":
             continue
 
         table_name = _table_name_from_stream_arn(source_arn)
@@ -175,10 +174,32 @@ def _publish_record_to_sns(topic_arn: str, pipe: dict, record: dict):
     _sns._fanout(topic_arn, msg_id, message, subject, "", {})
 
 
-def _table_name_from_stream_arn(stream_arn: str) -> str:
-    if "/stream/" not in stream_arn:
+def _arn_service(arn: str) -> str:
+    """Classify a target ARN for dispatch; invalid stored targets are ignored."""
+    try:
+        return parse_arn(arn).service
+    except ArnParseError:
         return ""
-    return stream_arn.split("/stream/", 1)[0].rsplit("/", 1)[-1]
+
+
+def _table_name_from_stream_arn(stream_arn: str) -> str:
+    """Return a DynamoDB table name for Pipes runtime dispatch, or empty string."""
+    try:
+        spec = parse_arn(stream_arn)
+    except ArnParseError:
+        return ""
+    if spec.service != "dynamodb":
+        return ""
+    parts = spec.resource.split("/")
+    if (
+        len(parts) < 4
+        or parts[0] != "table"
+        or parts[2] != "stream"
+        or not parts[1]
+        or not parts[3]
+    ):
+        return ""
+    return parts[1]
 
 
 def _initial_position(pipe: dict) -> int:

--- a/tests/test_dynamodb_streams.py
+++ b/tests/test_dynamodb_streams.py
@@ -96,6 +96,17 @@ def test_describe_stream_unknown_arn_raises(ddb_streams):
     assert exc.value.response["Error"]["Code"] == "ResourceNotFoundException"
 
 
+@pytest.mark.parametrize("stream_arn", [
+    "arn:aws:dynamodb:us-east-1:000000000000",
+    "arn:aws:sns:us-east-1:000000000000:table/StreamsDescribe/stream/1970-01-01T00:00:00.000",
+    "arn:aws:dynamodb:us-east-1:000000000000:table/StreamsDescribe",
+])
+def test_describe_stream_rejects_invalid_or_wrong_service_arn(ddb_streams, stream_arn):
+    with pytest.raises(ClientError) as exc:
+        ddb_streams.describe_stream(StreamArn=stream_arn)
+    assert exc.value.response["Error"]["Code"] == "ResourceNotFoundException"
+
+
 # ---------------------------------------------------------------------------
 # GetShardIterator / GetRecords
 # ---------------------------------------------------------------------------
@@ -265,6 +276,21 @@ def test_get_shard_iterator_missing_sequence_number(ddb, ddb_streams):
             ShardIteratorType="AT_SEQUENCE_NUMBER",
         )
     assert exc.value.response["Error"]["Code"] == "ValidationException"
+
+
+@pytest.mark.parametrize("stream_arn", [
+    "arn:aws:dynamodb:us-east-1:000000000000",
+    "arn:aws:sns:us-east-1:000000000000:table/StreamsValidateSeq/stream/1970-01-01T00:00:00.000",
+    "arn:aws:dynamodb:us-east-1:000000000000:table/StreamsValidateSeq",
+])
+def test_get_shard_iterator_rejects_invalid_or_wrong_service_arn(ddb_streams, stream_arn):
+    with pytest.raises(ClientError) as exc:
+        ddb_streams.get_shard_iterator(
+            StreamArn=stream_arn,
+            ShardId=_DEFAULT_SHARD_ID,
+            ShardIteratorType="TRIM_HORIZON",
+        )
+    assert exc.value.response["Error"]["Code"] == "ResourceNotFoundException"
 
 
 def test_get_records_rejects_garbage_iterator(ddb_streams):

--- a/tests/test_pipes.py
+++ b/tests/test_pipes.py
@@ -1,0 +1,18 @@
+from ministack.services import pipes as _pipes
+
+
+def test_pipes_stream_table_name_parser_requires_dynamodb_stream_arn():
+    stream_arn = (
+        "arn:aws:dynamodb:us-east-1:000000000000:"
+        "table/PipeTable/stream/2026-05-22T00:00:00.000"
+    )
+    assert _pipes._table_name_from_stream_arn(stream_arn) == "PipeTable"
+    assert _pipes._table_name_from_stream_arn("not-an-arn") == ""
+
+    wrong_service_arn = (
+        "arn:aws:sns:us-east-1:000000000000:"
+        "table/PipeTable/stream/2026-05-22T00:00:00.000"
+    )
+    missing_stream_arn = "arn:aws:dynamodb:us-east-1:000000000000:table/PipeTable"
+    assert _pipes._table_name_from_stream_arn(wrong_service_arn) == ""
+    assert _pipes._table_name_from_stream_arn(missing_stream_arn) == ""


### PR DESCRIPTION
Summary
- Parse DynamoDB Streams stream ARNs with the shared ARN parser.
- Preserve existing Streams not-found behavior for malformed, wrong-service, and out-of-shape stream ARNs.
- Use parser-backed service classification for EventBridge Pipes runtime dispatch so invalid stored source or target ARNs are ignored instead of string-matched.

Validation
- `uv run --extra dev ruff check ministack/services/dynamodb_streams.py tests/test_dynamodb_streams.py ministack/services/pipes.py tests/test_pipes.py`
- `git -c core.fsmonitor=false diff --check`
- `git -c core.fsmonitor=false diff --no-index --check /dev/null tests/test_pipes.py`
- Source-backed MiniStack on `GATEWAY_PORT=14583`: `MINISTACK_ENDPOINT=http://localhost:14583 uv run --extra dev pytest tests/test_dynamodb_streams.py tests/test_pipes.py tests/test_cfn.py::test_cfn_pipes_dynamodb_stream_to_sns -q` (`23 passed`)
- `codex review --base upstream/feat/multi-region` reported no actionable correctness issues.