### PR TITLE
Validate API Gateway v2 tag ARNs

### DIFF
--- a/ministack/services/apigateway.py
+++ b/ministack/services/apigateway.py
@@ -51,6 +51,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 
+from ministack.core.arn import ArnParseError, parse_arn
 from ministack.core.responses import AccountScopedDict, error_response_json, get_account_id, get_region, new_uuid
 
 _HOST = os.environ.get("MINISTACK_HOST", "localhost")
@@ -168,7 +169,12 @@ def _apigw_error(code: str, message: str, status: int) -> tuple:
 
 
 def _api_arn(api_id: str) -> str:
-    return f"arn:aws:apigateway:{get_region()}::/apis/{api_id}"
+    return _api_resource_arn(api_id)
+
+
+def _api_resource_arn(api_id: str, *segments: str) -> str:
+    suffix = "".join(f"/{segment}" for segment in segments)
+    return f"arn:aws:apigateway:{get_region()}::/apis/{api_id}{suffix}"
 
 
 def _extract_lambda_ref_from_integration_uri(uri: str) -> str:
@@ -259,7 +265,7 @@ async def handle_request(method, path, headers, body, query_params):
     # /v2/tags/{resourceArn} — tags endpoint
     if resource == "tags":
         # resourceArn may contain slashes; rejoin everything after "tags/"
-        resource_arn = "/".join(parts[2:]) if len(parts) > 2 else ""
+        resource_arn = urllib.parse.unquote("/".join(parts[2:])) if len(parts) > 2 else ""
         if method == "GET":
             return _get_tags(resource_arn)
         if method == "POST":
@@ -1215,13 +1221,13 @@ def _get_apis():
 
 
 def _delete_api(api_id):
+    _delete_api_tag_resources(api_id)
     _apis.pop(api_id, None)
     _api_regions.pop(api_id, None)
     _routes.pop(api_id, None)
     _integrations.pop(api_id, None)
     _stages.pop(api_id, None)
     _deployments.pop(api_id, None)
-    _api_tags.pop(_api_arn(api_id), None)
     return 204, {}, b""
 
 
@@ -1314,6 +1320,7 @@ def _update_route(api_id, route_id, data):
 
 def _delete_route(api_id, route_id):
     _routes.get(api_id, {}).pop(route_id, None)
+    _api_tags.pop(_api_resource_arn(api_id, "routes", route_id), None)
     return 204, {}, b""
 
 
@@ -1387,6 +1394,7 @@ def _update_integration(api_id, int_id, data):
 
 def _delete_integration(api_id, int_id):
     _integrations.get(api_id, {}).pop(int_id, None)
+    _api_tags.pop(_api_resource_arn(api_id, "integrations", int_id), None)
     return 204, {}, b""
 
 
@@ -1408,6 +1416,8 @@ def _create_stage(api_id, data):
         "tags": data.get("tags", {}),
     }
     _stages.setdefault(api_id, {})[stage_name] = stage
+    if data.get("tags"):
+        _api_tags[_api_resource_arn(api_id, "stages", stage_name)] = dict(data.get("tags", {}))
     return _apigw_response(stage, 201)
 
 
@@ -1436,6 +1446,7 @@ def _update_stage(api_id, stage_name, data):
 
 def _delete_stage(api_id, stage_name):
     _stages.get(api_id, {}).pop(stage_name, None)
+    _api_tags.pop(_api_resource_arn(api_id, "stages", stage_name), None)
     return 204, {}, b""
 
 
@@ -1468,24 +1479,98 @@ def _get_deployment(api_id, deployment_id):
 
 def _delete_deployment(api_id, deployment_id):
     _deployments.get(api_id, {}).pop(deployment_id, None)
+    _api_tags.pop(_api_resource_arn(api_id, "deployments", deployment_id), None)
     return 204, {}, b""
 
 
 # ---- Control plane: Tags ----
 
+def _invalid_tag_resource_arn(resource_arn: str):
+    return _apigw_error(
+        "BadRequestException",
+        f"Invalid API Gateway v2 ResourceArn: {resource_arn}",
+        400,
+    )
+
+
+def _tag_resource_not_found(resource_arn: str):
+    return _apigw_error(
+        "NotFoundException",
+        f"API Gateway v2 resource not found: {resource_arn}",
+        404,
+    )
+
+
+def _api_exists_in_request_region(api_id: str) -> bool:
+    return api_id in _apis and _api_regions.get(api_id, get_region()) == get_region()
+
+
+def _validate_tag_resource_arn(resource_arn: str) -> tuple[str | None, tuple | None]:
+    try:
+        spec = parse_arn(resource_arn)
+    except ArnParseError:
+        return None, _invalid_tag_resource_arn(resource_arn)
+
+    if (
+        spec.partition != "aws"
+        or spec.service != "apigateway"
+        or not spec.region
+        or spec.region != get_region()
+        or spec.account_id != ""
+        or not spec.resource.startswith("/")
+    ):
+        return None, _invalid_tag_resource_arn(resource_arn)
+
+    segments = spec.resource[1:].split("/")
+    if not segments or any(segment == "" for segment in segments):
+        return None, _invalid_tag_resource_arn(resource_arn)
+    if len(segments) not in (2, 4) or segments[0] != "apis":
+        return None, _invalid_tag_resource_arn(resource_arn)
+
+    api_id = segments[1]
+    if not _api_exists_in_request_region(api_id):
+        return None, _tag_resource_not_found(resource_arn)
+    if len(segments) == 2:
+        return _api_arn(api_id), None
+
+    resource_type, resource_id = segments[2], segments[3]
+    if resource_type != "stages":
+        return None, _invalid_tag_resource_arn(resource_arn)
+    if resource_id not in _stages.get(api_id, {}):
+        return None, _tag_resource_not_found(resource_arn)
+    return _api_resource_arn(api_id, resource_type, resource_id), None
+
+
+def _delete_api_tag_resources(api_id: str):
+    api_arn = _api_arn(api_id)
+    nested_prefix = f"{api_arn}/"
+    for resource_arn in list(_api_tags):
+        if resource_arn == api_arn or resource_arn.startswith(nested_prefix):
+            _api_tags.pop(resource_arn, None)
+
+
 def _get_tags(resource_arn: str):
-    tags = _api_tags.get(resource_arn, {})
+    canonical_arn, err = _validate_tag_resource_arn(resource_arn)
+    if err:
+        return err
+    tags = _api_tags.get(canonical_arn, {})
     return _apigw_response({"tags": tags})
 
 
 def _tag_resource(resource_arn: str, data: dict):
+    canonical_arn, err = _validate_tag_resource_arn(resource_arn)
+    if err:
+        return err
     tags = data.get("tags", {})
-    _api_tags.setdefault(resource_arn, {}).update(tags)
+    _api_tags.setdefault(canonical_arn, {}).update(tags)
     return 201, {}, b""
 
 
 def _untag_resource(resource_arn: str, tag_keys: list):
-    existing = _api_tags.get(resource_arn, {})
+    canonical_arn, err = _validate_tag_resource_arn(resource_arn)
+    if err:
+        return err
+    existing = _api_tags.get(canonical_arn, {})
     for key in tag_keys:
         existing.pop(key, None)
     return 204, {}, b""
@@ -1538,6 +1623,7 @@ def _update_authorizer(api_id, auth_id, data):
 
 def _delete_authorizer(api_id, auth_id):
     _authorizers.get(api_id, {}).pop(auth_id, None)
+    _api_tags.pop(_api_resource_arn(api_id, "authorizers", auth_id), None)
     return 204, {}, b""
 
 

--- a/tests/test_apigatewayv2_tag_arns.py
+++ b/tests/test_apigatewayv2_tag_arns.py
@@ -1,0 +1,146 @@
+import asyncio
+import json
+import urllib.parse
+
+import pytest
+
+from ministack.core.responses import get_account_id, get_region, set_request_account_id, set_request_region
+from ministack.services import apigateway as _apigw
+
+
+@pytest.fixture(autouse=True)
+def _reset_apigateway_state():
+    original_account = get_account_id()
+    original_region = get_region()
+    set_request_account_id("000000000000")
+    set_request_region("us-east-1")
+    _apigw.reset()
+    try:
+        yield
+    finally:
+        _apigw.reset()
+        set_request_account_id(original_account)
+        set_request_region(original_region)
+
+
+def _payload(response):
+    status, _headers, body = response
+    return status, json.loads(body or b"{}")
+
+
+def _post_tags_path(resource_arn, tags):
+    encoded_arn = urllib.parse.quote(resource_arn, safe="")
+    body = json.dumps({"tags": tags}).encode("utf-8")
+    return asyncio.run(_apigw.handle_request("POST", f"/v2/tags/{encoded_arn}", {}, body, {}))
+
+
+def _create_api(name="tag-arn-api"):
+    status, body = _payload(_apigw._create_api({"name": name, "protocolType": "HTTP"}))
+    assert status == 201
+    return body["apiId"]
+
+
+def test_apigwv2_tag_api_arn_decodes_and_uses_canonical_key():
+    api_id = _create_api()
+    api_arn = _apigw._api_arn(api_id)
+
+    status, _headers, _body = _post_tags_path(api_arn, {"env": "test"})
+
+    assert status == 201
+    assert _apigw._api_tags.get(api_arn) == {"env": "test"}
+
+    status, body = _payload(_apigw._get_tags(api_arn))
+    assert status == 200
+    assert body["tags"] == {"env": "test"}
+
+
+def test_apigwv2_tag_arns_accept_existing_local_api_and_stage_resources():
+    api_id = _create_api("tag-stage-api")
+
+    stage_status, _stage_body = _payload(
+        _apigw._create_stage(api_id, {"stageName": "$default", "tags": {"created": "stage"}})
+    )
+    assert stage_status == 201
+
+    stage_arn = _apigw._api_resource_arn(api_id, "stages", "$default")
+    status, _headers, _body = _apigw._tag_resource(stage_arn, {"tags": {"owner": "team-a"}})
+    assert status == 201
+
+    stage_status, stage_body = _payload(_apigw._get_tags(stage_arn))
+    assert stage_status == 200
+    assert stage_body["tags"] == {"created": "stage", "owner": "team-a"}
+
+
+def test_apigwv2_tag_arns_reject_invalid_or_nonlocal_resources_before_touching_tags():
+    api_id = _create_api("tag-reject-api")
+    route_status, route = _payload(_apigw._create_route(api_id, {"routeKey": "GET /items"}))
+    assert route_status == 201
+    integration_status, integration = _payload(
+        _apigw._create_integration(
+            api_id,
+            {
+                "integrationType": "HTTP_PROXY",
+                "integrationUri": "https://example.com",
+                "integrationMethod": "GET",
+            },
+        )
+    )
+    assert integration_status == 201
+    deployment_status, deployment = _payload(_apigw._create_deployment(api_id, {}))
+    assert deployment_status == 201
+    authorizer_status, authorizer = _payload(
+        _apigw._create_authorizer(
+            api_id,
+            {
+                "name": "request-auth",
+                "authorizerType": "REQUEST",
+                "authorizerUri": "not-an-arn",
+                "authorizerCredentialsArn": "also-not-an-arn",
+            },
+        )
+    )
+    assert authorizer_status == 201
+
+    bad_arns = [
+        ("not-an-arn", "BadRequestException"),
+        (f"arn:aws-us-gov:apigateway:us-east-1::/apis/{api_id}", "BadRequestException"),
+        (f"arn:aws:execute-api:us-east-1::/apis/{api_id}", "BadRequestException"),
+        (f"arn:aws:apigateway:us-west-2::/apis/{api_id}", "BadRequestException"),
+        (f"arn:aws:apigateway:us-east-1:000000000000:/apis/{api_id}", "BadRequestException"),
+        ("arn:aws:apigateway:us-east-1::/domainnames/example.com", "BadRequestException"),
+        (f"arn:aws:apigateway:us-east-1::/apis/{api_id}/routes", "BadRequestException"),
+        (f"arn:aws:apigateway:us-east-1::/apis/{api_id}/routes/{route['routeId']}", "BadRequestException"),
+        (
+            f"arn:aws:apigateway:us-east-1::/apis/{api_id}/integrations/{integration['integrationId']}",
+            "BadRequestException",
+        ),
+        (
+            f"arn:aws:apigateway:us-east-1::/apis/{api_id}/deployments/{deployment['deploymentId']}",
+            "BadRequestException",
+        ),
+        (
+            f"arn:aws:apigateway:us-east-1::/apis/{api_id}/authorizers/{authorizer['authorizerId']}",
+            "BadRequestException",
+        ),
+        ("arn:aws:apigateway:us-east-1::/apis/missing", "NotFoundException"),
+        (f"arn:aws:apigateway:us-east-1::/apis/{api_id}/stages/missing", "NotFoundException"),
+    ]
+
+    for resource_arn, expected_code in bad_arns:
+        before = dict(_apigw._api_tags.items())
+        status, body = _payload(_apigw._tag_resource(resource_arn, {"tags": {"bad": "tag"}}))
+        assert status in (400, 404)
+        assert body["__type"] == expected_code
+        assert dict(_apigw._api_tags.items()) == before
+        assert _apigw._api_tags.get(resource_arn) is None
+
+    stage_status, _stage = _payload(_apigw._create_stage(api_id, {"stageName": "prod"}))
+    assert stage_status == 201
+    stage_arn = _apigw._api_resource_arn(api_id, "stages", "prod")
+    assert _apigw._tag_resource(stage_arn, {"tags": {"ok": "yes"}})[0] == 201
+    assert _apigw._api_tags.get(stage_arn) == {"ok": "yes"}
+    assert _apigw._delete_stage(api_id, "prod")[0] == 204
+    status, body = _payload(_apigw._get_tags(stage_arn))
+    assert status == 404
+    assert body["__type"] == "NotFoundException"
+    assert _apigw._api_tags.get(stage_arn) is None


### PR DESCRIPTION
## Why
API Gateway v2 tag APIs should validate API and stage ARNs before reading or mutating tag state.

## What
- Adds parser-backed validation and canonical tag keys for local API Gateway v2 API and stage tag ARNs.
- Adds focused coverage for encoded resource ARNs, valid API/stage tagging, invalid or nonlocal resources, missing resources, and untouched authorizer metadata behavior.

## Validation
- `uv run --offline --extra dev ruff check ministack/services/apigateway.py tests/test_apigatewayv2.py tests/test_apigatewayv2_tag_arns.py`
- `uv run --offline --extra dev pytest tests/test_apigatewayv2.py tests/test_apigatewayv2_tag_arns.py -v`