### PR TITLE
Adopt ARN parsing for Cognito Identity tags

### DIFF
--- a/ministack/services/cognito.py
+++ b/ministack/services/cognito.py
@@ -68,6 +68,7 @@ from xml.etree.ElementTree import tostring as xml_tostring
 
 from defusedxml.ElementTree import fromstring as safe_xml_parse
 
+from ministack.core.arn import ArnParseError, parse_arn
 from ministack.core.persistence import PERSIST_STATE, load_state
 from ministack.core.responses import (
     AccountScopedDict,
@@ -384,6 +385,28 @@ def _identity_pool_id() -> str:
 
 def _identity_id(pool_id: str) -> str:
     return f"{get_region()}:{new_uuid()}"
+
+
+class _InvalidCognitoIdentityArn(ValueError):
+    pass
+
+
+def _identity_pool_id_from_arn(resource_arn: str) -> str | None:
+    try:
+        spec = parse_arn(resource_arn)
+    except ArnParseError as exc:
+        raise _InvalidCognitoIdentityArn("Invalid Cognito Identity resource ARN.") from exc
+    if spec.service != "cognito-identity":
+        raise _InvalidCognitoIdentityArn("Invalid Cognito Identity resource ARN.")
+    if spec.region != get_region() or spec.account_id != get_account_id():
+        return None
+    prefix = "identitypool/"
+    if not spec.resource.startswith(prefix):
+        raise _InvalidCognitoIdentityArn("Invalid Cognito Identity resource ARN.")
+    pool_id = spec.resource[len(prefix):]
+    if not pool_id:
+        raise _InvalidCognitoIdentityArn("Invalid Cognito Identity resource ARN.")
+    return pool_id
 
 
 def _fake_token(sub: str, pool_id: str, client_id: str, token_type: str = "access",
@@ -4608,8 +4631,12 @@ def _unlink_identity(data):
 def _identity_tag_resource(data):
     arn = data.get("ResourceArn", "")
     tags = data.get("Tags", {})
-    # ARN format: arn:aws:cognito-identity:region:account:identitypool/id
-    iid = arn.split("/")[-1] if "/" in arn else arn
+    try:
+        iid = _identity_pool_id_from_arn(arn)
+    except _InvalidCognitoIdentityArn as exc:
+        return error_response_json("InvalidParameterException", str(exc), 400)
+    if not iid or iid not in _identity_pools:
+        return error_response_json("ResourceNotFoundException", f"Resource {arn} not found.", 400)
     _identity_tags.setdefault(iid, {}).update(tags)
     return json_response({})
 
@@ -4617,7 +4644,12 @@ def _identity_tag_resource(data):
 def _identity_untag_resource(data):
     arn = data.get("ResourceArn", "")
     tag_keys = data.get("TagKeys", [])
-    iid = arn.split("/")[-1] if "/" in arn else arn
+    try:
+        iid = _identity_pool_id_from_arn(arn)
+    except _InvalidCognitoIdentityArn as exc:
+        return error_response_json("InvalidParameterException", str(exc), 400)
+    if not iid or iid not in _identity_pools:
+        return error_response_json("ResourceNotFoundException", f"Resource {arn} not found.", 400)
     for k in tag_keys:
         _identity_tags.get(iid, {}).pop(k, None)
     return json_response({})
@@ -4625,7 +4657,12 @@ def _identity_untag_resource(data):
 
 def _identity_list_tags_for_resource(data):
     arn = data.get("ResourceArn", "")
-    iid = arn.split("/")[-1] if "/" in arn else arn
+    try:
+        iid = _identity_pool_id_from_arn(arn)
+    except _InvalidCognitoIdentityArn as exc:
+        return error_response_json("InvalidParameterException", str(exc), 400)
+    if not iid or iid not in _identity_pools:
+        return error_response_json("ResourceNotFoundException", f"Resource {arn} not found.", 400)
     return json_response({"Tags": _identity_tags.get(iid, {})})
 
 

--- a/tests/test_cognito.py
+++ b/tests/test_cognito.py
@@ -21,6 +21,11 @@ from ministack.core import persistence
 
 # ========== from test_cognito.py ==========
 
+
+def _identity_pool_arn(identity_pool_id, region="us-east-1", account="000000000000"):
+    return f"arn:aws:cognito-identity:{region}:{account}:identitypool/{identity_pool_id}"
+
+
 def test_cognito_create_and_describe_user_pool(cognito_idp):
     resp = cognito_idp.create_user_pool(PoolName="TestPool")
     pool = resp["UserPool"]
@@ -409,6 +414,56 @@ def test_cognito_identity_pool_crud(cognito_identity):
     cognito_identity.delete_identity_pool(IdentityPoolId=iid)
     pools2 = cognito_identity.list_identity_pools(MaxResults=60)["IdentityPools"]
     assert not any(p["IdentityPoolId"] == iid for p in pools2)
+
+
+def test_cognito_identity_pool_tags(cognito_identity):
+    resp = cognito_identity.create_identity_pool(
+        IdentityPoolName="IdentityTagPool",
+        AllowUnauthenticatedIdentities=True,
+    )
+    arn = _identity_pool_arn(resp["IdentityPoolId"])
+
+    cognito_identity.tag_resource(ResourceArn=arn, Tags={"project": "ministack"})
+    tags = cognito_identity.list_tags_for_resource(ResourceArn=arn)["Tags"]
+    assert tags["project"] == "ministack"
+
+    cognito_identity.untag_resource(ResourceArn=arn, TagKeys=["project"])
+    tags = cognito_identity.list_tags_for_resource(ResourceArn=arn)["Tags"]
+    assert "project" not in tags
+
+
+def test_cognito_identity_pool_tag_apis_reject_invalid_arns(cognito_identity):
+    iid = cognito_identity.create_identity_pool(
+        IdentityPoolName="IdentityInvalidArnTagPool",
+        AllowUnauthenticatedIdentities=True,
+    )["IdentityPoolId"]
+    valid_arn = _identity_pool_arn(iid)
+    invalid_cases = [
+        ("not-an-arn-but-long-enough", "InvalidParameterException"),
+        ("arn:aws:cognito-identity:us-east-1", "InvalidParameterException"),
+        (f"arn:aws:cognito-idp:us-east-1:000000000000:identitypool/{iid}", "InvalidParameterException"),
+        (f"arn:aws:cognito-identity:us-east-1:000000000000:identity/{iid}", "InvalidParameterException"),
+        (_identity_pool_arn(iid, region="us-west-2"), "ResourceNotFoundException"),
+        (_identity_pool_arn(iid, account="111111111111"), "ResourceNotFoundException"),
+    ]
+
+    for bad_arn, expected_code in invalid_cases:
+        with pytest.raises(ClientError) as exc:
+            cognito_identity.tag_resource(ResourceArn=bad_arn, Tags={"bad": "value"})
+        assert exc.value.response["Error"]["Code"] == expected_code
+
+    assert cognito_identity.list_tags_for_resource(ResourceArn=valid_arn)["Tags"] == {}
+
+
+def test_cognito_identity_pool_list_and_untag_reject_invalid_arns(cognito_identity):
+    for operation, kwargs in [
+        (cognito_identity.list_tags_for_resource, {}),
+        (cognito_identity.untag_resource, {"TagKeys": ["missing"]}),
+    ]:
+        with pytest.raises(ClientError) as exc:
+            operation(ResourceArn="arn:aws:sqs:us-east-1:000000000000:identitypool/not-a-pool", **kwargs)
+        assert exc.value.response["Error"]["Code"] == "InvalidParameterException"
+
 
 def test_cognito_get_id_and_credentials(cognito_identity):
     resp = cognito_identity.create_identity_pool(


### PR DESCRIPTION
## Summary

- add parser-backed Cognito Identity pool ARN handling for tag, untag, and list-tags operations
- reject malformed, wrong-service, and wrong-resource Cognito Identity ARNs instead of deriving a pool id with string splitting
- return not-found behavior for valid but wrong-account or wrong-region identity pool ARNs
- add focused Cognito Identity tag API coverage

## Validation

- `uv run --extra dev ruff check ministack/services/cognito.py tests/test_cognito.py`
- source-backed MiniStack on `GATEWAY_PORT=14612`
- focused new tests
  - `3 passed`
- broader Cognito Identity subset
  - `11 passed, 117 deselected`