### PR TITLE
Resolve CloudFormation Lambda refs with ARN parser

### DIFF
--- a/ministack/services/cloudformation/provisioners.py
+++ b/ministack/services/cloudformation/provisioners.py
@@ -1002,19 +1002,38 @@ def _kinesis_stream_delete(physical_id, props):
 
 # --- Lambda Permission ---
 
+def _lambda_function_for_cfn_ref(function_ref: str) -> tuple[dict | None, str, str, str | None]:
+    if isinstance(function_ref, str) and function_ref.startswith("arn:"):
+        name, qualifier = _lambda_svc._resolve_request_scoped_name_and_qualifier(function_ref)
+        if name == function_ref:
+            return None, function_ref, function_ref, None
+        func = _lambda_svc._functions.get(name)
+        if not _lambda_svc._function_qualifier_exists(func, qualifier):
+            return None, function_ref, function_ref, qualifier
+    else:
+        name, qualifier = _lambda_svc._resolve_name_and_qualifier(function_ref)
+        func = _lambda_svc._functions.get(name)
+        if func is not None and not _lambda_svc._function_qualifier_exists(func, qualifier):
+            return None, function_ref, function_ref, qualifier
+
+    if func is None:
+        return None, function_ref, function_ref, qualifier
+
+    resource_arn = func["config"]["FunctionArn"]
+    if qualifier:
+        resource_arn = f"{resource_arn}:{qualifier}"
+    return func, name, resource_arn, qualifier
+
+
 def _lambda_permission_create(logical_id, props, stack_name):
-    func_name = props.get("FunctionName", "")
-    # Resolve ARN to function name
-    if func_name.startswith("arn:"):
-        func_name = func_name.rsplit(":", 1)[-1]
-    func = _lambda_svc._functions.get(func_name)
+    func, _func_name, resource_arn, _qualifier = _lambda_function_for_cfn_ref(props.get("FunctionName", ""))
     if func:
         stmt = {
             "Sid": props.get("Id") or logical_id,
             "Effect": "Allow",
             "Principal": props.get("Principal", "*"),
             "Action": props.get("Action", "lambda:InvokeFunction"),
-            "Resource": func["config"]["FunctionArn"],
+            "Resource": resource_arn,
         }
         source_arn = props.get("SourceArn")
         if source_arn:
@@ -1025,10 +1044,7 @@ def _lambda_permission_create(logical_id, props, stack_name):
 
 
 def _lambda_permission_delete(physical_id, props):
-    func_name = props.get("FunctionName", "")
-    if func_name.startswith("arn:"):
-        func_name = func_name.rsplit(":", 1)[-1]
-    func = _lambda_svc._functions.get(func_name)
+    func, _func_name, _resource_arn, _qualifier = _lambda_function_for_cfn_ref(props.get("FunctionName", ""))
     if func:
         sid = props.get("Id") or ""
         func["policy"]["Statement"] = [
@@ -1039,10 +1055,7 @@ def _lambda_permission_delete(physical_id, props):
 # --- Lambda Version ---
 
 def _lambda_version_create(logical_id, props, stack_name):
-    func_name = props.get("FunctionName", "")
-    if func_name.startswith("arn:"):
-        func_name = func_name.rsplit(":", 1)[-1]
-    func = _lambda_svc._functions.get(func_name)
+    func, func_name, _resource_arn, _qualifier = _lambda_function_for_cfn_ref(props.get("FunctionName", ""))
     if func:
         import copy
         ver_num = func["next_version"]
@@ -1612,18 +1625,16 @@ def _apigw_account_delete(physical_id, props):
 # --- Lambda EventSourceMapping ---
 
 def _lambda_esm_create(logical_id, props, stack_name):
-    func_name = props.get("FunctionName", "")
-    if func_name.startswith("arn:"):
-        func_name = func_name.rsplit(":", 1)[-1]
+    func, func_name, resource_arn, qualifier = _lambda_function_for_cfn_ref(props.get("FunctionName", ""))
     esm_id = new_uuid()
-    func = _lambda_svc._functions.get(func_name)
-    func_arn = func["config"]["FunctionArn"] if func else f"arn:aws:lambda:{get_region()}:{get_account_id()}:function:{func_name}"
+    func_arn = resource_arn if func else f"arn:aws:lambda:{get_region()}:{get_account_id()}:function:{func_name}"
 
     esm = {
         "UUID": esm_id,
         "EventSourceArn": props.get("EventSourceArn", ""),
         "FunctionArn": func_arn,
         "FunctionName": func_name,
+        "Qualifier": qualifier,
         "State": "Enabled",
         "StateTransitionReason": "USER_INITIATED",
         "BatchSize": int(props.get("BatchSize", 10)),
@@ -1674,13 +1685,10 @@ def _pipes_pipe_delete(physical_id, props):
 # --- Lambda Alias ---
 
 def _lambda_alias_create(logical_id, props, stack_name):
-    func_name = props.get("FunctionName", "")
-    if func_name.startswith("arn:"):
-        func_name = func_name.rsplit(":", 1)[-1]
+    func, func_name, _resource_arn, _qualifier = _lambda_function_for_cfn_ref(props.get("FunctionName", ""))
     alias_name = props.get("Name", "")
     func_version = props.get("FunctionVersion", "$LATEST")
 
-    func = _lambda_svc._functions.get(func_name)
     if func:
         alias = {
             "AliasArn": f"arn:aws:lambda:{get_region()}:{get_account_id()}:function:{func_name}:{alias_name}",
@@ -1700,11 +1708,8 @@ def _lambda_alias_create(logical_id, props, stack_name):
 
 
 def _lambda_alias_delete(physical_id, props):
-    func_name = props.get("FunctionName", "")
-    if func_name.startswith("arn:"):
-        func_name = func_name.rsplit(":", 1)[-1]
+    func, _func_name, _resource_arn, _qualifier = _lambda_function_for_cfn_ref(props.get("FunctionName", ""))
     alias_name = props.get("Name", "")
-    func = _lambda_svc._functions.get(func_name)
     if func:
         func["aliases"].pop(alias_name, None)
 

--- a/tests/test_cfn.py
+++ b/tests/test_cfn.py
@@ -944,6 +944,60 @@ def test_cfn_lambda_permission(cfn, lam):
     _wait_stack(cfn, "cfn-lambda-perm")
     lam.delete_function(FunctionName="cfn-perm-fn")
 
+
+def test_cfn_lambda_permission_qualified_arn_uses_base_function_policy(cfn, lam):
+    """Qualified FunctionName refs should add permission to the base function policy."""
+    suffix = _uuid_mod.uuid4().hex[:8]
+    fn = f"cfn-perm-qualified-{suffix}"
+    stack_name = f"cfn-lambda-perm-qualified-{suffix}"
+    code = "def handler(e,c): return {}"
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("index.py", code)
+    lam.create_function(
+        FunctionName=fn,
+        Runtime="python3.11",
+        Role="arn:aws:iam::000000000000:role/r",
+        Handler="index.handler",
+        Code={"ZipFile": buf.getvalue()},
+    )
+    version = lam.publish_version(FunctionName=fn)["Version"]
+    alias_arn = lam.create_alias(FunctionName=fn, Name="live", FunctionVersion=version)["AliasArn"]
+    template = {
+        "AWSTemplateFormatVersion": "2010-09-09",
+        "Resources": {
+            "Perm": {
+                "Type": "AWS::Lambda::Permission",
+                "Properties": {
+                    "FunctionName": alias_arn,
+                    "Action": "lambda:InvokeFunction",
+                    "Principal": "s3.amazonaws.com",
+                    "SourceArn": "arn:aws:s3:::my-bucket",
+                },
+            },
+        },
+    }
+    try:
+        cfn.create_stack(StackName=stack_name, TemplateBody=json.dumps(template))
+        stack = _wait_stack(cfn, stack_name)
+        assert stack["StackStatus"] == "CREATE_COMPLETE"
+
+        policy = json.loads(lam.get_policy(FunctionName=fn)["Policy"])
+        statements = policy["Statement"]
+        assert len(statements) == 1
+        assert statements[0]["Resource"] == alias_arn
+    finally:
+        try:
+            cfn.delete_stack(StackName=stack_name)
+            _wait_stack(cfn, stack_name)
+        except Exception:
+            pass
+        try:
+            lam.delete_function(FunctionName=fn)
+        except Exception:
+            pass
+
+
 def test_cfn_lambda_version(cfn, lam):
     """AWS::Lambda::Version creates a published version."""
     code = "def handler(e,c): return {'v': 1}"
@@ -974,6 +1028,239 @@ def test_cfn_lambda_version(cfn, lam):
     cfn.delete_stack(StackName="cfn-lambda-ver")
     _wait_stack(cfn, "cfn-lambda-ver")
     lam.delete_function(FunctionName="cfn-ver-fn")
+
+
+def test_cfn_lambda_alias_and_esm_keep_function_name(cfn, lam):
+    """Lambda Alias and ESM provisioners need function names, not permission resource ARNs."""
+    suffix = _uuid_mod.uuid4().hex[:8]
+    fn = f"cfn-alias-esm-{suffix}"
+    stack_name = f"cfn-alias-esm-{suffix}"
+    code = "def handler(e,c): return {}"
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("index.py", code)
+    lam.create_function(
+        FunctionName=fn,
+        Runtime="python3.11",
+        Role="arn:aws:iam::000000000000:role/r",
+        Handler="index.handler",
+        Code={"ZipFile": buf.getvalue()},
+    )
+    template = {
+        "AWSTemplateFormatVersion": "2010-09-09",
+        "Resources": {
+            "Alias": {
+                "Type": "AWS::Lambda::Alias",
+                "Properties": {"FunctionName": fn, "Name": "live", "FunctionVersion": "$LATEST"},
+            },
+            "Esm": {
+                "Type": "AWS::Lambda::EventSourceMapping",
+                "Properties": {
+                    "FunctionName": fn,
+                    "EventSourceArn": f"arn:aws:sqs:us-east-1:000000000000:source-{suffix}",
+                },
+            },
+        },
+    }
+    try:
+        cfn.create_stack(StackName=stack_name, TemplateBody=json.dumps(template))
+        stack = _wait_stack(cfn, stack_name)
+        assert stack["StackStatus"] == "CREATE_COMPLETE", stack.get("StackStatusReason")
+
+        aliases = lam.list_aliases(FunctionName=fn)["Aliases"]
+        assert aliases[0]["AliasArn"].endswith(f":function:{fn}:live")
+
+        mappings = lam.list_event_source_mappings(FunctionName=fn)["EventSourceMappings"]
+        assert len(mappings) == 1
+        assert mappings[0]["FunctionArn"].endswith(f":function:{fn}")
+    finally:
+        try:
+            cfn.delete_stack(StackName=stack_name)
+            _wait_stack(cfn, stack_name)
+        except Exception:
+            pass
+        try:
+            lam.delete_function(FunctionName=fn)
+        except Exception:
+            pass
+
+
+def test_cfn_lambda_esm_preserves_qualified_function_ref(cfn, lam):
+    suffix = _uuid_mod.uuid4().hex[:8]
+    fn = f"cfn-esm-qualified-{suffix}"
+    stack_name = f"cfn-esm-qualified-{suffix}"
+    code = "def handler(e,c): return {}"
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("index.py", code)
+    lam.create_function(
+        FunctionName=fn,
+        Runtime="python3.11",
+        Role="arn:aws:iam::000000000000:role/r",
+        Handler="index.handler",
+        Code={"ZipFile": buf.getvalue()},
+    )
+    version = lam.publish_version(FunctionName=fn)["Version"]
+    lam.create_alias(FunctionName=fn, Name="live", FunctionVersion=version)
+    template = {
+        "AWSTemplateFormatVersion": "2010-09-09",
+        "Resources": {
+            "Esm": {
+                "Type": "AWS::Lambda::EventSourceMapping",
+                "Properties": {
+                    "FunctionName": f"{fn}:live",
+                    "EventSourceArn": f"arn:aws:sqs:us-east-1:000000000000:source-{suffix}",
+                    "BatchSize": 1,
+                },
+            },
+        },
+    }
+    try:
+        cfn.create_stack(StackName=stack_name, TemplateBody=json.dumps(template))
+        stack = _wait_stack(cfn, stack_name)
+        assert stack["StackStatus"] == "CREATE_COMPLETE", stack.get("StackStatusReason")
+
+        mappings = lam.list_event_source_mappings(FunctionName=fn)["EventSourceMappings"]
+        assert len(mappings) == 1
+        assert mappings[0]["FunctionArn"].endswith(f":function:{fn}:live")
+    finally:
+        try:
+            cfn.delete_stack(StackName=stack_name)
+            _wait_stack(cfn, stack_name)
+        except Exception:
+            pass
+        try:
+            lam.delete_function(FunctionName=fn)
+        except Exception:
+            pass
+
+
+def test_cfn_lambda_provisioners_do_not_tail_resolve_wrong_service_arns(cfn, lam):
+    """Lambda CFN provisioners must not map a non-Lambda ARN tail to a local function."""
+    suffix = _uuid_mod.uuid4().hex[:8]
+    fn = f"cfn-lambda-arn-guard-{suffix}"
+    code = "def handler(e,c): return {}"
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("index.py", code)
+    lam.create_function(
+        FunctionName=fn,
+        Runtime="python3.11",
+        Role="arn:aws:iam::000000000000:role/r",
+        Handler="index.handler",
+        Code={"ZipFile": buf.getvalue()},
+    )
+    wrong_ref = f"arn:aws:sqs:us-east-1:000000000000:function:{fn}"
+    stack_name = f"cfn-lambda-arn-guard-{suffix}"
+    template = {
+        "AWSTemplateFormatVersion": "2010-09-09",
+        "Resources": {
+            "Perm": {
+                "Type": "AWS::Lambda::Permission",
+                "Properties": {
+                    "FunctionName": wrong_ref,
+                    "Action": "lambda:InvokeFunction",
+                    "Principal": "s3.amazonaws.com",
+                    "SourceArn": "arn:aws:s3:::my-bucket",
+                },
+            },
+            "Ver": {
+                "Type": "AWS::Lambda::Version",
+                "Properties": {"FunctionName": wrong_ref},
+            },
+            "Alias": {
+                "Type": "AWS::Lambda::Alias",
+                "Properties": {"FunctionName": wrong_ref, "Name": "live", "FunctionVersion": "1"},
+            },
+            "Esm": {
+                "Type": "AWS::Lambda::EventSourceMapping",
+                "Properties": {
+                    "FunctionName": wrong_ref,
+                    "EventSourceArn": f"arn:aws:sqs:us-east-1:000000000000:source-{suffix}",
+                },
+            },
+        },
+    }
+    try:
+        cfn.create_stack(StackName=stack_name, TemplateBody=json.dumps(template))
+        stack = _wait_stack(cfn, stack_name)
+        assert stack["StackStatus"] == "CREATE_COMPLETE", stack.get("StackStatusReason")
+
+        policy = json.loads(lam.get_policy(FunctionName=fn)["Policy"])
+        assert policy["Statement"] == []
+
+        versions = lam.list_versions_by_function(FunctionName=fn)["Versions"]
+        assert [v["Version"] for v in versions] == ["$LATEST"]
+
+        assert lam.list_aliases(FunctionName=fn)["Aliases"] == []
+        assert lam.list_event_source_mappings(FunctionName=fn)["EventSourceMappings"] == []
+    finally:
+        try:
+            cfn.delete_stack(StackName=stack_name)
+            _wait_stack(cfn, stack_name)
+        except Exception:
+            pass
+        lam.delete_function(FunctionName=fn)
+
+
+def test_cfn_lambda_provisioners_reject_missing_bare_qualifier(cfn, lam):
+    suffix = _uuid_mod.uuid4().hex[:8]
+    fn = f"cfn-lambda-missing-qual-{suffix}"
+    code = "def handler(e,c): return {}"
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("index.py", code)
+    lam.create_function(
+        FunctionName=fn,
+        Runtime="python3.11",
+        Role="arn:aws:iam::000000000000:role/r",
+        Handler="index.handler",
+        Code={"ZipFile": buf.getvalue()},
+    )
+    missing_ref = f"{fn}:missing"
+    stack_name = f"cfn-lambda-missing-qual-{suffix}"
+    template = {
+        "AWSTemplateFormatVersion": "2010-09-09",
+        "Resources": {
+            "Perm": {
+                "Type": "AWS::Lambda::Permission",
+                "Properties": {
+                    "FunctionName": missing_ref,
+                    "Action": "lambda:InvokeFunction",
+                    "Principal": "s3.amazonaws.com",
+                    "SourceArn": "arn:aws:s3:::my-bucket",
+                },
+            },
+            "Alias": {
+                "Type": "AWS::Lambda::Alias",
+                "Properties": {"FunctionName": missing_ref, "Name": "live", "FunctionVersion": "1"},
+            },
+            "Esm": {
+                "Type": "AWS::Lambda::EventSourceMapping",
+                "Properties": {
+                    "FunctionName": missing_ref,
+                    "EventSourceArn": f"arn:aws:sqs:us-east-1:000000000000:source-{suffix}",
+                },
+            },
+        },
+    }
+    try:
+        cfn.create_stack(StackName=stack_name, TemplateBody=json.dumps(template))
+        stack = _wait_stack(cfn, stack_name)
+        assert stack["StackStatus"] == "CREATE_COMPLETE", stack.get("StackStatusReason")
+
+        policy = json.loads(lam.get_policy(FunctionName=fn)["Policy"])
+        assert policy["Statement"] == []
+        assert lam.list_aliases(FunctionName=fn)["Aliases"] == []
+        assert lam.list_event_source_mappings(FunctionName=fn)["EventSourceMappings"] == []
+    finally:
+        try:
+            cfn.delete_stack(StackName=stack_name)
+            _wait_stack(cfn, stack_name)
+        except Exception:
+            pass
+        lam.delete_function(FunctionName=fn)
+
 
 def test_cfn_wait_condition(cfn):
     """AWS::CloudFormation::WaitCondition and WaitConditionHandle are no-ops."""


### PR DESCRIPTION
## Summary
- Add a CloudFormation Lambda reference resolver that uses the Lambda service helpers for full ARNs, qualified names, and bare refs.
- Apply the resolver to Lambda Permission, Version, EventSourceMapping, and Alias provisioners.
- Add coverage for qualified refs, wrong-service ARN rejection, and missing bare qualifier rejection.

## Validation
- Source-backed MiniStack: `tests/test_cfn.py::test_cfn_lambda_permission`, `tests/test_cfn.py::test_cfn_lambda_permission_qualified_arn_uses_base_function_policy`, `tests/test_cfn.py::test_cfn_lambda_version`, `tests/test_cfn.py::test_cfn_lambda_alias_and_esm_keep_function_name`, `tests/test_cfn.py::test_cfn_lambda_esm_preserves_qualified_function_ref`, `tests/test_cfn.py::test_cfn_lambda_provisioners_do_not_tail_resolve_wrong_service_arns`, and `tests/test_cfn.py::test_cfn_lambda_provisioners_reject_missing_bare_qualifier`
- `git diff --check`