### PR TITLE
Validate DynamoDB table ARNs by request scope

### DIFF
--- a/ministack/services/dynamodb.py
+++ b/ministack/services/dynamodb.py
@@ -24,6 +24,7 @@ import time
 from collections import defaultdict
 from decimal import Decimal, InvalidOperation
 
+from ministack.core.arn import ArnParseError, parse_arn
 from ministack.core.responses import (
     AccountScopedDict,
     error_response_json,
@@ -55,6 +56,9 @@ def _conditional_check_failed(data, old_item, message="The conditional request f
     }, json.dumps(body, ensure_ascii=False).encode("utf-8")
 
 REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
+_DDB_PARTITION_RE = re.compile(r"^aws(?:-[a-z]+)*$")
+_DDB_REGION_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)+-[0-9]+$")
+_DDB_ACCOUNT_RE = re.compile(r"^[0-9]{12}$")
 
 # Real AWS reports Export/Import as IN_PROGRESS at submit time; the flip to
 # COMPLETED happens asynchronously. We simulate that by holding IN_PROGRESS
@@ -3155,9 +3159,24 @@ def _describe_endpoints(data):
 # Tag operations
 # ---------------------------------------------------------------------------
 
+def _dynamodb_arn_spec(arn: str):
+    try:
+        spec = parse_arn(arn)
+    except ArnParseError:
+        return None
+    if (
+        not _DDB_PARTITION_RE.match(spec.partition)
+        or spec.service != "dynamodb"
+        or not _DDB_REGION_RE.match(spec.region)
+        or not _DDB_ACCOUNT_RE.match(spec.account_id)
+    ):
+        return None
+    return spec
+
+
 def _validate_tag_arn(arn: str) -> tuple | None:
     """ARN must (a) look like a DynamoDB ARN, (b) reference an existing table."""
-    if not isinstance(arn, str) or not arn.startswith("arn:aws:dynamodb:"):
+    if not isinstance(arn, str) or _dynamodb_arn_spec(arn) is None:
         return error_response_json("ValidationException",
             f"1 validation error detected: Value '{arn}' at 'resourceArn' failed to satisfy constraint: Member must satisfy regular expression pattern: arn:[a-z\\-]+:dynamodb:[a-z]{{2}}-[a-z]+-[0-9]:[0-9]{{12}}:.*", 400)
     tname = _table_name_from_arn(arn)
@@ -3199,7 +3218,7 @@ def _list_tags(data):
     # ListTagsOfResource on a non-existent (but syntactically valid) ARN
     # returns AccessDeniedException on AWS — the API does not reveal whether
     # the resource exists. Syntactic validation still uses ValidationException.
-    if not isinstance(arn, str) or not arn.startswith("arn:aws:dynamodb:"):
+    if not isinstance(arn, str) or _dynamodb_arn_spec(arn) is None:
         return error_response_json("ValidationException",
             f"1 validation error detected: Value '{arn}' at 'resourceArn' failed to satisfy constraint: Member must satisfy regular expression pattern: arn:[a-z\\-]+:dynamodb:[a-z]{{2}}-[a-z]+-[0-9]:[0-9]{{12}}:.*", 400)
     tname = _table_name_from_arn(arn)
@@ -3411,13 +3430,8 @@ def _update_kinesis_streaming_destination(data):
 def _normalize_table_name(value: str) -> str:
     if not isinstance(value, str):
         return value
-    if value.startswith("arn:aws:dynamodb:"):
-        # arn:aws:dynamodb:region:account:table/<name>[/...]
-        try:
-            _, _, after = value.partition(":table/")
-            return after.split("/")[0] if after else value
-        except Exception:
-            return value
+    if value.startswith("arn:"):
+        return _table_name_from_arn(value) or value
     return value
 
 
@@ -3556,9 +3570,19 @@ def _list_contributor_insights(data):
 # Per botocore: ResourceArn must be a table or stream ARN. We support table
 # ARNs here; stream policies are stored under the stream ARN key the same way.
 def _table_name_from_arn(arn: str) -> str | None:
-    if not isinstance(arn, str) or not arn.startswith("arn:aws:dynamodb:"):
+    if not isinstance(arn, str):
         return None
-    _, _, after = arn.partition(":table/")
+    spec = _dynamodb_arn_spec(arn)
+    if (
+        spec is None
+        or spec.region != get_region()
+        or spec.account_id != get_account_id()
+    ):
+        return None
+    prefix = "table/"
+    if not spec.resource.startswith(prefix):
+        return None
+    after = spec.resource[len(prefix):]
     if not after:
         return None
     # Strip /stream/... or /index/... suffixes.

--- a/tests/test_dynamodb.py
+++ b/tests/test_dynamodb.py
@@ -6,8 +6,24 @@ import uuid as _uuid_mod
 import zipfile
 from urllib.parse import urlparse
 
+import boto3
 import pytest
+from botocore.config import Config
 from botocore.exceptions import ClientError
+
+
+_ENDPOINT = os.environ.get("MINISTACK_ENDPOINT", "http://localhost:4566")
+
+
+def _ddb_client(region_name: str):
+    return boto3.client(
+        "dynamodb",
+        endpoint_url=_ENDPOINT,
+        aws_access_key_id="test",
+        aws_secret_access_key="test",
+        region_name=region_name,
+        config=Config(region_name=region_name, retries={"mode": "standard"}),
+    )
 
 
 def _make_zip(code: str) -> bytes:
@@ -2906,6 +2922,61 @@ def test_dynamodb_resource_policy_unknown_arn(ddb):
     with pytest.raises(ClientError) as e:
         ddb.put_resource_policy(ResourceArn=fake_arn, Policy="{}")
     assert e.value.response["Error"]["Code"] == "ResourceNotFoundException"
+
+
+def test_dynamodb_table_arn_scope_does_not_fallback_to_local_table(ddb):
+    name = "arn-scope-table"
+    arn = _ci_table(ddb, name)
+    try:
+        assert ddb.describe_contributor_insights(TableName=arn)["TableName"] == name
+
+        wrong_region = arn.replace(":us-east-1:", ":us-west-2:")
+        wrong_account = arn.replace(":000000000000:", ":111111111111:")
+        for bad_ref in (wrong_region, wrong_account):
+            with pytest.raises(ClientError) as e:
+                ddb.tag_resource(ResourceArn=bad_ref, Tags=[{"Key": "env", "Value": "test"}])
+            assert e.value.response["Error"]["Code"] == "ResourceNotFoundException"
+
+            with pytest.raises(ClientError) as e:
+                ddb.list_tags_of_resource(ResourceArn=bad_ref)
+            assert e.value.response["Error"]["Code"] == "AccessDeniedException"
+
+            with pytest.raises(ClientError) as e:
+                ddb.describe_contributor_insights(TableName=bad_ref)
+            assert e.value.response["Error"]["Code"] == "ResourceNotFoundException"
+
+            with pytest.raises(ClientError) as e:
+                ddb.put_resource_policy(ResourceArn=bad_ref, Policy="{}")
+            assert e.value.response["Error"]["Code"] == "ResourceNotFoundException"
+
+            with pytest.raises(ClientError) as e:
+                ddb.export_table_to_point_in_time(TableArn=bad_ref, S3Bucket="bucket")
+            assert e.value.response["Error"]["Code"] == "TableNotFoundException"
+    finally:
+        ddb.delete_table(TableName=name)
+
+
+def test_dynamodb_table_arn_accepts_multi_segment_region():
+    ddb = _ddb_client("us-gov-west-1")
+    name = f"arn-region-{_uuid_mod.uuid4().hex[:8]}"
+    try:
+        created = ddb.create_table(
+            TableName=name,
+            KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
+            AttributeDefinitions=[{"AttributeName": "pk", "AttributeType": "S"}],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        arn = created["TableDescription"]["TableArn"]
+        assert ":us-gov-west-1:" in arn
+
+        ddb.tag_resource(ResourceArn=arn, Tags=[{"Key": "env", "Value": "test"}])
+        tags = ddb.list_tags_of_resource(ResourceArn=arn)["Tags"]
+        assert {"Key": "env", "Value": "test"} in tags
+    finally:
+        try:
+            ddb.delete_table(TableName=name)
+        except Exception:
+            pass
 
 
 def test_dynamodb_export_table_to_point_in_time(ddb):


### PR DESCRIPTION
## Summary
- add parser-backed DynamoDB table ARN resolution for tag, policy, Contributor Insights, and export paths
- require request-scoped account and Region before resolving a table name from an ARN
- preserve valid multi-segment Region handling for generated DynamoDB ARNs

## Tests
- `uv run --extra dev pytest tests/test_dynamodb.py -q` (`254 passed`)
