### PR TITLE
Use ARN parser for IoT thing principals

### DIFF
--- a/ministack/services/iot.py
+++ b/ministack/services/iot.py
@@ -40,6 +40,7 @@ import uuid
 from datetime import datetime, timezone
 from typing import Awaitable, Callable
 
+from ministack.core.arn import ArnParseError, parse_arn
 from ministack.core.persistence import load_state
 from ministack.core.responses import (
     AccountScopedDict,
@@ -217,6 +218,25 @@ def _now_epoch() -> float:
 
 def _thing_arn(name: str) -> str:
     return f"arn:aws:iot:{get_region()}:{get_account_id()}:thing/{name}"
+
+
+def _thing_name_from_arn(arn: str) -> str:
+    try:
+        spec = parse_arn(arn)
+    except ArnParseError:
+        return ""
+    prefix = "thing/"
+    if (
+        spec.service != "iot"
+        or spec.account_id != get_account_id()
+        or spec.region != get_region()
+        or not spec.resource.startswith(prefix)
+    ):
+        return ""
+    name = spec.resource[len(prefix):]
+    if not name or "/" in name:
+        return ""
+    return name
 
 
 def _thing_type_arn(name: str) -> str:
@@ -1024,7 +1044,7 @@ def _list_principal_things(headers: dict, qp: dict) -> tuple:
         return _error_not_found("Principal", principal)
     things = []
     for arn in cert.get("attachedThings", []):
-        tname = arn.rsplit("/", 1)[-1]
+        tname = _thing_name_from_arn(arn)
         if tname in _things:
             things.append(tname)
     return json_response({"things": things})

--- a/tests/test_iot.py
+++ b/tests/test_iot.py
@@ -292,6 +292,37 @@ def test_iot_attach_detach_thing_principal(iot_client):
     iot_client.delete_thing(thingName=name)
 
 
+def test_iot_thing_arn_tail_parser_requires_iot_thing_scope():
+    from ministack.core.responses import (
+        get_account_id,
+        get_region,
+        set_request_account_id,
+        set_request_region,
+    )
+    from ministack.services import iot as _iot
+
+    original_account = get_account_id()
+    original_region = get_region()
+    try:
+        set_request_account_id("000000000000")
+        set_request_region("us-east-1")
+        assert _iot._thing_name_from_arn(
+            "arn:aws:iot:us-east-1:000000000000:thing/parser-thing"
+        ) == "parser-thing"
+        assert _iot._thing_name_from_arn(
+            "arn:aws:sqs:us-east-1:000000000000:thing/parser-thing"
+        ) == ""
+        assert _iot._thing_name_from_arn(
+            "arn:aws:iot:us-west-2:000000000000:thing/parser-thing"
+        ) == ""
+        assert _iot._thing_name_from_arn(
+            "arn:aws:iot:us-east-1:000000000000:thing/parser-thing/extra"
+        ) == ""
+    finally:
+        set_request_account_id(original_account)
+        set_request_region(original_region)
+
+
 # ---------------------------------------------------------------------------
 # Policies
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Use the shared ARN parser when resolving IoT thing names from attached principal ARNs.
- Require IoT thing ARNs to match the current account, region, and `thing/<name>` shape before returning names.
- Add regression coverage for rejecting out-of-scope or malformed thing ARNs.

## Validation
- `uv run --extra dev pytest -q tests/test_iot.py::test_iot_thing_arn_tail_parser_requires_iot_thing_scope`
- Source-backed MiniStack: `tests/test_iot.py::test_iot_attach_detach_thing_principal` and `tests/test_iot.py::test_iot_thing_arn_tail_parser_requires_iot_thing_scope`
- `git diff --check`