### PR TITLE
Validate Lambda layer attachment ARNs

### DIFF
--- a/ministack/services/lambda_svc.py
+++ b/ministack/services/lambda_svc.py
@@ -29,13 +29,13 @@ import base64
 import contextvars
 import copy
 import hashlib
-import secrets
 import importlib
 import io
 import json
 import logging
 import os
 import re
+import secrets
 import socket
 import subprocess
 import tempfile
@@ -1012,25 +1012,86 @@ def _build_config(name: str, data: dict, code_zip: bytes | None = None) -> dict:
     return config
 
 
-def _validate_layer_regions(layers: list | None):
+def _lambda_layer_version_name_and_number_from_arn_spec(spec) -> tuple[str, int] | None:
+    if spec.service != "lambda":
+        return None
+    parts = spec.resource.split(":", 2)
+    if len(parts) != 3 or parts[0] != "layer" or not parts[1] or not parts[2].isdigit():
+        return None
+    return parts[1], int(parts[2])
+
+
+def _invalid_layer_version_arn(layer_arn: str):
+    return error_response_json(
+        "InvalidParameterValueException",
+        f"Layer version ARN {layer_arn} is invalid.",
+        400,
+    )
+
+
+def _resolve_layer_version_for_attachment(layer_arn: str):
+    try:
+        spec = parse_arn(layer_arn)
+    except ArnParseError:
+        return None, _invalid_layer_version_arn(layer_arn)
+
+    layer_ref = _lambda_layer_version_name_and_number_from_arn_spec(spec)
+    if layer_ref is None:
+        return None, _invalid_layer_version_arn(layer_arn)
+
+    if spec.account_id != get_account_id():
+        return None, error_response_json(
+            "AccessDeniedException",
+            "User is not authorized to access this resource.",
+            403,
+        )
+    if spec.region != get_region():
+        return None, error_response_json(
+            "InvalidParameterValueException",
+            f"Layer version ARN {layer_arn} is in region {spec.region}; "
+            f"function region is {get_region()}",
+            400,
+        )
+
+    layer_name, version = layer_ref
+    layer = _layers.get_scoped(spec.account_id, spec.region, layer_name)
+    if not layer:
+        return None, error_response_json(
+            "InvalidParameterValueException",
+            f"Layer version {layer_arn} does not exist.",
+            400,
+        )
+    for version_config in layer["versions"]:
+        if version_config["Version"] == version:
+            return version_config, None
+    return None, error_response_json(
+        "InvalidParameterValueException",
+        f"Layer version {layer_arn} does not exist.",
+        400,
+    )
+
+
+def _layer_config_from_version(layer_arn: str, version_config: dict) -> dict:
+    return {
+        "Arn": layer_arn,
+        "CodeSize": version_config.get("Content", {}).get("CodeSize", 0),
+    }
+
+
+def _normalize_layer_attachments(layers: list | None):
+    layers_cfg = []
     for layer in layers or []:
         layer_arn = layer if isinstance(layer, str) else (layer or {}).get("Arn")
         if not layer_arn:
-            continue
-        try:
-            spec = parse_arn(layer_arn)
-        except ArnParseError:
-            continue
-        if spec.service != "lambda" or not spec.resource.startswith("layer:"):
-            continue
-        if spec.region != get_region():
-            return error_response_json(
-                "InvalidParameterValueException",
-                f"Layer version ARN {layer_arn} is in region {spec.region}; "
-                f"function region is {get_region()}",
-                400,
-            )
-    return None
+            return None, _invalid_layer_version_arn(str(layer_arn or ""))
+        version_config, err = _resolve_layer_version_for_attachment(layer_arn)
+        if err:
+            return None, err
+        normalized = _layer_config_from_version(layer_arn, version_config)
+        if isinstance(layer, dict):
+            normalized.update({k: v for k, v in layer.items() if k not in normalized})
+        layers_cfg.append(normalized)
+    return layers_cfg, None
 
 
 
@@ -1520,9 +1581,12 @@ def _create_function(data: dict):
     err = _validate_dead_letter_config(data.get("DeadLetterConfig"))
     if err:
         return err
-    err = _validate_layer_regions(data.get("Layers"))
+    layers_cfg, err = _normalize_layer_attachments(data.get("Layers"))
     if err:
         return err
+    if data.get("Layers") is not None:
+        data = dict(data)
+        data["Layers"] = layers_cfg
 
     config = _build_config(name, data, code_zip)
     if image_uri:
@@ -1957,9 +2021,11 @@ def _update_config(name: str, data: dict):
     if err:
         return err
     if "Layers" in data:
-        err = _validate_layer_regions(data.get("Layers"))
+        layers_cfg, err = _normalize_layer_attachments(data.get("Layers"))
         if err:
             return err
+        data = dict(data)
+        data["Layers"] = layers_cfg
     config = _functions[name]["config"]
     for key in (
         "Runtime",
@@ -4011,21 +4077,10 @@ def _layer_codesize_for_arn(layer_arn_str: str) -> int:
     version can't be resolved. Real AWS surfaces the actual layer code size on
     `GetFunctionConfiguration.Layers[*].CodeSize` so callers can sanity-check
     against quotas (250 MB unzipped function + layers)."""
-    segs = layer_arn_str.split(":")
-    if len(segs) < 8:
+    version_config, err = _resolve_layer_version_for_attachment(layer_arn_str)
+    if err:
         return 0
-    layer_name = segs[6]
-    try:
-        version = int(segs[7])
-    except (ValueError, IndexError):
-        return 0
-    layer = _layers.get(layer_name)
-    if not layer:
-        return 0
-    for v in layer["versions"]:
-        if v["Version"] == version:
-            return v.get("Content", {}).get("CodeSize", 0)
-    return 0
+    return version_config.get("Content", {}).get("CodeSize", 0)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_lambda.py
+++ b/tests/test_lambda.py
@@ -2337,6 +2337,55 @@ def test_lambda_rejects_cross_region_layers_on_create_and_update():
     finally:
         east.delete_function(FunctionName=update_name)
 
+
+def test_lambda_rejects_wrong_account_layers_on_create_and_update(lam):
+    suffix = _uuid_mod.uuid4().hex[:8]
+
+    layer_buf = io.BytesIO()
+    with zipfile.ZipFile(layer_buf, "w") as z:
+        z.writestr("layer.py", "")
+    layer_arn = lam.publish_layer_version(
+        LayerName=f"wrong-account-layer-{suffix}",
+        Content={"ZipFile": layer_buf.getvalue()},
+    )["LayerVersionArn"]
+    arn_parts = layer_arn.split(":")
+    arn_parts[4] = "111111111111" if arn_parts[4] != "111111111111" else "222222222222"
+    wrong_account_arn = ":".join(arn_parts)
+
+    create_name = f"wrong-account-layer-create-{suffix}"
+    update_name = f"wrong-account-layer-update-{suffix}"
+    try:
+        with pytest.raises(ClientError) as create_exc:
+            lam.create_function(
+                FunctionName=create_name,
+                Runtime="python3.12",
+                Role=_LAMBDA_ROLE,
+                Handler="index.handler",
+                Code={"ZipFile": _make_zip(_LAMBDA_CODE)},
+                Layers=[wrong_account_arn],
+            )
+        assert create_exc.value.response["Error"]["Code"] == "AccessDeniedException"
+
+        lam.create_function(
+            FunctionName=update_name,
+            Runtime="python3.12",
+            Role=_LAMBDA_ROLE,
+            Handler="index.handler",
+            Code={"ZipFile": _make_zip(_LAMBDA_CODE)},
+        )
+        with pytest.raises(ClientError) as update_exc:
+            lam.update_function_configuration(FunctionName=update_name, Layers=[wrong_account_arn])
+        assert update_exc.value.response["Error"]["Code"] == "AccessDeniedException"
+        cfg = lam.get_function_configuration(FunctionName=update_name)
+        assert cfg["Layers"] == []
+    finally:
+        for name in (create_name, update_name):
+            try:
+                lam.delete_function(FunctionName=name)
+            except ClientError:
+                pass
+
+
 def test_lambda_docker_cp_dir_arcname_creates_subdir_in_existing_parent():
     """Docker's put_archive requires dest_dir to exist. For /opt/layer_N
     (which doesn't exist in the base RIE image), the fix is to extract into
@@ -2439,7 +2488,7 @@ def test_lambda_function_with_layer_reports_real_code_size(lam):
     fn_zip = io.BytesIO()
     with zipfile.ZipFile(fn_zip, "w") as z:
         z.writestr("index.py", "def handler(e, c): return {}")
-    lam.create_function(
+    created = lam.create_function(
         FunctionName="codesize-fn",
         Runtime="python3.12",
         Role="arn:aws:iam::000000000000:role/test",
@@ -2447,6 +2496,8 @@ def test_lambda_function_with_layer_reports_real_code_size(lam):
         Code={"ZipFile": fn_zip.getvalue()},
         Layers=[layer_arn],
     )
+    assert created["Layers"][0]["Arn"] == layer_arn
+    assert created["Layers"][0]["CodeSize"] == expected_size
     cfg = lam.get_function_configuration(FunctionName="codesize-fn")
     assert cfg["Layers"][0]["Arn"] == layer_arn
     assert cfg["Layers"][0]["CodeSize"] == expected_size
@@ -2461,11 +2512,13 @@ def test_lambda_update_function_configuration_layer_attachment_invokes_with_laye
     layer_buf = io.BytesIO()
     with zipfile.ZipFile(layer_buf, "w") as z:
         z.writestr("python/mylayermod.py", "VALUE = 'from-layer'")
-    layer_arn = lam.publish_layer_version(
+    layer_resp = lam.publish_layer_version(
         LayerName="late-attach-layer",
         Content={"ZipFile": layer_buf.getvalue()},
         CompatibleRuntimes=["python3.12"],
-    )["LayerVersionArn"]
+    )
+    layer_arn = layer_resp["LayerVersionArn"]
+    expected_size = layer_resp["Content"]["CodeSize"]
 
     # Function created WITHOUT the layer first — handler tolerates the absence
     # so the initial invoke can warm a worker.
@@ -2494,12 +2547,14 @@ def test_lambda_update_function_configuration_layer_attachment_invokes_with_laye
     assert pre_body == {"layer_value": None}
 
     # Attach the layer via UpdateFunctionConfiguration.
-    lam.update_function_configuration(FunctionName="late-attach-fn", Layers=[layer_arn])
+    update_resp = lam.update_function_configuration(FunctionName="late-attach-fn", Layers=[layer_arn])
+    assert update_resp["Layers"][0]["Arn"] == layer_arn
+    assert update_resp["Layers"][0]["CodeSize"] == expected_size
 
     # (a) CodeSize on GetFunctionConfiguration matches the layer's real size.
     cfg = lam.get_function_configuration(FunctionName="late-attach-fn")
     assert cfg["Layers"][0]["Arn"] == layer_arn
-    assert cfg["Layers"][0]["CodeSize"] > 0
+    assert cfg["Layers"][0]["CodeSize"] == expected_size
 
     # (b) Next invoke must use a fresh worker that has the layer mounted on
     #     /opt/python — the import succeeds and the handler returns the layer value.


### PR DESCRIPTION
## Summary
- parse and validate layer version ARNs when creating or updating function layers
- return the attached layer version's stored `CodeSize` for valid same-region layer attachments
- reject foreign-region layer ARNs with `InvalidParameterValueException` and wrong-account layer ARNs with `AccessDeniedException`

## Validation
- `AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test AWS_DEFAULT_REGION=us-east-1 uv run --extra dev pytest tests/test_lambda.py -v` (`239 passed, 1 skipped`)
- `uv run --extra dev ruff check ministack/services/lambda_svc.py`
- `python3 -m py_compile ministack/services/lambda_svc.py tests/test_lambda.py`
- `git diff --check -- ministack/services/lambda_svc.py tests/test_lambda.py`
