### PR TITLE
Validate S3Files tag resource ARNs

### DIFF
--- a/ministack/services/s3files.py
+++ b/ministack/services/s3files.py
@@ -20,6 +20,7 @@ import re
 import time
 from urllib.parse import unquote
 
+from ministack.core.arn import ArnParseError, parse_arn
 from ministack.core.persistence import load_state
 from ministack.core.responses import (
     AccountScopedDict,
@@ -94,6 +95,8 @@ def reset():
 # ---------------------------------------------------------------------------
 
 _FS_ARN_RE = re.compile(r"^arn:aws[-a-z]*:s3files:[^:]*:[^:]*:file-system/(fs-[0-9a-f]{17,40})(?:/access-point/(fsap-[0-9a-f]{17,40}))?$")
+_FS_ID_RE = re.compile(r"^fs-[0-9a-f]{17,40}$")
+_AP_ID_RE = re.compile(r"^fsap-[0-9a-f]{17,40}$")
 
 
 def _hex_id(prefix):
@@ -116,6 +119,39 @@ def _resolve_id(value, prefer="fs"):
     if prefer == "ap":
         return m.group(2) or m.group(1)
     return m.group(2) or m.group(1)
+
+
+def _resolve_tag_resource_id(value):
+    if not value:
+        return "", _VALIDATION("resourceId is required")
+    if not value.startswith("arn:"):
+        return _resolve_id(value, prefer="any"), None
+
+    try:
+        spec = parse_arn(value)
+    except ArnParseError:
+        return "", _VALIDATION(f"Invalid resource ARN: {value}")
+
+    if (
+        spec.partition != "aws"
+        or spec.service != "s3files"
+        or spec.region != get_region()
+        or spec.account_id != get_account_id()
+    ):
+        return "", _VALIDATION(f"Invalid resource ARN: {value}")
+
+    parts = spec.resource.split("/")
+    if len(parts) == 2 and parts[0] == "file-system" and _FS_ID_RE.fullmatch(parts[1]):
+        return parts[1], None
+    if (
+        len(parts) == 4
+        and parts[0] == "file-system"
+        and _FS_ID_RE.fullmatch(parts[1])
+        and parts[2] == "access-point"
+        and _AP_ID_RE.fullmatch(parts[3])
+    ):
+        return parts[3], None
+    return "", _VALIDATION(f"Invalid resource ARN: {value}")
 
 
 def _fs_arn(fs_id):
@@ -275,7 +311,9 @@ async def handle_request(method, path, headers, body, query_params):
 
     # /resource-tags/{resourceId}
     if parts and parts[0] == "resource-tags" and len(parts) >= 2:
-        resource_id = _resolve_id("/".join(parts[1:]), prefer="any")
+        resource_id, err = _resolve_tag_resource_id("/".join(parts[1:]))
+        if err:
+            return err
         if method == "POST":
             return _tag_resource(resource_id, data)
         if method == "DELETE":

--- a/tests/test_s3files.py
+++ b/tests/test_s3files.py
@@ -12,7 +12,6 @@ import urllib.parse
 import urllib.request
 import uuid
 
-
 ENDPOINT = "http://localhost:4566"
 BUCKET_ARN = "arn:aws:s3:::test-bucket"
 ROLE_ARN = "arn:aws:iam::000000000000:role/s3files-role"
@@ -53,6 +52,10 @@ def _req(method, path, body=None, query=None, account=None):
 
 def _uid():
     return uuid.uuid4().hex[:6]
+
+
+def _resource_tags_path(resource_id):
+    return "/resource-tags/" + urllib.parse.quote(resource_id, safe="")
 
 
 # ---------------------------------------------------------------------------
@@ -201,7 +204,7 @@ def test_access_point_lifecycle():
         assert s == 200
         assert ap["accessPointId"].startswith("fsap-")
         assert ap["fileSystemId"] == fs_id
-        assert ap["accessPointArn"].startswith(f"arn:aws:s3files:")
+        assert ap["accessPointArn"].startswith("arn:aws:s3files:")
         assert "/access-point/" in ap["accessPointArn"]
         assert ap["name"] == "ap-test"
 
@@ -321,6 +324,82 @@ def test_tag_unknown_resource_returns_404():
     })
     assert s == 404
     assert body.get("__type") == "ResourceNotFoundException"
+
+
+def test_resource_tags_accept_file_system_and_access_point_arns():
+    s, fs = _req("PUT", "/file-systems", {"bucket": BUCKET_ARN, "roleArn": ROLE_ARN})
+    fs_id = fs["fileSystemId"]
+    fs_arn = fs["fileSystemArn"]
+    try:
+        s, _ = _req("POST", _resource_tags_path(fs_arn), {
+            "tags": [{"key": "Scope", "value": "filesystem"}],
+        })
+        assert s == 200
+
+        s, listed = _req("GET", _resource_tags_path(fs_arn))
+        assert s == 200
+        assert {t["key"]: t["value"] for t in listed["tags"]} == {"Scope": "filesystem"}
+
+        s, ap = _req("PUT", "/access-points", {"fileSystemId": fs_id})
+        assert s == 200
+        ap_arn = ap["accessPointArn"]
+
+        s, _ = _req("POST", _resource_tags_path(ap_arn), {
+            "tags": [{"key": "Scope", "value": "accesspoint"}],
+        })
+        assert s == 200
+
+        s, listed = _req("GET", _resource_tags_path(ap_arn))
+        assert s == 200
+        assert {t["key"]: t["value"] for t in listed["tags"]} == {"Scope": "accesspoint"}
+
+        s, _ = _req("DELETE", _resource_tags_path(ap_arn), query={"tagKeys": ["Scope"]})
+        assert s == 200
+        s, listed = _req("GET", _resource_tags_path(ap_arn))
+        assert listed["tags"] == []
+    finally:
+        _req("DELETE", f"/file-systems/{fs_id}")
+
+
+def test_resource_tags_reject_out_of_scope_arns_before_touching_tags():
+    s, fs = _req("PUT", "/file-systems", {"bucket": BUCKET_ARN, "roleArn": ROLE_ARN})
+    fs_id = fs["fileSystemId"]
+    try:
+        s, _ = _req("POST", f"/resource-tags/{fs_id}", {
+            "tags": [{"key": "Keep", "value": "true"}],
+        })
+        assert s == 200
+
+        bad_arns = [
+            "arn:nope",
+            f"arn:aws-cn:s3files:us-east-1:000000000000:file-system/{fs_id}",
+            f"arn:aws:s3:us-east-1:000000000000:file-system/{fs_id}",
+            f"arn:aws:s3files:us-west-2:000000000000:file-system/{fs_id}",
+            f"arn:aws:s3files:us-east-1:111111111111:file-system/{fs_id}",
+            f"arn:aws:s3files:us-east-1:000000000000:mount-target/{fs_id}",
+            "arn:aws:s3files:us-east-1:000000000000:file-system/fs-nothex",
+            f"arn:aws:s3files:us-east-1:000000000000:file-system/{fs_id}/access-point/fs-nothex",
+        ]
+        for arn in bad_arns:
+            for method, body, query in (
+                ("POST", {"tags": [{"key": "Bad", "value": "false"}]}, None),
+                ("DELETE", None, {"tagKeys": ["Keep"]}),
+                ("GET", None, None),
+            ):
+                s, response = _req(method, _resource_tags_path(arn), body=body, query=query)
+                assert s == 400, (method, arn, response)
+                assert response.get("__type") == "ValidationException"
+
+        missing = "arn:aws:s3files:us-east-1:000000000000:file-system/fs-deadbeefdeadbeefdea"
+        s, response = _req("GET", _resource_tags_path(missing))
+        assert s == 404
+        assert response.get("__type") == "ResourceNotFoundException"
+
+        s, listed = _req("GET", f"/resource-tags/{fs_id}")
+        assert s == 200
+        assert {t["key"]: t["value"] for t in listed["tags"]} == {"Keep": "true"}
+    finally:
+        _req("DELETE", f"/file-systems/{fs_id}")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why
S3Files tag routes should validate ARN-shaped resource IDs before resolving them to local file-system or access-point IDs.

## What
- Adds parser-backed validation for local S3Files file-system and access-point tag resource ARNs while preserving bare ID behavior.
- Adds coverage for URL-encoded ARN tag paths, invalid scope rejection, missing resource behavior, and no-mutation failures.

## Validation
- `uv run --offline --extra dev ruff check ministack/services/s3files.py tests/test_s3files.py`
- `uv run --offline --extra dev pytest tests/test_s3files.py -v`