### PR TITLE
Validate SESv2 tag resource ARNs

### DIFF
--- a/ministack/services/ses_v2.py
+++ b/ministack/services/ses_v2.py
@@ -15,6 +15,7 @@ import os
 import re
 import time
 
+from ministack.core.arn import ArnParseError, parse_arn
 from ministack.core.persistence import PERSIST_STATE, load_state
 from ministack.core.responses import AccountScopedDict, get_account_id, get_region, json_response, new_uuid, now_iso
 from ministack.services.ses import _build_mime_message, _parse_raw_mime, _sent_emails_list, _smtp_relay
@@ -56,6 +57,66 @@ except Exception:
 def _json_err(code, message, status=400):
     body = json.dumps({"message": message, "name": code}).encode("utf-8")
     return status, {"Content-Type": "application/json"}, body
+
+
+def _resource_arn(kind, name):
+    return f"arn:aws:ses:{get_region()}:{get_account_id()}:{kind}/{name}"
+
+
+def _invalid_resource_arn(arn):
+    return _json_err("BadRequestException", f"Invalid ResourceArn: {arn}")
+
+
+def _not_found_resource_arn(arn):
+    return _json_err("NotFoundException", f"Resource {arn} not found", 404)
+
+
+def _first_query_value(query_params, key, default=""):
+    value = query_params.get(key, default)
+    if isinstance(value, list):
+        return value[0] if value else default
+    return value
+
+
+def _query_values(query_params, key):
+    value = query_params.get(key, [])
+    if isinstance(value, list):
+        return value
+    if value:
+        return [value]
+    return []
+
+
+def _local_ses_v2_resource_arn(arn):
+    if not arn:
+        return None, _json_err("BadRequestException", "ResourceArn is required")
+    try:
+        spec = parse_arn(arn)
+    except ArnParseError:
+        return None, _invalid_resource_arn(arn)
+
+    if (
+        spec.partition != "aws"
+        or spec.service != "ses"
+        or spec.account_id != get_account_id()
+        or spec.region != get_region()
+    ):
+        return None, _invalid_resource_arn(arn)
+
+    kind, sep, name = spec.resource.partition("/")
+    if sep != "/" or not name or "/" in name:
+        return None, _invalid_resource_arn(arn)
+
+    if kind == "identity":
+        if name not in _identities:
+            return None, _not_found_resource_arn(arn)
+    elif kind == "configuration-set":
+        if name not in _config_sets:
+            return None, _not_found_resource_arn(arn)
+    else:
+        return None, _invalid_resource_arn(arn)
+
+    return str(spec), None
 
 
 async def handle_request(method, path, headers, body, query_params):
@@ -164,6 +225,7 @@ async def handle_request(method, path, headers, body, query_params):
             "Tags": data.get("Tags", []),
             "CreatedTimestamp": now_iso(),
         }
+        _ses_tags[_resource_arn("identity", identity)] = list(data.get("Tags", []))
         return json_response({
             "IdentityType": identity_type,
             "VerifiedForSendingStatus": True,
@@ -198,6 +260,7 @@ async def handle_request(method, path, headers, body, query_params):
         if not name:
             return _json_err("BadRequestException", "ConfigurationSetName is required")
         _config_sets[name] = {"ConfigurationSetName": name, "Tags": data.get("Tags", [])}
+        _ses_tags[_resource_arn("configuration-set", name)] = list(data.get("Tags", []))
         return json_response({})
 
     # GET /v2/email/configuration-sets  (ListConfigurationSets)
@@ -219,22 +282,31 @@ async def handle_request(method, path, headers, body, query_params):
 
     # GET/POST/DELETE /v2/email/tags  (ListTagsForResource / TagResource / UntagResource)
     if sub == "/tags" and method == "GET":
-        arn = query_params.get("ResourceArn", [""])[0] if isinstance(query_params.get("ResourceArn"), list) else query_params.get("ResourceArn", "")
-        return json_response({"Tags": _ses_tags.get(arn, [])})
+        arn = _first_query_value(query_params, "ResourceArn")
+        canonical_arn, err = _local_ses_v2_resource_arn(arn)
+        if err:
+            return err
+        return json_response({"Tags": _ses_tags.get(canonical_arn, [])})
 
     m = re.match(r"^/tags$", sub)
     if m and method == "POST":
         arn = data.get("ResourceArn", "")
-        existing = {t["Key"]: t for t in _ses_tags.get(arn, [])}
+        canonical_arn, err = _local_ses_v2_resource_arn(arn)
+        if err:
+            return err
+        existing = {t["Key"]: t for t in _ses_tags.get(canonical_arn, [])}
         for tag in data.get("Tags", []):
             existing[tag["Key"]] = tag
-        _ses_tags[arn] = list(existing.values())
+        _ses_tags[canonical_arn] = list(existing.values())
         return json_response({})
 
     if sub == "/tags" and method == "DELETE":
-        arn = query_params.get("ResourceArn", [""])[0] if isinstance(query_params.get("ResourceArn"), list) else query_params.get("ResourceArn", "")
-        remove_keys = set(query_params.get("TagKeys", []))
-        _ses_tags[arn] = [t for t in _ses_tags.get(arn, []) if t["Key"] not in remove_keys]
+        arn = _first_query_value(query_params, "ResourceArn")
+        canonical_arn, err = _local_ses_v2_resource_arn(arn)
+        if err:
+            return err
+        remove_keys = set(_query_values(query_params, "TagKeys"))
+        _ses_tags[canonical_arn] = [t for t in _ses_tags.get(canonical_arn, []) if t["Key"] not in remove_keys]
         return json_response({})
 
     return _json_err("NotFoundException", f"Unknown SES v2 path: {method} {path}", 404)

--- a/tests/test_ses_v2_arn_parser.py
+++ b/tests/test_ses_v2_arn_parser.py
@@ -1,0 +1,192 @@
+import asyncio
+import json
+
+import pytest
+
+from ministack.core.responses import set_request_account_id, set_request_region
+
+ACCOUNT_ID = "000000000000"
+REGION = "us-east-1"
+
+
+@pytest.fixture()
+def ses_v2():
+    from ministack.services import ses_v2 as service
+
+    set_request_account_id(ACCOUNT_ID)
+    set_request_region(REGION)
+    service.reset()
+    yield service
+    service.reset()
+
+
+def _arn(kind, name, *, partition="aws", service="ses", region=REGION, account=ACCOUNT_ID):
+    return f"arn:{partition}:{service}:{region}:{account}:{kind}/{name}"
+
+
+def _call(service, method, path="/v2/email/tags", *, body=None, query=None):
+    raw_body = json.dumps(body).encode("utf-8") if body is not None else b""
+    status, _headers, raw = asyncio.run(
+        service.handle_request(method, path, {}, raw_body, query or {})
+    )
+    return status, json.loads(raw.decode("utf-8")) if raw else {}
+
+
+def test_ses_v2_identity_tag_resource_uses_parser_backed_resource_arn(ses_v2):
+    identity = "parser.example.com"
+    resource_arn = _arn("identity", identity)
+
+    status, _body = _call(
+        ses_v2,
+        "POST",
+        "/v2/email/identities",
+        body={
+            "EmailIdentity": identity,
+            "Tags": [{"Key": "created", "Value": "yes"}],
+        },
+    )
+    assert status == 200
+
+    status, body = _call(
+        ses_v2,
+        "GET",
+        query={"ResourceArn": [resource_arn]},
+    )
+    assert status == 200
+    assert body["Tags"] == [{"Key": "created", "Value": "yes"}]
+
+    status, _body = _call(
+        ses_v2,
+        "POST",
+        body={
+            "ResourceArn": resource_arn,
+            "Tags": [
+                {"Key": "created", "Value": "updated"},
+                {"Key": "team", "Value": "platform"},
+            ],
+        },
+    )
+    assert status == 200
+
+    status, body = _call(ses_v2, "GET", query={"ResourceArn": [resource_arn]})
+    assert status == 200
+    assert body["Tags"] == [
+        {"Key": "created", "Value": "updated"},
+        {"Key": "team", "Value": "platform"},
+    ]
+
+    status, _body = _call(
+        ses_v2,
+        "DELETE",
+        query={"ResourceArn": [resource_arn], "TagKeys": ["created"]},
+    )
+    assert status == 200
+
+    status, body = _call(ses_v2, "GET", query={"ResourceArn": [resource_arn]})
+    assert status == 200
+    assert body["Tags"] == [{"Key": "team", "Value": "platform"}]
+
+
+def test_ses_v2_configuration_set_tag_resource_uses_parser_backed_resource_arn(ses_v2):
+    config_set_name = "parser-config"
+    resource_arn = _arn("configuration-set", config_set_name)
+
+    status, _body = _call(
+        ses_v2,
+        "POST",
+        "/v2/email/configuration-sets",
+        body={
+            "ConfigurationSetName": config_set_name,
+            "Tags": [{"Key": "created", "Value": "yes"}],
+        },
+    )
+    assert status == 200
+
+    status, _body = _call(
+        ses_v2,
+        "POST",
+        body={
+            "ResourceArn": resource_arn,
+            "Tags": [{"Key": "team", "Value": "email"}],
+        },
+    )
+    assert status == 200
+
+    status, body = _call(ses_v2, "GET", query={"ResourceArn": [resource_arn]})
+    assert status == 200
+    assert body["Tags"] == [
+        {"Key": "created", "Value": "yes"},
+        {"Key": "team", "Value": "email"},
+    ]
+
+
+@pytest.mark.parametrize(
+    "bad_arn",
+    [
+        "not-an-arn",
+        f"arn:aws:ses:{REGION}:{ACCOUNT_ID}",
+        _arn("identity", "parser.example.com", partition="aws-cn"),
+        _arn("identity", "parser.example.com", service="sesv2"),
+        _arn("identity", "parser.example.com", region="us-west-2"),
+        _arn("identity", "parser.example.com", account="111111111111"),
+        _arn("template", "parser-template"),
+        f"arn:aws:ses:{REGION}:{ACCOUNT_ID}:identity/parser.example.com/extra",
+    ],
+)
+@pytest.mark.parametrize("method", ["GET", "POST", "DELETE"])
+def test_ses_v2_tag_apis_reject_invalid_resource_arns_before_touching_tags(ses_v2, bad_arn, method):
+    identity = "parser.example.com"
+    valid_arn = _arn("identity", identity)
+    _call(ses_v2, "POST", "/v2/email/identities", body={"EmailIdentity": identity})
+    _call(
+        ses_v2,
+        "POST",
+        body={"ResourceArn": valid_arn, "Tags": [{"Key": "keep", "Value": "yes"}]},
+    )
+
+    if method == "POST":
+        status, body = _call(
+            ses_v2,
+            method,
+            body={"ResourceArn": bad_arn, "Tags": [{"Key": "bad", "Value": "no"}]},
+        )
+    elif method == "DELETE":
+        status, body = _call(
+            ses_v2,
+            method,
+            query={"ResourceArn": [bad_arn], "TagKeys": ["keep"]},
+        )
+    else:
+        status, body = _call(ses_v2, method, query={"ResourceArn": [bad_arn]})
+
+    assert status == 400
+    assert body["name"] == "BadRequestException"
+    assert ses_v2._ses_tags.get(bad_arn) is None
+
+    status, body = _call(ses_v2, "GET", query={"ResourceArn": [valid_arn]})
+    assert status == 200
+    assert body["Tags"] == [{"Key": "keep", "Value": "yes"}]
+
+
+@pytest.mark.parametrize("method", ["GET", "POST", "DELETE"])
+def test_ses_v2_tag_apis_reject_missing_local_resources_before_touching_tags(ses_v2, method):
+    missing_arn = _arn("identity", "missing.example.com")
+
+    if method == "POST":
+        status, body = _call(
+            ses_v2,
+            method,
+            body={"ResourceArn": missing_arn, "Tags": [{"Key": "bad", "Value": "no"}]},
+        )
+    elif method == "DELETE":
+        status, body = _call(
+            ses_v2,
+            method,
+            query={"ResourceArn": [missing_arn], "TagKeys": ["bad"]},
+        )
+    else:
+        status, body = _call(ses_v2, method, query={"ResourceArn": [missing_arn]})
+
+    assert status == 404
+    assert body["name"] == "NotFoundException"
+    assert ses_v2._ses_tags.get(missing_arn) is None


### PR DESCRIPTION
## Why
SES v2 tag APIs should validate identity and configuration-set ARNs before storing tags by raw ARN.

## What
- Adds parser-backed validation and canonical tag keys for SES v2 identity and configuration-set resource ARNs.
- Adds focused coverage for valid tagging, malformed and out-of-scope ARNs, unsupported shapes, and missing local resources.

## Validation
- `uv run --offline --extra dev ruff check ministack/services/ses_v2.py tests/test_ses.py tests/test_ses_v2_arn_parser.py`
- `uv run --offline --extra dev pytest tests/test_ses.py tests/test_ses_v2_arn_parser.py -v`