### PR TITLE
Use ARN parser for ELBv2 resource tails

### DIFF
--- a/ministack/services/alb.py
+++ b/ministack/services/alb.py
@@ -118,6 +118,31 @@ def _parse_tags(params):
     return tags
 
 
+def _elbv2_resource_tail(arn: str, prefix: str) -> str:
+    """Return a stored ELBv2 ARN tail for ID generation, or empty string."""
+    try:
+        spec = parse_arn(arn)
+    except ArnParseError:
+        return ""
+    if spec.service != "elasticloadbalancing" or not spec.resource.startswith(prefix):
+        return ""
+    return spec.resource[len(prefix):]
+
+
+def _load_balancer_id_from_arn(arn: str) -> str:
+    tail = _elbv2_resource_tail(arn, "loadbalancer/")
+    return tail.rpartition("/")[2] if tail else ""
+
+
+def _listener_id_from_arn(arn: str) -> str:
+    tail = _elbv2_resource_tail(arn, "listener/")
+    return tail.rpartition("/")[2] if tail else ""
+
+
+def _target_group_full_name_from_arn(arn: str) -> str:
+    return _elbv2_resource_tail(arn, "targetgroup/")
+
+
 def _parse_actions(params, prefix="DefaultActions"):
     actions, i = [], 1
     while True:
@@ -574,7 +599,7 @@ def _create_listener(params):
     lid = _short_id()
     lb = _lbs[lb_arn]
     lb_name = lb["LoadBalancerName"]
-    lb_id = lb_arn.split("/")[-1]
+    lb_id = _load_balancer_id_from_arn(lb_arn)
     l_arn = (f"arn:aws:elasticloadbalancing:{get_region()}:{get_account_id()}"
              f":listener/app/{lb_name}/{lb_id}/{lid}")
     actions = _parse_actions(params, "DefaultActions")
@@ -689,8 +714,8 @@ def _create_rule(params):
     listener = _listeners[l_arn]
     lb_arn = listener["LoadBalancerArn"]
     lb_name = _lbs[lb_arn]["LoadBalancerName"]
-    lb_id = lb_arn.split("/")[-1]
-    l_id = l_arn.split("/")[-1]
+    lb_id = _load_balancer_id_from_arn(lb_arn)
+    l_id = _listener_id_from_arn(l_arn)
     rule_id = _short_id()
     rule_arn = (f"arn:aws:elasticloadbalancing:{get_region()}:{get_account_id()}"
                 f":listener-rule/app/{lb_name}/{lb_id}/{l_id}/{rule_id}")

--- a/ministack/services/cloudformation/provisioners.py
+++ b/ministack/services/cloudformation/provisioners.py
@@ -2645,7 +2645,7 @@ def _elbv2_listener_create(logical_id, props, stack_name):
 
     listener_id = _alb._short_id()
     lb_name = lb["LoadBalancerName"]
-    lb_id = lb_arn.split("/")[-1]
+    lb_id = _alb._load_balancer_id_from_arn(lb_arn)
     listener_arn = (
         f"arn:aws:elasticloadbalancing:{get_region()}:{get_account_id()}:"
         f"listener/app/{lb_name}/{lb_id}/{listener_id}"
@@ -2939,7 +2939,11 @@ def _elbv2_target_group_create(logical_id, props, stack_name):
         {"Key": "stickiness.enabled", "Value": "false"},
         {"Key": "stickiness.type", "Value": "lb_cookie"},
     ]
-    return arn, {"TargetGroupArn": arn, "TargetGroupName": name, "TargetGroupFullName": arn.split(":targetgroup/", 1)[-1]}
+    return arn, {
+        "TargetGroupArn": arn,
+        "TargetGroupName": name,
+        "TargetGroupFullName": _alb._target_group_full_name_from_arn(arn),
+    }
 
 
 def _elbv2_target_group_delete(physical_id, props):
@@ -2990,8 +2994,8 @@ def _elbv2_listener_rule_create(logical_id, props, stack_name):
     listener = _alb._listeners[l_arn]
     lb_arn = listener["LoadBalancerArn"]
     lb_name = _alb._lbs[lb_arn]["LoadBalancerName"]
-    lb_id = lb_arn.split("/")[-1]
-    l_id = l_arn.split("/")[-1]
+    lb_id = _alb._load_balancer_id_from_arn(lb_arn)
+    l_id = _alb._listener_id_from_arn(l_arn)
     import random as _random
     import string as _string
     rule_id = "".join(_random.choices(_string.ascii_lowercase + _string.digits, k=16))

--- a/tests/test_alb.py
+++ b/tests/test_alb.py
@@ -12,6 +12,27 @@ from botocore.exceptions import ClientError
 _endpoint = os.environ.get("MINISTACK_ENDPOINT", "http://localhost:4566")
 _EXECUTE_PORT = urlparse(_endpoint).port or 4566
 
+
+def test_elbv2_arn_tail_helpers_require_elbv2_resource_scope():
+    from ministack.services import alb
+
+    assert alb._load_balancer_id_from_arn(
+        "arn:aws:elasticloadbalancing:us-east-1:000000000000:loadbalancer/app/my-lb/lb-id"
+    ) == "lb-id"
+    assert alb._listener_id_from_arn(
+        "arn:aws:elasticloadbalancing:us-east-1:000000000000:listener/app/my-lb/lb-id/listener-id"
+    ) == "listener-id"
+    assert alb._target_group_full_name_from_arn(
+        "arn:aws:elasticloadbalancing:us-east-1:000000000000:targetgroup/my-tg/tg-id"
+    ) == "my-tg/tg-id"
+    assert alb._load_balancer_id_from_arn(
+        "arn:aws:sqs:us-east-1:000000000000:loadbalancer/app/my-lb/lb-id"
+    ) == ""
+    assert alb._listener_id_from_arn(
+        "arn:aws:elasticloadbalancing:us-east-1:000000000000:targetgroup/my-tg/tg-id"
+    ) == ""
+
+
 def test_elbv2_create_describe_delete_lb(elbv2):
     resp = elbv2.create_load_balancer(Name="qa-alb", Type="application", Scheme="internet-facing")
     lb = resp["LoadBalancers"][0]


### PR DESCRIPTION
## Summary
- Add parser-backed helpers for ELBv2 load balancer, listener, and target group ARN resource tails.
- Use the helpers in ALB listener/rule creation and CloudFormation ELBv2 provisioners.
- Add coverage for rejecting out-of-scope ELBv2 ARN resources.

## Validation
- `uv run --extra dev ruff check ministack/services/alb.py ministack/services/cloudformation/provisioners.py tests/test_alb.py`
- `uv run --extra dev pytest -q tests/test_alb.py::test_elbv2_arn_tail_helpers_require_elbv2_resource_scope`
- Source-backed MiniStack: `tests/test_alb.py::test_elbv2_listener_crud`, `tests/test_alb.py::test_elbv2_rule_crud`, and `tests/test_cfn.py::test_cfn_elbv2_load_balancer_and_listener`
- `git diff --check`