### PR TITLE
Adopt ARN parsing for Resource Groups

### DIFF
--- a/ministack/services/resource_groups.py
+++ b/ministack/services/resource_groups.py
@@ -21,6 +21,7 @@ import json
 import logging
 import re
 
+from ministack.core.arn import ArnParseError, parse_arn
 from ministack.core.persistence import load_state
 from ministack.core.responses import (
     AccountScopedDict,
@@ -31,9 +32,7 @@ from ministack.core.responses import (
 logger = logging.getLogger("resource_groups")
 
 _GROUP_NAME_RE = re.compile(r"^[A-Za-z0-9_.\-]{1,300}$")
-_GROUP_ARN_RE = re.compile(
-    r"^arn:aws[-a-z]*:resource-groups:[^:]*:[^:]*:group/(?P<name>[A-Za-z0-9_.\-]+)$"
-)
+_AWS_PARTITION_RE = re.compile(r"^aws(?:-[a-z]+)*$")
 _VALID_QUERY_TYPES = {"TAG_FILTERS_1_0", "CLOUDFORMATION_STACK_1_0"}
 
 _groups = AccountScopedDict()           # name -> Group dict
@@ -91,6 +90,26 @@ def _arn(name):
     return f"arn:aws:resource-groups:{get_region()}:{get_account_id()}:group/{name}"
 
 
+class _InvalidResourceGroupsArn(ValueError):
+    pass
+
+
+def _validate_aws_partition(spec, message):
+    if not _AWS_PARTITION_RE.match(spec.partition):
+        raise _InvalidResourceGroupsArn(message)
+
+
+def _validate_resource_arn(arn):
+    try:
+        spec = parse_arn(arn)
+    except ArnParseError as exc:
+        raise _InvalidResourceGroupsArn("Invalid resource ARN.") from exc
+    _validate_aws_partition(spec, "Invalid resource ARN.")
+    if not spec.service or not spec.resource:
+        raise _InvalidResourceGroupsArn("Invalid resource ARN.")
+    return spec
+
+
 def _resolve_name(group_name=None, group=None):
     """Accepts either GroupName (bare) or Group (name or full ARN). Returns
     the bare name, or None if both inputs are missing."""
@@ -98,9 +117,8 @@ def _resolve_name(group_name=None, group=None):
         return group_name
     if not group:
         return None
-    m = _GROUP_ARN_RE.match(group)
-    if m:
-        return m.group("name")
+    if isinstance(group, str) and group.startswith("arn:"):
+        return _resolve_arn_group(group) or group
     return group
 
 
@@ -329,7 +347,9 @@ def _group_resources(data):
     arns = list(data.get("ResourceArns") or [])
     if not arns:
         return _bad_request("ResourceArns is required.")
-    members = _group_members.get(name) or []
+    for arn in arns:
+        _validate_resource_arn(arn)
+    members = list(_group_members.get(name) or [])
     seen = set(members)
     succeeded = []
     for arn in arns:
@@ -350,6 +370,8 @@ def _ungroup_resources(data):
     arns = list(data.get("ResourceArns") or [])
     if not arns:
         return _bad_request("ResourceArns is required.")
+    for arn in arns:
+        _validate_resource_arn(arn)
     members = list(_group_members.get(name) or [])
     target = set(arns)
     _group_members[name] = [a for a in members if a not in target]
@@ -433,10 +455,24 @@ def _update_account_settings(data):
 def _resolve_arn_group(arn):
     if not arn:
         return None
-    m = _GROUP_ARN_RE.match(arn)
-    if not m:
+    try:
+        spec = parse_arn(arn)
+    except ArnParseError as exc:
+        raise _InvalidResourceGroupsArn("Invalid Resource Groups group ARN.") from exc
+    _validate_aws_partition(spec, "Invalid Resource Groups group ARN.")
+    if spec.service != "resource-groups":
+        raise _InvalidResourceGroupsArn("Invalid Resource Groups group ARN.")
+    if not spec.region or not spec.account_id:
+        raise _InvalidResourceGroupsArn("Invalid Resource Groups group ARN.")
+    if spec.region != get_region() or spec.account_id != get_account_id():
         return None
-    return m.group("name")
+    prefix = "group/"
+    if not spec.resource.startswith(prefix):
+        raise _InvalidResourceGroupsArn("Invalid Resource Groups group ARN.")
+    name = spec.resource[len(prefix):]
+    if not _GROUP_NAME_RE.match(name):
+        raise _InvalidResourceGroupsArn("Invalid Resource Groups group ARN.")
+    return name
 
 
 def _tag(arn, data):
@@ -476,11 +512,9 @@ def _get_tags(arn):
 def _resource_type_from_arn(arn):
     """Best-effort extraction of `AWS::Service::ResourceType` from an ARN.
     Returns the raw ARN service slot uppercased when the type can't be inferred."""
-    parts = arn.split(":", 5) if isinstance(arn, str) else []
-    if len(parts) < 6:
-        return ""
-    service = parts[2]
-    tail = parts[5]
+    spec = _validate_resource_arn(arn)
+    service = spec.service
+    tail = spec.resource
     sub = tail.split("/", 1)[0] if "/" in tail else tail.split(":", 1)[0]
     if not sub:
         sub = "Resource"
@@ -523,17 +557,23 @@ async def handle_request(method, path, headers, body, query_params):
     if method == "POST":
         handler = _POST_ROUTES.get(path)
         if handler:
-            return handler(data)
+            try:
+                return handler(data)
+            except _InvalidResourceGroupsArn as exc:
+                return _bad_request(str(exc))
 
     m = _TAG_ARN_PATH_RE.match(path)
     if m:
         from urllib.parse import unquote
         arn = unquote(m.group("arn"))
-        if method == "GET":
-            return _get_tags(arn)
-        if method == "PUT":
-            return _tag(arn, data)
-        if method == "PATCH":
-            return _untag(arn, data)
+        try:
+            if method == "GET":
+                return _get_tags(arn)
+            if method == "PUT":
+                return _tag(arn, data)
+            if method == "PATCH":
+                return _untag(arn, data)
+        except _InvalidResourceGroupsArn as exc:
+            return _bad_request(str(exc))
 
     return _bad_request(f"Unknown Resource Groups route: {method} {path}")

--- a/tests/test_resource_groups.py
+++ b/tests/test_resource_groups.py
@@ -13,7 +13,6 @@ import pytest
 from botocore.config import Config
 from botocore.exceptions import ClientError
 
-
 ENDPOINT = "http://localhost:4566"
 REGION = "us-east-1"
 
@@ -86,6 +85,41 @@ def test_get_group_by_name_and_by_arn(rg):
         by_arn = rg.get_group(Group=arn)
         assert by_name["Group"]["Name"] == name
         assert by_arn["Group"]["Name"] == name
+    finally:
+        rg.delete_group(Group=name)
+
+
+def test_group_arn_region_and_account_must_match_request(rg):
+    name = f"g-{_uid()}"
+    arn = rg.create_group(Name=name, ResourceQuery=_tag_query())["Group"]["GroupArn"]
+    foreign_region = arn.replace(":us-east-1:", ":us-west-2:")
+    foreign_account = arn.replace(":000000000000:", ":111111111111:")
+    try:
+        for group_arn in (foreign_region, foreign_account):
+            with pytest.raises(ClientError) as exc:
+                rg.get_group(Group=group_arn)
+            assert exc.value.response["Error"]["Code"] == "NotFoundException"
+
+            with pytest.raises(ClientError) as exc:
+                rg.tag(Arn=group_arn, Tags={"env": "foreign"})
+            assert exc.value.response["Error"]["Code"] == "NotFoundException"
+
+        assert rg.get_group(Group=arn)["Group"]["Name"] == name
+    finally:
+        rg.delete_group(Group=name)
+
+
+def test_malformed_group_arn_does_not_resolve_as_group_name(rg):
+    name = f"g-{_uid()}"
+    rg.create_group(Name=name, ResourceQuery=_tag_query())
+    try:
+        malformed = f"arn:aws:resource-groups:us-east-1:000000000000:group/{name}:extra"
+        invalid_partition = f"arn:notaws:resource-groups:us-east-1:000000000000:group/{name}"
+        wrong_service = f"arn:aws:sns:us-east-1:000000000000:group/{name}"
+        for group_arn in (malformed, invalid_partition, wrong_service):
+            with pytest.raises(ClientError) as exc:
+                rg.get_group(Group=group_arn)
+            assert exc.value.response["Error"]["Code"] == "BadRequestException"
     finally:
         rg.delete_group(Group=name)
 
@@ -211,6 +245,60 @@ def test_group_and_ungroup_and_list_resources(rg):
         after_arns = {r["ResourceArn"] for r in after["ResourceIdentifiers"]}
         assert arns[0] not in after_arns
         assert arns[1] in after_arns
+    finally:
+        rg.delete_group(Group=name)
+
+
+def test_group_resources_rejects_malformed_resource_arn(rg):
+    name = f"g-{_uid()}"
+    rg.create_group(Name=name, ResourceQuery=_tag_query())
+    try:
+        valid = "arn:aws:ec2:us-east-1:000000000000:instance/i-aaa"
+        malformed = "arn:aws:ec2:us-east-1:000000000000"
+        invalid_partition = "arn:notaws:ec2:us-east-1:000000000000:instance/i-aaa"
+        for resource_arn in (malformed, invalid_partition):
+            with pytest.raises(ClientError) as exc:
+                rg.group_resources(Group=name, ResourceArns=[valid, resource_arn])
+            assert exc.value.response["Error"]["Code"] == "BadRequestException"
+            assert rg.list_group_resources(GroupName=name)["ResourceIdentifiers"] == []
+    finally:
+        rg.delete_group(Group=name)
+
+
+def test_group_resources_failed_request_does_not_partially_mutate_existing_members(rg):
+    name = f"g-{_uid()}"
+    rg.create_group(Name=name, ResourceQuery=_tag_query())
+    try:
+        existing = "arn:aws:ec2:us-east-1:000000000000:instance/i-existing"
+        valid = "arn:aws:ec2:us-east-1:000000000000:instance/i-new"
+        malformed = "arn:aws:ec2:us-east-1:000000000000"
+        rg.group_resources(Group=name, ResourceArns=[existing])
+
+        with pytest.raises(ClientError) as exc:
+            rg.group_resources(Group=name, ResourceArns=[valid, malformed])
+
+        assert exc.value.response["Error"]["Code"] == "BadRequestException"
+        listed = rg.list_group_resources(GroupName=name)["ResourceIdentifiers"]
+        assert [resource["ResourceArn"] for resource in listed] == [existing]
+    finally:
+        rg.delete_group(Group=name)
+
+
+def test_ungroup_resources_failed_request_does_not_partially_mutate_existing_members(rg):
+    name = f"g-{_uid()}"
+    rg.create_group(Name=name, ResourceQuery=_tag_query())
+    try:
+        keep = "arn:aws:ec2:us-east-1:000000000000:instance/i-keep"
+        remove = "arn:aws:ec2:us-east-1:000000000000:instance/i-remove"
+        malformed = "arn:aws:ec2:us-east-1:000000000000"
+        rg.group_resources(Group=name, ResourceArns=[keep, remove])
+
+        with pytest.raises(ClientError) as exc:
+            rg.ungroup_resources(Group=name, ResourceArns=[remove, malformed])
+
+        assert exc.value.response["Error"]["Code"] == "BadRequestException"
+        listed = rg.list_group_resources(GroupName=name)["ResourceIdentifiers"]
+        assert [resource["ResourceArn"] for resource in listed] == [keep, remove]
     finally:
         rg.delete_group(Group=name)
 


### PR DESCRIPTION
## Summary
- Replace Resource Groups ARN regex handling with the shared ARN parser for group and resource identifiers.
- Validate partition, service, region/account scope, and group resource shape for Resource Groups group ARNs.
- Validate `GroupResources` and `UngroupResources` member ARNs before mutation so failed requests remain atomic.

## Tests
- `uv run --extra dev ruff check ministack/services/resource_groups.py tests/test_resource_groups.py`
- `uv run --extra dev pytest tests/test_resource_groups.py -q` (`23 passed`)
