### PR TITLE
Validate Athena tag resource ARNs

### DIFF
--- a/ministack/services/athena.py
+++ b/ministack/services/athena.py
@@ -26,6 +26,7 @@ import xml.etree.ElementTree as ET
 from datetime import date
 from urllib.parse import urlparse
 
+from ministack.core.arn import ArnParseError, parse_arn
 from ministack.core.persistence import PERSIST_STATE, load_state
 from ministack.core.responses import (
     AccountScopedDict,
@@ -168,6 +169,38 @@ def _arn_workgroup(name):
 
 def _arn_datacatalog(name):
     return f"arn:aws:athena:{get_region()}:{get_account_id()}:datacatalog/{name}"
+
+
+def _is_taggable_athena_resource(resource):
+    for prefix in ("workgroup/", "datacatalog/"):
+        if resource.startswith(prefix):
+            name = resource[len(prefix):]
+            return bool(name) and "/" not in name
+    return False
+
+
+def _validate_tag_resource_arn(arn):
+    try:
+        spec = parse_arn(arn)
+    except ArnParseError:
+        return error_response_json(
+            "InvalidRequestException",
+            f"Invalid ResourceARN: {arn}",
+            400,
+        )
+    if (
+        spec.partition != "aws"
+        or spec.service != "athena"
+        or spec.region != get_region()
+        or spec.account_id != get_account_id()
+        or not _is_taggable_athena_resource(spec.resource)
+    ):
+        return error_response_json(
+            "InvalidRequestException",
+            f"Invalid ResourceARN: {arn}",
+            400,
+        )
+    return None
 
 
 async def handle_request(method, path, headers, body, query_params):
@@ -1004,6 +1037,9 @@ def _list_table_metadata(data):
 
 def _tag_resource(data):
     arn = data.get("ResourceARN", "")
+    validation_error = _validate_tag_resource_arn(arn)
+    if validation_error:
+        return validation_error
     tags = data.get("Tags", [])
     tag_dict = _tags.setdefault(arn, {})
     for t in tags:
@@ -1013,6 +1049,9 @@ def _tag_resource(data):
 
 def _untag_resource(data):
     arn = data.get("ResourceARN", "")
+    validation_error = _validate_tag_resource_arn(arn)
+    if validation_error:
+        return validation_error
     keys = data.get("TagKeys", [])
     tag_dict = _tags.get(arn, {})
     for k in keys:
@@ -1022,6 +1061,9 @@ def _untag_resource(data):
 
 def _list_tags_for_resource(data):
     arn = data.get("ResourceARN", "")
+    validation_error = _validate_tag_resource_arn(arn)
+    if validation_error:
+        return validation_error
     tag_dict = _tags.get(arn, {})
     tags = [{"Key": k, "Value": v} for k, v in tag_dict.items()]
     return json_response({"Tags": tags})

--- a/tests/test_athena.py
+++ b/tests/test_athena.py
@@ -178,6 +178,101 @@ def test_athena_tags_v2(athena):
     resp2 = athena.list_tags_for_resource(ResourceARN=wg_arn)
     assert not any(t["Key"] == "env" for t in resp2["Tags"])
 
+
+def test_athena_tag_resource_arn_parser_accepts_local_resource_shapes():
+    from ministack.core.responses import (
+        get_account_id,
+        get_region,
+        set_request_account_id,
+        set_request_region,
+    )
+    from ministack.services import athena as m
+
+    original_account = get_account_id()
+    original_region = get_region()
+    original_tags = dict(m._tags._data)
+
+    try:
+        m._tags.clear()
+        set_request_account_id("000000000000")
+        set_request_region("us-east-1")
+
+        workgroup_arn = "arn:aws:athena:us-east-1:000000000000:workgroup/parser-wg"
+        catalog_arn = "arn:aws:athena:us-east-1:000000000000:datacatalog/parser-catalog"
+
+        assert m._tag_resource({
+            "ResourceARN": workgroup_arn,
+            "Tags": [{"Key": "env", "Value": "east"}],
+        })[0] == 200
+        assert m._tag_resource({
+            "ResourceARN": catalog_arn,
+            "Tags": [{"Key": "team", "Value": "data"}],
+        })[0] == 200
+
+        _status, _headers, body = m._list_tags_for_resource({"ResourceARN": workgroup_arn})
+        assert json.loads(body)["Tags"] == [{"Key": "env", "Value": "east"}]
+
+        assert m._untag_resource({"ResourceARN": workgroup_arn, "TagKeys": ["env"]})[0] == 200
+        _status, _headers, body = m._list_tags_for_resource({"ResourceARN": workgroup_arn})
+        assert json.loads(body)["Tags"] == []
+        assert m._tags.get(catalog_arn) == {"team": "data"}
+    finally:
+        m._tags.clear()
+        m._tags._data.update(original_tags)
+        set_request_account_id(original_account)
+        set_request_region(original_region)
+
+
+def test_athena_tag_resource_arn_parser_rejects_invalid_scope_without_mutation():
+    from ministack.core.responses import (
+        get_account_id,
+        get_region,
+        set_request_account_id,
+        set_request_region,
+    )
+    from ministack.services import athena as m
+
+    original_account = get_account_id()
+    original_region = get_region()
+    original_tags = dict(m._tags._data)
+
+    def assert_invalid(response):
+        status, headers, body = response
+        assert status == 400
+        assert headers["x-amzn-errortype"] == "InvalidRequestException"
+        assert json.loads(body)["__type"] == "InvalidRequestException"
+
+    try:
+        m._tags.clear()
+        set_request_account_id("000000000000")
+        set_request_region("us-east-1")
+
+        invalid_arns = [
+            "not-an-arn",
+            "arn:aws:s3:us-east-1:000000000000:workgroup/parser-wg",
+            "arn:aws-cn:athena:us-east-1:000000000000:workgroup/parser-wg",
+            "arn:aws:athena:us-west-2:000000000000:workgroup/parser-wg",
+            "arn:aws:athena:us-east-1:111111111111:workgroup/parser-wg",
+            "arn:aws:athena:us-east-1:000000000000:namedquery/parser-query",
+            "arn:aws:athena:us-east-1:000000000000:workgroup/parser-wg/extra",
+        ]
+
+        for arn in invalid_arns:
+            assert_invalid(m._tag_resource({
+                "ResourceARN": arn,
+                "Tags": [{"Key": "env", "Value": "bad"}],
+            }))
+            assert_invalid(m._untag_resource({"ResourceARN": arn, "TagKeys": ["env"]}))
+            assert_invalid(m._list_tags_for_resource({"ResourceARN": arn}))
+
+        assert m._tags._data == {}
+    finally:
+        m._tags.clear()
+        m._tags._data.update(original_tags)
+        set_request_account_id(original_account)
+        set_request_region(original_region)
+
+
 def test_athena_update_workgroup(athena):
     import uuid as _uuid
 


### PR DESCRIPTION
## Why
Athena tag APIs should validate tag resource ARNs before using them as tag-state keys.

## What
- Adds parser-backed validation for Athena workgroup and data catalog tag resource ARNs.
- Adds regression coverage for accepted local resource shapes and malformed, wrong service, wrong partition, wrong account, wrong Region, and unsupported resource ARNs.

## Validation
- `uv run --offline --extra dev ruff check ministack/services/athena.py tests/test_athena.py`
- `uv run --offline --extra dev pytest tests/test_athena.py -v`