### PR TITLE
Validate ServiceDiscovery tag ARNs

### DIFF
--- a/ministack/services/servicediscovery.py
+++ b/ministack/services/servicediscovery.py
@@ -10,6 +10,7 @@ import os
 import time
 import xml.etree.ElementTree as ET
 
+from ministack.core.arn import ArnParseError, parse_arn
 from ministack.core.responses import (
     AccountScopedDict,
     error_response_json,
@@ -135,6 +136,44 @@ def _namespace_arn(ns_id: str) -> str:
 
 def _service_arn(svc_id: str) -> str:
     return f"arn:aws:servicediscovery:{get_region()}:{get_account_id()}:service/{svc_id}"
+
+
+def _invalid_resource_arn(arn):
+    return error_response_json("InvalidInput", f"Invalid ResourceARN: {arn}", 400)
+
+
+def _resolve_taggable_resource_arn(arn):
+    if not arn:
+        return None, error_response_json("InvalidInput", "ResourceARN is required", 400)
+    try:
+        spec = parse_arn(arn)
+    except ArnParseError:
+        return None, _invalid_resource_arn(arn)
+    if (
+        spec.partition != "aws"
+        or spec.service != "servicediscovery"
+        or spec.account_id != get_account_id()
+        or spec.region != get_region()
+    ):
+        return None, _invalid_resource_arn(arn)
+
+    resource_type, separator, resource_id = spec.resource.partition("/")
+    if separator != "/" or not resource_id or "/" in resource_id:
+        return None, _invalid_resource_arn(arn)
+
+    if resource_type == "namespace":
+        namespace = _namespaces.get(resource_id)
+        if not namespace or namespace.get("Arn") != arn:
+            return None, error_response_json("NamespaceNotFound", "Namespace not found", 404)
+        return arn, None
+
+    if resource_type == "service":
+        service = _services.get(resource_id)
+        if not service or service.get("Arn") != arn:
+            return None, error_response_json("ServiceNotFound", "Service not found", 404)
+        return arn, None
+
+    return None, _invalid_resource_arn(arn)
 
 
 def _create_operation(op_type: str, targets=None):
@@ -621,9 +660,9 @@ def _update_service(data):
 
 
 def _tag_resource(data):
-    arn = data.get("ResourceARN")
-    if not arn:
-        return error_response_json("InvalidInput", "ResourceARN is required", 400)
+    arn, err = _resolve_taggable_resource_arn(data.get("ResourceARN"))
+    if err:
+        return err
 
     incoming = data.get("Tags", [])
     existing = {t.get("Key"): t for t in _resource_tags.get(arn, []) if t.get("Key")}
@@ -636,9 +675,9 @@ def _tag_resource(data):
 
 
 def _untag_resource(data):
-    arn = data.get("ResourceARN")
-    if not arn:
-        return error_response_json("InvalidInput", "ResourceARN is required", 400)
+    arn, err = _resolve_taggable_resource_arn(data.get("ResourceARN"))
+    if err:
+        return err
 
     keys = set(data.get("TagKeys", []))
     if arn in _resource_tags:
@@ -647,7 +686,7 @@ def _untag_resource(data):
 
 
 def _list_tags_for_resource(data):
-    arn = data.get("ResourceARN")
-    if not arn:
-        return error_response_json("InvalidInput", "ResourceARN is required", 400)
+    arn, err = _resolve_taggable_resource_arn(data.get("ResourceARN"))
+    if err:
+        return err
     return json_response({"Tags": _resource_tags.get(arn, [])})

--- a/tests/test_servicediscovery_arn_adoption.py
+++ b/tests/test_servicediscovery_arn_adoption.py
@@ -1,0 +1,135 @@
+import json
+
+import pytest
+
+import ministack.services.servicediscovery as sd_svc
+
+
+@pytest.fixture(autouse=True)
+def reset_servicediscovery_state():
+    sd_svc.reset()
+    yield
+    sd_svc.reset()
+
+
+def _json_result(response):
+    status, headers, body = response
+    return status, headers, json.loads(body.decode("utf-8"))
+
+
+def _seed_namespace(ns_id="ns-direct"):
+    arn = sd_svc._namespace_arn(ns_id)
+    sd_svc._namespaces[ns_id] = {
+        "Id": ns_id,
+        "Arn": arn,
+        "Name": "direct.local",
+        "Type": "HTTP",
+    }
+    return arn
+
+
+def _seed_service(svc_id="srv-direct"):
+    ns_id = "ns-for-service"
+    sd_svc._namespaces[ns_id] = {
+        "Id": ns_id,
+        "Arn": sd_svc._namespace_arn(ns_id),
+        "Name": "service.local",
+        "Type": "HTTP",
+    }
+    arn = sd_svc._service_arn(svc_id)
+    sd_svc._services[svc_id] = {
+        "Id": svc_id,
+        "Arn": arn,
+        "Name": "direct-service",
+        "NamespaceId": ns_id,
+    }
+    return arn
+
+
+@pytest.mark.parametrize("seed_resource", [_seed_namespace, _seed_service])
+def test_servicediscovery_tag_apis_accept_local_namespace_and_service_arns(seed_resource):
+    arn = seed_resource()
+
+    status, _, body = _json_result(
+        sd_svc._tag_resource(
+            {
+                "ResourceARN": arn,
+                "Tags": [
+                    {"Key": "env", "Value": "test"},
+                    {"Key": "owner", "Value": "platform"},
+                ],
+            }
+        )
+    )
+    assert status == 200
+    assert body == {}
+
+    status, _, body = _json_result(sd_svc._list_tags_for_resource({"ResourceARN": arn}))
+    assert status == 200
+    assert body["Tags"] == [
+        {"Key": "env", "Value": "test"},
+        {"Key": "owner", "Value": "platform"},
+    ]
+
+    status, _, body = _json_result(sd_svc._untag_resource({"ResourceARN": arn, "TagKeys": ["env"]}))
+    assert status == 200
+    assert body == {}
+
+    status, _, body = _json_result(sd_svc._list_tags_for_resource({"ResourceARN": arn}))
+    assert status == 200
+    assert body["Tags"] == [{"Key": "owner", "Value": "platform"}]
+
+
+@pytest.mark.parametrize(
+    "bad_arn",
+    [
+        "not-an-arn",
+        "arn:aws-cn:servicediscovery:us-east-1:000000000000:namespace/ns-direct",
+        "arn:aws:s3:us-east-1:000000000000:namespace/ns-direct",
+        "arn:aws:servicediscovery:us-east-1:111122223333:namespace/ns-direct",
+        "arn:aws:servicediscovery:us-west-2:000000000000:namespace/ns-direct",
+        "arn:aws:servicediscovery:us-east-1:000000000000:instance/ns-direct/inst-1",
+        "arn:aws:servicediscovery:us-east-1:000000000000:namespace/ns-direct/child",
+        "arn:aws:servicediscovery:us-east-1:000000000000:service",
+    ],
+)
+def test_servicediscovery_tag_apis_reject_invalid_resource_arns_before_touching_tags(bad_arn):
+    valid_arn = _seed_namespace()
+    sd_svc._resource_tags[valid_arn] = [{"Key": "keep", "Value": "yes"}]
+
+    status, _, body = _json_result(
+        sd_svc._tag_resource({"ResourceARN": bad_arn, "Tags": [{"Key": "new", "Value": "tag"}]})
+    )
+    assert status == 400
+    assert body["__type"] == "InvalidInput"
+    assert sd_svc._resource_tags.get(bad_arn) is None
+
+    status, _, body = _json_result(sd_svc._untag_resource({"ResourceARN": bad_arn, "TagKeys": ["keep"]}))
+    assert status == 400
+    assert body["__type"] == "InvalidInput"
+
+    status, _, body = _json_result(sd_svc._list_tags_for_resource({"ResourceARN": bad_arn}))
+    assert status == 400
+    assert body["__type"] == "InvalidInput"
+
+    assert sd_svc._resource_tags[valid_arn] == [{"Key": "keep", "Value": "yes"}]
+
+
+@pytest.mark.parametrize(
+    ("resource_arn", "expected_error"),
+    [
+        ("arn:aws:servicediscovery:us-east-1:000000000000:namespace/ns-missing", "NamespaceNotFound"),
+        ("arn:aws:servicediscovery:us-east-1:000000000000:service/srv-missing", "ServiceNotFound"),
+    ],
+)
+def test_servicediscovery_tag_apis_reject_missing_local_resources(resource_arn, expected_error):
+    for call in (
+        lambda: sd_svc._tag_resource({"ResourceARN": resource_arn, "Tags": [{"Key": "new", "Value": "tag"}]}),
+        lambda: sd_svc._untag_resource({"ResourceARN": resource_arn, "TagKeys": ["old"]}),
+        lambda: sd_svc._list_tags_for_resource({"ResourceARN": resource_arn}),
+    ):
+        status, _, body = _json_result(call())
+        assert status == 404
+        assert body["__type"] == expected_error
+
+    assert sd_svc._resource_tags.get(resource_arn) is None


### PR DESCRIPTION
## Why
Cloud Map tag APIs should validate namespace and service ARNs before touching tag state.

## What
- Adds parser-backed validation for local ServiceDiscovery namespace and service tag ARNs, including existence checks.
- Adds focused coverage for accepted local namespace/service ARNs, invalid scope, unsupported shapes, and missing local resources.

## Validation
- `uv run --offline --extra dev ruff check ministack/services/servicediscovery.py tests/test_servicediscovery.py tests/test_servicediscovery_arn_adoption.py`
- `uv run --offline --extra dev pytest tests/test_servicediscovery.py tests/test_servicediscovery_arn_adoption.py -v`