### PR TITLE
Parse Lambda event source mapping tag ARNs by request scope

### DIFF
--- a/ministack/services/lambda_svc.py
+++ b/ministack/services/lambda_svc.py
@@ -4276,9 +4276,21 @@ def _get_policy(
 
 def _esm_id_from_arn(resource_arn: str) -> str | None:
     """Return the ESM UUID if the ARN points to an event-source-mapping, else None."""
-    if ":event-source-mapping:" in resource_arn:
-        return resource_arn.rsplit(":", 1)[-1]
-    return None
+    try:
+        spec = parse_arn(resource_arn)
+    except ArnParseError:
+        return None
+    if (
+        spec.service != "lambda"
+        or spec.account_id != get_account_id()
+        or spec.region != get_region()
+    ):
+        return None
+    prefix = "event-source-mapping:"
+    if not spec.resource.startswith(prefix):
+        return None
+    esm_id = spec.resource[len(prefix):]
+    return esm_id or None
 
 
 def _list_tags(resource_arn: str):

--- a/tests/test_lambda.py
+++ b/tests/test_lambda.py
@@ -2033,6 +2033,15 @@ def test_lambda_event_source_mapping_tags(lam, sqs):
     assert "Env" not in tags
     assert tags["Team"] == "platform"
 
+    wrong_region = esm_arn.replace(":us-east-1:", ":us-west-2:")
+    wrong_account = esm_arn.replace(":000000000000:", ":111111111111:")
+    wrong_service = esm_arn.replace(":lambda:", ":sns:")
+    wrong_resource = esm_arn.replace(":event-source-mapping:", ":function:")
+    for bad_ref in (wrong_region, wrong_account, wrong_service, wrong_resource):
+        with pytest.raises(ClientError) as exc:
+            lam.list_tags(Resource=bad_ref)
+        assert exc.value.response["Error"]["Code"] == "ResourceNotFoundException"
+
     lam.delete_event_source_mapping(UUID=esm["UUID"])
     lam.delete_function(FunctionName=fn)
     sqs.delete_queue(QueueUrl=q["QueueUrl"])


### PR DESCRIPTION
## Summary
- parse Lambda event-source-mapping tag ARNs with the shared ARN parser
- require the ARN to match the current account and Region before resolving the ESM UUID
- add coverage that wrong-scope ESM ARNs do not fall back to local mappings

## Tests
- `uv run --extra dev pytest tests/test_lambda.py -q` (`234 passed, 1 skipped`)
