### PR TITLE
fix(cloudformation): DescribeStackResources handles LogicalResourceId filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to MiniStack will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Versioning follows [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- **CloudFormation — `DescribeStackResources` now honors the `LogicalResourceId` filter** — The handler now reads the optional `LogicalResourceId` parameter and, when present, returns only the matching resource or a `ValidationError` if it does not exist in the stack.
+
+---
+
 ## [1.3.62] — 2026-06-11
 
 ### Added

--- a/ministack/services/cloudformation/handlers.py
+++ b/ministack/services/cloudformation/handlers.py
@@ -307,6 +307,7 @@ def _describe_stack_resource(params):
 def _describe_stack_resources(params):
     from ministack.services.cloudformation import _stacks
     stack_name = _p(params, "StackName")
+    logical_resource_id = _p(params, "LogicalResourceId")
 
     stack = _stacks.get(stack_name)
     if not stack:
@@ -314,8 +315,17 @@ def _describe_stack_resources(params):
                       f"Stack [{stack_name}] does not exist")
 
     resources = stack.get("_resources", {})
+
+    if logical_resource_id:
+        if logical_resource_id not in resources:
+            return _error("ValidationError",
+                          f"Resource [{logical_resource_id}] does not exist in stack [{stack_name}]")
+        items = [(logical_resource_id, resources[logical_resource_id])]
+    else:
+        items = list(resources.items())
+
     members = ""
-    for logical_id, res in resources.items():
+    for logical_id, res in items:
         members += (
             "<member>"
             f"<LogicalResourceId>{_esc(logical_id)}</LogicalResourceId>"

--- a/tests/test_cfn.py
+++ b/tests/test_cfn.py
@@ -500,6 +500,37 @@ def test_cfn_stack_events(cfn):
     assert len(events) > 0
     assert all("ResourceStatus" in e for e in events)
 
+def test_cfn_describe_stack_resources_logical_id_filter(cfn, s3, sqs):
+    template = {
+        "AWSTemplateFormatVersion": "2010-09-09",
+        "Resources": {
+            "Bucket": {
+                "Type": "AWS::S3::Bucket",
+                "Properties": {"BucketName": "cfn-t10-bucket"},
+            },
+            "Queue": {
+                "Type": "AWS::SQS::Queue",
+                "Properties": {"QueueName": "cfn-t10-queue"},
+            },
+        },
+    }
+    cfn.create_stack(StackName="cfn-t10", TemplateBody=json.dumps(template))
+    _wait_stack(cfn, "cfn-t10")
+
+    filtered = cfn.describe_stack_resources(
+        StackName="cfn-t10", LogicalResourceId="Bucket"
+    )["StackResources"]
+    assert len(filtered) == 1
+    assert filtered[0]["LogicalResourceId"] == "Bucket"
+    assert filtered[0]["ResourceType"] == "AWS::S3::Bucket"
+
+    with pytest.raises(ClientError) as exc_info:
+        cfn.describe_stack_resources(
+            StackName="cfn-t10", LogicalResourceId="DoesNotExist"
+        )
+    assert exc_info.value.response["Error"]["Code"] == "ValidationError"
+
+
 def test_cfn_yaml_template(cfn, s3):
     yaml_body = """
 AWSTemplateFormatVersion: '2010-09-09'


### PR DESCRIPTION
## What

`DescribeStackResources` accepted the optional `LogicalResourceId` parameter but never read it, so filtering by `LogicalResourceId` returned all resources in the stack rather than the single matching one. This is inconsistent with the [AWS API](https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_DescribeStackResources.html).

The handler now reads `LogicalResourceId`, filters the resource list when present, and returns a `ValidationError` for an unknown id — matching the behavior of the singular `DescribeStackResource` call.

## Shape

The fix lives entirely in `services/cloudformation/handlers.py`; it reuses the existing `_p` helper and `_error` pattern already used by the sibling `_describe_stack_resource` function immediately above it.

## Behavior Notes

* When `LogicalResourceId` is absent the response is unchanged — all resources are returned as before.
* The `ValidationError` message mirrors the singular call: `Resource [<id>] does not exist in stack [<name>]`.

## Test Plan

* New `test_cfn_describe_stack_resources_logical_id_filter`: creates a two-resource stack (S3 + SQS), asserts the filtered call returns exactly the one named resource with the correct `ResourceType`, and a nonexistent id raises `ValidationError`.
* Full `tests/test_cfn.py` passes.
* `ruff check` clean on the changed file.
