### PR TITLE
Feat/ddb delayed completed status

### DIFF
--- a/ministack/services/dynamodb.py
+++ b/ministack/services/dynamodb.py
@@ -3651,13 +3651,6 @@ def _export_table_to_point_in_time(data):
         desc["S3SseKmsKeyId"] = data["S3SseKmsKeyId"]
     if client_token:
         desc["ClientToken"] = client_token
-    # Immediate completion — local emulator has no async snapshot work.
-    table = _tables[table_name]
-    desc["ItemCount"] = len(table.get("items", {}))
-    desc["BilledSizeBytes"] = table.get("TableSizeBytes", 0)
-    desc["ExportStatus"] = "COMPLETED"
-    desc["EndTime"] = time.time()
-    desc["ExportManifest"] = f"AWSDynamoDB/{arn.split('/')[-1]}/manifest-summary.json"
     _exports[arn] = desc
     return json_response({"ExportDescription": desc})
 
@@ -3671,6 +3664,15 @@ def _describe_export(data):
     if not desc:
         return error_response_json("ExportNotFoundException",
             f"Export not found: {arn}", 400)
+    if desc.get("ExportStatus") == "IN_PROGRESS":
+        table_name = _table_name_from_arn(desc["TableArn"])
+        table = _tables.get(table_name)
+        if table:
+            desc["ItemCount"] = len(table.get("items", {}))
+            desc["BilledSizeBytes"] = table.get("TableSizeBytes", 0)
+        desc["ExportStatus"] = "COMPLETED"
+        desc["EndTime"] = time.time()
+        desc["ExportManifest"] = f"AWSDynamoDB/{arn.split('/')[-1]}/manifest-summary.json"
     return json_response({"ExportDescription": desc})
 
 

--- a/tests/test_dynamodb.py
+++ b/tests/test_dynamodb.py
@@ -2916,11 +2916,12 @@ def test_dynamodb_export_table_to_point_in_time(ddb):
         desc = r["ExportDescription"]
         assert desc["TableArn"] == arn
         assert desc["S3Bucket"] == "my-bucket"
-        assert desc["ExportStatus"] in ("IN_PROGRESS", "COMPLETED")
+        assert desc["ExportStatus"] == "IN_PROGRESS"
         export_arn = desc["ExportArn"]
 
         d = ddb.describe_export(ExportArn=export_arn)
         assert d["ExportDescription"]["ExportArn"] == export_arn
+        assert d["ExportDescription"]["ExportStatus"] == "COMPLETED"
 
         lst = ddb.list_exports(TableArn=arn)
         arns = [s["ExportArn"] for s in lst["ExportSummaries"]]


### PR DESCRIPTION
Adds expected behaviour in Issue #788 point 3.

`_export_table_to_point_in_time` does not immediately mark the export as complete. The code updating the response to mark it as complete is moved to `_describe_export`, where the description export status is checked, and if `IN_PROGRESS`, is populated.

`test_dynamodb_export_table_to_point_in_time` is updated to cover the changing of the status.