### PR TITLE
Adopt ARN parsing for CloudTrail trails

### DIFF
--- a/ministack/services/cloudtrail.py
+++ b/ministack/services/cloudtrail.py
@@ -20,6 +20,7 @@ import logging
 import os
 import time
 
+from ministack.core.arn import ArnParseError, parse_arn
 from ministack.core.persistence import load_state
 from ministack.core.responses import AccountScopedDict, get_account_id, get_region, new_uuid
 
@@ -90,6 +91,37 @@ def _scrub(params: dict) -> dict:
 
 def _trail_arn(name: str) -> str:
     return f"arn:aws:cloudtrail:{get_region()}:{get_account_id()}:trail/{name}"
+
+
+def _parse_trail_arn(arn: str):
+    try:
+        spec = parse_arn(arn)
+    except ArnParseError as exc:
+        raise ValueError("Invalid CloudTrail trail ARN.") from exc
+
+    if spec.service != "cloudtrail" or not spec.resource.startswith("trail/"):
+        raise ValueError("Invalid CloudTrail trail ARN.")
+    trail_name = spec.resource[len("trail/"):]
+    if not trail_name or "/" in trail_name:
+        raise ValueError("Invalid CloudTrail trail ARN.")
+    return spec, trail_name
+
+
+def _trail_name_from_arn(arn: str) -> str | None:
+    spec, trail_name = _parse_trail_arn(arn)
+    if spec.region != get_region() or spec.account_id != get_account_id():
+        return None
+    return trail_name
+
+
+def _trail_name_from_read_arn(arn: str) -> str | None:
+    spec, trail_name = _parse_trail_arn(arn)
+    if spec.account_id != get_account_id():
+        return None
+    trail = _trails.get(trail_name)
+    if trail is None or trail.get("TrailARN") != str(spec):
+        return None
+    return trail_name
 
 
 def _get_event_queue() -> collections.deque:
@@ -227,10 +259,38 @@ def _lookup_events(body: dict):
     return _ok({"Events": filtered})
 
 
-def _resolve_trail_name(name: str) -> str:
+def _resolve_trail_name(name: str, *, allow_cross_region_arn: bool = False) -> str | None:
     if name.startswith("arn:"):
-        return name.rsplit("/", 1)[-1]
+        if allow_cross_region_arn:
+            return _trail_name_from_read_arn(name)
+        return _trail_name_from_arn(name)
     return name
+
+
+def _resolve_trail_name_or_error(name: str, *, allow_cross_region_arn: bool = False):
+    try:
+        return _resolve_trail_name(name, allow_cross_region_arn=allow_cross_region_arn), None
+    except ValueError as exc:
+        return None, _err("CloudTrailARNInvalidException", str(exc))
+
+
+def _validate_trail_arn(arn: str):
+    try:
+        name = _trail_name_from_arn(arn)
+    except ValueError as exc:
+        return _err("CloudTrailARNInvalidException", str(exc))
+    if name is None:
+        return _err("CloudTrailARNInvalidException", "Invalid CloudTrail trail ARN.")
+    return None
+
+
+def _resolve_existing_trail_name_or_error(raw: str, *, allow_cross_region_arn: bool = False):
+    name, error = _resolve_trail_name_or_error(raw, allow_cross_region_arn=allow_cross_region_arn)
+    if error:
+        return None, error
+    if name is None or _trails.get(name) is None:
+        return None, _err("TrailNotFoundException", f"Unknown trail: {raw!r}", 404)
+    return name, None
 
 
 def _create_trail(body: dict):
@@ -274,7 +334,9 @@ def _delete_trail(body: dict):
     raw = body.get("Name", "").strip()
     if not raw:
         return _err("InvalidTrailNameException", "Trail name is required.")
-    name = _resolve_trail_name(raw)
+    name, error = _resolve_trail_name_or_error(raw)
+    if error:
+        return error
     if _trails.get(name) is None:
         return _err("TrailNotFoundException", f"Unknown trail: {name!r}", 404)
     del _trails[name]
@@ -286,7 +348,9 @@ def _get_trail(body: dict):
     raw = body.get("Name", "").strip()
     if not raw:
         return _err("InvalidTrailNameException", "Trail name is required.")
-    name = _resolve_trail_name(raw)
+    name, error = _resolve_trail_name_or_error(raw, allow_cross_region_arn=True)
+    if error:
+        return error
     trail = _trails.get(name)
     if trail is None:
         return _err("TrailNotFoundException", f"Unknown trail: {name!r}", 404)
@@ -297,7 +361,12 @@ def _describe_trails(body: dict):
     trail_names = body.get("trailNameList", [])
     all_trails = [v for _, v in _trails.items()]
     if trail_names:
-        resolved = {_resolve_trail_name(n) for n in trail_names}
+        resolved = set()
+        for trail_name in trail_names:
+            name, error = _resolve_trail_name_or_error(trail_name, allow_cross_region_arn=True)
+            if error:
+                return error
+            resolved.add(name)
         all_trails = [t for t in all_trails if t["Name"] in resolved]
     return _ok({"trailList": all_trails})
 
@@ -306,7 +375,9 @@ def _get_trail_status(body: dict):
     raw = body.get("Name", "").strip()
     if not raw:
         return _err("InvalidTrailNameException", "Trail name is required.")
-    name = _resolve_trail_name(raw)
+    name, error = _resolve_trail_name_or_error(raw, allow_cross_region_arn=True)
+    if error:
+        return error
     trail = _trails.get(name)
     if trail is None:
         return _err("TrailNotFoundException", f"Unknown trail: {name!r}", 404)
@@ -328,7 +399,9 @@ def _start_logging(body: dict):
     raw = body.get("Name", "").strip()
     if not raw:
         return _err("InvalidTrailNameException", "Trail name is required.")
-    name = _resolve_trail_name(raw)
+    name, error = _resolve_trail_name_or_error(raw)
+    if error:
+        return error
     trail = _trails.get(name)
     if trail is None:
         return _err("TrailNotFoundException", f"Unknown trail: {name!r}", 404)
@@ -342,7 +415,9 @@ def _stop_logging(body: dict):
     raw = body.get("Name", "").strip()
     if not raw:
         return _err("InvalidTrailNameException", "Trail name is required.")
-    name = _resolve_trail_name(raw)
+    name, error = _resolve_trail_name_or_error(raw)
+    if error:
+        return error
     trail = _trails.get(name)
     if trail is None:
         return _err("TrailNotFoundException", f"Unknown trail: {name!r}", 404)
@@ -369,7 +444,9 @@ def _update_trail(body: dict):
     raw = body.get("Name", "").strip()
     if not raw:
         return _err("InvalidTrailNameException", "Trail name is required.")
-    name = _resolve_trail_name(raw)
+    name, error = _resolve_trail_name_or_error(raw)
+    if error:
+        return error
     trail = _trails.get(name)
     if trail is None:
         return _err("TrailNotFoundException", f"Unknown trail: {name!r}", 404)
@@ -410,7 +487,9 @@ def _put_event_selectors(body: dict):
     raw = body.get("TrailName", "").strip()
     if not raw:
         return _err("InvalidTrailNameException", "Trail name is required.")
-    name = _resolve_trail_name(raw)
+    name, error = _resolve_existing_trail_name_or_error(raw)
+    if error:
+        return error
     selectors = body.get("EventSelectors", [])
     _event_selectors[name] = selectors
     return _ok({"TrailARN": _trail_arn(name), "EventSelectors": selectors})
@@ -420,11 +499,14 @@ def _get_event_selectors(body: dict):
     raw = body.get("TrailName", "").strip()
     if not raw:
         return _err("InvalidTrailNameException", "Trail name is required.")
-    name = _resolve_trail_name(raw)
+    name, error = _resolve_existing_trail_name_or_error(raw, allow_cross_region_arn=True)
+    if error:
+        return error
+    trail = _trails.get(name) or {}
     selectors = _event_selectors.get(name) or []
     return _ok(
         {
-            "TrailARN": _trail_arn(name),
+            "TrailARN": trail.get("TrailARN", _trail_arn(name)),
             "EventSelectors": selectors,
             "AdvancedEventSelectors": [],
         }
@@ -435,6 +517,9 @@ def _add_tags(body: dict):
     arn = body.get("ResourceId", "").strip()
     if not arn:
         return _err("CloudTrailARNInvalidException", "ResourceId (trail ARN) is required.")
+    error = _validate_trail_arn(arn)
+    if error:
+        return error
     existing = _trail_tags.get(arn) or {}
     for tag in body.get("TagsList", []):
         existing[tag["Key"]] = tag["Value"]
@@ -444,6 +529,10 @@ def _add_tags(body: dict):
 
 def _list_tags(body: dict):
     arns = body.get("ResourceIdList", [])
+    for arn in arns:
+        error = _validate_trail_arn(arn)
+        if error:
+            return error
     result = [
         {
             "ResourceId": arn,
@@ -458,6 +547,9 @@ def _remove_tags(body: dict):
     arn = body.get("ResourceId", "").strip()
     if not arn:
         return _err("CloudTrailARNInvalidException", "ResourceId (trail ARN) is required.")
+    error = _validate_trail_arn(arn)
+    if error:
+        return error
     existing = _trail_tags.get(arn) or {}
     for tag in body.get("TagsList", []):
         existing.pop(tag.get("Key", ""), None)

--- a/tests/test_cloudtrail.py
+++ b/tests/test_cloudtrail.py
@@ -12,6 +12,7 @@ Tests are split into two sections:
 """
 
 import time
+from datetime import datetime, timedelta, timezone
 
 import boto3
 import pytest
@@ -22,13 +23,13 @@ ENDPOINT = "http://localhost:4566"
 REGION = "us-east-1"
 
 
-def _client(service):
+def _client(service, region=REGION):
     return boto3.client(
         service,
         endpoint_url=ENDPOINT,
         aws_access_key_id="test",
         aws_secret_access_key="test",
-        region_name=REGION,
+        region_name=region,
     )
 
 
@@ -97,6 +98,51 @@ def test_get_trail(ct):
     resp = ct.get_trail(Name=name)
     assert resp["Trail"]["Name"] == name
     assert "TrailARN" in resp["Trail"]
+
+
+def test_get_trail_by_arn(ct):
+    name = f"trail-get-arn-{_uid()}"
+    created = ct.create_trail(Name=name, S3BucketName="bucket")
+    resp = ct.get_trail(Name=created["TrailARN"])
+    assert resp["Trail"]["Name"] == name
+
+
+def test_get_trail_rejects_wrong_service_arn(ct):
+    name = f"trail-wrong-service-{_uid()}"
+    ct.create_trail(Name=name, S3BucketName="bucket")
+    with pytest.raises(ClientError) as exc:
+        ct.get_trail(Name=f"arn:aws:sns:{REGION}:000000000000:trail/{name}")
+    assert exc.value.response["Error"]["Code"] == "CloudTrailARNInvalidException"
+
+
+def test_get_trail_rejects_malformed_arn_identifier(ct):
+    with pytest.raises(ClientError) as exc:
+        ct.get_trail(Name="arn:nope")
+    assert exc.value.response["Error"]["Code"] == "CloudTrailARNInvalidException"
+
+
+def test_get_trail_does_not_resolve_foreign_region_arn_by_tail(ct):
+    name = f"trail-foreign-region-{_uid()}"
+    arn = ct.create_trail(Name=name, S3BucketName="bucket")["TrailARN"]
+    foreign_arn = arn.replace(f":{REGION}:", ":us-west-2:")
+    with pytest.raises(ClientError) as exc:
+        ct.get_trail(Name=foreign_arn)
+    assert exc.value.response["Error"]["Code"] == "TrailNotFoundException"
+
+
+def test_read_trail_by_arn_from_different_request_region(ct):
+    name = f"trail-cross-region-read-{_uid()}"
+    arn = ct.create_trail(Name=name, S3BucketName="bucket")["TrailARN"]
+    west_ct = _client("cloudtrail", region="us-west-2")
+
+    get_resp = west_ct.get_trail(Name=arn)
+    assert get_resp["Trail"]["Name"] == name
+
+    status_resp = west_ct.get_trail_status(Name=arn)
+    assert status_resp["IsLogging"] is True
+
+    desc_resp = west_ct.describe_trails(trailNameList=[arn])
+    assert [trail["TrailARN"] for trail in desc_resp["trailList"]] == [arn]
 
 
 def test_get_trail_not_found(ct):
@@ -226,6 +272,31 @@ def test_put_get_event_selectors(ct):
     assert get_resp["AdvancedEventSelectors"] == []
 
 
+def test_put_event_selectors_rejects_foreign_region_trail_arn(ct):
+    name = f"trail-sel-foreign-{_uid()}"
+    arn = ct.create_trail(Name=name, S3BucketName="bucket")["TrailARN"]
+    foreign_arn = arn.replace(f":{REGION}:", ":us-west-2:")
+    selectors = [{"ReadWriteType": "All", "IncludeManagementEvents": True, "DataResources": []}]
+
+    with pytest.raises(ClientError) as exc:
+        ct.put_event_selectors(TrailName=foreign_arn, EventSelectors=selectors)
+    assert exc.value.response["Error"]["Code"] == "TrailNotFoundException"
+
+    assert ct.get_event_selectors(TrailName=name)["EventSelectors"] == []
+
+
+def test_get_event_selectors_by_arn_from_different_request_region(ct):
+    name = f"trail-sel-cross-region-{_uid()}"
+    arn = ct.create_trail(Name=name, S3BucketName="bucket")["TrailARN"]
+    selectors = [{"ReadWriteType": "All", "IncludeManagementEvents": True, "DataResources": []}]
+    ct.put_event_selectors(TrailName=name, EventSelectors=selectors)
+
+    west_ct = _client("cloudtrail", region="us-west-2")
+    resp = west_ct.get_event_selectors(TrailName=arn)
+    assert resp["TrailARN"] == arn
+    assert resp["EventSelectors"] == selectors
+
+
 def test_get_event_selectors_empty(ct):
     name = f"trail-nosel-{_uid()}"
     ct.create_trail(Name=name, S3BucketName="bucket")
@@ -249,6 +320,28 @@ def test_add_list_remove_tags(ct):
     tags2 = {t["Key"]: t["Value"] for item in list_resp2["ResourceTagList"] for t in item["TagsList"]}
     assert "env" not in tags2
     assert tags2["team"] == "ops"
+
+
+def test_add_tags_rejects_malformed_trail_arn(ct):
+    with pytest.raises(ClientError) as exc:
+        ct.add_tags(ResourceId="not-an-arn", TagsList=[{"Key": "env", "Value": "test"}])
+    assert exc.value.response["Error"]["Code"] == "CloudTrailARNInvalidException"
+
+
+def test_add_tags_rejects_foreign_region_trail_arn(ct):
+    name = f"trail-tags-foreign-{_uid()}"
+    arn = ct.create_trail(Name=name, S3BucketName="bucket")["TrailARN"]
+    foreign_arn = arn.replace(f":{REGION}:", ":us-west-2:")
+
+    with pytest.raises(ClientError) as exc:
+        ct.add_tags(ResourceId=foreign_arn, TagsList=[{"Key": "env", "Value": "test"}])
+    assert exc.value.response["Error"]["Code"] == "CloudTrailARNInvalidException"
+
+
+def test_list_tags_rejects_wrong_service_trail_arn(ct):
+    with pytest.raises(ClientError) as exc:
+        ct.list_tags(ResourceIdList=[f"arn:aws:sns:{REGION}:000000000000:trail/not-a-trail"])
+    assert exc.value.response["Error"]["Code"] == "CloudTrailARNInvalidException"
 
 
 # ---------------------------------------------------------------------------
@@ -361,7 +454,6 @@ def test_lookup_no_match(ct):
 
 def test_lookup_time_range_match(ct, s3):
     bucket = f"ct-time-{_uid()}"
-    from datetime import datetime, timezone, timedelta
 
     before = datetime.now(timezone.utc) - timedelta(seconds=2)
     s3.create_bucket(Bucket=bucket)
@@ -376,8 +468,6 @@ def test_lookup_time_range_match(ct, s3):
 
 
 def test_lookup_time_range_future_empty(ct):
-    from datetime import datetime, timezone, timedelta
-
     future_start = datetime.now(timezone.utc) + timedelta(hours=1)
     future_end = datetime.now(timezone.utc) + timedelta(hours=2)
     resp = ct.lookup_events(StartTime=future_start, EndTime=future_end)


### PR DESCRIPTION
## Summary
- Adopt the shared ARN parser for CloudTrail trail ARN resolution and validation.
- Reject malformed, wrong-service, and out-of-scope trail ARNs on mutation/tag paths while preserving cross-request-region reads for stored trail ARNs.
- Add CloudTrail regressions for ARN lookup, malformed identifiers, foreign-region behavior, event selector handling, and tag validation.

## Tests
- `uv run --extra dev ruff check ministack/services/cloudtrail.py tests/test_cloudtrail.py`
- `uv run --extra dev pytest tests/test_cloudtrail.py -q` (`49 passed`)
