### PR TITLE
Validate AppSync tag and authorizer ARNs

### DIFF
--- a/ministack/services/appsync.py
+++ b/ministack/services/appsync.py
@@ -24,6 +24,7 @@ import os
 import re
 import time
 
+from ministack.core.arn import ArnParseError, parse_arn
 from ministack.core.persistence import PERSIST_STATE, load_state
 from ministack.core.responses import (
     AccountScopedDict,
@@ -72,6 +73,29 @@ def _now():
 
 def _api_arn(api_id):
     return f"arn:aws:appsync:{get_region()}:{get_account_id()}:apis/{api_id}"
+
+
+def _api_id_from_local_arn(arn):
+    try:
+        spec = parse_arn(arn)
+    except ArnParseError:
+        return None
+    if spec.service != "appsync" or spec.account_id != get_account_id() or spec.region != get_region():
+        return None
+
+    prefix = "apis/"
+    if not spec.resource.startswith(prefix):
+        return None
+    api_id = spec.resource[len(prefix):]
+    return api_id if api_id and "/" not in api_id else None
+
+
+def _validate_tag_resource_arn(arn):
+    api_id = _api_id_from_local_arn(arn)
+    api = _apis.get(api_id) if api_id else None
+    if not api or api.get("arn") != arn:
+        return error_response_json("NotFoundException", f"GraphQL API {api_id or arn} not found", 404)
+    return None
 
 
 def _json(status, body):
@@ -442,11 +466,17 @@ def _list_types(api_id, query_params):
 def _tag_resource(body):
     arn = body.get("resourceArn", "")
     tags = body.get("tags", {})
+    validation_error = _validate_tag_resource_arn(arn)
+    if validation_error:
+        return validation_error
     _tags.setdefault(arn, {}).update(tags)
     return _json(200, {})
 
 
 def _untag_resource(arn, query_params):
+    validation_error = _validate_tag_resource_arn(arn)
+    if validation_error:
+        return validation_error
     tag_keys = query_params.get("tagKeys", [])
     if isinstance(tag_keys, str):
         tag_keys = [tag_keys]
@@ -457,6 +487,9 @@ def _untag_resource(arn, query_params):
 
 
 def _list_tags_for_resource(arn):
+    validation_error = _validate_tag_resource_arn(arn)
+    if validation_error:
+        return validation_error
     tags = _tags.get(arn, {})
     return _json(200, {"tags": tags})
 
@@ -714,10 +747,9 @@ def _invoke_lambda_authorizer(
 
     import ministack.services.lambda_svc as _lambda_svc
 
-    func_name = func_arn.rsplit(":", 1)[-1]
-    func = _lambda_svc._functions.get(func_name)
-    if not func:
-        logger.warning("Lambda authorizer %s not found in ministack", func_name)
+    func, func_config, func_name = _lambda_svc._get_func_record_for_ref(func_arn)
+    if not func or not func_config:
+        logger.warning("Lambda authorizer %s not found in ministack", func_arn)
         raise _AuthorizerRejected("authorizer Lambda not found")
 
     # AWS-verified authorizer event shape — apiId / accountId / requestId /
@@ -737,7 +769,8 @@ def _invoke_lambda_authorizer(
     }
 
     try:
-        result = _lambda_svc._execute_function(func, authorizer_event)
+        exec_record = _lambda_svc._execution_record_for_config(func, func_config)
+        result = _lambda_svc._execute_function_with_config_scope(exec_record, authorizer_event)
     except Exception as e:
         logger.warning("Lambda authorizer invocation failed: %s", e)
         raise _AuthorizerRejected("authorizer invocation failed") from e

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,6 +94,7 @@ _SERIAL_TESTS = {
     "tests/test_appsync.py::test_appsync_lambda_event_variables_substituted",
     "tests/test_appsync.py::test_appsync_lambda_unhandled_exception_becomes_error",
     "tests/test_appsync.py::test_appsync_lambda_authorizer_rejection_returns_unauthorized",
+    "tests/test_appsync.py::test_appsync_lambda_authorizer_wrong_region_arn_does_not_fallback",
     "tests/test_appsync.py::test_appsync_lambda_missing_authorizer_returns_unauthorized",
     "tests/test_appsync.py::test_appsync_lambda_failing_authorizer_returns_unauthorized",
 }

--- a/tests/test_appsync.py
+++ b/tests/test_appsync.py
@@ -48,6 +48,29 @@ def test_appsync_api_key_crud():
     assert len(keys) >= 1
     appsync.delete_api_key(apiId=api["apiId"], id=key["id"])
 
+
+def test_appsync_tags_reject_wrong_region_api_arn(appsync):
+    import boto3
+
+    api = appsync.create_graphql_api(name="tag-region-api", authenticationType="API_KEY")["graphqlApi"]
+    arn_parts = api["arn"].split(":")
+    wrong_region = "us-west-2" if arn_parts[3] != "us-west-2" else "us-east-2"
+    arn_parts[3] = wrong_region
+    wrong_region_arn = ":".join(arn_parts)
+    regional_appsync = boto3.client(
+        "appsync",
+        endpoint_url=_ENDPOINT,
+        region_name=wrong_region,
+        aws_access_key_id="test",
+        aws_secret_access_key="test",
+    )
+
+    with pytest.raises(ClientError) as exc:
+        regional_appsync.tag_resource(resourceArn=wrong_region_arn, tags={"env": "test"})
+
+    assert exc.value.response["Error"]["Code"] == "NotFoundException"
+
+
 def test_appsync_data_source_crud():
     from conftest import make_client
     appsync = make_client("appsync")
@@ -645,6 +668,25 @@ def test_appsync_lambda_authorizer_rejection_returns_unauthorized(appsync, lam):
     auth_arn = _appsync_create_lambda(lam, "authz-reject-test", authorizer)
     _, url = _appsync_setup_lambda_auth_api(appsync, lam, "authz-reject-api", auth_arn,
                                             _APPSYNC_IDENTITY_PROBE_RESOLVER)
+    _appsync_expect_unauthorized(url, "{ testField { hasIdentity } }",
+                                 headers={"Authorization": "Bearer fake-jwt"})
+
+
+def test_appsync_lambda_authorizer_wrong_region_arn_does_not_fallback(appsync, lam):
+    """A wrong-region authorizer ARN must not invoke a same-named local Lambda."""
+    authorizer = (
+        "def handler(event, ctx):\n"
+        "    return {'isAuthorized': True, 'resolverContext': {'region': 'current'}}\n"
+    )
+    auth_arn = _appsync_create_lambda(lam, "authz-wrong-region-test", authorizer)
+    arn_parts = auth_arn.split(":")
+    arn_parts[3] = "us-west-2" if arn_parts[3] != "us-west-2" else "us-east-2"
+    wrong_region_arn = ":".join(arn_parts)
+
+    _, url = _appsync_setup_lambda_auth_api(
+        appsync, lam, "authz-wrong-region-api", wrong_region_arn,
+        _APPSYNC_IDENTITY_PROBE_RESOLVER,
+    )
     _appsync_expect_unauthorized(url, "{ testField { hasIdentity } }",
                                  headers={"Authorization": "Bearer fake-jwt"})
 


### PR DESCRIPTION
## Why
AppSync tag and Lambda authorizer paths should resolve ARNs by account and region instead of falling back to same-named local resources.

## What
- Validate AppSync tag ARNs against the stored API ARN
- Resolve Lambda authorizers with the scoped Lambda ARN helper
- Add regressions for wrong-region API tags and wrong-region authorizer ARNs

## References
- `uv run --extra dev ruff check ministack/services/appsync.py tests/test_appsync.py tests/conftest.py`
- `uv run --extra dev pytest tests/test_appsync.py -q`