### PR TITLE
Add RDS global switchover and failover metadata support

### DIFF
--- a/ministack/services/rds.py
+++ b/ministack/services/rds.py
@@ -19,7 +19,8 @@ Supports: CreateDBInstance, DeleteDBInstance, DescribeDBInstances, ModifyDBInsta
           DescribeDBEngineVersions, DescribeOrderableDBInstanceOptions,
           DescribePendingMaintenanceActions,
           CreateGlobalCluster, DescribeGlobalClusters, DeleteGlobalCluster,
-          RemoveFromGlobalCluster, ModifyGlobalCluster.
+          RemoveFromGlobalCluster, ModifyGlobalCluster,
+          SwitchoverGlobalCluster, FailoverGlobalCluster.
 
 When Docker is available, CreateDBInstance spins up a real Postgres/MySQL container
 and returns the actual host:port as the endpoint.
@@ -857,6 +858,12 @@ def _refresh_global_cluster_readers(global_cluster):
     reader_arns = [m["DBClusterArn"] for m in members if not m.get("IsWriter")]
     for member in members:
         member["Readers"] = reader_arns if member.get("IsWriter") else []
+
+
+def _set_global_cluster_writer(global_cluster, target_member):
+    for member in global_cluster.get("GlobalClusterMembers", []):
+        member["IsWriter"] = member["DBClusterArn"] == target_member["DBClusterArn"]
+    _refresh_global_cluster_readers(global_cluster)
 
 
 def _attach_cluster_to_global(global_cluster, cluster, is_writer):
@@ -2905,6 +2912,88 @@ def _modify_global_cluster(p):
         f"<ModifyGlobalClusterResult><GlobalCluster>{_global_cluster_xml(gc)}</GlobalCluster></ModifyGlobalClusterResult>")
 
 
+def _find_global_cluster_target_member(gc, target_cluster_id):
+    cluster = _resolve_cluster(target_cluster_id)
+    db_cluster_arn = cluster["DBClusterArn"] if cluster else target_cluster_id
+    members = gc.get("GlobalClusterMembers", [])
+    member = next((m for m in members if m["DBClusterArn"] == db_cluster_arn), None)
+    return cluster, member
+
+
+def _switch_global_cluster_writer(p, *, allow_data_loss=False):
+    gc_id = _p(p, "GlobalClusterIdentifier")
+    target_cluster_id = _p(p, "TargetDbClusterIdentifier")
+    invalid_id = _invalid_global_cluster_identifier_error(gc_id)
+    if invalid_id:
+        return invalid_id
+    gc = _resolve_global_cluster(gc_id)
+    if not gc:
+        return _error("GlobalClusterNotFoundFault",
+            f"Global cluster {gc_id} not found.", 404)
+    if not target_cluster_id:
+        return _error("MissingParameter", "TargetDbClusterIdentifier is required", 400)
+
+    _target_cluster, target_member = _find_global_cluster_target_member(gc, target_cluster_id)
+    if not target_member:
+        cluster = _resolve_cluster(target_cluster_id)
+        if not cluster:
+            return _error("DBClusterNotFoundFault",
+                f"DBCluster {target_cluster_id} not found.", 404)
+        return _error("InvalidGlobalClusterStateFault",
+            f"DBCluster {target_cluster_id} is not a secondary member of global cluster {gc_id}.", 400)
+
+    members = gc.get("GlobalClusterMembers", [])
+    current_writer = next((m for m in members if m.get("IsWriter")), None)
+    if not current_writer or target_member.get("IsWriter") or len(members) < 2:
+        return _error("InvalidGlobalClusterStateFault",
+            f"Global cluster {gc_id} does not have a secondary target to promote.", 400)
+
+    _set_global_cluster_writer(gc, target_member)
+    gc["Status"] = "available"
+
+    response_gc = copy.deepcopy(gc)
+    response_gc["Status"] = "switching-over" if not allow_data_loss else "failing-over"
+    response_gc["FailoverState"] = {
+        "Status": "pending",
+        "FromDbClusterArn": current_writer["DBClusterArn"],
+        "ToDbClusterArn": target_member["DBClusterArn"],
+        "IsDataLossAllowed": bool(allow_data_loss),
+    }
+    return response_gc
+
+
+def _switchover_global_cluster(p):
+    result = _switch_global_cluster_writer(p, allow_data_loss=False)
+    if isinstance(result, tuple):
+        return result
+    return _xml(200, "SwitchoverGlobalClusterResponse",
+        f"<SwitchoverGlobalClusterResult><GlobalCluster>{_global_cluster_xml(result)}</GlobalCluster></SwitchoverGlobalClusterResult>")
+
+
+def _failover_global_cluster(p):
+    gc_id = _p(p, "GlobalClusterIdentifier")
+    invalid_id = _invalid_global_cluster_identifier_error(gc_id)
+    if invalid_id:
+        return invalid_id
+    if not _resolve_global_cluster(gc_id):
+        return _error("GlobalClusterNotFoundFault",
+            f"Global cluster {gc_id} not found.", 404)
+
+    both_failover_modes_specified = "AllowDataLoss" in p and "Switchover" in p
+    allow_data_loss = str(_p(p, "AllowDataLoss")).lower() == "true"
+    if both_failover_modes_specified:
+        return _error(
+            "InvalidParameterCombination",
+            "AllowDataLoss and Switchover cannot both be specified.",
+            400,
+        )
+    result = _switch_global_cluster_writer(p, allow_data_loss=allow_data_loss)
+    if isinstance(result, tuple):
+        return result
+    return _xml(200, "FailoverGlobalClusterResponse",
+        f"<FailoverGlobalClusterResult><GlobalCluster>{_global_cluster_xml(result)}</GlobalCluster></FailoverGlobalClusterResult>")
+
+
 def _enable_http_endpoint(p):
     arn = _p(p, "ResourceArn")
     wrong_region = _resource_not_found_error_for_arn(arn)
@@ -2933,6 +3022,15 @@ def _global_cluster_xml(gc):
             <GlobalWriteForwardingStatus>{m.get('GlobalWriteForwardingStatus', 'disabled')}</GlobalWriteForwardingStatus>
             <SynchronizationStatus>{m.get('SynchronizationStatus', 'connected')}</SynchronizationStatus>
         </GlobalClusterMember>"""
+    failover_state = gc.get("FailoverState") or {}
+    failover_state_xml = ""
+    if failover_state:
+        failover_state_xml = f"""<FailoverState>
+            <Status>{failover_state.get('Status', '')}</Status>
+            <FromDbClusterArn>{_esc(failover_state.get('FromDbClusterArn', ''))}</FromDbClusterArn>
+            <ToDbClusterArn>{_esc(failover_state.get('ToDbClusterArn', ''))}</ToDbClusterArn>
+            <IsDataLossAllowed>{str(failover_state.get('IsDataLossAllowed', False)).lower()}</IsDataLossAllowed>
+        </FailoverState>"""
     return f"""<GlobalClusterIdentifier>{gc['GlobalClusterIdentifier']}</GlobalClusterIdentifier>
         <GlobalClusterArn>{gc['GlobalClusterArn']}</GlobalClusterArn>
         <GlobalClusterResourceId>{gc['GlobalClusterResourceId']}</GlobalClusterResourceId>
@@ -2942,6 +3040,7 @@ def _global_cluster_xml(gc):
         <DatabaseName>{gc.get('DatabaseName', '')}</DatabaseName>
         <StorageEncrypted>{str(gc.get('StorageEncrypted', False)).lower()}</StorageEncrypted>
         <DeletionProtection>{str(gc.get('DeletionProtection', False)).lower()}</DeletionProtection>
+        {failover_state_xml}
         <GlobalClusterMembers>{member_xml}</GlobalClusterMembers>"""
 
 
@@ -3680,6 +3779,8 @@ _ACTION_MAP = {
     "DeleteGlobalCluster": _delete_global_cluster,
     "RemoveFromGlobalCluster": _remove_from_global_cluster,
     "ModifyGlobalCluster": _modify_global_cluster,
+    "SwitchoverGlobalCluster": _switchover_global_cluster,
+    "FailoverGlobalCluster": _failover_global_cluster,
     "EnableHttpEndpoint": _enable_http_endpoint,
 }
 

--- a/ministack/services/stepfunctions.py
+++ b/ministack/services/stepfunctions.py
@@ -4313,7 +4313,7 @@ _XML_BOOLEAN_FIELDS = frozenset({
     "CopyTagsToSnapshot", "IamDatabaseAuthenticationEnabled",
     "PerformanceInsightsEnabled", "HttpEndpointEnabled",
     "CrossAccountClone", "CustomerOwnedIpEnabled",
-    "IsStorageConfigUpgradeAvailable", "IsWriter",
+    "IsStorageConfigUpgradeAvailable", "IsWriter", "IsDataLossAllowed",
 })
 
 
@@ -4406,11 +4406,17 @@ _AWS_ACRONYMS = frozenset({
 })
 
 # Most query-protocol RDS params expand SDK-style "Db" to wire-format "DB".
-# RemoveFromGlobalCluster is the AWS-shape exception: its member is
+# Some global-cluster operations are AWS-shape exceptions: their members use
 # "DbClusterIdentifier", and sending "DBClusterIdentifier" is ignored.
 _QUERY_PARAM_NAME_OVERRIDES = {
     ("rds", "RemoveFromGlobalCluster"): {
         "DbClusterIdentifier": "DbClusterIdentifier",
+    },
+    ("rds", "SwitchoverGlobalCluster"): {
+        "TargetDbClusterIdentifier": "TargetDbClusterIdentifier",
+    },
+    ("rds", "FailoverGlobalCluster"): {
+        "TargetDbClusterIdentifier": "TargetDbClusterIdentifier",
     },
     ("ec2", "CreateSecurityGroup"): {
         "Description": "GroupDescription",

--- a/tests/test_rds_regions.py
+++ b/tests/test_rds_regions.py
@@ -56,6 +56,21 @@ def _delete_global_cluster(client, global_id):
         pass
 
 
+def _cleanup_two_member_global(east, global_id, primary_arn=None, secondary_arn=None):
+    if primary_arn:
+        try:
+            east.switchover_global_cluster(
+                GlobalClusterIdentifier=global_id,
+                TargetDbClusterIdentifier=primary_arn,
+            )
+        except ClientError:
+            pass
+    for cluster_arn in (secondary_arn, primary_arn):
+        if cluster_arn:
+            _remove_global_member(east, global_id, cluster_arn)
+    _delete_global_cluster(east, global_id)
+
+
 def test_rds_clusters_are_region_scoped():
     east = _regional_rds("us-east-1")
     west = _regional_rds("us-west-2")
@@ -520,6 +535,154 @@ def test_aurora_global_metadata_spans_regions():
         _delete_global_cluster(east, global_id)
         _delete_cluster(west, secondary_id)
         _delete_cluster(east, primary_id)
+
+
+def test_switchover_global_cluster_promotes_foreign_region_member_arn():
+    east = _regional_rds("us-east-1")
+    west = _regional_rds("us-west-2")
+    suffix = uuid.uuid4().hex[:8]
+    primary_id = f"global-switch-primary-{suffix}"
+    secondary_id = f"global-switch-secondary-{suffix}"
+    global_id = f"global-switch-{suffix}"
+    primary_arn = None
+    secondary_arn = None
+
+    try:
+        primary = east.create_db_cluster(
+            DBClusterIdentifier=primary_id,
+            Engine="aurora-mysql",
+            MasterUsername="admin",
+            MasterUserPassword="password123",
+        )["DBCluster"]
+        primary_arn = primary["DBClusterArn"]
+        east.create_global_cluster(
+            GlobalClusterIdentifier=global_id,
+            SourceDBClusterIdentifier=primary_arn,
+        )
+        secondary = west.create_db_cluster(
+            DBClusterIdentifier=secondary_id,
+            Engine="aurora-mysql",
+            GlobalClusterIdentifier=global_id,
+            MasterUsername="admin",
+            MasterUserPassword="password123",
+        )["DBCluster"]
+        secondary_arn = secondary["DBClusterArn"]
+
+        response = east.switchover_global_cluster(
+            GlobalClusterIdentifier=global_id,
+            TargetDbClusterIdentifier=secondary_arn,
+        )["GlobalCluster"]
+        assert response["Status"] == "switching-over"
+        assert response["FailoverState"]["Status"] == "pending"
+        assert response["FailoverState"]["FromDbClusterArn"] == primary_arn
+        assert response["FailoverState"]["ToDbClusterArn"] == secondary_arn
+        assert response["FailoverState"]["IsDataLossAllowed"] is False
+
+        members = {m["DBClusterArn"]: m for m in response["GlobalClusterMembers"]}
+        assert members[primary_arn]["IsWriter"] is False
+        assert members[secondary_arn]["IsWriter"] is True
+        assert members[secondary_arn]["Readers"] == [primary_arn]
+
+        final = west.describe_global_clusters(
+            GlobalClusterIdentifier=global_id,
+        )["GlobalClusters"][0]
+        final_members = {m["DBClusterArn"]: m for m in final["GlobalClusterMembers"]}
+        assert final["Status"] == "available"
+        assert "FailoverState" not in final
+        assert final_members[primary_arn]["IsWriter"] is False
+        assert final_members[secondary_arn]["IsWriter"] is True
+
+        switchback = west.switchover_global_cluster(
+            GlobalClusterIdentifier=global_id,
+            TargetDbClusterIdentifier=primary_arn,
+        )["GlobalCluster"]
+        switchback_members = {
+            m["DBClusterArn"]: m for m in switchback["GlobalClusterMembers"]
+        }
+        assert switchback_members[primary_arn]["IsWriter"] is True
+        assert switchback_members[secondary_arn]["IsWriter"] is False
+    finally:
+        _cleanup_two_member_global(east, global_id, primary_arn, secondary_arn)
+        _delete_cluster(west, secondary_id)
+        _delete_cluster(east, primary_id)
+
+
+def test_failover_global_cluster_allows_data_loss_promotes_target():
+    east = _regional_rds("us-east-1")
+    west = _regional_rds("us-west-2")
+    suffix = uuid.uuid4().hex[:8]
+    primary_id = f"global-fail-primary-{suffix}"
+    secondary_id = f"global-fail-secondary-{suffix}"
+    global_id = f"global-fail-{suffix}"
+    primary_arn = None
+    secondary_arn = None
+
+    try:
+        primary = east.create_db_cluster(
+            DBClusterIdentifier=primary_id,
+            Engine="aurora-mysql",
+            MasterUsername="admin",
+            MasterUserPassword="password123",
+        )["DBCluster"]
+        primary_arn = primary["DBClusterArn"]
+        east.create_global_cluster(
+            GlobalClusterIdentifier=global_id,
+            SourceDBClusterIdentifier=primary_arn,
+        )
+        secondary = west.create_db_cluster(
+            DBClusterIdentifier=secondary_id,
+            Engine="aurora-mysql",
+            GlobalClusterIdentifier=global_id,
+            MasterUsername="admin",
+            MasterUserPassword="password123",
+        )["DBCluster"]
+        secondary_arn = secondary["DBClusterArn"]
+
+        response = east.failover_global_cluster(
+            GlobalClusterIdentifier=global_id,
+            TargetDbClusterIdentifier=secondary_arn,
+            AllowDataLoss=True,
+        )["GlobalCluster"]
+        assert response["Status"] == "failing-over"
+        assert response["FailoverState"]["Status"] == "pending"
+        assert response["FailoverState"]["IsDataLossAllowed"] is True
+        members = {m["DBClusterArn"]: m for m in response["GlobalClusterMembers"]}
+        assert members[primary_arn]["IsWriter"] is False
+        assert members[secondary_arn]["IsWriter"] is True
+
+        with pytest.raises(ClientError) as exc:
+            east.failover_global_cluster(
+                GlobalClusterIdentifier=global_id,
+                TargetDbClusterIdentifier=primary_arn,
+                AllowDataLoss=True,
+                Switchover=True,
+            )
+        assert exc.value.response["Error"]["Code"] == "InvalidParameterCombination"
+
+        with pytest.raises(ClientError) as exc:
+            east.failover_global_cluster(
+                GlobalClusterIdentifier=global_id,
+                TargetDbClusterIdentifier=primary_arn,
+                AllowDataLoss=False,
+                Switchover=True,
+            )
+        assert exc.value.response["Error"]["Code"] == "InvalidParameterCombination"
+    finally:
+        _cleanup_two_member_global(east, global_id, primary_arn, secondary_arn)
+        _delete_cluster(west, secondary_id)
+        _delete_cluster(east, primary_id)
+
+
+def test_failover_global_cluster_missing_global_validated_before_parameter_combo():
+    east = _regional_rds("us-east-1")
+    with pytest.raises(ClientError) as exc:
+        east.failover_global_cluster(
+            GlobalClusterIdentifier=f"missing-global-{uuid.uuid4().hex[:8]}",
+            TargetDbClusterIdentifier="arn:aws:rds:us-east-1:000000000000:cluster:missing-secondary",
+            AllowDataLoss=True,
+            Switchover=True,
+        )
+    assert exc.value.response["Error"]["Code"] == "GlobalClusterNotFoundFault"
 
 
 def test_create_global_cluster_rejects_already_attached_source_cluster():

--- a/tests/test_stepfunctions.py
+++ b/tests/test_stepfunctions.py
@@ -1606,6 +1606,114 @@ def test_sfn_aws_sdk_rds_create_global_cluster_from_described_cluster_arn(sfn_sy
             pass
 
 
+def test_sfn_aws_sdk_rds_switchover_global_cluster(sfn_sync):
+    """aws-sdk:rds SwitchoverGlobalCluster accepts a foreign-Region member ARN."""
+    east = _regional_rds("us-east-1")
+    west = _regional_rds("us-west-2")
+    suffix = _uuid_mod.uuid4().hex[:8]
+    primary_id = f"sfn-switch-primary-{suffix}"
+    secondary_id = f"sfn-switch-secondary-{suffix}"
+    global_id = f"sfn-switch-global-{suffix}"
+    sm_name = f"sdk-rds-switch-{suffix}"
+    sm_arn = None
+    primary_arn = None
+    secondary_arn = None
+
+    try:
+        primary = east.create_db_cluster(
+            DBClusterIdentifier=primary_id,
+            Engine="aurora-postgresql",
+            MasterUsername="admin",
+            MasterUserPassword="testpass123",
+        )["DBCluster"]
+        primary_arn = primary["DBClusterArn"]
+        east.create_global_cluster(
+            GlobalClusterIdentifier=global_id,
+            SourceDBClusterIdentifier=primary_arn,
+        )
+        secondary = west.create_db_cluster(
+            DBClusterIdentifier=secondary_id,
+            Engine="aurora-postgresql",
+            GlobalClusterIdentifier=global_id,
+            MasterUsername="admin",
+            MasterUserPassword="testpass123",
+        )["DBCluster"]
+        secondary_arn = secondary["DBClusterArn"]
+
+        definition = json.dumps({
+            "StartAt": "SwitchGlobal",
+            "States": {
+                "SwitchGlobal": {
+                    "Type": "Task",
+                    "Resource": "arn:aws:states:::aws-sdk:rds:switchoverGlobalCluster",
+                    "Parameters": {
+                        "GlobalClusterIdentifier": global_id,
+                        "TargetDbClusterIdentifier": secondary_arn,
+                    },
+                    "End": True,
+                },
+            },
+        })
+        sm_arn = sfn_sync.create_state_machine(
+            name=sm_name,
+            definition=definition,
+            roleArn="arn:aws:iam::000000000000:role/sfn-role",
+        )["stateMachineArn"]
+
+        resp = sfn_sync.start_sync_execution(stateMachineArn=sm_arn, input=json.dumps({}))
+        assert resp["status"] == "SUCCEEDED", f"Execution failed: {resp.get('error')} — {resp.get('cause')}"
+        output = json.loads(resp["output"])
+        assert output["GlobalCluster"]["Status"] == "switching-over"
+        assert output["GlobalCluster"]["FailoverState"]["Status"] == "pending"
+        assert output["GlobalCluster"]["FailoverState"]["IsDataLossAllowed"] is False
+        members = {
+            member["DbClusterArn"]: member
+            for member in output["GlobalCluster"]["GlobalClusterMembers"]
+        }
+        assert members[primary_arn]["IsWriter"] is False
+        assert members[secondary_arn]["IsWriter"] is True
+
+        final = east.describe_global_clusters(
+            GlobalClusterIdentifier=global_id,
+        )["GlobalClusters"][0]
+        final_members = {m["DBClusterArn"]: m for m in final["GlobalClusterMembers"]}
+        assert final["Status"] == "available"
+        assert final_members[primary_arn]["IsWriter"] is False
+        assert final_members[secondary_arn]["IsWriter"] is True
+    finally:
+        if sm_arn:
+            sfn_sync.delete_state_machine(stateMachineArn=sm_arn)
+        if primary_arn:
+            try:
+                east.switchover_global_cluster(
+                    GlobalClusterIdentifier=global_id,
+                    TargetDbClusterIdentifier=primary_arn,
+                )
+            except ClientError:
+                pass
+        for cluster_arn in (secondary_arn, primary_arn):
+            if cluster_arn:
+                try:
+                    east.remove_from_global_cluster(
+                        GlobalClusterIdentifier=global_id,
+                        DbClusterIdentifier=cluster_arn,
+                    )
+                except ClientError:
+                    pass
+        try:
+            east.delete_global_cluster(GlobalClusterIdentifier=global_id)
+        except ClientError:
+            pass
+        try:
+            west.delete_db_cluster(DBClusterIdentifier=secondary_id, SkipFinalSnapshot=True)
+        except ClientError:
+            pass
+        try:
+            east.delete_db_cluster(DBClusterIdentifier=primary_id, SkipFinalSnapshot=True)
+        except ClientError:
+            pass
+
+
 def test_sfn_aws_sdk_rds_global_cluster_readers_are_lists(sfn_sync, rds):
     primary_id = f"sfn-global-primary-{_uuid_mod.uuid4().hex[:8]}"
     secondary_id = f"sfn-global-secondary-{_uuid_mod.uuid4().hex[:8]}"
@@ -1840,6 +1948,36 @@ def test_sfn_aws_sdk_rds_global_not_found_error_uses_aws_name(sfn, sfn_sync):
                 "Resource": "arn:aws:states:::aws-sdk:rds:DescribeGlobalClusters",
                 "Parameters": {
                     "GlobalClusterIdentifier": "this-global-cluster-does-not-exist",
+                },
+                "End": True,
+            },
+        },
+    })
+    sm_arn = sfn_sync.create_state_machine(
+        name=sm_name,
+        definition=definition,
+        roleArn="arn:aws:iam::000000000000:role/sfn-role",
+    )["stateMachineArn"]
+
+    resp = sfn_sync.start_sync_execution(stateMachineArn=sm_arn, input=json.dumps({}))
+    assert resp["status"] == "FAILED"
+    assert resp.get("error") == "Rds.GlobalClusterNotFoundException"
+
+    sfn_sync.delete_state_machine(stateMachineArn=sm_arn)
+
+
+def test_sfn_aws_sdk_rds_switchover_missing_global_uses_aws_name(sfn_sync):
+    sm_name = f"sdk-rds-switch-notfound-{_uuid_mod.uuid4().hex[:8]}"
+
+    definition = json.dumps({
+        "StartAt": "SwitchMissing",
+        "States": {
+            "SwitchMissing": {
+                "Type": "Task",
+                "Resource": "arn:aws:states:::aws-sdk:rds:switchoverGlobalCluster",
+                "Parameters": {
+                    "GlobalClusterIdentifier": "this-global-cluster-does-not-exist",
+                    "TargetDbClusterIdentifier": "arn:aws:rds:us-east-1:000000000000:cluster:missing-secondary",
                 },
                 "End": True,
             },


### PR DESCRIPTION
## Summary

- add RDS `SwitchoverGlobalCluster` and `FailoverGlobalCluster` support
- update global cluster member metadata so the target member becomes writer and prior writers become readers
- return AWS-style transient response metadata for switchover/failover while keeping persisted final state available
- add Step Functions AWS SDK integration support for the new RDS actions
- cover direct RDS switchover/failover paths and Step Functions switchover execution/error handling

## Validation

- `uv run --extra dev ruff check ministack/services/rds.py ministack/services/stepfunctions.py tests/test_rds_regions.py tests/test_stepfunctions.py`
- `git diff --check upstream/feat/multi-region -- ministack/services/rds.py ministack/services/stepfunctions.py tests/test_rds_regions.py tests/test_stepfunctions.py`
- `MINISTACK_ENDPOINT=http://localhost:14583 uv run --extra dev pytest tests/test_rds.py tests/test_rds_regions.py tests/test_rds_data.py tests/test_stepfunctions.py -q`
  - `271 passed, 1 skipped`