### PR TITLE
feat(glue): add BatchUpdatePartition support

### DIFF
--- a/ministack/services/glue.py
+++ b/ministack/services/glue.py
@@ -185,6 +185,7 @@ async def handle_request(method, path, headers, body, query_params):
         "GetPartitions": _get_partitions,
         "BatchCreatePartition": _batch_create_partition,
         "BatchGetPartition": _batch_get_partition,
+        "BatchUpdatePartition": _batch_update_partition,
         # Partition Indexes
         "CreatePartitionIndex": _create_partition_index,
         "GetPartitionIndexes": _get_partition_indexes,
@@ -532,6 +533,41 @@ def _batch_get_partition(data):
         else:
             unprocessed.append(entry)
     return json_response({"Partitions": partitions, "UnprocessedKeys": unprocessed})
+
+
+def _batch_update_partition(data):
+    db_name = data.get("DatabaseName")
+    table_name = data.get("TableName")
+    key = f"{db_name}/{table_name}"
+    if key not in _tables:
+        return error_response_json("EntityNotFoundException",
+            f"Table {table_name} not found in {db_name}", 400)
+    parts = _partitions.get(key, [])
+    errors = []
+    for entry in data.get("Entries", []):
+        values = entry.get("PartitionValueList", [])
+        partition_input = entry.get("PartitionInput", {})
+        target = None
+        for p in parts:
+            if p.get("Values") == values:
+                target = p
+                break
+        if target is None:
+            errors.append({"PartitionValueList": values, "ErrorDetail": {
+                "ErrorCode": "EntityNotFoundException",
+                "ErrorMessage": "Partition not found"}})
+            continue
+        creation_time = target.get("CreationTime")
+        target.clear()
+        target.update({
+            **partition_input,
+            "DatabaseName": db_name,
+            "TableName": table_name,
+            "CreationTime": creation_time,
+            "LastAccessTime": int(time.time()),
+            "CatalogId": get_account_id(),
+        })
+    return json_response({"Errors": errors})
 
 
 # ---- Partition Indexes ----

--- a/tests/test_glue.py
+++ b/tests/test_glue.py
@@ -603,6 +603,114 @@ def test_glue_batch_create_partition(glue):
 
 
 # ---------------------------------------------------------------------------
+# BatchUpdatePartition
+# ---------------------------------------------------------------------------
+
+def test_glue_batch_update_partition(glue):
+    db = "qa-bup-db"
+    tbl = "qa-bup-tbl"
+    glue.create_database(DatabaseInput={"Name": db})
+    glue.create_table(
+        DatabaseName=db,
+        TableInput={
+            "Name": tbl,
+            "StorageDescriptor": {
+                "Columns": [],
+                "Location": "s3://b/k",
+                "InputFormat": "",
+                "OutputFormat": "",
+                "SerdeInfo": {},
+            },
+            "PartitionKeys": [{"Name": "dt", "Type": "string"}],
+        },
+    )
+    glue.batch_create_partition(
+        DatabaseName=db,
+        TableName=tbl,
+        PartitionInputList=[
+            {
+                "Values": ["2024-05"],
+                "StorageDescriptor": {
+                    "Columns": [],
+                    "Location": "s3://b/k/dt=2024-05",
+                    "InputFormat": "",
+                    "OutputFormat": "",
+                    "SerdeInfo": {},
+                },
+            },
+        ],
+    )
+    before = glue.get_partition(
+        DatabaseName=db,
+        TableName=tbl,
+        PartitionValues=["2024-05"],
+    )["Partition"]
+    creation_time = before["CreationTime"]
+    resp = glue.batch_update_partition(
+        DatabaseName=db,
+        TableName=tbl,
+        Entries=[
+            {
+                "PartitionValueList": ["2024-05"],
+                "PartitionInput": {
+                    "Values": ["2024-05"],
+                    "StorageDescriptor": {
+                        "Columns": [],
+                        "Location": "s3://b/k/dt=2024-05-updated",
+                        "InputFormat": "",
+                        "OutputFormat": "",
+                        "SerdeInfo": {},
+                    },
+                },
+            },
+        ],
+    )
+    assert resp.get("Errors", []) == []
+    part = glue.get_partition(
+        DatabaseName=db,
+        TableName=tbl,
+        PartitionValues=["2024-05"],
+    )["Partition"]
+    assert part["StorageDescriptor"]["Location"] == "s3://b/k/dt=2024-05-updated"
+    # CreationTime is preserved across an update (LastAccessTime is refreshed)
+    assert part["CreationTime"] == creation_time
+    # updating a partition that does not exist returns an error entry
+    resp2 = glue.batch_update_partition(
+        DatabaseName=db,
+        TableName=tbl,
+        Entries=[
+            {
+                "PartitionValueList": ["no-such"],
+                "PartitionInput": {
+                    "Values": ["no-such"],
+                    "StorageDescriptor": {
+                        "Columns": [],
+                        "Location": "s3://b/k/dt=no-such",
+                        "InputFormat": "",
+                        "OutputFormat": "",
+                        "SerdeInfo": {},
+                    },
+                },
+            },
+        ],
+    )
+    assert len(resp2["Errors"]) == 1
+    assert resp2["Errors"][0]["PartitionValueList"] == ["no-such"]
+    assert resp2["Errors"][0]["ErrorDetail"]["ErrorCode"] == "EntityNotFoundException"
+    # updating against a nonexistent table fails at the request level
+    with pytest.raises(ClientError) as exc:
+        glue.batch_update_partition(
+            DatabaseName=db,
+            TableName="no-such-tbl",
+            Entries=[{"PartitionValueList": ["x"], "PartitionInput": {"Values": ["x"]}}],
+        )
+    assert exc.value.response["Error"]["Code"] == "EntityNotFoundException"
+    # cleanup
+    glue.delete_table(DatabaseName=db, Name=tbl)
+    glue.delete_database(Name=db)
+
+
+# ---------------------------------------------------------------------------
 # GetCrawlerMetrics
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Adds the `BatchUpdatePartition` action to the Glue mock — the only partition action that was missing.

- Wires `"BatchUpdatePartition": _batch_update_partition` into the action dispatch map.
- `_batch_update_partition` matches each entry's `PartitionValueList` against the stored partition's `Values` and replaces it with `PartitionInput`, preserving `CreationTime` and refreshing `LastAccessTime`.
- Not-found entries are returned per-entry in `Errors` as `BatchUpdatePartitionFailureEntry` items; an unknown table fails with `EntityNotFoundException`. Response shape is `{"Errors": [...]}`, matching real Glue.

Fixes #830.

## Test plan

- [x] Update round-trip: `batch_update_partition` then `get_partition` returns the new `StorageDescriptor`, with `CreationTime` unchanged.
- [x] Not-found entry reported in `Errors` with `EntityNotFoundException`.
- [x] Unknown table raises `EntityNotFoundException`.
- [x] `pytest tests/test_glue.py` — 45 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)