### PR TITLE
Validate WAFv2 tag resource ARNs

### DIFF
--- a/ministack/services/waf.py
+++ b/ministack/services/waf.py
@@ -14,6 +14,7 @@ import json
 import logging
 import os
 
+from ministack.core.arn import ArnParseError, parse_arn
 from ministack.core.persistence import PERSIST_STATE, load_state
 from ministack.core.responses import (
     AccountScopedDict,
@@ -34,6 +35,12 @@ _ip_sets = AccountScopedDict()        # id -> ipset
 _rule_groups = AccountScopedDict()    # id -> rulegroup
 _associations = AccountScopedDict()   # resource_arn -> webacl_arn
 _waf_tags = AccountScopedDict()       # resource_arn -> [tags]
+
+_WAF_RESOURCE_SCOPES = {
+    "webacl": {"regional", "cloudfront", "global"},
+    "ipset": {"regional", "global"},
+    "rulegroup": {"regional", "global"},
+}
 
 
 def get_state():
@@ -69,6 +76,14 @@ def _waf_err(code, message):
     return error_response_json(code, message, 400)
 
 
+def _waf_invalid_arn(arn):
+    return _waf_err("WAFInvalidParameterException", f"Invalid WAFv2 resource ARN: {arn}")
+
+
+def _waf_not_found(arn):
+    return _waf_err("WAFNonexistentItemException", f"WAFv2 resource {arn} not found")
+
+
 def _acl_arn(name, uid):
     return f"arn:aws:wafv2:{get_region()}:{get_account_id()}:regional/webacl/{name}/{uid}"
 
@@ -79,6 +94,57 @@ def _ipset_arn(name, uid):
 
 def _rg_arn(name, uid):
     return f"arn:aws:wafv2:{get_region()}:{get_account_id()}:regional/rulegroup/{name}/{uid}"
+
+
+def _parse_local_waf_arn(arn, allowed_types):
+    try:
+        spec = parse_arn(arn)
+    except ArnParseError:
+        return None, None, _waf_invalid_arn(arn)
+
+    if (
+        spec.partition != "aws"
+        or spec.service != "wafv2"
+        or spec.region != get_region()
+        or spec.account_id != get_account_id()
+    ):
+        return None, None, _waf_invalid_arn(arn)
+
+    parts = spec.resource.split("/")
+    if len(parts) != 4:
+        return None, None, _waf_invalid_arn(arn)
+    scope, resource_type, name, uid = parts
+    if resource_type not in allowed_types or not name or not uid:
+        return None, None, _waf_invalid_arn(arn)
+    if scope not in _WAF_RESOURCE_SCOPES.get(resource_type, set()):
+        return None, None, _waf_invalid_arn(arn)
+    return resource_type, uid, None
+
+
+def _resolve_local_waf_resource_arn(arn, allowed_types=("webacl", "ipset", "rulegroup")):
+    resource_type, uid, err = _parse_local_waf_arn(arn, allowed_types)
+    if err:
+        return None, err
+
+    stores = {
+        "webacl": _web_acls,
+        "ipset": _ip_sets,
+        "rulegroup": _rule_groups,
+    }
+    resource = stores[resource_type].get(uid)
+    if not resource or resource.get("ARN") != arn:
+        return None, _waf_not_found(arn)
+    return arn, None
+
+
+def _resolve_local_web_acl(web_acl_arn):
+    arn, err = _resolve_local_waf_resource_arn(web_acl_arn, ("webacl",))
+    if err:
+        return None, err
+    for acl in _web_acls.values():
+        if acl["ARN"] == arn:
+            return acl, None
+    return None, _waf_not_found(web_acl_arn)
 
 
 async def handle_request(method, path, headers, body, query_params):
@@ -211,6 +277,9 @@ def _list_web_acls(data):
 
 def _associate_web_acl(data):
     web_acl_arn = data.get("WebACLArn", "")
+    _, err = _resolve_local_web_acl(web_acl_arn)
+    if err:
+        return err
     resource_arn = data.get("ResourceArn", "")
     _associations[resource_arn] = web_acl_arn
     return json_response({})
@@ -236,6 +305,9 @@ def _get_web_acl_for_resource(data):
 
 def _list_resources_for_web_acl(data):
     web_acl_arn = data.get("WebACLArn", "")
+    _, err = _resolve_local_web_acl(web_acl_arn)
+    if err:
+        return err
     arns = [r for r, a in _associations.items() if a == web_acl_arn]
     return json_response({"ResourceArns": arns})
 
@@ -368,6 +440,9 @@ def _list_rule_groups(data):
 
 def _tag_resource(data):
     arn = data.get("ResourceARN", "")
+    arn, err = _resolve_local_waf_resource_arn(arn)
+    if err:
+        return err
     existing = {t["Key"]: t for t in _waf_tags.get(arn, [])}
     for tag in data.get("Tags", []):
         existing[tag["Key"]] = tag
@@ -377,6 +452,9 @@ def _tag_resource(data):
 
 def _untag_resource(data):
     arn = data.get("ResourceARN", "")
+    arn, err = _resolve_local_waf_resource_arn(arn)
+    if err:
+        return err
     remove_keys = set(data.get("TagKeys", []))
     _waf_tags[arn] = [t for t in _waf_tags.get(arn, []) if t["Key"] not in remove_keys]
     return json_response({})
@@ -384,6 +462,9 @@ def _untag_resource(data):
 
 def _list_tags_for_resource(data):
     arn = data.get("ResourceARN", "")
+    arn, err = _resolve_local_waf_resource_arn(arn)
+    if err:
+        return err
     return json_response({"TagInfoForResource": {"ResourceARN": arn, "TagList": _waf_tags.get(arn, [])}})
 
 

--- a/tests/test_waf.py
+++ b/tests/test_waf.py
@@ -9,6 +9,72 @@ from urllib.parse import urlparse
 import pytest
 from botocore.exceptions import ClientError
 
+from ministack.core.responses import (
+    get_account_id,
+    get_region,
+    set_request_account_id,
+    set_request_region,
+)
+from ministack.services import waf as waf_service
+
+
+def _waf_payload(response):
+    status, _headers, body = response
+    return status, json.loads(body)
+
+
+@pytest.fixture
+def direct_waf_scope():
+    original_account = get_account_id()
+    original_region = get_region()
+    set_request_account_id("000000000000")
+    set_request_region("us-east-1")
+    waf_service.reset()
+    yield
+    waf_service.reset()
+    set_request_account_id(original_account)
+    set_request_region(original_region)
+
+
+def _direct_web_acl_arn(name="direct-acl"):
+    status, payload = _waf_payload(waf_service._create_web_acl({
+        "Name": name,
+        "Scope": "REGIONAL",
+        "DefaultAction": {"Allow": {}},
+        "VisibilityConfig": {
+            "SampledRequestsEnabled": False,
+            "CloudWatchMetricsEnabled": False,
+            "MetricName": name,
+        },
+    }))
+    assert status == 200
+    return payload["Summary"]["ARN"]
+
+
+def _direct_cloudfront_web_acl_arn(name="direct-cloudfront-acl", arn_scope="cloudfront"):
+    uid = _uuid_mod.uuid4().hex
+    arn = f"arn:aws:wafv2:{get_region()}:{get_account_id()}:{arn_scope}/webacl/{name}/{uid}"
+    waf_service._web_acls[uid] = {
+        "ARN": arn,
+        "Id": uid,
+        "Name": name,
+        "Description": "",
+        "DefaultAction": {"Allow": {}},
+        "Rules": [],
+        "VisibilityConfig": {},
+        "Capacity": 0,
+        "LockToken": _uuid_mod.uuid4().hex,
+        "Scope": "CLOUDFRONT",
+    }
+    waf_service._waf_tags[arn] = []
+    return arn
+
+
+def _assert_waf_error(response, code):
+    status, payload = _waf_payload(response)
+    assert status == 400
+    assert payload["__type"] == code
+
 
 def test_waf_web_acl_crud(wafv2):
     resp = wafv2.create_web_acl(
@@ -150,6 +216,160 @@ def test_waf_tags(wafv2):
     wafv2.untag_resource(ResourceARN=arn, TagKeys=["env"])
     tags_resp3 = wafv2.list_tags_for_resource(ResourceARN=arn)
     assert not any(t["Key"] == "env" for t in tags_resp3["TagInfoForResource"]["TagList"])
+
+
+def test_waf_tag_apis_accept_local_waf_resource_arns_direct(direct_waf_scope):
+    web_acl_arn = _direct_web_acl_arn("direct-tag-acl")
+    cloudfront_web_acl_arn = _direct_cloudfront_web_acl_arn("direct-tag-cf-acl")
+    global_web_acl_arn = _direct_cloudfront_web_acl_arn(
+        "direct-tag-global-acl",
+        arn_scope="global",
+    )
+    ip_set_arn = _waf_payload(waf_service._create_ip_set({
+        "Name": "direct-tag-ipset",
+        "Scope": "REGIONAL",
+        "IPAddressVersion": "IPV4",
+        "Addresses": ["192.0.2.0/24"],
+    }))[1]["Summary"]["ARN"]
+    rule_group_arn = _waf_payload(waf_service._create_rule_group({
+        "Name": "direct-tag-rg",
+        "Scope": "REGIONAL",
+        "Capacity": 10,
+        "VisibilityConfig": {
+            "SampledRequestsEnabled": False,
+            "CloudWatchMetricsEnabled": False,
+            "MetricName": "direct-tag-rg",
+        },
+    }))[1]["Summary"]["ARN"]
+
+    for arn in (
+        web_acl_arn,
+        cloudfront_web_acl_arn,
+        global_web_acl_arn,
+        ip_set_arn,
+        rule_group_arn,
+    ):
+        status, _payload = _waf_payload(waf_service._tag_resource({
+            "ResourceARN": arn,
+            "Tags": [{"Key": "team", "Value": "security"}],
+        }))
+        assert status == 200
+        status, payload = _waf_payload(waf_service._list_tags_for_resource({
+            "ResourceARN": arn,
+        }))
+        assert status == 200
+        assert payload["TagInfoForResource"]["TagList"] == [
+            {"Key": "team", "Value": "security"}
+        ]
+        status, _payload = _waf_payload(waf_service._untag_resource({
+            "ResourceARN": arn,
+            "TagKeys": ["team"],
+        }))
+        assert status == 200
+
+
+@pytest.mark.parametrize("resource_arn", [
+    "not-an-arn",
+    "arn:aws-cn:wafv2:us-east-1:000000000000:regional/webacl/name/id",
+    "arn:aws:s3:us-east-1:000000000000:regional/webacl/name/id",
+    "arn:aws:wafv2:us-west-2:000000000000:regional/webacl/name/id",
+    "arn:aws:wafv2:us-east-1:111111111111:regional/webacl/name/id",
+    "arn:aws:wafv2:us-east-1:000000000000:cloudfront/ipset/name/id",
+    "arn:aws:wafv2:us-east-1:000000000000:regional/regexset/name/id",
+    "arn:aws:wafv2:us-east-1:000000000000:regional/webacl/name/id/extra",
+])
+def test_waf_tag_apis_reject_invalid_resource_arns_direct(direct_waf_scope, resource_arn):
+    _assert_waf_error(
+        waf_service._tag_resource({
+            "ResourceARN": resource_arn,
+            "Tags": [{"Key": "team", "Value": "security"}],
+        }),
+        "WAFInvalidParameterException",
+    )
+    _assert_waf_error(
+        waf_service._untag_resource({
+            "ResourceARN": resource_arn,
+            "TagKeys": ["team"],
+        }),
+        "WAFInvalidParameterException",
+    )
+    _assert_waf_error(
+        waf_service._list_tags_for_resource({"ResourceARN": resource_arn}),
+        "WAFInvalidParameterException",
+    )
+    assert resource_arn not in waf_service._waf_tags
+
+
+def test_waf_tag_apis_reject_missing_local_resource_arn_direct(direct_waf_scope):
+    missing_arn = "arn:aws:wafv2:us-east-1:000000000000:regional/webacl/missing/id"
+
+    _assert_waf_error(
+        waf_service._tag_resource({
+            "ResourceARN": missing_arn,
+            "Tags": [{"Key": "team", "Value": "security"}],
+        }),
+        "WAFNonexistentItemException",
+    )
+    assert missing_arn not in waf_service._waf_tags
+
+
+def test_waf_association_validates_web_acl_arn_but_not_resource_arn_direct(direct_waf_scope):
+    web_acl_arn = _direct_web_acl_arn("direct-assoc-acl")
+    opaque_resource_arn = "not-a-waf-resource-arn"
+
+    status, _payload = _waf_payload(waf_service._associate_web_acl({
+        "WebACLArn": web_acl_arn,
+        "ResourceArn": opaque_resource_arn,
+    }))
+    assert status == 200
+
+    status, payload = _waf_payload(waf_service._list_resources_for_web_acl({
+        "WebACLArn": web_acl_arn,
+    }))
+    assert status == 200
+    assert payload["ResourceArns"] == [opaque_resource_arn]
+
+    cloudfront_web_acl_arn = _direct_cloudfront_web_acl_arn("direct-assoc-cf-acl")
+    cloudfront_resource_arn = "arn:aws:cloudfront::000000000000:distribution/dist"
+    status, _payload = _waf_payload(waf_service._associate_web_acl({
+        "WebACLArn": cloudfront_web_acl_arn,
+        "ResourceArn": cloudfront_resource_arn,
+    }))
+    assert status == 200
+    status, payload = _waf_payload(waf_service._list_resources_for_web_acl({
+        "WebACLArn": cloudfront_web_acl_arn,
+    }))
+    assert status == 200
+    assert payload["ResourceArns"] == [cloudfront_resource_arn]
+
+    global_web_acl_arn = _direct_cloudfront_web_acl_arn(
+        "direct-assoc-global-acl",
+        arn_scope="global",
+    )
+    global_resource_arn = "arn:aws:cloudfront::000000000000:distribution/global-dist"
+    status, _payload = _waf_payload(waf_service._associate_web_acl({
+        "WebACLArn": global_web_acl_arn,
+        "ResourceArn": global_resource_arn,
+    }))
+    assert status == 200
+    status, payload = _waf_payload(waf_service._list_resources_for_web_acl({
+        "WebACLArn": global_web_acl_arn,
+    }))
+    assert status == 200
+    assert payload["ResourceArns"] == [global_resource_arn]
+
+    wrong_service_arn = web_acl_arn.replace(":wafv2:", ":s3:")
+    _assert_waf_error(
+        waf_service._associate_web_acl({
+            "WebACLArn": wrong_service_arn,
+            "ResourceArn": "arn:aws:elasticloadbalancing:us-east-1:000000000000:loadbalancer/app/app/id",
+        }),
+        "WAFInvalidParameterException",
+    )
+    _assert_waf_error(
+        waf_service._list_resources_for_web_acl({"WebACLArn": wrong_service_arn}),
+        "WAFInvalidParameterException",
+    )
 
 def test_waf_check_capacity(wafv2):
     resp = wafv2.check_capacity(


### PR DESCRIPTION
## Why
WAFv2 tag APIs and WebACL association inputs should validate WAF-owned ARNs before using them for local state.

## What
- Adds parser-backed validation for local WAFv2 tag resource ARNs and WebACL ARN references while keeping associated target resource ARNs opaque.
- Adds focused coverage for regional and CloudFront/global WebACL shapes, invalid WAF ARNs, missing resources, and opaque association resource ARNs.

## Validation
- `uv run --offline --extra dev ruff check ministack/services/waf.py tests/test_waf.py`
- `uv run --offline --extra dev pytest tests/test_waf.py -v`