### PR TITLE
Validate Step Functions tag ARNs

### DIFF
--- a/ministack/services/stepfunctions.py
+++ b/ministack/services/stepfunctions.py
@@ -893,7 +893,9 @@ async def _get_activity_task(data):
 def _tag_resource(data):
     arn = data.get("resourceArn")
     new_tags = data.get("tags", [])
-    account_id, region = _scope_from_resource_arn(arn)
+    account_id, region, error = _tag_resource_scope_from_arn(arn)
+    if error:
+        return error
     existing = _tags.get_scoped(account_id, region, arn)
     if existing is None:
         existing = []
@@ -912,7 +914,9 @@ def _tag_resource(data):
 def _untag_resource(data):
     arn = data.get("resourceArn")
     keys_to_remove = set(data.get("tagKeys", []))
-    account_id, region = _scope_from_resource_arn(arn)
+    account_id, region, error = _tag_resource_scope_from_arn(arn)
+    if error:
+        return error
     existing = _tags.get_scoped(account_id, region, arn, [])
     _tags.set_scoped(
         account_id,
@@ -925,18 +929,42 @@ def _untag_resource(data):
 
 def _list_tags_for_resource(data):
     arn = data.get("resourceArn")
-    account_id, region = _scope_from_resource_arn(arn)
+    account_id, region, error = _tag_resource_scope_from_arn(arn)
+    if error:
+        return error
     return json_response({"tags": _tags.get_scoped(account_id, region, arn, [])})
 
 
-def _scope_from_resource_arn(arn):
+def _tag_resource_scope_from_arn(arn):
     try:
         spec = parse_arn(arn)
     except ArnParseError:
-        return get_account_id(), get_region()
-    if spec.service != "states":
-        return get_account_id(), get_region()
-    return get_account_id(), spec.region or get_region()
+        return None, None, _invalid_tag_resource_arn(arn)
+    if spec.service != "states" or not _is_stepfunctions_taggable_resource(spec.resource):
+        return None, None, _invalid_tag_resource_arn(arn)
+    if spec.account_id != get_account_id():
+        return None, None, error_response_json(
+            "AccessDeniedException",
+            "User is not authorized to access this resource.",
+            400,
+        )
+    if spec.region != get_region():
+        return None, None, error_response_json(
+            "InvalidArn",
+            f"Invalid ARN: {arn} is expected to be within the request region {get_region()}.",
+            400,
+        )
+    return spec.account_id, spec.region, None
+
+
+def _is_stepfunctions_taggable_resource(resource):
+    return isinstance(resource, str) and (
+        resource.startswith("stateMachine:") or resource.startswith("activity:")
+    )
+
+
+def _invalid_tag_resource_arn(arn):
+    return error_response_json("InvalidArn", f"Invalid resource ARN: {arn}", 400)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_stepfunctions.py
+++ b/tests/test_stepfunctions.py
@@ -414,29 +414,53 @@ def test_sfn_tags_scope_by_resource_arn_region():
     original_account = get_account_id()
     original_region = get_region()
     original_tags = dict(m._tags._data)
-    arn = "arn:aws:states:us-west-2:000000000000:stateMachine:tagged-west"
+    arn = "arn:aws:states:us-east-1:000000000000:stateMachine:tagged-east"
+    foreign_region_arn = "arn:aws:states:us-west-2:000000000000:stateMachine:tagged-west"
+    foreign_account_arn = "arn:aws:states:us-east-1:111111111111:stateMachine:foreign"
+
+    def assert_error(response, code):
+        status, headers, body = response
+        assert status == 400
+        assert headers["x-amzn-errortype"] == code
+        assert json.loads(body)["__type"] == code
 
     try:
         m._tags.clear()
         set_request_account_id("000000000000")
         set_request_region("us-east-1")
 
-        m._tag_resource({"resourceArn": arn, "tags": [{"key": "env", "value": "west"}]})
+        m._tag_resource({"resourceArn": arn, "tags": [{"key": "env", "value": "east"}]})
 
-        assert m._tags.get_scoped("000000000000", "us-west-2", arn) == [
-            {"key": "env", "value": "west"},
+        assert m._tags.get_scoped("000000000000", "us-east-1", arn) == [
+            {"key": "env", "value": "east"},
         ]
-        assert m._tags.get_scoped("000000000000", "us-east-1", arn) is None
+        assert m._tags.get_scoped("000000000000", "us-west-2", arn) is None
 
         _status, _headers, body = m._list_tags_for_resource({"resourceArn": arn})
-        assert json.loads(body)["tags"] == [{"key": "env", "value": "west"}]
+        assert json.loads(body)["tags"] == [{"key": "env", "value": "east"}]
 
-        foreign_arn = "arn:aws:states:us-west-2:111111111111:stateMachine:foreign"
-        m._tag_resource({"resourceArn": foreign_arn, "tags": [{"key": "owner", "value": "other"}]})
-        assert m._tags.get_scoped("111111111111", "us-west-2", foreign_arn) is None
-        assert m._tags.get_scoped("000000000000", "us-west-2", foreign_arn) == [
-            {"key": "owner", "value": "other"},
-        ]
+        assert_error(
+            m._tag_resource({
+                "resourceArn": foreign_region_arn,
+                "tags": [{"key": "env", "value": "west"}],
+            }),
+            "InvalidArn",
+        )
+        assert m._tags.get_scoped("000000000000", "us-west-2", foreign_region_arn) is None
+
+        assert_error(
+            m._tag_resource({
+                "resourceArn": foreign_account_arn,
+                "tags": [{"key": "owner", "value": "other"}],
+            }),
+            "AccessDeniedException",
+        )
+        assert_error(
+            m._list_tags_for_resource({"resourceArn": foreign_account_arn}),
+            "AccessDeniedException",
+        )
+        assert m._tags.get_scoped("111111111111", "us-east-1", foreign_account_arn) is None
+        assert m._tags.get_scoped("000000000000", "us-east-1", foreign_account_arn) is None
     finally:
         m._tags.clear()
         m._tags._data.update(original_tags)


### PR DESCRIPTION
## Summary
- validate Step Functions tag resource ARNs before reading or mutating tag state
- reject wrong-account state machine tag/list requests with `AccessDeniedException`
- reject foreign-region state machine tag/untag/list requests with `InvalidArn`

## Validation
- `AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test AWS_DEFAULT_REGION=us-east-1 uv run --extra dev pytest tests/test_stepfunctions.py -v` (`144 passed`)
- `uv run --extra dev ruff check ministack/services/stepfunctions.py tests/test_stepfunctions.py`
- `git diff --check -- ministack/services/stepfunctions.py tests/test_stepfunctions.py`
