### PR TITLE
Validate CloudTrail trail ARN partitions

### DIFF
--- a/ministack/services/cloudtrail.py
+++ b/ministack/services/cloudtrail.py
@@ -274,13 +274,28 @@ def _resolve_trail_name_or_error(name: str, *, allow_cross_region_arn: bool = Fa
         return None, _err("CloudTrailARNInvalidException", str(exc))
 
 
-def _validate_trail_arn(arn: str):
+def _is_non_aws_trail_arn_partition(raw: str) -> bool:
     try:
-        name = _trail_name_from_arn(arn)
+        spec, _ = _parse_trail_arn(raw)
+    except ValueError:
+        return False
+    return spec.partition != "aws"
+
+
+def _validate_trail_arn(arn: str, *, require_existing: bool = False):
+    try:
+        spec, trail_name = _parse_trail_arn(arn)
     except ValueError as exc:
         return _err("CloudTrailARNInvalidException", str(exc))
-    if name is None:
+
+    if spec.partition != "aws" or spec.region != get_region() or spec.account_id != get_account_id():
         return _err("CloudTrailARNInvalidException", "Invalid CloudTrail trail ARN.")
+
+    if require_existing:
+        trail = _trails.get(trail_name)
+        if trail is None or trail.get("TrailARN") != str(spec):
+            return _err("ResourceNotFoundException", f"Unknown trail: {arn!r}")
+
     return None
 
 
@@ -348,6 +363,8 @@ def _get_trail(body: dict):
     raw = body.get("Name", "").strip()
     if not raw:
         return _err("InvalidTrailNameException", "Trail name is required.")
+    if raw.startswith("arn:") and _is_non_aws_trail_arn_partition(raw):
+        return _err("InvalidTrailNameException", "Invalid trail name.")
     name, error = _resolve_trail_name_or_error(raw, allow_cross_region_arn=True)
     if error:
         return error
@@ -517,7 +534,7 @@ def _add_tags(body: dict):
     arn = body.get("ResourceId", "").strip()
     if not arn:
         return _err("CloudTrailARNInvalidException", "ResourceId (trail ARN) is required.")
-    error = _validate_trail_arn(arn)
+    error = _validate_trail_arn(arn, require_existing=True)
     if error:
         return error
     existing = _trail_tags.get(arn) or {}
@@ -530,7 +547,7 @@ def _add_tags(body: dict):
 def _list_tags(body: dict):
     arns = body.get("ResourceIdList", [])
     for arn in arns:
-        error = _validate_trail_arn(arn)
+        error = _validate_trail_arn(arn, require_existing=True)
         if error:
             return error
     result = [
@@ -547,7 +564,7 @@ def _remove_tags(body: dict):
     arn = body.get("ResourceId", "").strip()
     if not arn:
         return _err("CloudTrailARNInvalidException", "ResourceId (trail ARN) is required.")
-    error = _validate_trail_arn(arn)
+    error = _validate_trail_arn(arn, require_existing=True)
     if error:
         return error
     existing = _trail_tags.get(arn) or {}

--- a/tests/test_cloudtrail.py
+++ b/tests/test_cloudtrail.py
@@ -121,6 +121,14 @@ def test_get_trail_rejects_malformed_arn_identifier(ct):
     assert exc.value.response["Error"]["Code"] == "CloudTrailARNInvalidException"
 
 
+@pytest.mark.parametrize("partition", ["aws-cn", "notaws"])
+def test_get_trail_rejects_non_aws_partition_as_invalid_trail_name(ct, partition):
+    arn = f"arn:{partition}:cloudtrail:{REGION}:000000000000:trail/missing-{_uid()}"
+    with pytest.raises(ClientError) as exc:
+        ct.get_trail(Name=arn)
+    assert exc.value.response["Error"]["Code"] == "InvalidTrailNameException"
+
+
 def test_get_trail_does_not_resolve_foreign_region_arn_by_tail(ct):
     name = f"trail-foreign-region-{_uid()}"
     arn = ct.create_trail(Name=name, S3BucketName="bucket")["TrailARN"]
@@ -149,6 +157,13 @@ def test_get_trail_not_found(ct):
     with pytest.raises(ClientError) as exc:
         ct.get_trail(Name=f"nonexistent-{_uid()}")
     assert "TrailNotFoundException" in str(exc.value)
+
+
+def test_get_trail_missing_aws_partition_arn_returns_not_found(ct):
+    arn = f"arn:aws:cloudtrail:{REGION}:000000000000:trail/missing-{_uid()}"
+    with pytest.raises(ClientError) as exc:
+        ct.get_trail(Name=arn)
+    assert exc.value.response["Error"]["Code"] == "TrailNotFoundException"
 
 
 def test_delete_trail(ct):
@@ -328,6 +343,21 @@ def test_add_tags_rejects_malformed_trail_arn(ct):
     assert exc.value.response["Error"]["Code"] == "CloudTrailARNInvalidException"
 
 
+@pytest.mark.parametrize("partition", ["aws-cn", "notaws"])
+def test_add_tags_rejects_non_aws_partition_trail_arn(ct, partition):
+    arn = f"arn:{partition}:cloudtrail:{REGION}:000000000000:trail/missing-{_uid()}"
+    with pytest.raises(ClientError) as exc:
+        ct.add_tags(ResourceId=arn, TagsList=[{"Key": "env", "Value": "test"}])
+    assert exc.value.response["Error"]["Code"] == "CloudTrailARNInvalidException"
+
+
+def test_add_tags_missing_aws_partition_trail_arn_returns_resource_not_found(ct):
+    arn = f"arn:aws:cloudtrail:{REGION}:000000000000:trail/missing-{_uid()}"
+    with pytest.raises(ClientError) as exc:
+        ct.add_tags(ResourceId=arn, TagsList=[{"Key": "env", "Value": "test"}])
+    assert exc.value.response["Error"]["Code"] == "ResourceNotFoundException"
+
+
 def test_add_tags_rejects_foreign_region_trail_arn(ct):
     name = f"trail-tags-foreign-{_uid()}"
     arn = ct.create_trail(Name=name, S3BucketName="bucket")["TrailARN"]
@@ -342,6 +372,36 @@ def test_list_tags_rejects_wrong_service_trail_arn(ct):
     with pytest.raises(ClientError) as exc:
         ct.list_tags(ResourceIdList=[f"arn:aws:sns:{REGION}:000000000000:trail/not-a-trail"])
     assert exc.value.response["Error"]["Code"] == "CloudTrailARNInvalidException"
+
+
+@pytest.mark.parametrize("partition", ["aws-cn", "notaws"])
+def test_list_tags_rejects_non_aws_partition_trail_arn(ct, partition):
+    arn = f"arn:{partition}:cloudtrail:{REGION}:000000000000:trail/missing-{_uid()}"
+    with pytest.raises(ClientError) as exc:
+        ct.list_tags(ResourceIdList=[arn])
+    assert exc.value.response["Error"]["Code"] == "CloudTrailARNInvalidException"
+
+
+def test_list_tags_missing_aws_partition_trail_arn_returns_resource_not_found(ct):
+    arn = f"arn:aws:cloudtrail:{REGION}:000000000000:trail/missing-{_uid()}"
+    with pytest.raises(ClientError) as exc:
+        ct.list_tags(ResourceIdList=[arn])
+    assert exc.value.response["Error"]["Code"] == "ResourceNotFoundException"
+
+
+@pytest.mark.parametrize("partition", ["aws-cn", "notaws"])
+def test_remove_tags_rejects_non_aws_partition_trail_arn(ct, partition):
+    arn = f"arn:{partition}:cloudtrail:{REGION}:000000000000:trail/missing-{_uid()}"
+    with pytest.raises(ClientError) as exc:
+        ct.remove_tags(ResourceId=arn, TagsList=[{"Key": "env"}])
+    assert exc.value.response["Error"]["Code"] == "CloudTrailARNInvalidException"
+
+
+def test_remove_tags_missing_aws_partition_trail_arn_returns_resource_not_found(ct):
+    arn = f"arn:aws:cloudtrail:{REGION}:000000000000:trail/missing-{_uid()}"
+    with pytest.raises(ClientError) as exc:
+        ct.remove_tags(ResourceId=arn, TagsList=[{"Key": "env"}])
+    assert exc.value.response["Error"]["Code"] == "ResourceNotFoundException"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- preserve normal not-found behavior for missing `arn:aws` CloudTrail trail ARNs
- reject non-`aws` partition trail ARNs with operation-specific CloudTrail errors
- apply existing-trail validation consistently across add, list, and remove tag APIs

## Validation
- `AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test AWS_DEFAULT_REGION=us-east-1 uv run --extra dev pytest tests/test_cloudtrail.py -v` (`61 passed`)
- `uv run --extra dev ruff check ministack/services/cloudtrail.py tests/test_cloudtrail.py`
- `git diff --check -- ministack/services/cloudtrail.py tests/test_cloudtrail.py`
