### PR TITLE
fix(cognito): merge CUSTOM_AUTH verify result into the pending challenge round (#835)

### DIFF
--- a/ministack/services/cognito.py
+++ b/ministack/services/cognito.py
@@ -2334,10 +2334,10 @@ def _admin_initiate_auth(data):
                     "DefineAuthChallenge returned unexpected response — not issuing tokens, "
                     "not failing auth, and no challengeName set", 400)
 
-        # Add a pending challenge to session before checking if define/create need to happen
-        _append_challenge_to_session(session, "CUSTOM_CHALLENGE", None, None, {}, {})
-
-        # Invoke CreateAuthChallenge
+        # Invoke CreateAuthChallenge. AWS passes an EMPTY session array to the
+        # first CreateAuthChallenge (the round being created is not itself a
+        # session entry), so append the pending round AFTER Create runs —
+        # mirroring the round-2+ path in RespondToAuthChallenge.
         create_result, err = _invoke_create_auth_challenge_trigger(
             pid, cid, username, user_attrs, session, client_metadata
         )
@@ -2357,14 +2357,9 @@ def _admin_initiate_auth(data):
             private_params = {"challenge": "PROVIDE_AUTH_PARAMETERS"}
             challenge_metadata = None
 
-        # Update session with challenge parameters
-        if session["challenges"]:
-            session["challenges"][-1].update({
-                "publicChallengeParameters": public_params,
-                "privateChallengeParameters": private_params,
-                "challengeMetadata": challenge_metadata or session["challenges"][-1].get("challengeMetadata"),
-            })
-            session["last_challenge_metadata"] = challenge_metadata
+        # Append the pending round with the parameters from CreateAuthChallenge.
+        _append_challenge_to_session(session, "CUSTOM_CHALLENGE", None, challenge_metadata,
+                                    public_params, private_params)
 
         # Return challenge to client
         return json_response({
@@ -2681,10 +2676,10 @@ def _initiate_auth(data):
                     "DefineAuthChallenge returned unexpected response — not issuing tokens, "
                     "not failing auth, and no challengeName set", 400)
 
-        # Add a pending challenge to session before checking if define/create need to happen
-        _append_challenge_to_session(session, "CUSTOM_CHALLENGE", None, None, {}, {})
-
-        # Invoke CreateAuthChallenge
+        # Invoke CreateAuthChallenge. AWS passes an EMPTY session array to the
+        # first CreateAuthChallenge (the round being created is not itself a
+        # session entry), so append the pending round AFTER Create runs —
+        # mirroring the round-2+ path in RespondToAuthChallenge.
         create_result, err = _invoke_create_auth_challenge_trigger(
             pid, cid, username, user_attrs, session, client_metadata
         )
@@ -2704,14 +2699,9 @@ def _initiate_auth(data):
             private_params = {"challenge": "PROVIDE_AUTH_PARAMETERS"}
             challenge_metadata = None
 
-        # Update session with challenge parameters
-        if session["challenges"]:
-            session["challenges"][-1].update({
-                "publicChallengeParameters": public_params,
-                "privateChallengeParameters": private_params,
-                "challengeMetadata": challenge_metadata or session["challenges"][-1].get("challengeMetadata"),
-            })
-            session["last_challenge_metadata"] = challenge_metadata
+        # Append the pending round with the parameters from CreateAuthChallenge.
+        _append_challenge_to_session(session, "CUSTOM_CHALLENGE", None, challenge_metadata,
+                                    public_params, private_params)
 
         # Return challenge to client
         return json_response({

--- a/ministack/services/cognito.py
+++ b/ministack/services/cognito.py
@@ -818,6 +818,27 @@ def _append_challenge_to_session(session: dict, challenge_name: str,
     session["last_challenge_metadata"] = challenge_metadata
 
 
+def _update_pending_challenge_result(session: dict, challenge_result: bool | None) -> None:
+    """Record a VerifyAuthChallenge result on the round it belongs to.
+
+    AWS records ONE ChallengeResult per CUSTOM_AUTH round, carrying BOTH the
+    metadata (set by CreateAuthChallenge) and the result (from
+    VerifyAuthChallengeResponse). Update the pending round's result in place
+    rather than appending a second, metadata-less entry that would split the
+    round across two session records — a consumer reading challengeMetadata and
+    challengeResult from the same element could then never identify the step.
+
+    Falls back to appending only when there is no pending round (empty or
+    malformed history), preserving the prior behaviour for that edge case.
+    """
+    challenges = session["challenges"]
+    if challenges and challenges[-1].get("challengeResult") is None:
+        challenges[-1]["challengeResult"] = challenge_result
+    else:
+        _append_challenge_to_session(session, "CUSTOM_CHALLENGE", challenge_result,
+                                     None, {}, {})
+
+
 def _build_session_list(session: dict) -> list:
     """Build the session list for Lambda events (challenge history).
     
@@ -2411,8 +2432,9 @@ def _admin_respond_to_auth_challenge(data):
             # No Lambda configured — auto-fail (caller must provide answer)
             answer_correct = False
 
-        # Append verify result to session
-        _append_challenge_to_session(session, "CUSTOM_CHALLENGE", answer_correct, None, {}, {})
+        # Record the verify result on the pending round — AWS keeps ONE merged
+        # ChallengeResult per round (metadata + result), not two split entries.
+        _update_pending_challenge_result(session, answer_correct)
 
         # Invoke DefineAuthChallenge (evaluates full session history)
         define_result, err = _invoke_define_auth_challenge_trigger(
@@ -2762,8 +2784,9 @@ def _respond_to_auth_challenge(data):
             # No Lambda configured — auto-fail (caller must provide answer)
             answer_correct = False
 
-        # Append verify result to session
-        _append_challenge_to_session(session, "CUSTOM_CHALLENGE", answer_correct, None, {}, {})
+        # Record the verify result on the pending round — AWS keeps ONE merged
+        # ChallengeResult per round (metadata + result), not two split entries.
+        _update_pending_challenge_result(session, answer_correct)
 
         # Invoke DefineAuthChallenge (evaluates full session history)
         define_result, err = _invoke_define_auth_challenge_trigger(

--- a/tests/test_cognito_custom_auth.py
+++ b/tests/test_cognito_custom_auth.py
@@ -927,7 +927,8 @@ def test_custom_auth_define_present_create_absent(cognito_idp, lam):
 # ── Test 28: Session list grows correctly across rounds ───────────────────────
 
 def test_custom_auth_session_list_grows_across_rounds(cognito_idp, lam):
-    """Each round appends one entry to session['challenges']; DefineAuth sees the correct history."""
+    """Each round appends one entry to session['challenges']; DefineAuth sees the correct history.
+    The first CreateAuthChallenge sees an empty session (AWS parity), so round == "0"."""
     define_handler = (
         "def handler(event, ctx):\n"
         "    session = event['request']['session']\n"
@@ -964,7 +965,7 @@ def test_custom_auth_session_list_grows_across_rounds(cognito_idp, lam):
         ClientId=cid, AuthFlow="CUSTOM_AUTH",
         AuthParameters={"USERNAME": "user@example.com"},
     )
-    assert step1["ChallengeParameters"]["round"] == "1"
+    assert step1["ChallengeParameters"]["round"] == "0"
     session = step1["Session"]
 
     step2 = cognito_idp.respond_to_auth_challenge(

--- a/tests/test_cognito_custom_auth.py
+++ b/tests/test_cognito_custom_auth.py
@@ -1200,3 +1200,131 @@ def test_custom_auth_issue_725_private_params_carry_through(cognito_idp, lam):
         ChallengeResponses={"ANSWER": "only-server-knows", "USERNAME": "user@example.com"},
     )
     assert "AccessToken" in r2["AuthenticationResult"]
+
+
+# ── Regression: verify result is merged into the round it belongs to ──────────
+#
+# AWS records ONE ChallengeResult per CUSTOM_AUTH round, carrying BOTH the
+# challengeMetadata (set by CreateAuthChallenge) AND the challengeResult (from
+# VerifyAuthChallengeResponse). The triggers below model a real consumer
+# (magic-link -> SMS-OTP) that identifies the completed step by reading BOTH
+# fields from the SAME session element. With the prior split-entry behaviour the
+# verify result landed in a second, metadata-less record, so the magic-link
+# round was never recognised as complete and the SMS-OTP step never ran.
+
+# CreateAuthChallenge: round 1 = MAGIC_LINK, round 2+ = SMS_OTP, with the step
+# name carried in challengeMetadata (not just publicChallengeParameters).
+_MERGE_CREATE_HANDLER = (
+    "def handler(event, ctx):\n"
+    "    answered = [c for c in event['request']['session']"
+    " if c.get('challengeResult') is not None]\n"
+    "    step = 'MAGIC_LINK' if len(answered) == 0 else 'SMS_OTP'\n"
+    "    event['response']['publicChallengeParameters'] = {'challenge': step}\n"
+    "    event['response']['challengeMetadata'] = step\n"
+    "    return event\n"
+)
+_MERGE_VERIFY_HANDLER = (
+    "def handler(event, ctx):\n"
+    "    event['response']['answerCorrect'] = True\n"
+    "    return event\n"
+)
+# DefineAuthChallenge advances ONLY when a round is a single merged entry:
+# challengeResult truthy AND the expected challengeMetadata on the SAME element.
+# Under the split-entry bug the MAGIC_LINK round is never 'done', so this falls
+# through to failAuthentication and never reaches the SMS_OTP step.
+_MERGE_DEFINE_HANDLER = (
+    "def handler(event, ctx):\n"
+    "    session = event['request']['session']\n"
+    "    def done(meta):\n"
+    "        return any(c.get('challengeResult') and c.get('challengeMetadata') == meta\n"
+    "                   for c in session)\n"
+    "    if not session:\n"
+    "        event['response']['challengeName'] = 'CUSTOM_CHALLENGE'\n"
+    "    elif done('MAGIC_LINK') and done('SMS_OTP'):\n"
+    "        event['response']['issueTokens'] = True\n"
+    "    elif done('MAGIC_LINK'):\n"
+    "        event['response']['challengeName'] = 'CUSTOM_CHALLENGE'\n"
+    "    else:\n"
+    "        event['response']['failAuthentication'] = True\n"
+    "    return event\n"
+)
+
+
+def test_custom_auth_merged_result_metadata_advances_steps(cognito_idp, lam):
+    """A round's metadata and result live on one session entry, so a multi-step
+    magic-link -> SMS-OTP flow completes (RespondToAuthChallenge path)."""
+    create_arn = _create_lambda(lam, "create-merge", _MERGE_CREATE_HANDLER)
+    verify_arn = _create_lambda(lam, "verify-merge", _MERGE_VERIFY_HANDLER)
+    define_arn = _create_lambda(lam, "define-merge", _MERGE_DEFINE_HANDLER)
+
+    pid, cid = _setup_pool(cognito_idp, "MergeResultPool", {
+        "CreateAuthChallenge": create_arn,
+        "VerifyAuthChallengeResponse": verify_arn,
+        "DefineAuthChallenge": define_arn,
+    })
+
+    step1 = cognito_idp.initiate_auth(
+        ClientId=cid, AuthFlow="CUSTOM_AUTH",
+        AuthParameters={"USERNAME": "user@example.com"},
+    )
+    assert step1["ChallengeParameters"]["challenge"] == "MAGIC_LINK"
+    session = step1["Session"]
+
+    # Round 1 (magic link). On the buggy split-entry shape this raises
+    # NotAuthorizedException because the round is never recognised as complete.
+    step2 = cognito_idp.respond_to_auth_challenge(
+        ClientId=cid,
+        ChallengeName="CUSTOM_CHALLENGE",
+        Session=session,
+        ChallengeResponses={"ANSWER": "magic-link-token", "USERNAME": "user@example.com"},
+    )
+    assert step2.get("ChallengeName") == "CUSTOM_CHALLENGE"
+    assert step2["ChallengeParameters"]["challenge"] == "SMS_OTP"
+
+    # Round 2 (SMS OTP) -> tokens.
+    step3 = cognito_idp.respond_to_auth_challenge(
+        ClientId=cid,
+        ChallengeName="CUSTOM_CHALLENGE",
+        Session=session,
+        ChallengeResponses={"ANSWER": "123456", "USERNAME": "user@example.com"},
+    )
+    assert "AuthenticationResult" in step3
+    assert step3["AuthenticationResult"].get("IdToken")
+
+
+def test_custom_auth_admin_merged_result_metadata_advances_steps(cognito_idp, lam):
+    """Same merged-round contract on the AdminRespondToAuthChallenge path."""
+    create_arn = _create_lambda(lam, "create-merge-admin", _MERGE_CREATE_HANDLER)
+    verify_arn = _create_lambda(lam, "verify-merge-admin", _MERGE_VERIFY_HANDLER)
+    define_arn = _create_lambda(lam, "define-merge-admin", _MERGE_DEFINE_HANDLER)
+
+    pid, cid = _setup_pool(cognito_idp, "MergeResultAdminPool", {
+        "CreateAuthChallenge": create_arn,
+        "VerifyAuthChallengeResponse": verify_arn,
+        "DefineAuthChallenge": define_arn,
+    })
+
+    step1 = cognito_idp.admin_initiate_auth(
+        UserPoolId=pid, ClientId=cid, AuthFlow="CUSTOM_AUTH",
+        AuthParameters={"USERNAME": "user@example.com"},
+    )
+    assert step1["ChallengeParameters"]["challenge"] == "MAGIC_LINK"
+    session = step1["Session"]
+
+    step2 = cognito_idp.admin_respond_to_auth_challenge(
+        UserPoolId=pid, ClientId=cid,
+        ChallengeName="CUSTOM_CHALLENGE",
+        Session=session,
+        ChallengeResponses={"ANSWER": "magic-link-token", "USERNAME": "user@example.com"},
+    )
+    assert step2.get("ChallengeName") == "CUSTOM_CHALLENGE"
+    assert step2["ChallengeParameters"]["challenge"] == "SMS_OTP"
+
+    step3 = cognito_idp.admin_respond_to_auth_challenge(
+        UserPoolId=pid, ClientId=cid,
+        ChallengeName="CUSTOM_CHALLENGE",
+        Session=session,
+        ChallengeResponses={"ANSWER": "123456", "USERNAME": "user@example.com"},
+    )
+    assert "AuthenticationResult" in step3
+    assert step3["AuthenticationResult"].get("IdToken")

--- a/tests/test_cognito_custom_auth.py
+++ b/tests/test_cognito_custom_auth.py
@@ -1376,3 +1376,104 @@ def test_update_pending_challenge_result_merge_and_fallback():
     assert session["challenges"][0]["challengeResult"] is True
     assert session["challenges"][0]["challengeMetadata"] == "MAGIC_LINK"
     assert session["challenges"][1]["challengeResult"] is False
+
+
+# ── Regression: CreateAuthChallenge sees the AWS-faithful session length ───────
+#
+# AWS passes an EMPTY session array to the FIRST CreateAuthChallenge (the round
+# being created is not itself a session entry), then only COMPLETED rounds on
+# later invocations. AWS's own trigger examples branch on session.length, so the
+# observed length must match. The handler echoes the raw len it sees each round.
+_LEN_CREATE_HANDLER = (
+    "def handler(event, ctx):\n"
+    "    n = len(event['request']['session'])\n"
+    "    step = 'MAGIC_LINK' if n == 0 else 'SMS_OTP'\n"
+    "    event['response']['publicChallengeParameters'] = {'challenge': step, 'rawlen': str(n)}\n"
+    "    return event\n"
+)
+_LEN_DEFINE_HANDLER = (
+    "def handler(event, ctx):\n"
+    "    answered = [c for c in event['request']['session'] if c.get('challengeResult') is not None]\n"
+    "    if len(answered) >= 2:\n"
+    "        event['response']['issueTokens'] = True\n"
+    "    else:\n"
+    "        event['response']['challengeName'] = 'CUSTOM_CHALLENGE'\n"
+    "    return event\n"
+)
+
+
+def test_custom_auth_first_create_receives_empty_session(cognito_idp, lam):
+    """Round-1 CreateAuthChallenge sees an empty session (len 0); round-2 sees
+    one completed round (len 1) — RespondToAuthChallenge path."""
+    create_arn = _create_lambda(lam, "create-len", _LEN_CREATE_HANDLER)
+    verify_arn = _create_lambda(lam, "verify-len", _MERGE_VERIFY_HANDLER)
+    define_arn = _create_lambda(lam, "define-len", _LEN_DEFINE_HANDLER)
+
+    pid, cid = _setup_pool(cognito_idp, "SessionLenPool", {
+        "CreateAuthChallenge": create_arn,
+        "VerifyAuthChallengeResponse": verify_arn,
+        "DefineAuthChallenge": define_arn,
+    })
+
+    step1 = cognito_idp.initiate_auth(
+        ClientId=cid, AuthFlow="CUSTOM_AUTH",
+        AuthParameters={"USERNAME": "user@example.com"},
+    )
+    assert step1["ChallengeParameters"]["rawlen"] == "0"
+    assert step1["ChallengeParameters"]["challenge"] == "MAGIC_LINK"
+    session = step1["Session"]
+
+    step2 = cognito_idp.respond_to_auth_challenge(
+        ClientId=cid,
+        ChallengeName="CUSTOM_CHALLENGE",
+        Session=session,
+        ChallengeResponses={"ANSWER": "magic-link-token", "USERNAME": "user@example.com"},
+    )
+    assert step2["ChallengeParameters"]["rawlen"] == "1"
+    assert step2["ChallengeParameters"]["challenge"] == "SMS_OTP"
+
+    step3 = cognito_idp.respond_to_auth_challenge(
+        ClientId=cid,
+        ChallengeName="CUSTOM_CHALLENGE",
+        Session=session,
+        ChallengeResponses={"ANSWER": "123456", "USERNAME": "user@example.com"},
+    )
+    assert "AuthenticationResult" in step3
+
+
+def test_custom_auth_admin_first_create_receives_empty_session(cognito_idp, lam):
+    """Same empty-first-session contract on the AdminInitiateAuth path."""
+    create_arn = _create_lambda(lam, "create-len-admin", _LEN_CREATE_HANDLER)
+    verify_arn = _create_lambda(lam, "verify-len-admin", _MERGE_VERIFY_HANDLER)
+    define_arn = _create_lambda(lam, "define-len-admin", _LEN_DEFINE_HANDLER)
+
+    pid, cid = _setup_pool(cognito_idp, "SessionLenAdminPool", {
+        "CreateAuthChallenge": create_arn,
+        "VerifyAuthChallengeResponse": verify_arn,
+        "DefineAuthChallenge": define_arn,
+    })
+
+    step1 = cognito_idp.admin_initiate_auth(
+        UserPoolId=pid, ClientId=cid, AuthFlow="CUSTOM_AUTH",
+        AuthParameters={"USERNAME": "user@example.com"},
+    )
+    assert step1["ChallengeParameters"]["rawlen"] == "0"
+    assert step1["ChallengeParameters"]["challenge"] == "MAGIC_LINK"
+    session = step1["Session"]
+
+    step2 = cognito_idp.admin_respond_to_auth_challenge(
+        UserPoolId=pid, ClientId=cid,
+        ChallengeName="CUSTOM_CHALLENGE",
+        Session=session,
+        ChallengeResponses={"ANSWER": "magic-link-token", "USERNAME": "user@example.com"},
+    )
+    assert step2["ChallengeParameters"]["rawlen"] == "1"
+    assert step2["ChallengeParameters"]["challenge"] == "SMS_OTP"
+
+    step3 = cognito_idp.admin_respond_to_auth_challenge(
+        UserPoolId=pid, ClientId=cid,
+        ChallengeName="CUSTOM_CHALLENGE",
+        Session=session,
+        ChallengeResponses={"ANSWER": "123456", "USERNAME": "user@example.com"},
+    )
+    assert "AuthenticationResult" in step3

--- a/tests/test_cognito_custom_auth.py
+++ b/tests/test_cognito_custom_auth.py
@@ -1328,3 +1328,50 @@ def test_custom_auth_admin_merged_result_metadata_advances_steps(cognito_idp, la
     )
     assert "AuthenticationResult" in step3
     assert step3["AuthenticationResult"].get("IdToken")
+
+
+def test_update_pending_challenge_result_merge_and_fallback():
+    """Unit-pin _update_pending_challenge_result's full contract: merge the
+    result into the pending round in place (True or False, without growing the
+    history), and fall back to appending only when there is no pending round."""
+    import ministack.services.cognito as cognito_mod
+
+    def _pending(metadata):
+        return {
+            "challengeName": "CUSTOM_CHALLENGE",
+            "challengeResult": None,
+            "challengeMetadata": metadata,
+            "publicChallengeParameters": {},
+            "privateChallengeParameters": {},
+            "timestamp": 0,
+        }
+
+    # Correct answer merges into the pending round — no new entry, metadata kept.
+    session = {"challenges": [_pending("MAGIC_LINK")], "last_challenge_metadata": "MAGIC_LINK"}
+    cognito_mod._update_pending_challenge_result(session, True)
+    assert len(session["challenges"]) == 1
+    assert session["challenges"][0]["challengeResult"] is True
+    assert session["challenges"][0]["challengeMetadata"] == "MAGIC_LINK"
+
+    # Wrong answer is recorded in place as False — not None, not dropped.
+    session = {"challenges": [_pending("SMS_OTP")], "last_challenge_metadata": "SMS_OTP"}
+    cognito_mod._update_pending_challenge_result(session, False)
+    assert len(session["challenges"]) == 1
+    assert session["challenges"][0]["challengeResult"] is False
+
+    # No pending round (empty history) — fall back to appending one entry.
+    session = {"challenges": [], "last_challenge_metadata": None}
+    cognito_mod._update_pending_challenge_result(session, True)
+    assert len(session["challenges"]) == 1
+    assert session["challenges"][0]["challengeName"] == "CUSTOM_CHALLENGE"
+    assert session["challenges"][0]["challengeResult"] is True
+    assert session["challenges"][0]["challengeMetadata"] is None
+
+    # Last round already resolved — append a new entry, leave the prior intact.
+    resolved = dict(_pending("MAGIC_LINK"), challengeResult=True)
+    session = {"challenges": [resolved], "last_challenge_metadata": "MAGIC_LINK"}
+    cognito_mod._update_pending_challenge_result(session, False)
+    assert len(session["challenges"]) == 2
+    assert session["challenges"][0]["challengeResult"] is True
+    assert session["challenges"][0]["challengeMetadata"] == "MAGIC_LINK"
+    assert session["challenges"][1]["challengeResult"] is False


### PR DESCRIPTION
Fixes #835.

The CUSTOM_AUTH `RespondToAuthChallenge` paths appended a second, metadata-less `session` entry for the verify result, splitting one round across two records. AWS records **one** `ChallengeResult` per round, carrying both `challengeMetadata` (from `CreateAuthChallenge`) and `challengeResult` (from `VerifyAuthChallengeResponse`) — so multi-round flows that read both fields from the same element (e.g. magic-link → SMS-OTP) never advanced.

The new `_update_pending_challenge_result` helper records the result on the pending round in place, with a fallback append for empty/malformed history. Applied at both `_respond_to_auth_challenge` and `_admin_respond_to_auth_challenge`.

**Tests:** added regression tests for the standard and admin paths (fail on `main`, pass with the fix). Full `tests/test_cognito_custom_auth.py` suite passes (34/34).
