### PR TITLE
fix(cognito): derive issuer host from environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -710,6 +710,7 @@ end-to-end without any client config.
 | `MINISTACK_SSL_CERT` | _(unset)_ | Optional PEM-encoded server certificate path; required together with `MINISTACK_SSL_KEY`. When unset, MiniStack auto-generates a self-signed cert under `${TMPDIR}/ministack-tls/` (cached across restarts) |
 | `MINISTACK_SSL_KEY` | _(unset)_ | Optional PEM-encoded private key path; required together with `MINISTACK_SSL_CERT` |
 | `MINISTACK_IMDS_V2_REQUIRED` | `0` | Reject token-less GETs on `/latest/meta-data/...`. When set, callers must first `PUT /latest/api/token` and pass the token as `X-aws-ec2-metadata-token`, matching real-AWS hop-limit-1 IMDSv2-only instances |
+| `MINISTACK_COGNITO_ISSUER_BASE_URL` | _(unset)_ | Override the base URL used in Cognito User Pool JWT tokens' `iss` claim and JWKS fetches. If not set and the `MINISTACK_HOST` is set, the base URL is derived from the host and pool ID, otherwise defaults to `https://cognito-idp.{region}.amazonaws.com/{pool_id}` |
 
 ### API Gateway HTTP proxy execution model
 

--- a/ministack/app.py
+++ b/ministack/app.py
@@ -631,9 +631,8 @@ async def _handle_cognito_get_request(method: str, path: str, headers: dict, que
             if pool_id:
                 cognito = _get_module("cognito")
                 if cognito._get_pool_unscoped(pool_id) is not None:
-                    region = extract_region(headers) or "us-east-1"
                     host = headers.get("host") or headers.get("Host")
-                    return cognito.well_known_openid_configuration(pool_id, region, host)
+                    return cognito.well_known_openid_configuration(pool_id, host)
 
     if path == "/oauth2/authorize" and method == "GET":
         return _get_module("cognito").handle_oauth2_authorize(method, path, headers, query_params)

--- a/ministack/services/cognito.py
+++ b/ministack/services/cognito.py
@@ -173,7 +173,7 @@ def well_known_openid_configuration(pool_id: str, host: str | None = None):
     # from the pool's region (encoded in pool_id), so do the same here. The
     # `region` argument from the request scope is only used as a last-resort
     # fallback for malformed pool_ids.
-    issuer = _get_issuer_base_url(pool_id)
+    issuer = _get_issuer_url(pool_id)
     base = f"http://{host}" if host else f"http://{_MINISTACK_HOST}:{_MINISTACK_PORT}"
     pool_base = f"{base}/{pool_id}"
     doc = {
@@ -369,8 +369,8 @@ def _pool_region(pool_id: str) -> str:
     return get_region()
 
 
-def _get_issuer_base_url(pool_id: str) -> str:
-    """Return the issuer host for a pool, derived from environment variables or the pool's region."""
+def _get_issuer_url(pool_id: str) -> str:
+    """Return the issuer host for a pool, derived from environment variables and pool_id."""
     if issuer_env := os.getenv("MINISTACK_COGNITO_ISSUER_BASE_URL"):
         return f"{issuer_env}/{pool_id}"
 
@@ -416,7 +416,7 @@ def _fake_token(sub: str, pool_id: str, client_id: str, token_type: str = "acces
     origin_jti = new_uuid()
     claims = {
         "sub": sub,
-        "iss": _get_issuer_base_url(pool_id),
+        "iss": _get_issuer_url(pool_id),
         "token_use": token_type,
         "iat": now,
         "exp": now + 3600,

--- a/ministack/services/cognito.py
+++ b/ministack/services/cognito.py
@@ -159,7 +159,7 @@ def well_known_jwks(pool_id: str):
     return 200, {"Content-Type": "application/json"}, json.dumps({"keys": [_JWKS_KEY]}).encode()
 
 
-def well_known_openid_configuration(pool_id: str, region: str | None = None, host: str | None = None):
+def well_known_openid_configuration(pool_id: str, host: str | None = None):
     """Return OpenID Connect discovery document.
 
     `issuer` matches the JWT `iss` claim (real AWS URL) so OIDC clients that
@@ -173,8 +173,7 @@ def well_known_openid_configuration(pool_id: str, region: str | None = None, hos
     # from the pool's region (encoded in pool_id), so do the same here. The
     # `region` argument from the request scope is only used as a last-resort
     # fallback for malformed pool_ids.
-    r = _pool_region(pool_id) if pool_id else (region or get_region())
-    issuer = f"https://cognito-idp.{r}.amazonaws.com/{pool_id}"
+    issuer = _get_issuer_base_url(pool_id)
     base = f"http://{host}" if host else f"http://{_MINISTACK_HOST}:{_MINISTACK_PORT}"
     pool_base = f"{base}/{pool_id}"
     doc = {
@@ -370,14 +369,14 @@ def _pool_region(pool_id: str) -> str:
     return get_region()
 
 
-def _get_issuer_host(pool_id: str) -> str:
-    """Return the issuer host for a pool, derived from environment variables or pool region."""
-    if issuer_env := os.getenv("MINISTACK_COGNITO_ISSUER_HOST"):
-        return issuer_env
+def _get_issuer_base_url(pool_id: str) -> str:
+    """Return the issuer host for a pool, derived from environment variables or the pool's region."""
+    if issuer_env := os.getenv("MINISTACK_COGNITO_ISSUER_BASE_URL"):
+        return f"{issuer_env}/{pool_id}"
 
     if host_env := os.getenv("MINISTACK_HOST"):
         if not host_env.startswith("http://") and not host_env.startswith("https://"):
-            host_env = f"http://{host_env}"
+            host_env = f"http://{host_env}/{pool_id}"
         return host_env
 
     return f"https://cognito-idp.{_pool_region(pool_id)}.amazonaws.com/{pool_id}"
@@ -417,7 +416,7 @@ def _fake_token(sub: str, pool_id: str, client_id: str, token_type: str = "acces
     origin_jti = new_uuid()
     claims = {
         "sub": sub,
-        "iss": _get_issuer_host(pool_id),
+        "iss": _get_issuer_base_url(pool_id),
         "token_use": token_type,
         "iat": now,
         "exp": now + 3600,

--- a/ministack/services/cognito.py
+++ b/ministack/services/cognito.py
@@ -370,6 +370,19 @@ def _pool_region(pool_id: str) -> str:
     return get_region()
 
 
+def _get_issuer_host(pool_id: str) -> str:
+    """Return the issuer host for a pool, derived from environment variables or pool region."""
+    if issuer_env := os.getenv("MINISTACK_COGNITO_ISSUER_HOST"):
+        return issuer_env
+
+    if host_env := os.getenv("MINISTACK_HOST"):
+        if not host_env.startswith("http://") and not host_env.startswith("https://"):
+            host_env = f"http://{host_env}"
+        return host_env
+
+    return f"https://cognito-idp.{_pool_region(pool_id)}.amazonaws.com/{pool_id}"
+
+
 def _client_id() -> str:
     return "".join(secrets.choice(string.digits + string.ascii_letters) for _ in range(26))
 
@@ -404,7 +417,7 @@ def _fake_token(sub: str, pool_id: str, client_id: str, token_type: str = "acces
     origin_jti = new_uuid()
     claims = {
         "sub": sub,
-        "iss": f"https://cognito-idp.{_pool_region(pool_id)}.amazonaws.com/{pool_id}",
+        "iss": _get_issuer_host(pool_id),
         "token_use": token_type,
         "iat": now,
         "exp": now + 3600,

--- a/tests/test_cognito.py
+++ b/tests/test_cognito.py
@@ -3154,7 +3154,7 @@ def test_cognito_openid_discovery_issuer_uses_pool_region():
     pool_id = "eu-central-1_abcdef123"
     # Even if the request scope says us-east-1, discovery must return eu-central-1
     # because that's what the JWT iss will encode.
-    _status, _headers, body = mod.well_known_openid_configuration(pool_id, region="us-east-1", host="localhost:4566")
+    _status, _headers, body = mod.well_known_openid_configuration(pool_id, host="localhost:4566")
     doc = json.loads(body)
     assert doc["issuer"] == f"https://cognito-idp.eu-central-1.amazonaws.com/{pool_id}", doc["issuer"]
 


### PR DESCRIPTION
## Problem

The JWT generator hardcodes the `iss` (issuer) claim to `amazonaws.com`. When local backends validate tokens against a local endpoint (e.g., aws.local), verification fails with an Invalid issuer error because the token claim doesn't match the local authority URI.


## Solution

Dynamically determine the issuer host using a flexible fallback hierarchy:

1. `MINISTACK_COGNITO_ISSUER_BASE_URL`: Explicit override (e.g., `http://aws.local:4566`).
2. `MINISTACK_HOST`: Smart default. Automatically prepends `http://` if a URI scheme is missing to ensure spec compliance.
3. AWS Default: Fallback to `https://cognito-idp.{region}.amazonaws.com` if neither variable is set.