### PR TITLE
Validate Inspector2 resource ARNs

### DIFF
--- a/ministack/services/inspector2.py
+++ b/ministack/services/inspector2.py
@@ -9,6 +9,7 @@ import logging
 import time
 import uuid
 
+from ministack.core.arn import ArnParseError, parse_arn
 from ministack.core.persistence import load_state
 from ministack.core.responses import (
     AccountScopedDict,
@@ -34,6 +35,29 @@ def _now_iso():
 
 def _finding_arn(acct_id, finding_id):
     return f"arn:aws:inspector2:{get_region()}:{acct_id}:finding/{finding_id}"
+
+
+def _parse_local_resource_arn(arn, account_id, resource_prefixes):
+    try:
+        spec = parse_arn(arn)
+    except ArnParseError:
+        return None
+
+    if spec.service != "inspector2" or spec.account_id != account_id or spec.region != get_region():
+        return None
+
+    for prefix in resource_prefixes:
+        if spec.resource.startswith(prefix) and spec.resource[len(prefix):]:
+            return spec
+    return None
+
+
+def _resource_not_found(arn):
+    return error_response_json(
+        "ResourceNotFoundException",
+        f"The resource with arn '{arn}' does not exist",
+        400,
+    )
 
 
 _STUB_PACKAGES = [
@@ -836,6 +860,8 @@ def _tag_resource(data, account_id):
     tags = data.get("tags", {})
     if not arn:
         return error_response_json("ValidationException", "resourceArn is required", 400)
+    if not _parse_local_resource_arn(arn, account_id, ("finding/", "filter/")):
+        return _resource_not_found(arn)
 
     existing = _tags.get(account_id, {}).get(arn, {})
     existing.update(tags)
@@ -850,6 +876,8 @@ def _untag_resource(data, account_id):
     tag_keys = data.get("tagKeys", [])
     if not arn:
         return error_response_json("ValidationException", "resourceArn is required", 400)
+    if not _parse_local_resource_arn(arn, account_id, ("finding/", "filter/")):
+        return _resource_not_found(arn)
 
     existing = _tags.get(account_id, {}).get(arn, {})
     for key in tag_keys:
@@ -864,6 +892,8 @@ def _list_tags_for_resource(data, account_id):
     arn = data.get("resourceArn", "")
     if not arn:
         return error_response_json("ValidationException", "resourceArn is required", 400)
+    if not _parse_local_resource_arn(arn, account_id, ("finding/", "filter/")):
+        return _resource_not_found(arn)
 
     tags = _tags.get(account_id, {}).get(arn, {})
     return json_response({"tags": tags})
@@ -914,8 +944,8 @@ def _delete_filter(data, account_id):
     if not arn:
         return error_response_json("ValidationException", "arn is required", 400)
 
-    # Extract filter name from ARN: arn:aws:inspector2:...:filter/<name>
-    name = arn.split("/")[-1] if "/" in arn else ""
+    spec = _parse_local_resource_arn(arn, account_id, ("filter/",))
+    name = spec.resource[len("filter/"):] if spec else ""
     account_filters = _filters.get(account_id, {})
 
     if name not in account_filters:

--- a/tests/test_inspector2.py
+++ b/tests/test_inspector2.py
@@ -469,6 +469,22 @@ class TestMultitenancy:
         assert filters_a[0]["name"] == "acct-a-filter"
         assert filters_b[0]["name"] == "acct-b-filter"
 
+    def test_delete_filter_rejects_wrong_account_arn(self):
+        from ministack.services import inspector2 as _inspector2
+
+        _inspector2.reset()
+        client_a = self._client("111111111111")
+
+        created = client_a.create_filter(name="scoped-filter", action="NONE", filterCriteria={})
+        wrong_account_arn = created["arn"].replace(":111111111111:", ":222222222222:")
+
+        with pytest.raises(ClientError) as exc:
+            client_a.delete_filter(arn=wrong_account_arn)
+
+        assert exc.value.response["Error"]["Code"] == "ResourceNotFoundException"
+        filters = client_a.list_filters()["filters"]
+        assert any(f["name"] == "scoped-filter" for f in filters)
+
     def test_tags_isolated_by_account(self):
         from ministack.services import inspector2 as _inspector2
 
@@ -476,15 +492,28 @@ class TestMultitenancy:
         client_a = self._client("111111111111")
         client_b = self._client("222222222222")
 
-        arn = "arn:aws:inspector2:us-east-1:000000000000:finding/shared-arn"
-        client_a.tag_resource(resourceArn=arn, tags={"owner": "a"})
-        client_b.tag_resource(resourceArn=arn, tags={"owner": "b"})
+        arn_a = "arn:aws:inspector2:us-east-1:111111111111:finding/shared-arn"
+        arn_b = "arn:aws:inspector2:us-east-1:222222222222:finding/shared-arn"
+        client_a.tag_resource(resourceArn=arn_a, tags={"owner": "a"})
+        client_b.tag_resource(resourceArn=arn_b, tags={"owner": "b"})
 
-        tags_a = client_a.list_tags_for_resource(resourceArn=arn)["tags"]
-        tags_b = client_b.list_tags_for_resource(resourceArn=arn)["tags"]
+        tags_a = client_a.list_tags_for_resource(resourceArn=arn_a)["tags"]
+        tags_b = client_b.list_tags_for_resource(resourceArn=arn_b)["tags"]
 
         assert tags_a["owner"] == "a"
         assert tags_b["owner"] == "b"
+
+    def test_tags_reject_wrong_account_arn(self):
+        from ministack.services import inspector2 as _inspector2
+
+        _inspector2.reset()
+        client_a = self._client("111111111111")
+        wrong_account_arn = "arn:aws:inspector2:us-east-1:222222222222:finding/shared-arn"
+
+        with pytest.raises(ClientError) as exc:
+            client_a.tag_resource(resourceArn=wrong_account_arn, tags={"owner": "a"})
+
+        assert exc.value.response["Error"]["Code"] == "ResourceNotFoundException"
 
 
 class TestAdvancedFiltering:


### PR DESCRIPTION
## Why
Inspector2 filter and tag operations should not infer resources from raw ARN string splitting or accept ARNs outside the request account and region.

## What
- Parse Inspector2 filter and tag resource ARNs before interpreting resource tails
- Reject wrong-account and wrong-region resource ARNs with the existing not-found error shape
- Add regressions for wrong-account filter deletion and tag requests

## References
- `uv run --extra dev ruff check ministack/services/inspector2.py tests/test_inspector2.py`
- `uv run --extra dev pytest tests/test_inspector2.py -q`