### PR TITLE
fix(sfn): Fix context resolution in pass parameters.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to MiniStack will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Versioning follows [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- **Step Functions — Pass state `Parameters` now resolve context object paths** — `$$.*` references resolved to `null` in Pass states because `_execute_pass` applied `Parameters` without forwarding the execution context. It now forwards the context correctly when evaluating `Parameters`, fixing context object resolution for Pass states.
+
+---
+
 ## [1.3.62] — 2026-06-11
 
 ### Added

--- a/ministack/services/stepfunctions.py
+++ b/ministack/services/stepfunctions.py
@@ -1328,7 +1328,7 @@ def _execute_pass(state_def, raw_input, ctx=None):
         return output, _next_or_end(state_def)
 
     effective = _apply_input_path(state_def, raw_input)
-    effective = _apply_parameters(state_def, effective)
+    effective = _apply_parameters(state_def, effective, ctx)
 
     result = state_def.get("Result", effective)
     result = _apply_result_selector(state_def, result)

--- a/tests/test_stepfunctions.py
+++ b/tests/test_stepfunctions.py
@@ -282,6 +282,41 @@ def test_sfn_intrinsic_string_to_json(sfn, sfn_sync):
     output = json.loads(resp["output"])
     assert output["parsed"] == {"a": 1, "b": 2}
 
+def test_sfn_pass_parameters_resolve_context_object(sfn):
+    """Pass state Parameters can resolve Step Functions context object paths."""
+    unique = str(time.time_ns())
+    execution_name = f"pass-context-{unique}"
+    definition = json.dumps({
+        "StartAt": "Build",
+        "States": {
+            "Build": {
+                "Type": "Pass",
+                "Parameters": {
+                    "executionName.$": "$$.Execution.Name",
+                    "inputValue.$": "$.value",
+                },
+                "End": True,
+            }
+        },
+    })
+    sm = sfn.create_state_machine(
+        name=f"sfn-pass-context-{unique}",
+        definition=definition,
+        roleArn="arn:aws:iam::000000000000:role/R",
+    )
+    ex = sfn.start_execution(
+        stateMachineArn=sm["stateMachineArn"],
+        name=execution_name,
+        input=json.dumps({"value": "from-input"}),
+    )
+
+    desc = _wait_sfn(sfn, ex["executionArn"])
+    assert desc["status"] == "SUCCEEDED"
+    assert json.loads(desc["output"]) == {
+        "executionName": execution_name,
+        "inputValue": "from-input",
+    }
+
 def test_sfn_intrinsic_json_merge(sfn, sfn_sync):
     """States.JsonMerge shallow-merges two objects."""
     definition = json.dumps({


### PR DESCRIPTION
## Why
Pass state `Parameters` should be able to resolve Step Functions context object paths.

Before this change, Pass state parameter evaluation did not receive the execution context, so context object references inside `Parameters` resolved incorrectly.

## What
- Pass the Step Functions execution context into Pass state `Parameters` evaluation.
- Add a test covering `$$.Execution.Name` resolution inside Pass state `Parameters`.

## Validation
- `uv run pytest tests/test_stepfunctions.py -v`
  - `135 passed`
- `uv run ruff check ministack/services/stepfunctions.py`
  - `All checks passed`
- `uv run ruff check tests/test_stepfunctions.py`
  - `All checks passed`