### PR TITLE
Adopt ARN parsing for ECS resolvers

### DIFF
--- a/ministack/services/ecs.py
+++ b/ministack/services/ecs.py
@@ -31,6 +31,7 @@ import secrets
 import threading
 import time
 
+from ministack.core.arn import ArnParseError, parse_arn
 from ministack.core.persistence import load_state
 from ministack.core.responses import (
     AccountScopedDict,
@@ -625,6 +626,8 @@ def _reconcile_service_tasks(cluster_name, svc_key):
 
 def _create_service(data):
     cluster_name = _resolve_cluster_name(data.get("cluster", "default"))
+    if cluster_name is None:
+        return error_response_json("ClusterNotFoundException", "Cluster not found.", 400)
     if cluster_name not in _clusters:
         _create_cluster({"clusterName": cluster_name})
 
@@ -641,6 +644,9 @@ def _create_service(data):
 
     td_ref = data.get("taskDefinition", "")
     td_key = _resolve_td_key(td_ref)
+    if td_ref.startswith("arn:") and td_key is None:
+        return error_response_json("ClientException",
+            f"Unable to find task definition: {td_ref}", 400)
     td_arn = _task_defs[td_key]["taskDefinitionArn"] if td_key in _task_defs else td_ref
 
     desired = data.get("desiredCount", 1)
@@ -695,8 +701,17 @@ def _create_service(data):
 
 def _delete_service(data):
     cluster_name = _resolve_cluster_name(data.get("cluster", "default"))
+    if cluster_name is None:
+        return error_response_json("ClusterNotFoundException", "Cluster not found.", 400)
     service_ref = data.get("service", "")
-    svc_name = _resolve_service_name(service_ref)
+    svc_ref = _resolve_service_ref(service_ref)
+    if svc_ref is None:
+        return error_response_json("ServiceNotFoundException",
+            "Service not found.", 400)
+    svc_name, svc_cluster_name = svc_ref
+    if svc_cluster_name is not None and svc_cluster_name != cluster_name:
+        return error_response_json("ServiceNotFoundException",
+            "Service not found.", 400)
     svc_key = f"{cluster_name}/{svc_name}"
     svc = _services.get(svc_key)
     if not svc:
@@ -731,12 +746,21 @@ def _delete_service(data):
 
 def _describe_services(data):
     cluster_name = _resolve_cluster_name(data.get("cluster", "default"))
+    if cluster_name is None:
+        return error_response_json("ClusterNotFoundException", "Cluster not found.", 400)
     refs = data.get("services", [])
     include = set(data.get("include", []))
     result = []
     failures = []
     for ref in refs:
-        svc_name = _resolve_service_name(ref)
+        svc_ref = _resolve_service_ref(ref)
+        if svc_ref is None:
+            failures.append({"arn": ref, "reason": "MISSING"})
+            continue
+        svc_name, svc_cluster_name = svc_ref
+        if svc_cluster_name is not None and svc_cluster_name != cluster_name:
+            failures.append({"arn": ref, "reason": "MISSING"})
+            continue
         svc_key = f"{cluster_name}/{svc_name}"
         if svc_key in _services:
             s = dict(_services[svc_key])
@@ -752,8 +776,15 @@ def _describe_services(data):
 
 def _update_service(data):
     cluster_name = _resolve_cluster_name(data.get("cluster", "default"))
+    if cluster_name is None:
+        return error_response_json("ClusterNotFoundException", "Cluster not found.", 400)
     service_ref = data.get("service", "")
-    svc_name = _resolve_service_name(service_ref)
+    svc_ref = _resolve_service_ref(service_ref)
+    if svc_ref is None:
+        return error_response_json("ServiceNotFoundException", "Service not found.", 400)
+    svc_name, svc_cluster_name = svc_ref
+    if svc_cluster_name is not None and svc_cluster_name != cluster_name:
+        return error_response_json("ServiceNotFoundException", "Service not found.", 400)
     svc_key = f"{cluster_name}/{svc_name}"
     svc = _services.get(svc_key)
     if not svc:
@@ -765,6 +796,9 @@ def _update_service(data):
 
     if new_td is not None:
         td_key = _resolve_td_key(new_td)
+        if new_td.startswith("arn:") and td_key is None:
+            return error_response_json("ClientException",
+                f"Unable to find task definition: {new_td}", 400)
         td_arn = _task_defs[td_key]["taskDefinitionArn"] if td_key in _task_defs else new_td
         if td_arn != svc["taskDefinition"]:
             for dep in svc["deployments"]:
@@ -810,6 +844,8 @@ def _update_service(data):
 
 def _list_services(data):
     cluster_name = _resolve_cluster_name(data.get("cluster", "default"))
+    if cluster_name is None:
+        return error_response_json("ClusterNotFoundException", "Cluster not found.", 400)
     launch_type = data.get("launchType")
     scheduling = data.get("schedulingStrategy")
     arns = []
@@ -985,6 +1021,8 @@ def _build_run_kwargs(cdef, td, env, port_bindings, ecs_network,
 
 def _run_task(data):
     cluster_name = _resolve_cluster_name(data.get("cluster", "default"))
+    if cluster_name is None:
+        return error_response_json("ClusterNotFoundException", "Cluster not found.", 400)
     if cluster_name not in _clusters:
         _create_cluster({"clusterName": cluster_name})
 
@@ -1127,6 +1165,8 @@ def _run_task(data):
 def _stop_task(data):
     task_ref = data.get("task", "")
     cluster_name = _resolve_cluster_name(data.get("cluster", "default"))
+    if cluster_name is None:
+        return error_response_json("ClusterNotFoundException", "Cluster not found.", 400)
     reason = data.get("reason", "Task stopped by user")
 
     task = _resolve_task(task_ref, cluster_name)
@@ -1170,6 +1210,8 @@ def _stop_task(data):
 
 def _describe_tasks(data):
     cluster_name = _resolve_cluster_name(data.get("cluster", "default"))
+    if cluster_name is None:
+        return error_response_json("ClusterNotFoundException", "Cluster not found.", 400)
     task_refs = data.get("tasks", [])
     include = set(data.get("include", []))
     result = []
@@ -1238,6 +1280,8 @@ def _maybe_mark_stopped(task):
 
 def _list_tasks(data):
     cluster_name = _resolve_cluster_name(data.get("cluster", "default"))
+    if cluster_name is None:
+        return error_response_json("ClusterNotFoundException", "Cluster not found.", 400)
     cluster_arn = f"arn:aws:ecs:{get_region()}:{get_account_id()}:cluster/{cluster_name}"
     status_filter = data.get("desiredStatus", "RUNNING")
     family = data.get("family", "")
@@ -1332,6 +1376,8 @@ def _list_tags_for_resource(data):
 
 def _execute_command(data):
     cluster_name = _resolve_cluster_name(data.get("cluster", "default"))
+    if cluster_name is None:
+        return error_response_json("ClusterNotFoundException", "Cluster not found.", 400)
     task_ref = data.get("task", "")
     task = _resolve_task(task_ref, cluster_name)
     if not task:
@@ -1396,6 +1442,7 @@ def _put_account_setting(data):
 
 def _describe_capacity_providers(data):
     names = data.get("capacityProviders", [])
+    resolved_names = [_resolve_capacity_provider_name(name) for name in names]
     include = data.get("include", [])
     providers = []
     defaults = [
@@ -1403,7 +1450,7 @@ def _describe_capacity_providers(data):
         {"name": "FARGATE_SPOT", "status": "ACTIVE", "autoScalingGroupProvider": {}},
     ]
     for p in defaults:
-        if not names or p["name"] in names:
+        if not names or p["name"] in resolved_names:
             cp = {
                 "capacityProviderArn": f"arn:aws:ecs:{get_region()}:{get_account_id()}:capacity-provider/{p['name']}",
                 "name": p["name"],
@@ -1416,7 +1463,7 @@ def _describe_capacity_providers(data):
             providers.append(cp)
 
     for cp_name, cp in _capacity_providers.items():
-        if not names or cp_name in names:
+        if not names or cp_name in resolved_names:
             entry = dict(cp)
             if "TAGS" in include:
                 entry["tags"] = _tags.get(cp["capacityProviderArn"], [])
@@ -1463,9 +1510,7 @@ def _create_capacity_provider(data):
 
 
 def _delete_capacity_provider(data):
-    name = data.get("capacityProvider", "")
-    if name.startswith("arn:"):
-        name = name.split("/")[-1]
+    name = _resolve_capacity_provider_name(data.get("capacityProvider", ""))
 
     cp = _capacity_providers.pop(name, None)
     if not cp:
@@ -1526,24 +1571,45 @@ def _resolve_cluster_name(ref):
     if not ref:
         return "default"
     if ref.startswith("arn:"):
-        return ref.split("/")[-1]
+        return _ecs_single_resource_tail(ref, "cluster")
     if "/" in ref:
         return ref.split("/")[-1]
     return ref
 
 
-def _resolve_service_name(ref):
+def _resolve_service_ref(ref):
+    if not ref:
+        return "", None
     if ref.startswith("arn:"):
-        return ref.split("/")[-1]
+        service_tail = _ecs_resource_tail(ref, "service")
+        if service_tail is None:
+            return None
+        parts = service_tail.split("/")
+        if len(parts) == 1:
+            service_name = parts[0]
+            service_cluster_name = None
+        elif len(parts) == 2:
+            service_cluster_name, service_name = parts
+            if not service_cluster_name:
+                return None
+        else:
+            return None
+        if not service_name:
+            return None
+        return service_name, service_cluster_name
     if "/" in ref:
-        return ref.split("/")[-1]
-    return ref
+        return None
+    return ref, None
 
 
 def _resolve_td_key(ref):
     if not ref:
         return ""
-    if "task-definition/" in ref:
+    if ref.startswith("arn:"):
+        ref = _ecs_single_resource_tail(ref, "task-definition")
+        if ref is None:
+            return None
+    elif "task-definition/" in ref:
         ref = ref.split("task-definition/")[-1]
     if ":" not in ref:
         rev = _task_def_latest.get(ref)
@@ -1553,19 +1619,44 @@ def _resolve_td_key(ref):
     return ref
 
 
+def _resolve_td_delete_key(ref):
+    if not ref:
+        return ""
+    if ref.startswith("arn:"):
+        ref = _ecs_single_resource_tail(ref, "task-definition")
+        if ref is None:
+            return None
+    elif "task-definition/" in ref:
+        ref = ref.split("task-definition/")[-1]
+    if ":" not in ref:
+        return None
+    return ref
+
+
 def _resolve_task(ref, cluster_name="default"):
     """Look up a task by full ARN or short ID, optionally scoped to a cluster."""
-    task = _tasks.get(ref)
-    if task:
-        return task
+    if cluster_name is None:
+        return None
+    is_arn = ref.startswith("arn:")
+    task_ref = _resolve_task_ref(ref)
+    if task_ref is None:
+        return None
+    task_id, arn_cluster_name = task_ref
+    if arn_cluster_name is not None and arn_cluster_name != cluster_name:
+        return None
     cluster_arn = f"arn:aws:ecs:{get_region()}:{get_account_id()}:cluster/{cluster_name}"
+    task = _tasks.get(ref)
+    if task and task.get("clusterArn") == cluster_arn:
+        return task
     for arn, t in _tasks.items():
         if t.get("clusterArn") != cluster_arn:
             continue
-        if arn.endswith(f"/{ref}") or arn.endswith(ref):
+        if arn.endswith(f"/{task_id}") or arn.endswith(task_id):
             return t
+    if is_arn:
+        return None
     for arn, t in _tasks.items():
-        if arn.endswith(f"/{ref}") or arn.endswith(ref):
+        if arn.endswith(f"/{task_id}") or arn.endswith(task_id):
             return t
     return None
 
@@ -1573,7 +1664,70 @@ def _resolve_task(ref, cluster_name="default"):
 def _cluster_name_from_arn(arn):
     if not arn:
         return ""
+    if arn.startswith("arn:"):
+        return _ecs_single_resource_tail(arn, "cluster") or ""
     return arn.split("/")[-1] if "/" in arn else arn
+
+
+def _resolve_task_ref(ref):
+    if not ref:
+        return "", None
+    if ref.startswith("arn:"):
+        task_tail = _ecs_resource_tail(ref, "task")
+        if task_tail is None:
+            return None
+        parts = task_tail.split("/")
+        if len(parts) == 1:
+            task_id = parts[0]
+            task_cluster_name = None
+        elif len(parts) == 2:
+            task_cluster_name, task_id = parts
+            if not task_cluster_name:
+                return None
+        else:
+            return None
+        if not task_id:
+            return None
+        return task_id, task_cluster_name
+    if "/" in ref:
+        return None
+    return ref, None
+
+
+def _resolve_capacity_provider_name(ref):
+    if not ref:
+        return ""
+    if ref.startswith("arn:"):
+        return _ecs_single_resource_tail(ref, "capacity-provider")
+    if "/" in ref:
+        return None
+    return ref
+
+
+def _ecs_resource_tail(ref, resource_type):
+    try:
+        spec = parse_arn(ref)
+    except ArnParseError:
+        return None
+    if (
+        spec.partition != "aws"
+        or spec.service != "ecs"
+        or spec.region != get_region()
+        or spec.account_id != get_account_id()
+    ):
+        return None
+    prefix = f"{resource_type}/"
+    if not spec.resource.startswith(prefix):
+        return None
+    tail = spec.resource[len(prefix):]
+    return tail or None
+
+
+def _ecs_single_resource_tail(ref, resource_type):
+    tail = _ecs_resource_tail(ref, resource_type)
+    if tail is None or "/" in tail:
+        return None
+    return tail
 
 
 def _sanitize(obj):
@@ -1606,13 +1760,15 @@ def _list_task_definition_families(data):
 def _delete_task_definitions(data):
     arns = data.get("taskDefinitions", [])
     failures = []
+    task_definitions = []
     for arn in arns:
-        key = arn.split("/")[-1] if "/" in arn else arn
+        key = _resolve_td_delete_key(arn)
         if key in _task_defs:
             _task_defs[key]["status"] = "DELETE_IN_PROGRESS"
+            task_definitions.append(_task_defs[key])
         else:
             failures.append({"arn": arn, "reason": "TASK_DEFINITION_NOT_FOUND"})
-    return json_response({"taskDefinitions": [_task_defs.get(a.split("/")[-1], {}) for a in arns if a.split("/")[-1] in _task_defs], "failures": failures})
+    return json_response({"taskDefinitions": task_definitions, "failures": failures})
 
 
 # ---------------------------------------------------------------------------
@@ -1693,7 +1849,7 @@ def _list_attributes(data):
 # ---------------------------------------------------------------------------
 
 def _update_capacity_provider(data):
-    name = data.get("name", "")
+    name = _resolve_capacity_provider_name(data.get("name", ""))
     cp = _capacity_providers.get(name)
     if not cp:
         return error_response_json("ClientException", f"Capacity provider {name} not found", 400)

--- a/tests/test_ecs.py
+++ b/tests/test_ecs.py
@@ -9,6 +9,22 @@ from urllib.parse import urlparse
 import pytest
 from botocore.exceptions import ClientError
 
+from ministack.services import ecs as ecs_service
+
+
+def _replace_arn_section(arn, index, value):
+    parts = arn.split(":", 5)
+    parts[index] = value
+    return ":".join(parts)
+
+
+def _different_region(region):
+    return "us-west-2" if region != "us-west-2" else "us-east-1"
+
+
+def _replace_arn_region(arn):
+    return _replace_arn_section(arn, 3, _different_region(arn.split(":", 5)[3]))
+
 
 def test_ecs_cluster(ecs):
     ecs.create_cluster(clusterName="test-cluster")
@@ -363,6 +379,277 @@ def test_ecs_capacity_provider(ecs):
     desc = ecs.describe_capacity_providers(capacityProviders=["test-cp"])
     assert any(cp["name"] == "test-cp" for cp in desc["capacityProviders"])
     ecs.delete_capacity_provider(capacityProvider="test-cp")
+
+
+def test_ecs_cluster_arn_parser_does_not_tail_resolve_invalid_arns(ecs):
+    resp = ecs.create_cluster(clusterName="ecs-arn-cluster")
+    cluster_arn = resp["cluster"]["clusterArn"]
+    valid = ecs.describe_clusters(clusters=[cluster_arn])
+    assert valid["clusters"][0]["clusterName"] == "ecs-arn-cluster"
+
+    wrong_service = _replace_arn_section(cluster_arn, 2, "lambda")
+    wrong_partition = _replace_arn_section(cluster_arn, 1, "aws-cn")
+    wrong_region = _replace_arn_region(cluster_arn)
+    wrong_account = _replace_arn_section(cluster_arn, 4, "111111111111")
+    wrong_resource = cluster_arn.replace(":cluster/", ":service/")
+    malformed_resource = f"{cluster_arn}/extra"
+    malformed = "arn:aws:ecs:us-east-1"
+
+    for ref in [wrong_service, wrong_partition, wrong_region, wrong_account, wrong_resource, malformed_resource, malformed]:
+        resp = ecs.describe_clusters(clusters=[ref])
+        assert resp["clusters"] == []
+        assert resp["failures"] == [{"arn": ref, "reason": "MISSING"}]
+
+
+def test_ecs_service_arn_parser_does_not_tail_resolve_invalid_arns(ecs):
+    cluster = "ecs-arn-service-cluster"
+    cluster_arn = ecs.create_cluster(clusterName=cluster)["cluster"]["clusterArn"]
+    ecs.register_task_definition(
+        family="ecs-arn-service-td",
+        containerDefinitions=[{"name": "app", "image": "nginx", "cpu": 64, "memory": 128}],
+    )
+    created = ecs.create_service(
+        cluster=cluster,
+        serviceName="ecs-arn-service",
+        taskDefinition="ecs-arn-service-td",
+        desiredCount=0,
+    )
+    service_arn = created["service"]["serviceArn"]
+    valid = ecs.describe_services(cluster=cluster, services=[service_arn])
+    assert valid["services"][0]["serviceName"] == "ecs-arn-service"
+    ecs.create_service(
+        cluster=cluster,
+        serviceName="None",
+        taskDefinition="ecs-arn-service-td",
+        desiredCount=0,
+    )
+    ecs.create_cluster(clusterName="None")
+    ecs.create_service(
+        cluster="None",
+        serviceName="ecs-arn-service",
+        taskDefinition="ecs-arn-service-td",
+        desiredCount=0,
+    )
+    other_cluster = "ecs-arn-other-service-cluster"
+    ecs.create_cluster(clusterName=other_cluster)
+    other_service = ecs.create_service(
+        cluster=other_cluster,
+        serviceName="ecs-arn-service",
+        taskDefinition="ecs-arn-service-td",
+        desiredCount=0,
+    )["service"]
+
+    wrong_service = _replace_arn_section(service_arn, 2, "lambda")
+    wrong_partition = _replace_arn_section(service_arn, 1, "aws-cn")
+    wrong_region = _replace_arn_region(service_arn)
+    wrong_account = _replace_arn_section(service_arn, 4, "111111111111")
+    wrong_resource = service_arn.replace(":service/", ":cluster/")
+    wrong_cluster_service = other_service["serviceArn"]
+    malformed_resource = service_arn.replace(f":service/{cluster}/", f":service/extra/{cluster}/")
+    malformed = "arn:aws:ecs:us-east-1"
+
+    for ref in [
+        wrong_service,
+        wrong_partition,
+        wrong_region,
+        wrong_account,
+        wrong_resource,
+        wrong_cluster_service,
+        malformed_resource,
+        malformed,
+    ]:
+        resp = ecs.describe_services(cluster=cluster, services=[ref])
+        assert resp["services"] == []
+        assert resp["failures"] == [{"arn": ref, "reason": "MISSING"}]
+
+    wrong_cluster = _replace_arn_region(cluster_arn)
+    with pytest.raises(ClientError) as exc:
+        ecs.describe_services(cluster=wrong_cluster, services=["ecs-arn-service"])
+    assert exc.value.response["Error"]["Code"] == "ClusterNotFoundException"
+
+    with pytest.raises(ClientError) as exc:
+        ecs.update_service(cluster=cluster, service=wrong_service, desiredCount=1)
+    assert exc.value.response["Error"]["Code"] == "ServiceNotFoundException"
+    none_service = ecs.describe_services(cluster=cluster, services=["None"])
+    assert none_service["services"][0]["desiredCount"] == 0
+
+    with pytest.raises(ClientError) as exc:
+        ecs.delete_service(cluster=cluster, service=wrong_service, force=True)
+    assert exc.value.response["Error"]["Code"] == "ServiceNotFoundException"
+    none_service = ecs.describe_services(cluster=cluster, services=["None"])
+    assert none_service["services"][0]["status"] == "ACTIVE"
+
+    with pytest.raises(ClientError) as exc:
+        ecs.update_service(cluster=cluster, service=wrong_cluster_service, desiredCount=1)
+    assert exc.value.response["Error"]["Code"] == "ServiceNotFoundException"
+    service = ecs.describe_services(cluster=cluster, services=["ecs-arn-service"])
+    assert service["services"][0]["desiredCount"] == 0
+
+    with pytest.raises(ClientError) as exc:
+        ecs.delete_service(cluster=cluster, service=wrong_cluster_service, force=True)
+    assert exc.value.response["Error"]["Code"] == "ServiceNotFoundException"
+    service = ecs.describe_services(cluster=cluster, services=["ecs-arn-service"])
+    assert service["services"][0]["status"] == "ACTIVE"
+
+
+def test_ecs_task_definition_arn_parser_does_not_tail_resolve_invalid_arns(ecs):
+    resp = ecs.register_task_definition(
+        family="ecs-arn-td",
+        containerDefinitions=[{"name": "app", "image": "nginx", "cpu": 64, "memory": 128}],
+    )
+    task_definition_arn = resp["taskDefinition"]["taskDefinitionArn"]
+    valid = ecs.describe_task_definition(taskDefinition=task_definition_arn)
+    assert valid["taskDefinition"]["family"] == "ecs-arn-td"
+
+    wrong_service = _replace_arn_section(task_definition_arn, 2, "lambda")
+    wrong_partition = _replace_arn_section(task_definition_arn, 1, "aws-cn")
+    wrong_region = _replace_arn_region(task_definition_arn)
+    wrong_account = _replace_arn_section(task_definition_arn, 4, "111111111111")
+    wrong_resource = task_definition_arn.replace(":task-definition/", ":cluster/")
+    malformed_resource = f"{task_definition_arn}/extra"
+    malformed = "arn:aws:ecs:us-east-1"
+
+    for ref in [wrong_service, wrong_partition, wrong_region, wrong_account, wrong_resource, malformed_resource, malformed]:
+        with pytest.raises(ClientError) as exc:
+            ecs.describe_task_definition(taskDefinition=ref)
+        assert exc.value.response["Error"]["Code"] == "ClientException"
+
+    delete_resp = ecs.delete_task_definitions(taskDefinitions=[wrong_service])
+    assert delete_resp["taskDefinitions"] == []
+    assert delete_resp["failures"] == [
+        {"arn": wrong_service, "reason": "TASK_DEFINITION_NOT_FOUND"},
+    ]
+    delete_resp = ecs.delete_task_definitions(taskDefinitions=["ecs-arn-td"])
+    assert delete_resp["taskDefinitions"] == []
+    assert delete_resp["failures"] == [
+        {"arn": "ecs-arn-td", "reason": "TASK_DEFINITION_NOT_FOUND"},
+    ]
+    valid = ecs.describe_task_definition(taskDefinition=task_definition_arn)
+    assert valid["taskDefinition"]["status"] == "ACTIVE"
+
+    cluster = "ecs-arn-td-service-cluster"
+    ecs.create_cluster(clusterName=cluster)
+    with pytest.raises(ClientError) as exc:
+        ecs.create_service(
+            cluster=cluster,
+            serviceName="ecs-arn-invalid-td-service",
+            taskDefinition=wrong_region,
+            desiredCount=0,
+        )
+    assert exc.value.response["Error"]["Code"] == "ClientException"
+
+    created = ecs.create_service(
+        cluster=cluster,
+        serviceName="ecs-arn-valid-td-service",
+        taskDefinition=task_definition_arn,
+        desiredCount=0,
+    )
+    assert created["service"]["taskDefinition"] == task_definition_arn
+    with pytest.raises(ClientError) as exc:
+        ecs.update_service(
+            cluster=cluster,
+            service="ecs-arn-valid-td-service",
+            taskDefinition=wrong_region,
+        )
+    assert exc.value.response["Error"]["Code"] == "ClientException"
+    described = ecs.describe_services(cluster=cluster, services=["ecs-arn-valid-td-service"])
+    assert described["services"][0]["taskDefinition"] == task_definition_arn
+
+
+def test_ecs_task_arn_parser_does_not_tail_resolve_invalid_arns():
+    cluster_name = "ecs-arn-task-cluster"
+    region = ecs_service.get_region()
+    account_id = ecs_service.get_account_id()
+    task_id = str(_uuid_mod.uuid4())
+    cluster_arn = f"arn:aws:ecs:{region}:{account_id}:cluster/{cluster_name}"
+    task_arn = f"arn:aws:ecs:{region}:{account_id}:task/{cluster_name}/{task_id}"
+    task = {"taskArn": task_arn, "clusterArn": cluster_arn}
+    foreign_region = _different_region(region)
+    foreign_region_task_arn = f"arn:aws:ecs:{foreign_region}:{account_id}:task/{cluster_name}/{task_id}"
+    foreign_region_task = {
+        "taskArn": foreign_region_task_arn,
+        "clusterArn": f"arn:aws:ecs:{foreign_region}:{account_id}:cluster/{cluster_name}",
+    }
+
+    ecs_service._clusters[cluster_name] = {"clusterArn": cluster_arn, "status": "ACTIVE"}
+    ecs_service._tasks[task_arn] = task
+    ecs_service._tasks[foreign_region_task_arn] = foreign_region_task
+    try:
+        assert ecs_service._resolve_task(task_arn, cluster_name) == task
+        assert ecs_service._resolve_task(task_id, cluster_name) == task
+
+        wrong_service = _replace_arn_section(task_arn, 2, "lambda")
+        wrong_partition = _replace_arn_section(task_arn, 1, "aws-cn")
+        wrong_region = _replace_arn_region(task_arn)
+        wrong_account = _replace_arn_section(task_arn, 4, "111111111111")
+        wrong_resource = task_arn.replace(":task/", ":service/")
+        wrong_cluster = f"arn:aws:ecs:{region}:{account_id}:task/other-cluster/{task_id}"
+        slash_ref = f"other-cluster/{task_id}"
+        empty_task_id = f"arn:aws:ecs:{region}:{account_id}:task/{cluster_name}/"
+        malformed = "arn:aws:ecs:us-east-1"
+
+        for ref in [
+            wrong_service,
+            wrong_partition,
+            wrong_region,
+            wrong_account,
+            wrong_resource,
+            wrong_cluster,
+            slash_ref,
+            empty_task_id,
+            malformed,
+            foreign_region_task_arn,
+        ]:
+            assert ecs_service._resolve_task(ref, cluster_name) is None
+    finally:
+        ecs_service._tasks.pop(task_arn, None)
+        ecs_service._tasks.pop(foreign_region_task_arn, None)
+        ecs_service._clusters.pop(cluster_name, None)
+
+
+def test_ecs_capacity_provider_arn_parser_does_not_tail_resolve_invalid_arns(ecs):
+    resp = ecs.create_capacity_provider(
+        name="ecs-arn-cp",
+        autoScalingGroupProvider={
+            "autoScalingGroupArn": "arn:aws:autoscaling:us-east-1:000000000000:autoScalingGroup:xxx:autoScalingGroupName/asg-1",
+        },
+    )
+    capacity_provider_arn = resp["capacityProvider"]["capacityProviderArn"]
+    valid = ecs.describe_capacity_providers(capacityProviders=[capacity_provider_arn])
+    assert valid["capacityProviders"][0]["name"] == "ecs-arn-cp"
+
+    wrong_service = _replace_arn_section(capacity_provider_arn, 2, "lambda")
+    wrong_partition = _replace_arn_section(capacity_provider_arn, 1, "aws-cn")
+    wrong_region = _replace_arn_region(capacity_provider_arn)
+    wrong_account = _replace_arn_section(capacity_provider_arn, 4, "111111111111")
+    wrong_resource = capacity_provider_arn.replace(":capacity-provider/", ":cluster/")
+    malformed_resource = f"{capacity_provider_arn}/extra"
+    slash_ref = "bogus/ecs-arn-cp"
+    malformed = "arn:aws:ecs:us-east-1"
+
+    for ref in [
+        wrong_service,
+        wrong_partition,
+        wrong_region,
+        wrong_account,
+        wrong_resource,
+        malformed_resource,
+        slash_ref,
+        malformed,
+    ]:
+        resp = ecs.describe_capacity_providers(capacityProviders=[ref])
+        assert resp["capacityProviders"] == []
+
+    with pytest.raises(ClientError) as exc:
+        ecs.delete_capacity_provider(capacityProvider=wrong_service)
+    assert exc.value.response["Error"]["Code"] == "InvalidParameterException"
+    with pytest.raises(ClientError) as exc:
+        ecs.delete_capacity_provider(capacityProvider=slash_ref)
+    assert exc.value.response["Error"]["Code"] == "InvalidParameterException"
+    valid = ecs.describe_capacity_providers(capacityProviders=["ecs-arn-cp"])
+    assert valid["capacityProviders"][0]["name"] == "ecs-arn-cp"
+    ecs.delete_capacity_provider(capacityProvider="ecs-arn-cp")
+
 
 def test_ecs_update_cluster(ecs):
     ecs.create_cluster(clusterName="upd-cl")


### PR DESCRIPTION
## Summary

- add parser-backed ECS ARN resolution for clusters, services, task definitions, tasks, and capacity providers
- reject malformed, wrong-service, wrong-partition, wrong-account, wrong-region, wrong-resource, wrong-cluster, and over-deep ECS ARN tails instead of tail-matching local resources
- preserve service/task ARN cluster qualifier checks and task definition revision behavior
- add focused ECS regression coverage for invalid ARN no-fallback behavior

## Validation

- `uv run --extra dev ruff check ministack/services/ecs.py tests/test_ecs.py`
- `uv run --extra dev pytest tests/test_ecs.py::test_ecs_task_arn_parser_does_not_tail_resolve_invalid_arns -q`
  - `1 passed`
- `MINISTACK_ENDPOINT=http://localhost:14610 uv run --extra dev pytest tests/test_ecs.py -q -k "arn_parser"`
  - `5 passed, 30 deselected`