### PR TITLE
Adopt ARN parsing in Backup

### DIFF
--- a/ministack/services/backup.py
+++ b/ministack/services/backup.py
@@ -17,6 +17,7 @@ import json
 import logging
 import time
 
+from ministack.core.arn import ArnParseError, parse_arn
 from ministack.core.persistence import load_state
 from ministack.core.responses import AccountScopedDict, get_account_id, get_region, new_uuid
 
@@ -475,12 +476,22 @@ def _list_jobs(query):
 
 def _resolve_resource(arn):
     """Return the mutable tag dict for a supported backup ARN, or None."""
-    if ":backup-vault:" in arn:
-        name = arn.split(":")[-1]
+    try:
+        spec = parse_arn(arn)
+    except ArnParseError as exc:
+        raise ValueError("ResourceArn must be a Backup ARN.") from exc
+
+    if spec.service != "backup":
+        raise ValueError("ResourceArn must be a Backup ARN.")
+    if spec.region != get_region() or spec.account_id != get_account_id():
+        return None
+
+    if spec.resource.startswith("backup-vault:"):
+        name = spec.resource.removeprefix("backup-vault:")
         v = _vaults.get(name)
         return v["BackupVaultTags"] if v is not None else None
-    if ":backup-plan:" in arn:
-        pid = arn.split(":")[-1]
+    if spec.resource.startswith("backup-plan:"):
+        pid = spec.resource.removeprefix("backup-plan:")
         p = _plans.get(pid)
         return p["Tags"] if p is not None else None
     return None
@@ -488,7 +499,10 @@ def _resolve_resource(arn):
 
 def _tag_resource(arn, body):
     tags = body.get("Tags", {})
-    tag_dict = _resolve_resource(arn)
+    try:
+        tag_dict = _resolve_resource(arn)
+    except ValueError as exc:
+        return _err("InvalidParameterValueException", str(exc), 400)
     if tag_dict is None:
         return _err("ResourceNotFoundException", f"Resource '{arn}' not found.", 404)
     tag_dict.update(tags)
@@ -497,7 +511,10 @@ def _tag_resource(arn, body):
 
 def _untag_resource(arn, body):
     keys = body.get("TagKeyList", [])
-    tag_dict = _resolve_resource(arn)
+    try:
+        tag_dict = _resolve_resource(arn)
+    except ValueError as exc:
+        return _err("InvalidParameterValueException", str(exc), 400)
     if tag_dict is None:
         return _err("ResourceNotFoundException", f"Resource '{arn}' not found.", 404)
     for k in keys:
@@ -506,7 +523,10 @@ def _untag_resource(arn, body):
 
 
 def _list_tags(arn):
-    tag_dict = _resolve_resource(arn)
+    try:
+        tag_dict = _resolve_resource(arn)
+    except ValueError as exc:
+        return _err("InvalidParameterValueException", str(exc), 400)
     if tag_dict is None:
         return _err("ResourceNotFoundException", f"Resource '{arn}' not found.", 404)
     return _ok({"Tags": dict(tag_dict)})

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -425,6 +425,37 @@ def test_backup_tag_plan(backup):
     assert resp["Tags"]["Owner"] == "data-team"
 
 
+def test_backup_tag_rejects_malformed_arn(backup):
+    with pytest.raises(ClientError) as exc:
+        backup.tag_resource(ResourceArn="not-an-arn", Tags={"k": "v"})
+    assert exc.value.response["Error"]["Code"] == "InvalidParameterValueException"
+
+
+def test_backup_tag_rejects_wrong_service_arn(backup):
+    arn = f"arn:aws:sns:{REGION}:000000000000:backup-vault:not-a-vault"
+    with pytest.raises(ClientError) as exc:
+        backup.tag_resource(ResourceArn=arn, Tags={"k": "v"})
+    assert exc.value.response["Error"]["Code"] == "InvalidParameterValueException"
+
+
+def test_backup_tag_does_not_resolve_foreign_region_arn_by_tail(backup):
+    name = f"tag-foreign-region-{_uid()}"
+    backup.create_backup_vault(BackupVaultName=name)
+    arn = f"arn:aws:backup:us-west-2:000000000000:backup-vault:{name}"
+    with pytest.raises(ClientError) as exc:
+        backup.tag_resource(ResourceArn=arn, Tags={"k": "v"})
+    assert exc.value.response["Error"]["Code"] == "ResourceNotFoundException"
+
+
+def test_backup_tag_does_not_resolve_foreign_account_arn_by_tail(backup):
+    name = f"tag-foreign-account-{_uid()}"
+    backup.create_backup_vault(BackupVaultName=name)
+    arn = f"arn:aws:backup:{REGION}:111111111111:backup-vault:{name}"
+    with pytest.raises(ClientError) as exc:
+        backup.tag_resource(ResourceArn=arn, Tags={"k": "v"})
+    assert exc.value.response["Error"]["Code"] == "ResourceNotFoundException"
+
+
 def test_backup_tag_not_found(backup):
     arn = "arn:aws:backup:us-east-1:000000000000:backup-vault:no-such-vault"
     with pytest.raises(ClientError) as exc:


### PR DESCRIPTION
Summary
- Adopt shared ARN parsing for Backup tag, untag, and list-tags resource paths.
- Reject malformed or wrong-service Backup resource ARNs with the existing invalid-parameter response shape.
- Prevent wrong-Region and wrong-account Backup ARNs from tail-matching same-named local resources.

Validation
- `uv run --extra dev ruff check ministack/services/backup.py tests/test_backup.py`
- `git -c core.fsmonitor=false diff --check`
- Source-backed MiniStack on port 4566 with `uv run --extra dev pytest tests/test_backup.py -q` (`46 passed`)
- `codex review --base upstream/feat/multi-region` reported no actionable correctness issues.