### PR TITLE
Validate ECR repository ARNs

### DIFF
--- a/ministack/services/ecr.py
+++ b/ministack/services/ecr.py
@@ -11,6 +11,7 @@ import logging
 import os
 import time
 
+from ministack.core.arn import ArnParseError, parse_arn
 from ministack.core.persistence import PERSIST_STATE, load_state
 from ministack.core.responses import (
     AccountScopedDict,
@@ -603,10 +604,32 @@ def _find_image(repo_name, image_id):
 
 
 def _find_repo_by_arn(arn):
-    for repo in _repositories.values():
-        if repo["repositoryArn"] == arn:
-            return repo
-    return None
+    name = _repo_name_from_arn(arn)
+    if not name:
+        return None
+    repo = _repositories.get(name)
+    if not repo or repo.get("repositoryArn") != arn:
+        return None
+    return repo
+
+
+def _repo_name_from_arn(arn):
+    try:
+        spec = parse_arn(arn)
+    except ArnParseError:
+        return None
+    if (
+        spec.partition != "aws"
+        or spec.service != "ecr"
+        or spec.account_id != get_account_id()
+        or spec.region != get_region()
+    ):
+        return None
+    prefix = "repository/"
+    if not spec.resource.startswith(prefix):
+        return None
+    name = spec.resource[len(prefix):]
+    return name or None
 
 
 def _repo_shape(repo):

--- a/tests/test_ecr_arn_parser.py
+++ b/tests/test_ecr_arn_parser.py
@@ -1,0 +1,114 @@
+import json
+
+import pytest
+
+from ministack.core.responses import get_account_id, get_region, set_request_account_id, set_request_region
+from ministack.services import ecr as ecr_svc
+
+
+def _body(response):
+    return json.loads(response[2].decode("utf-8"))
+
+
+def _reset_ecr_state():
+    for store in (
+        ecr_svc._repositories,
+        ecr_svc._images,
+        ecr_svc._lifecycle_policies,
+        ecr_svc._repo_policies,
+        ecr_svc._layer_blobs,
+        ecr_svc._manifest_blobs,
+        ecr_svc._uploads,
+    ):
+        store.clear()
+
+
+@pytest.fixture(autouse=True)
+def ecr_module_state():
+    original_account = get_account_id()
+    original_region = get_region()
+    _reset_ecr_state()
+    set_request_account_id("000000000000")
+    set_request_region("us-east-1")
+    yield
+    _reset_ecr_state()
+    set_request_account_id(original_account)
+    set_request_region(original_region)
+
+
+def _create_repository(name):
+    response = ecr_svc._create_repository({"repositoryName": name})
+    assert response[0] == 200, _body(response)
+    return _body(response)["repository"]
+
+
+def _assert_repository_not_found(response):
+    assert response[0] == 400
+    assert _body(response)["__type"] == "RepositoryNotFoundException"
+
+
+def test_ecr_tag_apis_require_request_scope_and_stored_repository_arn_match():
+    repo_name = "arn-parser-region-scope"
+    stored = _create_repository(repo_name)
+    stored_arn = stored["repositoryArn"]
+    assert stored_arn == f"arn:aws:ecr:us-east-1:000000000000:repository/{repo_name}"
+
+    seed_response = ecr_svc._tag_resource({
+        "resourceArn": stored_arn,
+        "tags": [{"Key": "env", "Value": "east"}],
+    })
+    assert seed_response[0] == 200, _body(seed_response)
+
+    set_request_region("us-west-2")
+    fabricated_request_region_arn = f"arn:aws:ecr:us-west-2:000000000000:repository/{repo_name}"
+    for resource_arn in (stored_arn, fabricated_request_region_arn):
+        _assert_repository_not_found(ecr_svc._tag_resource({
+            "resourceArn": resource_arn,
+            "tags": [{"Key": "bad", "Value": "tag"}],
+        }))
+        _assert_repository_not_found(ecr_svc._list_tags_for_resource({"resourceArn": resource_arn}))
+        _assert_repository_not_found(ecr_svc._untag_resource({
+            "resourceArn": resource_arn,
+            "tagKeys": ["env"],
+        }))
+
+    set_request_region("us-east-1")
+    assert _body(ecr_svc._list_tags_for_resource({"resourceArn": stored_arn}))["tags"] == [
+        {"Key": "env", "Value": "east"}
+    ]
+
+
+@pytest.mark.parametrize(
+    "resource_arn",
+    [
+        "not-an-arn",
+        "arn:aws-cn:ecr:us-east-1:000000000000:repository/arn-parser-scope",
+        "arn:aws:ecr:us-west-2:000000000000:repository/arn-parser-scope",
+        "arn:aws:ecr:us-east-1:111111111111:repository/arn-parser-scope",
+        "arn:aws:sns:us-east-1:000000000000:repository/arn-parser-scope",
+        "arn:aws:ecr:us-east-1:000000000000:image/arn-parser-scope",
+        "arn:aws:ecr:us-east-1:000000000000:repository/",
+    ],
+)
+def test_ecr_tag_apis_reject_invalid_or_out_of_scope_repository_arns(resource_arn):
+    repo_name = "arn-parser-scope"
+    valid_arn = _create_repository(repo_name)["repositoryArn"]
+
+    seed_response = ecr_svc._tag_resource({
+        "resourceArn": valid_arn,
+        "tags": [{"Key": "existing", "Value": "tag"}],
+    })
+    assert seed_response[0] == 200, _body(seed_response)
+
+    _assert_repository_not_found(ecr_svc._tag_resource({
+        "resourceArn": resource_arn,
+        "tags": [{"Key": "bad", "Value": "tag"}],
+    }))
+    _assert_repository_not_found(ecr_svc._list_tags_for_resource({"resourceArn": resource_arn}))
+    _assert_repository_not_found(ecr_svc._untag_resource({
+        "resourceArn": resource_arn,
+        "tagKeys": ["existing"],
+    }))
+
+    tags = _body(ecr_svc._list_tags_for_resource({"resourceArn": valid_arn}))["tags"]
+    assert tags == [{"Key": "existing", "Value": "tag"}]


### PR DESCRIPTION
## Why
ECR tag APIs should validate repository ARN scope before resolving an account-scoped repository.

## What
- Adds parser-backed repository ARN resolution for ECR tag APIs with service, account, Region, partition, and resource-shape checks.
- Adds focused regression coverage for valid repository tagging and malformed or out-of-scope repository ARNs without tag mutation.

## Validation
- `uv run --offline --extra dev ruff check ministack/services/ecr.py tests/test_ecr.py tests/test_ecr_arn_parser.py`
- `uv run --offline --extra dev pytest tests/test_ecr.py tests/test_ecr_arn_parser.py -v`