### PR TITLE
Validate Kinesis stream and consumer ARNs

### DIFF
--- a/ministack/services/kinesis.py
+++ b/ministack/services/kinesis.py
@@ -21,6 +21,7 @@ import os
 import threading
 import time
 
+from ministack.core.arn import ArnParseError, parse_arn
 from ministack.core.responses import (
     AccountScopedDict,
     error_response_json,
@@ -116,6 +117,64 @@ def _route_to_shard(hash_key_int: int, stream: dict) -> str:
     return next(iter(stream["shards"]))
 
 
+def _kinesis_resource_tail(value, resource_type):
+    try:
+        spec = parse_arn(value)
+    except ArnParseError:
+        return None
+    if (
+        spec.partition != "aws"
+        or spec.service != "kinesis"
+        or spec.region != get_region()
+        or spec.account_id != get_account_id()
+    ):
+        return None
+    prefix = f"{resource_type}/"
+    if not spec.resource.startswith(prefix):
+        return None
+    tail = spec.resource[len(prefix):]
+    return tail or None
+
+
+def _stream_name_from_arn(stream_arn):
+    tail = _kinesis_resource_tail(stream_arn, "stream")
+    if not tail or "/" in tail:
+        return None
+    return tail
+
+
+def _resolve_stream_by_arn(stream_arn):
+    name = _stream_name_from_arn(stream_arn)
+    if not name:
+        return None
+    stream = _streams.get(name)
+    if stream and stream.get("StreamARN") == stream_arn:
+        return stream
+    return None
+
+
+def _consumer_from_arn(consumer_arn):
+    tail = _kinesis_resource_tail(consumer_arn, "stream")
+    if not tail:
+        return None
+    parts = tail.split("/")
+    if len(parts) != 3 or parts[1] != "consumer" or not parts[0] or not parts[2]:
+        return None
+    return _consumers.get(consumer_arn)
+
+
+def _consumer_by_stream_and_name(stream_arn, consumer_name):
+    if not _resolve_stream_by_arn(stream_arn):
+        return None
+    return next(
+        (
+            c for c in _consumers.values()
+            if c["StreamARN"] == stream_arn and c["ConsumerName"] == consumer_name
+        ),
+        None,
+    )
+
+
 def _expire_records(stream):
     cutoff = time.time() - stream["RetentionPeriodHours"] * 3600
     for shard in stream["shards"].values():
@@ -141,9 +200,9 @@ def _resolve_stream(data):
     if name and name in _streams:
         return name, _streams[name]
     if arn:
-        for n, s in _streams.items():
-            if s["StreamARN"] == arn:
-                return n, s
+        stream = _resolve_stream_by_arn(arn)
+        if stream:
+            return stream["StreamName"], stream
     return name or arn, None
 
 
@@ -159,7 +218,7 @@ def put_record_internal(stream_arn: str, partition_key: str, data: bytes) -> boo
     or not ACTIVE (matches AWS behaviour where delivery to a disabled
     destination is dropped without surfacing an error on the writer).
     """
-    stream = next((s for s in _streams.values() if s.get("StreamARN") == stream_arn), None)
+    stream = _resolve_stream_by_arn(stream_arn)
     if not stream or stream.get("StreamStatus") != "ACTIVE":
         return False
     _expire_records(stream)
@@ -859,7 +918,7 @@ def _register_consumer(data):
     if not stream_arn or not consumer_name:
         return error_response_json("ValidationException",
                                    "StreamARN and ConsumerName are required", 400)
-    stream = next((s for s in _streams.values() if s["StreamARN"] == stream_arn), None)
+    stream = _resolve_stream_by_arn(stream_arn)
     if not stream:
         return error_response_json("ResourceNotFoundException",
                                    f"Stream with ARN {stream_arn} not found", 400)
@@ -890,15 +949,15 @@ def _deregister_consumer(data):
     stream_arn = data.get("StreamARN")
     consumer_name = data.get("ConsumerName")
     if consumer_arn:
-        if consumer_arn not in _consumers:
+        consumer = _consumer_from_arn(consumer_arn)
+        if not consumer:
             return error_response_json("ResourceNotFoundException", "Consumer not found", 400)
-        del _consumers[consumer_arn]
+        del _consumers[consumer["ConsumerARN"]]
     elif stream_arn and consumer_name:
-        found = next((a for a, c in _consumers.items()
-                       if c["StreamARN"] == stream_arn and c["ConsumerName"] == consumer_name), None)
-        if not found:
+        consumer = _consumer_by_stream_and_name(stream_arn, consumer_name)
+        if not consumer:
             return error_response_json("ResourceNotFoundException", "Consumer not found", 400)
-        del _consumers[found]
+        del _consumers[consumer["ConsumerARN"]]
     else:
         return error_response_json("ValidationException",
                                    "ConsumerARN or StreamARN+ConsumerName required", 400)
@@ -909,6 +968,8 @@ def _list_consumers(data):
     stream_arn = data.get("StreamARN")
     if not stream_arn:
         return error_response_json("ValidationException", "StreamARN is required", 400)
+    if not _resolve_stream_by_arn(stream_arn):
+        return error_response_json("ResourceNotFoundException", f"Stream with ARN {stream_arn} not found", 400)
     max_results = data.get("MaxResults", 100)
     next_token = data.get("NextToken")
 
@@ -939,13 +1000,9 @@ def _describe_stream_consumer(data):
 
     consumer = None
     if consumer_arn:
-        consumer = _consumers.get(consumer_arn)
+        consumer = _consumer_from_arn(consumer_arn)
     elif stream_arn and consumer_name:
-        consumer = next(
-            (c for c in _consumers.values()
-             if c["StreamARN"] == stream_arn and c["ConsumerName"] == consumer_name),
-            None,
-        )
+        consumer = _consumer_by_stream_and_name(stream_arn, consumer_name)
 
     if not consumer:
         return error_response_json("ResourceNotFoundException", "Consumer not found", 400)

--- a/tests/test_kinesis.py
+++ b/tests/test_kinesis.py
@@ -6,10 +6,25 @@ import uuid as _uuid_mod
 import zipfile
 from urllib.parse import urlparse
 
+import boto3
 import pytest
+from botocore.config import Config
 from botocore.exceptions import ClientError
 
 _LAMBDA_ROLE = "arn:aws:iam::000000000000:role/lambda-role"
+
+
+def _regional_kin(region_name):
+    endpoint = os.environ.get("MINISTACK_ENDPOINT", "http://localhost:4566")
+    return boto3.client(
+        "kinesis",
+        endpoint_url=endpoint,
+        aws_access_key_id="test",
+        aws_secret_access_key="test",
+        region_name=region_name,
+        config=Config(region_name=region_name, retries={"mode": "standard"}),
+    )
+
 
 def test_kinesis_put_get(kin):
     kin.create_stream(StreamName="test-stream", ShardCount=1)
@@ -97,6 +112,23 @@ def test_kinesis_describe_stream_v2(kin):
 
     summary = kin.describe_stream_summary(StreamName="kin-desc-v2")
     assert summary["StreamDescriptionSummary"]["StreamName"] == "kin-desc-v2"
+
+
+def test_kinesis_stream_arn_rejects_foreign_region_without_name_fallback(kin):
+    """StreamARN inputs must be parsed before matching account-scoped state."""
+    west = _regional_kin("us-west-2")
+    stream_name = f"kin-arn-scope-{_uuid_mod.uuid4().hex[:8]}"
+    west.create_stream(StreamName=stream_name, ShardCount=1)
+    west_arn = west.describe_stream(StreamName=stream_name)["StreamDescription"]["StreamARN"]
+
+    with pytest.raises(ClientError) as exc:
+        kin.describe_stream(StreamARN=west_arn)
+    assert exc.value.response["Error"]["Code"] == "ResourceNotFoundException"
+
+    with pytest.raises(ClientError) as exc:
+        kin.put_record(StreamARN=west_arn, Data=b"no-fallback", PartitionKey="pk")
+    assert exc.value.response["Error"]["Code"] == "ResourceNotFoundException"
+
 
 def test_kinesis_tags_v2(kin):
     kin.create_stream(StreamName="kin-tag-v2", ShardCount=1)
@@ -215,6 +247,38 @@ def test_kinesis_register_deregister_consumer(kin):
     consumers2 = kin.list_stream_consumers(StreamARN=stream_arn)
     assert not any(c["ConsumerName"] == "my-consumer" for c in consumers2["Consumers"])
     kin.delete_stream(StreamName=sname)
+
+
+def test_kinesis_consumer_arns_reject_foreign_region_without_exact_key_fallback(kin):
+    """ConsumerARN paths must not resolve a consumer owned by another request region."""
+    west = _regional_kin("us-west-2")
+    stream_name = f"kin-consumer-arn-scope-{_uuid_mod.uuid4().hex[:8]}"
+    consumer_name = "west-consumer"
+    west.create_stream(StreamName=stream_name, ShardCount=1)
+    west_arn = west.describe_stream(StreamName=stream_name)["StreamDescription"]["StreamARN"]
+    consumer_arn = west.register_stream_consumer(
+        StreamARN=west_arn,
+        ConsumerName=consumer_name,
+    )["Consumer"]["ConsumerARN"]
+
+    with pytest.raises(ClientError) as exc:
+        kin.list_stream_consumers(StreamARN=west_arn)
+    assert exc.value.response["Error"]["Code"] == "ResourceNotFoundException"
+
+    for kwargs in (
+        {"ConsumerARN": consumer_arn},
+        {"StreamARN": west_arn, "ConsumerName": consumer_name},
+    ):
+        with pytest.raises(ClientError) as exc:
+            kin.describe_stream_consumer(**kwargs)
+        assert exc.value.response["Error"]["Code"] == "ResourceNotFoundException"
+
+    with pytest.raises(ClientError) as exc:
+        kin.deregister_stream_consumer(ConsumerARN=consumer_arn)
+    assert exc.value.response["Error"]["Code"] == "ResourceNotFoundException"
+
+    assert west.describe_stream_consumer(ConsumerARN=consumer_arn)["ConsumerDescription"]["ConsumerName"] == consumer_name
+
 
 def test_kinesis_at_timestamp_iterator(kin):
     """AT_TIMESTAMP shard iterator returns records after the given timestamp."""


### PR DESCRIPTION
## Summary
- Parse Kinesis `StreamARN` inputs before resolving streams from account-scoped state.
- Parse enhanced fan-out `ConsumerARN` and `StreamARN` + `ConsumerName` paths before resolving consumers.
- Reject foreign-region/account exact-key fallback while preserving existing local stream and consumer behavior.

## Validation
- `AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test AWS_DEFAULT_REGION=us-east-1 MINISTACK_ENDPOINT=http://localhost:4566 uv run --extra dev --with cbor2 pytest tests/test_kinesis.py -v`
- `AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test AWS_DEFAULT_REGION=us-east-1 uv run --extra dev --with cbor2 ruff check ministack/services/kinesis.py tests/test_kinesis.py`
- `git diff --check`
- `codex review --base upstream/feat/multi-region`