### PR TITLE
Validate ACM certificate ARNs

### DIFF
--- a/ministack/services/acm.py
+++ b/ministack/services/acm.py
@@ -13,6 +13,7 @@ import logging
 import os
 import time
 
+from ministack.core.arn import ArnParseError, parse_arn
 from ministack.core.persistence import PERSIST_STATE, load_state
 from ministack.core.responses import (
     AccountScopedDict,
@@ -29,6 +30,7 @@ logger = logging.getLogger("acm")
 REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 
 _certificates = AccountScopedDict()  # arn -> certificate dict
+_CERTIFICATE_RESOURCE_PREFIX = "certificate/"
 
 
 def get_state():
@@ -115,6 +117,34 @@ def _epoch(iso_or_epoch):
 
 def _cert_arn():
     return f"arn:aws:acm:{get_region()}:{get_account_id()}:certificate/{new_uuid()}"
+
+
+def _is_local_certificate_arn(arn):
+    try:
+        spec = parse_arn(arn)
+    except ArnParseError:
+        return False
+    if (
+        spec.partition != "aws"
+        or spec.service != "acm"
+        or spec.account_id != get_account_id()
+        or spec.region != get_region()
+    ):
+        return False
+    if not spec.resource.startswith(_CERTIFICATE_RESOURCE_PREFIX):
+        return False
+    certificate_id = spec.resource[len(_CERTIFICATE_RESOURCE_PREFIX):]
+    return bool(certificate_id) and "/" not in certificate_id
+
+
+def _get_local_certificate(arn):
+    if not _is_local_certificate_arn(arn):
+        return None
+    return _certificates.get(arn)
+
+
+def _certificate_not_found(arn):
+    return error_response_json("ResourceNotFoundException", f"Certificate {arn} not found", 400)
 
 
 def _validation_options(domain, method):
@@ -218,9 +248,9 @@ def _request_certificate(data):
 
 def _describe_certificate(data):
     arn = data.get("CertificateArn", "")
-    cert = _certificates.get(arn)
+    cert = _get_local_certificate(arn)
     if not cert:
-        return error_response_json("ResourceNotFoundException", f"Certificate {arn} not found", 400)
+        return _certificate_not_found(arn)
     return json_response({"Certificate": _cert_shape(cert)})
 
 
@@ -228,6 +258,8 @@ def _list_certificates(data):
     statuses = data.get("CertificateStatuses", [])
     summaries = []
     for arn, cert in _certificates.items():
+        if not _is_local_certificate_arn(arn):
+            continue
         if statuses and cert["Status"] not in statuses:
             continue
         summaries.append({
@@ -246,8 +278,8 @@ def _list_certificates(data):
 
 def _delete_certificate(data):
     arn = data.get("CertificateArn", "")
-    if arn not in _certificates:
-        return error_response_json("ResourceNotFoundException", f"Certificate {arn} not found", 400)
+    if _get_local_certificate(arn) is None:
+        return _certificate_not_found(arn)
     del _certificates[arn]
     return json_response({})
 
@@ -277,9 +309,9 @@ def _decode_pem_field(value):
 
 def _get_certificate(data):
     arn = data.get("CertificateArn", "")
-    cert = _certificates.get(arn)
+    cert = _get_local_certificate(arn)
     if cert is None:
-        return error_response_json("ResourceNotFoundException", f"Certificate {arn} not found", 400)
+        return _certificate_not_found(arn)
     # PrivateKey is intentionally never returned — real AWS only exposes
     # it via ExportCertificate (passphrase-protected).
     return json_response({
@@ -290,6 +322,8 @@ def _get_certificate(data):
 
 def _import_certificate(data):
     arn = data.get("CertificateArn") or _cert_arn()
+    if data.get("CertificateArn") and not _is_local_certificate_arn(arn):
+        return _certificate_not_found(arn)
     now = now_iso()
     cert_body = _decode_pem_field(data.get("Certificate"))
     cert_chain = _decode_pem_field(data.get("CertificateChain"))
@@ -323,9 +357,9 @@ def _import_certificate(data):
 
 def _add_tags(data):
     arn = data.get("CertificateArn", "")
-    cert = _certificates.get(arn)
+    cert = _get_local_certificate(arn)
     if not cert:
-        return error_response_json("ResourceNotFoundException", f"Certificate {arn} not found", 400)
+        return _certificate_not_found(arn)
     existing = {t["Key"]: t for t in cert.get("Tags", [])}
     for tag in data.get("Tags", []):
         existing[tag["Key"]] = tag
@@ -335,9 +369,9 @@ def _add_tags(data):
 
 def _remove_tags(data):
     arn = data.get("CertificateArn", "")
-    cert = _certificates.get(arn)
+    cert = _get_local_certificate(arn)
     if not cert:
-        return error_response_json("ResourceNotFoundException", f"Certificate {arn} not found", 400)
+        return _certificate_not_found(arn)
     remove_keys = {t["Key"] for t in data.get("Tags", [])}
     cert["Tags"] = [t for t in cert.get("Tags", []) if t["Key"] not in remove_keys]
     return json_response({})
@@ -345,32 +379,32 @@ def _remove_tags(data):
 
 def _list_tags(data):
     arn = data.get("CertificateArn", "")
-    cert = _certificates.get(arn)
+    cert = _get_local_certificate(arn)
     if not cert:
-        return error_response_json("ResourceNotFoundException", f"Certificate {arn} not found", 400)
+        return _certificate_not_found(arn)
     return json_response({"Tags": cert.get("Tags", [])})
 
 
 def _update_options(data):
     arn = data.get("CertificateArn", "")
-    cert = _certificates.get(arn)
+    cert = _get_local_certificate(arn)
     if not cert:
-        return error_response_json("ResourceNotFoundException", f"Certificate {arn} not found", 400)
+        return _certificate_not_found(arn)
     cert["Options"] = data.get("Options", {})
     return json_response({})
 
 
 def _renew_certificate(data):
     arn = data.get("CertificateArn", "")
-    if arn not in _certificates:
-        return error_response_json("ResourceNotFoundException", f"Certificate {arn} not found", 400)
+    if _get_local_certificate(arn) is None:
+        return _certificate_not_found(arn)
     return json_response({})
 
 
 def _resend_validation_email(data):
     arn = data.get("CertificateArn", "")
-    if arn not in _certificates:
-        return error_response_json("ResourceNotFoundException", f"Certificate {arn} not found", 400)
+    if _get_local_certificate(arn) is None:
+        return _certificate_not_found(arn)
     return json_response({})
 
 

--- a/tests/test_acm.py
+++ b/tests/test_acm.py
@@ -253,6 +253,153 @@ def test_re_import_preserves_arn_and_replaces_body(acm_client):
     assert got["Certificate"] == new_cert.decode()
 
 
+@pytest.fixture
+def acm_service_module():
+    import importlib
+
+    from ministack.core.responses import _request_account_id, _request_region
+
+    mod = importlib.import_module("ministack.services.acm")
+    mod._certificates._data.clear()
+    account_token = _request_account_id.set("000000000000")
+    region_token = _request_region.set("us-east-1")
+    try:
+        yield mod
+    finally:
+        mod._certificates._data.clear()
+        _request_region.reset(region_token)
+        _request_account_id.reset(account_token)
+
+
+def _json_body(response):
+    return json.loads(response[2].decode())
+
+
+def _error_code(response):
+    return _json_body(response)["__type"]
+
+
+@pytest.mark.parametrize(
+    "bad_arn",
+    [
+        "arn:nope",
+        "arn:aws-cn:acm:us-east-1:000000000000:certificate/wrong-partition",
+        "arn:aws:sns:us-east-1:000000000000:certificate/not-acm",
+        "arn:aws:acm:us-east-1:111111111111:certificate/wrong-account",
+        "arn:aws:acm:us-west-2:000000000000:certificate/wrong-region",
+        "arn:aws:acm:us-east-1:000000000000:not-a-certificate/not-acm-resource",
+    ],
+)
+def test_acm_certificate_arn_operations_reject_out_of_scope_arns(acm_service_module, bad_arn):
+    mod = acm_service_module
+    created = _json_body(mod._request_certificate({"DomainName": "parser-scope.example.com"}))
+    good_arn = created["CertificateArn"]
+
+    for handler in (
+        mod._describe_certificate,
+        mod._get_certificate,
+        mod._list_tags,
+        mod._renew_certificate,
+        mod._resend_validation_email,
+    ):
+        resp = handler({"CertificateArn": bad_arn})
+        assert resp[0] == 400
+        assert _error_code(resp) == "ResourceNotFoundException"
+
+    for handler, payload in (
+        (mod._add_tags, {"CertificateArn": bad_arn, "Tags": [{"Key": "bad", "Value": "tag"}]}),
+        (mod._remove_tags, {"CertificateArn": bad_arn, "Tags": [{"Key": "keep"}]}),
+        (
+            mod._update_options,
+            {
+                "CertificateArn": bad_arn,
+                "Options": {"CertificateTransparencyLoggingPreference": "DISABLED"},
+            },
+        ),
+        (mod._delete_certificate, {"CertificateArn": bad_arn}),
+    ):
+        resp = handler(payload)
+        assert resp[0] == 400
+        assert _error_code(resp) == "ResourceNotFoundException"
+
+    cert = _json_body(mod._describe_certificate({"CertificateArn": good_arn}))["Certificate"]
+    assert cert["CertificateArn"] == good_arn
+    assert cert["Options"] == {}
+    assert cert["Tags"] == []
+
+
+@pytest.mark.parametrize(
+    "bad_arn",
+    [
+        "arn:nope",
+        "arn:aws-cn:acm:us-east-1:000000000000:certificate/wrong-partition",
+        "arn:aws:sns:us-east-1:000000000000:certificate/not-acm",
+        "arn:aws:acm:us-east-1:111111111111:certificate/wrong-account",
+        "arn:aws:acm:us-west-2:000000000000:certificate/wrong-region",
+    ],
+)
+def test_acm_import_certificate_rejects_out_of_scope_certificate_arn(acm_service_module, bad_arn):
+    mod = acm_service_module
+
+    resp = mod._import_certificate(
+        {
+            "CertificateArn": bad_arn,
+            "Certificate": TEST_CERT_PEM,
+            "PrivateKey": TEST_PRIVATE_KEY_PEM,
+            "Tags": [{"Key": "bad", "Value": "import"}],
+        }
+    )
+
+    assert resp[0] == 400
+    assert _error_code(resp) == "ResourceNotFoundException"
+    assert mod._certificates._data == {}
+
+
+def test_acm_valid_reimport_preserves_existing_certificate_arn(acm_service_module):
+    mod = acm_service_module
+    created = _json_body(
+        mod._import_certificate(
+            {
+                "Certificate": TEST_CERT_PEM,
+                "PrivateKey": TEST_PRIVATE_KEY_PEM,
+            }
+        )
+    )
+    arn = created["CertificateArn"]
+
+    new_cert = TEST_CERT_PEM.replace(b"RoundTripTestCert", b"ParserAdoptedCert")
+    resp = mod._import_certificate(
+        {
+            "CertificateArn": arn,
+            "Certificate": new_cert,
+            "PrivateKey": TEST_PRIVATE_KEY_PEM,
+        }
+    )
+
+    assert resp[0] == 200
+    assert _json_body(resp)["CertificateArn"] == arn
+    assert _json_body(mod._get_certificate({"CertificateArn": arn}))["Certificate"] == new_cert.decode()
+
+
+def test_acm_list_certificates_filters_to_request_region(acm_service_module):
+    from ministack.core.responses import _request_region
+
+    mod = acm_service_module
+    east_arn = _json_body(mod._request_certificate({"DomainName": "east-list.example.com"}))["CertificateArn"]
+
+    west_token = _request_region.set("us-west-2")
+    try:
+        west_arn = _json_body(mod._request_certificate({"DomainName": "west-list.example.com"}))["CertificateArn"]
+        west_list = _json_body(mod._list_certificates({}))["CertificateSummaryList"]
+    finally:
+        _request_region.reset(west_token)
+
+    east_list = _json_body(mod._list_certificates({}))["CertificateSummaryList"]
+
+    assert [cert["CertificateArn"] for cert in west_list] == [west_arn]
+    assert [cert["CertificateArn"] for cert in east_list] == [east_arn]
+
+
 # ── PrivateKey persistence leak (in-process, not through the live server) ─
 
 def test_get_state_strips_private_key_from_persisted_snapshot():


### PR DESCRIPTION
## Why
ACM certificate operations should reject malformed or out-of-scope certificate ARNs instead of treating raw strings as local resources.

## What
- Adds parser-backed validation for ACM `CertificateArn` inputs across describe, get, delete, import, tag, option update, renew, and validation-email paths.
- Adds regression coverage for valid local reimport/list behavior and malformed, wrong partition, wrong service, wrong account, wrong Region, and wrong resource-shape ARNs.

## Validation
- `uv run --offline --extra dev ruff check ministack/services/acm.py tests/test_acm.py`
- `uv run --offline --extra dev pytest tests/test_acm.py -v`