### PR TITLE
Validate EKS tag resource ARNs

### DIFF
--- a/ministack/services/eks.py
+++ b/ministack/services/eks.py
@@ -22,6 +22,7 @@ import threading
 import time
 import urllib.parse
 
+from ministack.core.arn import ArnParseError, parse_arn
 from ministack.core.persistence import load_state
 from ministack.core.responses import (
     AccountScopedDict,
@@ -1161,7 +1162,78 @@ def _oidc_jwks():
 # Tags
 # ---------------------------------------------------------------------------
 
+def _invalid_tag_resource_arn(arn):
+    return _error(400, "InvalidParameterException", f"Invalid resourceArn: {arn}")
+
+
+def _tag_resource_not_found(arn):
+    return _error(404, "ResourceNotFoundException", f"No resource found for ARN: {arn}.")
+
+
+def _resolve_tag_resource_arn(arn):
+    try:
+        spec = parse_arn(arn)
+    except ArnParseError:
+        return None, _invalid_tag_resource_arn(arn)
+
+    if (
+        spec.partition != "aws"
+        or spec.service != "eks"
+        or spec.account_id != get_account_id()
+        or spec.region != get_region()
+    ):
+        return None, _invalid_tag_resource_arn(arn)
+
+    parts = spec.resource.split("/")
+    resource_type = parts[0] if parts else ""
+
+    if resource_type == "cluster":
+        if len(parts) != 2 or not parts[1]:
+            return None, _invalid_tag_resource_arn(arn)
+        cluster = _clusters.get(parts[1])
+        if not cluster or cluster.get("arn") != arn:
+            return None, _tag_resource_not_found(arn)
+        return cluster["arn"], None
+
+    if resource_type == "nodegroup":
+        if len(parts) != 4 or not all(parts[1:]):
+            return None, _invalid_tag_resource_arn(arn)
+        nodegroup = _nodegroups.get(f"{parts[1]}/{parts[2]}")
+        if not nodegroup or nodegroup.get("nodegroupArn") != arn:
+            return None, _tag_resource_not_found(arn)
+        return nodegroup["nodegroupArn"], None
+
+    if resource_type == "addon":
+        if len(parts) != 4 or not all(parts[1:]):
+            return None, _invalid_tag_resource_arn(arn)
+        addon = _addons.get(f"{parts[1]}/{parts[2]}")
+        if not addon or addon.get("addonArn") != arn:
+            return None, _tag_resource_not_found(arn)
+        return addon["addonArn"], None
+
+    if resource_type == "access-entry":
+        if len(parts) != 3 or not all(parts[1:]):
+            return None, _invalid_tag_resource_arn(arn)
+        for entry in _access_entries.values():
+            if entry.get("clusterName") == parts[1] and entry.get("accessEntryArn") == arn:
+                return entry["accessEntryArn"], None
+        return None, _tag_resource_not_found(arn)
+
+    if resource_type == "identityproviderconfig":
+        if len(parts) != 5 or parts[2] != "oidc" or not all(parts[1:]):
+            return None, _invalid_tag_resource_arn(arn)
+        cfg = _idp_configs.get(f"{parts[1]}\x00{parts[3]}")
+        if not cfg or cfg.get("arn") != arn:
+            return None, _tag_resource_not_found(arn)
+        return cfg["arn"], None
+
+    return None, _invalid_tag_resource_arn(arn)
+
+
 def _tag_resource(arn, body):
+    arn, err = _resolve_tag_resource_arn(arn)
+    if err:
+        return err
     tags = body.get("tags", {})
     existing = _tags.get(arn, {})
     existing.update(tags)
@@ -1170,6 +1242,9 @@ def _tag_resource(arn, body):
 
 
 def _untag_resource(arn, query):
+    arn, err = _resolve_tag_resource_arn(arn)
+    if err:
+        return err
     keys = query.get("tagKeys", [])
     if isinstance(keys, str):
         keys = [keys]
@@ -1184,6 +1259,9 @@ def _untag_resource(arn, query):
 
 
 def _list_tags(arn):
+    arn, err = _resolve_tag_resource_arn(arn)
+    if err:
+        return err
     return _json_resp(200, {"tags": _tags.get(arn, {})})
 
 
@@ -1358,7 +1436,7 @@ async def handle_request(method, path, headers, body_bytes, query_params):
 
     # Tags: /tags/{arn+}
     if path.startswith("/tags/"):
-        arn = path[6:]
+        arn = urllib.parse.unquote(path[6:])
         if method == "GET":
             return _list_tags(arn)
         if method == "POST":

--- a/tests/test_eks.py
+++ b/tests/test_eks.py
@@ -3,9 +3,11 @@ Integration tests for EKS service emulator.
 Tests cluster CRUD, nodegroup CRUD, tags, and CloudFormation provisioning.
 k3s Docker container tests require Docker socket access.
 """
+import asyncio
 import json
 import time
 import uuid
+from urllib.parse import quote
 
 import boto3
 import pytest
@@ -31,6 +33,46 @@ def cfn():
 
 def _uid():
     return uuid.uuid4().hex[:8]
+
+
+@pytest.fixture
+def eks_mod(monkeypatch):
+    from ministack.core.responses import set_request_account_id, set_request_region
+    from ministack.services import eks as eks_service
+
+    monkeypatch.setattr(eks_service, "_get_docker", lambda: None)
+    set_request_account_id("000000000000")
+    set_request_region(REGION)
+    eks_service.reset()
+    yield eks_service
+    eks_service.reset()
+
+
+def _eks_direct(eks_service, method, path, body=None, query=None):
+    payload = json.dumps(body or {}).encode("utf-8") if body is not None else b""
+    status, headers, raw_body = asyncio.run(
+        eks_service.handle_request(method, path, {}, payload, query or {})
+    )
+    if raw_body:
+        parsed_body = json.loads(raw_body.decode("utf-8"))
+    else:
+        parsed_body = {}
+    return status, headers, parsed_body
+
+
+def _eks_direct_create_cluster(eks_service, name):
+    status, _headers, body = _eks_direct(
+        eks_service,
+        "POST",
+        "/clusters",
+        {
+            "name": name,
+            "roleArn": "arn:aws:iam::000000000000:role/eks-role",
+            "resourcesVpcConfig": {},
+        },
+    )
+    assert status == 200
+    return body["cluster"]["arn"]
 
 
 # ---------------------------------------------------------------------------
@@ -205,6 +247,139 @@ def test_eks_tag_cluster(eks):
     assert resp["tags"]["team"] == "platform"
 
     eks.delete_cluster(name=name)
+
+
+def test_eks_tag_resource_accepts_supported_local_arn_shapes_direct(eks_mod):
+    cluster = f"tag-shapes-{_uid()}"
+    cluster_arn = _eks_direct_create_cluster(eks_mod, cluster)
+
+    status, _headers, body = _eks_direct(
+        eks_mod,
+        "POST",
+        f"/clusters/{cluster}/node-groups",
+        {
+            "nodegroupName": "workers",
+            "nodeRole": "arn:aws:iam::000000000000:role/node-role",
+            "subnets": ["subnet-1"],
+        },
+    )
+    assert status == 200
+    nodegroup_arn = body["nodegroup"]["nodegroupArn"]
+
+    status, _headers, body = _eks_direct(
+        eks_mod,
+        "POST",
+        f"/clusters/{cluster}/addons",
+        {"addonName": "vpc-cni"},
+    )
+    assert status == 200
+    addon_arn = body["addon"]["addonArn"]
+
+    principal = "arn:aws:iam::000000000000:role/eks-access"
+    status, _headers, body = _eks_direct(
+        eks_mod,
+        "POST",
+        f"/clusters/{cluster}/access-entries",
+        {"principalArn": principal},
+    )
+    assert status == 200
+    access_entry_arn = body["accessEntry"]["accessEntryArn"]
+
+    status, _headers, _body = _eks_direct(
+        eks_mod,
+        "POST",
+        f"/clusters/{cluster}/identity-provider-configs/associate",
+        {
+            "oidc": {
+                "identityProviderConfigName": "tag-idp",
+                "issuerUrl": "https://example/issuer",
+                "clientId": "client-1",
+            },
+        },
+    )
+    assert status == 200
+    status, _headers, body = _eks_direct(
+        eks_mod,
+        "POST",
+        f"/clusters/{cluster}/identity-provider-configs/describe",
+        {"identityProviderConfig": {"type": "oidc", "name": "tag-idp"}},
+    )
+    assert status == 200
+    idp_arn = body["identityProviderConfig"]["oidc"]["identityProviderConfigArn"]
+
+    for arn in (cluster_arn, nodegroup_arn, addon_arn, access_entry_arn, idp_arn):
+        path_arn = quote(arn, safe="") if arn == cluster_arn else arn
+        status, _headers, body = _eks_direct(
+            eks_mod,
+            "POST",
+            f"/tags/{path_arn}",
+            {"tags": {"scope": "local"}},
+        )
+        assert status == 200
+        assert body == {}
+
+        status, _headers, body = _eks_direct(eks_mod, "GET", f"/tags/{path_arn}")
+        assert status == 200
+        assert body["tags"]["scope"] == "local"
+        assert eks_mod._tags.get(arn) == {"scope": "local"}
+
+
+def test_eks_tag_apis_reject_invalid_resource_arns_before_tags_direct(eks_mod):
+    cluster = f"tag-invalid-{_uid()}"
+    cluster_arn = _eks_direct_create_cluster(eks_mod, cluster)
+    _eks_direct(eks_mod, "POST", f"/tags/{cluster_arn}", {"tags": {"existing": "tag"}})
+    existing_tags = dict(eks_mod._tags.items())
+
+    invalid_arns = [
+        "not-an-arn",
+        cluster_arn.replace("arn:aws:", "arn:aws-cn:"),
+        cluster_arn.replace(":eks:", ":sqs:"),
+        cluster_arn.replace(":000000000000:", ":111111111111:"),
+        cluster_arn.replace(f":{REGION}:", ":us-west-2:"),
+        f"{cluster_arn}/extra",
+        f"arn:aws:eks:{REGION}:000000000000:fargateprofile/{cluster}/fp/abc123",
+    ]
+
+    for arn in invalid_arns:
+        for method, request_body, query in (
+            ("GET", None, None),
+            ("POST", {"tags": {"bad": "tag"}}, None),
+            ("DELETE", None, {"tagKeys": "existing"}),
+        ):
+            status, _headers, body = _eks_direct(
+                eks_mod,
+                method,
+                f"/tags/{arn}",
+                request_body,
+                query,
+            )
+            assert status == 400
+            assert body["__type"] == "InvalidParameterException"
+            assert dict(eks_mod._tags.items()) == existing_tags
+
+
+def test_eks_tag_apis_reject_missing_local_resources_before_tags_direct(eks_mod):
+    cluster = f"tag-missing-{_uid()}"
+    cluster_arn = _eks_direct_create_cluster(eks_mod, cluster)
+    _eks_direct(eks_mod, "POST", f"/tags/{cluster_arn}", {"tags": {"existing": "tag"}})
+    existing_tags = dict(eks_mod._tags.items())
+    missing_arn = f"arn:aws:eks:{REGION}:000000000000:cluster/no-such-cluster"
+
+    for method, request_body, query in (
+        ("GET", None, None),
+        ("POST", {"tags": {"bad": "tag"}}, None),
+        ("DELETE", None, {"tagKeys": "existing"}),
+    ):
+        status, _headers, body = _eks_direct(
+            eks_mod,
+            method,
+            f"/tags/{missing_arn}",
+            request_body,
+            query,
+        )
+        assert status == 404
+        assert body["__type"] == "ResourceNotFoundException"
+        assert dict(eks_mod._tags.items()) == existing_tags
 
 
 # ---------------------------------------------------------------------------
@@ -805,7 +980,8 @@ def test_only_one_oidc_idp_per_cluster(eks):
 
 def test_idp_tags_returned_by_list_tags_for_resource(eks):
     """Tags set at associate time must be reachable via list_tags_for_resource
-    on the identityProviderConfigArn, and must clear after disassociate."""
+    on the identityProviderConfigArn, and the ARN must stop resolving after
+    disassociate removes the local IdP config."""
     cn = f"idp-tags-{_uid()}"
     _create_cluster_for_idp(eks, cn)
     try:
@@ -832,8 +1008,9 @@ def test_idp_tags_returned_by_list_tags_for_resource(eks):
             clusterName=cn,
             identityProviderConfig={"type": "oidc", "name": "tag-idp"},
         )
-        tags_after = eks.list_tags_for_resource(resourceArn=arn)["tags"]
-        assert tags_after == {}
+        with pytest.raises(ClientError) as exc:
+            eks.list_tags_for_resource(resourceArn=arn)
+        assert exc.value.response["Error"]["Code"] == "ResourceNotFoundException"
     finally:
         try:
             eks.delete_cluster(name=cn)


### PR DESCRIPTION
## Why
EKS tag APIs should parse and canonicalize supported local resource ARNs before touching tag state.

## What
- Adds parser-backed validation for supported local EKS tag resource ARN shapes and resolves them to canonical local ARNs.
- Adds focused coverage for cluster, nodegroup, addon, access entry, identity provider config, invalid dimensions, unsupported shapes, and missing resources.

## Validation
- `uv run --offline --extra dev ruff check ministack/services/eks.py tests/test_eks.py`
- `uv run --offline --extra dev pytest tests/test_eks.py -v`