### PR TITLE
Parse CloudWatch Logs group identifier ARNs by request scope

### DIFF
--- a/ministack/services/cloudwatch_logs.py
+++ b/ministack/services/cloudwatch_logs.py
@@ -170,6 +170,26 @@ def _resolve_group_by_arn(arn):
     return None
 
 
+def _log_group_name_from_identifier_arn(identifier: str) -> str | None:
+    try:
+        spec = parse_arn(identifier)
+    except ArnParseError:
+        return None
+    if (
+        spec.service != "logs"
+        or spec.account_id != get_account_id()
+        or spec.region != get_region()
+    ):
+        return None
+    prefix = "log-group:"
+    if not spec.resource.startswith(prefix):
+        return None
+    name = spec.resource[len(prefix):]
+    if name.endswith(":*"):
+        name = name[:-2]
+    return name or None
+
+
 def _decode_token(token):
     """Decode a pagination token to an integer offset."""
     if not token:
@@ -481,11 +501,7 @@ def _resolve_log_group_name(data):
     if not ident:
         return None
     if ident.startswith("arn:"):
-        # arn:aws:logs:<region>:<account>:log-group:<name>[:*]
-        parts = ident.split(":log-group:", 1)
-        if len(parts) == 2:
-            tail = parts[1]
-            return tail[:-2] if tail.endswith(":*") else tail
+        return _log_group_name_from_identifier_arn(ident) or ident
     return ident
 
 

--- a/tests/test_cloudwatch_logs.py
+++ b/tests/test_cloudwatch_logs.py
@@ -64,6 +64,27 @@ def test_logs_get_log_events_by_identifier_arn(logs):
     assert len(resp2["events"]) == 1
 
 
+def test_logs_identifier_arn_scope_does_not_fallback_to_local_group(logs):
+    group = f"/cwl/ident-arn-scope-{_uuid_mod.uuid4().hex[:8]}"
+    logs.create_log_group(logGroupName=group)
+    logs.create_log_stream(logGroupName=group, logStreamName="s1")
+    logs.put_log_events(
+        logGroupName=group,
+        logStreamName="s1",
+        logEvents=[{"timestamp": int(time.time() * 1000), "message": "hi"}],
+    )
+
+    arn = f"arn:aws:logs:us-east-1:000000000000:log-group:{group}:*"
+    wrong_region = arn.replace(":us-east-1:", ":us-west-2:")
+    wrong_account = arn.replace(":000000000000:", ":111111111111:")
+    wrong_service = arn.replace(":logs:", ":lambda:")
+    wrong_resource = arn.replace(":log-group:", ":delivery:")
+    for bad_ref in (wrong_region, wrong_account, wrong_service, wrong_resource):
+        with pytest.raises(ClientError) as exc:
+            logs.get_log_events(logGroupIdentifier=bad_ref, logStreamName="s1")
+        assert exc.value.response["Error"]["Code"] == "ResourceNotFoundException"
+
+
 def test_logs_filter_log_events_by_identifier_arn(logs):
     logs.create_log_group(logGroupName="/cwl/ident-arn-flt")
     logs.create_log_stream(logGroupName="/cwl/ident-arn-flt", logStreamName="s1")


### PR DESCRIPTION
## Summary
- add parser-backed resolution for CloudWatch Logs `logGroupIdentifier` ARNs
- require `logs` service, current account, current Region, and `log-group:` resource shape
- add coverage that wrong-scope log group ARNs do not resolve to local groups

## Tests
- `uv run --extra dev pytest tests/test_cloudwatch_logs.py -q` (`61 passed`)
