### PR TITLE
feat(cognito): caller-pinned user pool / client ids via ms-custom-id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [Unreleased]
+
+### Added
+- **Cognito — caller-pinned user pool / client ids via `ms-custom-id`** — parity with the API Gateway convention from #400. `CreateUserPool` honours an `ms-custom-id` key in `UserPoolTags` and pins `UserPool.Id` to the tag value; pins are validated against the `{region}_{alphanumeric}` pool-id shape because the region prefix feeds the pool ARN and the token `iss`. `CreateUserPoolClient` has no tags parameter, so an `ms-custom-id:` prefix on `ClientName` pins `ClientId` (the prefix is stripped from the stored name). Lets ephemeral environments put JWKS/issuer URLs and Amplify `userPoolId` / `userPoolClientId` into static env config at deploy time instead of pre-seeding `STATE_DIR/cognito.json`. Malformed or already-in-use pins fail with `InvalidParameterException` instead of silently falling back to a random id; LocalStack's `_custom_id_` tag / name prefix is intentionally rejected with a message pointing at `ms-custom-id`. Contributed by @prandogabriel. Fixes #883.
+
+---
+
 ## [1.3.61] — 2026-06-10
 
 ### Added

--- a/ministack/services/cognito.py
+++ b/ministack/services/cognito.py
@@ -354,19 +354,25 @@ def _pool_id() -> str:
     return f"{get_region()}_{suffix[:9]}"
 
 
+# Region prefix as encoded in pool ids. Accepts both 3-segment commercial
+# regions (e.g. ``us-east-1``, ``eu-central-1``) and 4-segment GovCloud / ISO
+# regions (e.g. ``us-gov-east-1``, ``us-iso-west-1``, ``eu-isoe-west-1``) —
+# Cognito is available in GovCloud, so the parser must not silently fall
+# through and reproduce the original `iss` bug there. _pool_region() parses
+# with this and _resolve_custom_pool_id() validates pinned ids against it,
+# so parsing and validation can never drift apart.
+_POOL_REGION_RE = re.compile(r"[a-z]+(-[a-z]+)+-\d+")
+
+
 def _pool_region(pool_id: str) -> str:
     """Return the region encoded in a pool_id (format ``{region}_{suffix}``).
 
     Falls back to get_region() for empty or non-standard IDs so callers
-    never have to special-case the edge cases. The regex accepts both
-    3-segment commercial regions (e.g. ``us-east-1``, ``eu-central-1``) and
-    4-segment GovCloud / ISO regions (e.g. ``us-gov-east-1``, ``us-iso-west-1``,
-    ``eu-isoe-west-1``) — Cognito is available in GovCloud, so the parser must
-    not silently fall through and reproduce the original `iss` bug there.
+    never have to special-case the edge cases.
     """
     if pool_id and "_" in pool_id:
         candidate = pool_id.rsplit("_", 1)[0]
-        if re.match(r"^[a-z]+(-[a-z]+)+-\d+$", candidate):
+        if _POOL_REGION_RE.fullmatch(candidate):
             return candidate
     return get_region()
 
@@ -1419,12 +1425,51 @@ async def _dispatch_identity(action: str, data: dict):
 # USER POOL CRUD
 # ===========================================================================
 
+def _resolve_custom_pool_id(tags) -> str | None:
+    """Return a caller-pinned user pool id from the ``ms-custom-id`` key in
+    ``UserPoolTags``, or None if the tag is not set (issue #883).
+
+    Pinned ids must look like real pool ids (``{region}_{alphanumeric}``)
+    because _pool_region() / _pool_arn() parse the region prefix out of the
+    id — a malformed pin would silently mis-region the pool ARN and the
+    token ``iss``. Raises ``ValueError`` for malformed or already-in-use ids
+    so misconfigs surface immediately instead of falling back to a random id.
+
+    LocalStack's ``_custom_id_`` tag is intentionally NOT supported (same
+    decision as ``ls-custom-id`` for API Gateway, issue #400) — callers
+    hitting it get a clear error pointing them at ``ms-custom-id`` so the
+    ministack-native key stays the only contract."""
+    if not isinstance(tags, dict):
+        return None
+    if "_custom_id_" in tags and "ms-custom-id" not in tags:
+        raise ValueError(
+            "_custom_id_ tag is not supported; use 'ms-custom-id' instead"
+        )
+    custom = tags.get("ms-custom-id")
+    if not custom:
+        return None
+    custom = str(custom)
+    if not re.fullmatch(_POOL_REGION_RE.pattern + r"_[0-9A-Za-z]+", custom):
+        raise ValueError(
+            f"User pool id '{custom}' (from ms-custom-id tag) must match "
+            "'<region>_<alphanumeric>', e.g. 'us-west-2_mypool1'"
+        )
+    if custom in _user_pools:
+        raise ValueError(
+            f"User pool id '{custom}' (from ms-custom-id tag) is already in use"
+        )
+    return custom
+
+
 def _create_user_pool(data):
     name = data.get("PoolName")
     if not name:
         return error_response_json("InvalidParameterException", "PoolName is required.", 400)
 
-    pid = _pool_id()
+    try:
+        pid = _resolve_custom_pool_id(data.get("UserPoolTags")) or _pool_id()
+    except ValueError as exc:
+        return error_response_json("InvalidParameterException", str(exc), 400)
     now = _now_epoch()
     pool = {
         "Id": pid,
@@ -1546,18 +1591,61 @@ def _pool_out(pool: dict) -> dict:
 # USER POOL CLIENT CRUD
 # ===========================================================================
 
+def _resolve_custom_client_id(client_name, pool: dict) -> str | None:
+    """Return a caller-pinned client id from an ``ms-custom-id:`` prefix on
+    ``ClientName``, or None for plain names (issue #883).
+
+    CreateUserPoolClient has no tags parameter, so the pin rides on the name
+    — the prefix convention LocalStack established with ``_custom_id_:``. The
+    prefix is stripped: ``ClientName="ms-custom-id:web1"`` stores ``web1`` as
+    both ClientId and ClientName. LocalStack's ``_custom_id_:`` prefix itself
+    is intentionally NOT supported — callers hitting it get a clear error
+    pointing them at ``ms-custom-id:`` (same decision as issue #400).
+
+    Raises ``ValueError`` for an empty pinned id or one already in use in
+    this user pool, so misconfigs surface immediately."""
+    if not isinstance(client_name, str):
+        return None
+    if client_name.startswith("_custom_id_:"):
+        raise ValueError(
+            "_custom_id_ ClientName prefix is not supported; use 'ms-custom-id:' instead"
+        )
+    if not client_name.startswith("ms-custom-id:"):
+        return None
+    custom = client_name[len("ms-custom-id:"):]
+    if not custom:
+        raise ValueError(
+            "Client id after the 'ms-custom-id:' ClientName prefix must not be empty"
+        )
+    if custom in pool["_clients"]:
+        raise ValueError(
+            f"Client id '{custom}' (from ms-custom-id: ClientName prefix) "
+            "is already in use in this user pool"
+        )
+    return custom
+
+
 def _create_user_pool_client(data):
     pid = data.get("UserPoolId")
     pool, err = _resolve_pool(pid)
     if err:
         return err
 
-    cid = _client_id()
+    client_name = data.get("ClientName", "")
+    try:
+        custom_cid = _resolve_custom_client_id(client_name, pool)
+    except ValueError as exc:
+        return error_response_json("InvalidParameterException", str(exc), 400)
+    if custom_cid:
+        cid = custom_cid
+        client_name = custom_cid
+    else:
+        cid = _client_id()
     now = _now_epoch()
     generate_secret = data.get("GenerateSecret", False)
     client = {
         "UserPoolId": pid,
-        "ClientName": data.get("ClientName", ""),
+        "ClientName": client_name,
         "ClientId": cid,
         "ClientSecret": _client_secret() if generate_secret else None,
         "CreationDate": now,

--- a/tests/test_cognito.py
+++ b/tests/test_cognito.py
@@ -5,6 +5,7 @@ import importlib
 import io
 import json
 import os
+import re
 import time
 import urllib.error
 import urllib.request
@@ -3214,3 +3215,113 @@ def test_cognito_email_disabled_env_skips_send(cognito_idp, monkeypatch):
     })
 
     assert len(ses_mod._sent_emails_list()) == before
+
+
+# ========== Caller-pinned ids via ms-custom-id (issue #883) ==========
+
+def test_cognito_pool_custom_id_via_ms_custom_id_tag(cognito_idp):
+    """ms-custom-id in UserPoolTags pins the user pool id; the region prefix
+    of the pinned id (not the request region) feeds the pool ARN."""
+    pinned = f"us-west-2_{_uuid_mod.uuid4().hex[:9]}"
+    pool = cognito_idp.create_user_pool(
+        PoolName="PinnedPool", UserPoolTags={"ms-custom-id": pinned},
+    )["UserPool"]
+    assert pool["Id"] == pinned
+    assert ":cognito-idp:us-west-2:" in pool["Arn"]
+    assert pool["Arn"].endswith(f":userpool/{pinned}")
+
+    desc = cognito_idp.describe_user_pool(UserPoolId=pinned)["UserPool"]
+    assert desc["Name"] == "PinnedPool"
+
+
+def test_cognito_pool_custom_id_rejects_localstack_custom_id_tag(cognito_idp):
+    """LocalStack's _custom_id_ tag is not supported; the error points the
+    caller at the ministack-native ms-custom-id key."""
+    with pytest.raises(ClientError) as exc_info:
+        cognito_idp.create_user_pool(
+            PoolName="LsTagPool", UserPoolTags={"_custom_id_": "us-west-2_lspool11"},
+        )
+    err = exc_info.value.response["Error"]
+    assert err["Code"] == "InvalidParameterException"
+    assert "ms-custom-id" in err["Message"]
+
+
+def test_cognito_pool_custom_id_duplicate_rejected(cognito_idp):
+    """Second CreateUserPool with the same pinned id in the same account fails
+    instead of silently falling back to a random id."""
+    pinned = f"us-east-1_{_uuid_mod.uuid4().hex[:9]}"
+    cognito_idp.create_user_pool(PoolName="DupPool1", UserPoolTags={"ms-custom-id": pinned})
+    with pytest.raises(ClientError) as exc_info:
+        cognito_idp.create_user_pool(PoolName="DupPool2", UserPoolTags={"ms-custom-id": pinned})
+    err = exc_info.value.response["Error"]
+    assert err["Code"] == "InvalidParameterException"
+    assert "already in use" in err["Message"]
+
+
+def test_cognito_pool_custom_id_malformed_rejected(cognito_idp):
+    """Pinned ids must match {region}_{alphanumeric} — _pool_region() parses
+    the region out of the id, so anything else would mis-region the ARN/iss."""
+    for bad in ("mypool", "us-west-2_", "us-west-2_my_pool", "US-WEST-2_pool1"):
+        with pytest.raises(ClientError) as exc_info:
+            cognito_idp.create_user_pool(
+                PoolName="BadPinPool", UserPoolTags={"ms-custom-id": bad},
+            )
+        err = exc_info.value.response["Error"]
+        assert err["Code"] == "InvalidParameterException", bad
+        assert "<region>_<alphanumeric>" in err["Message"], bad
+
+
+def test_cognito_pool_custom_id_absent_uses_random(cognito_idp):
+    """No tag → random {region}_{9 alphanumeric} id, exactly as before."""
+    pid = cognito_idp.create_user_pool(PoolName="RandomIdPool")["UserPool"]["Id"]
+    assert re.fullmatch(r"us-east-1_[0-9a-zA-Z]{9}", pid)
+
+
+def test_cognito_client_custom_id_via_client_name_prefix(cognito_idp):
+    """ms-custom-id: prefix on ClientName pins ClientId; the prefix is
+    stripped from the stored ClientName."""
+    pid = cognito_idp.create_user_pool(PoolName="ClientPinPool")["UserPool"]["Id"]
+    client = cognito_idp.create_user_pool_client(
+        UserPoolId=pid, ClientName="ms-custom-id:myclient123",
+    )["UserPoolClient"]
+    assert client["ClientId"] == "myclient123"
+    assert client["ClientName"] == "myclient123"
+
+    desc = cognito_idp.describe_user_pool_client(
+        UserPoolId=pid, ClientId="myclient123",
+    )["UserPoolClient"]
+    assert desc["ClientName"] == "myclient123"
+
+
+def test_cognito_client_custom_id_rejects_localstack_prefix(cognito_idp):
+    """LocalStack's _custom_id_: ClientName prefix is not supported; the error
+    points the caller at ms-custom-id:."""
+    pid = cognito_idp.create_user_pool(PoolName="LsPrefixPool")["UserPool"]["Id"]
+    with pytest.raises(ClientError) as exc_info:
+        cognito_idp.create_user_pool_client(
+            UserPoolId=pid, ClientName="_custom_id_:shouldfail",
+        )
+    err = exc_info.value.response["Error"]
+    assert err["Code"] == "InvalidParameterException"
+    assert "ms-custom-id" in err["Message"]
+
+
+def test_cognito_client_custom_id_duplicate_rejected(cognito_idp):
+    """Second client pinned to the same id within one pool is rejected."""
+    pid = cognito_idp.create_user_pool(PoolName="DupClientPool")["UserPool"]["Id"]
+    cognito_idp.create_user_pool_client(UserPoolId=pid, ClientName="ms-custom-id:dupclient1")
+    with pytest.raises(ClientError) as exc_info:
+        cognito_idp.create_user_pool_client(UserPoolId=pid, ClientName="ms-custom-id:dupclient1")
+    err = exc_info.value.response["Error"]
+    assert err["Code"] == "InvalidParameterException"
+    assert "already in use" in err["Message"]
+
+
+def test_cognito_client_custom_id_plain_name_uses_random(cognito_idp):
+    """Plain client names keep today's behavior: random 26-char id, name kept."""
+    pid = cognito_idp.create_user_pool(PoolName="PlainClientPool")["UserPool"]["Id"]
+    client = cognito_idp.create_user_pool_client(
+        UserPoolId=pid, ClientName="PlainApp",
+    )["UserPoolClient"]
+    assert client["ClientName"] == "PlainApp"
+    assert re.fullmatch(r"[0-9a-zA-Z]{26}", client["ClientId"])


### PR DESCRIPTION
Fixes #883 — parity with the API Gateway `ms-custom-id` convention from #400 (implemented in #408).

## What

When MiniStack runs in ephemeral environments (k8s preview envs, CI), apps need the Cognito pool/client IDs at deploy time — they feed static env config on both the server (JWKS URL, issuer validation) and the browser (Amplify `userPoolId` / `userPoolClientId`). Today the IDs are always random, forcing consumers to pre-seed `STATE_DIR/cognito.json`, which couples them to the internal persistence schema.

**User pool — `ms-custom-id` key in `UserPoolTags`** (CreateUserPool already accepts tags):

```bash
aws cognito-idp create-user-pool \
  --pool-name my-pool \
  --user-pool-tags ms-custom-id=us-west-2_mypool1
# => UserPool.Id == "us-west-2_mypool1"
```

**User pool client — `ms-custom-id:` prefix on `ClientName`** (CreateUserPoolClient has no tags parameter, so the pin rides on the name — the prefix convention LocalStack established with `_custom_id_:`; the prefix is stripped from the stored name):

```bash
aws cognito-idp create-user-pool-client \
  --user-pool-id us-west-2_mypool1 \
  --client-name ms-custom-id:myclient123
# => UserPoolClient.ClientId == "myclient123", ClientName stored as "myclient123"
```

## Semantics (mirroring `_resolve_custom_api_id` from #400)

- Tag / prefix absent → random ID exactly as today (no behavior change).
- Pinned pool IDs are validated against the `{region}_{alphanumeric}` pool-id shape, because `_pool_region()` / `_pool_arn()` parse the region prefix out of the id — a malformed pin would silently mis-region the pool ARN and the token `iss`. The validation reuses the same region regex as `_pool_region()` (extracted to a shared `_POOL_REGION_RE`) so parsing and validation can't drift apart. Malformed → `InvalidParameterException` (400).
- Pinned ID already in use (pool: caller's account; client: within the pool's client store) → `InvalidParameterException` with an "already in use" message instead of silent fallback. Happy to switch the code if you prefer something else — real AWS has no analog since these IDs are always server-generated.
- LocalStack's `_custom_id_` tag / name prefix is intentionally NOT supported, same decision as #400 for `ls-custom-id`: callers hitting it get a clear error pointing at `ms-custom-id`, so the ministack-native key stays the only contract.
- No changes to persistence or token issuance — pinned IDs flow through JWKS/issuer URLs and `PERSIST_STATE` exactly like random ones.

## Scope

- `ministack/services/cognito.py` — `_resolve_custom_pool_id` + `_resolve_custom_client_id`, wired into `_create_user_pool` / `_create_user_pool_client`.
- `tests/test_cognito.py` — 9 tests mirroring the #400 suite (pin, LocalStack-key rejection, duplicate rejection, malformed rejection, absent → random unchanged; for both pool and client).
- `CHANGELOG.md` — entry under `Unreleased`.
- Out (follow-up if there's interest): identity pools, user pool domains. README service-table phrase left for the release pass, as done for #400.

## Testing

- Full `tests/test_cognito.py` + `tests/test_cognito_custom_auth.py` pass locally against a dev server.
- End-to-end sanity check: pinned pool + pinned client → `AdminCreateUser` → `InitiateAuth` (USER_PASSWORD_AUTH) → access token `iss` ends with the pinned pool id, JWKS served at `/{pinned_pool_id}/.well-known/jwks.json`.
- `ruff check` clean on the touched files.