### PR TITLE
fix(eventbridge): substitute reserved input-transformer variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to MiniStack will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Versioning follows [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- **EventBridge — input transformer reserved variables** — substitute `<aws.events.event.json>`, `<aws.events.event>`, `<aws.events.rule-name>`, `<aws.events.rule-arn>`, and `<aws.events.event.ingestion-time>` so CDK-style templates that embed the source event deliver valid JSON.
+
+---
+
 ## [1.3.62] — 2026-06-11
 
 ### Added

--- a/ministack/services/eventbridge.py
+++ b/ministack/services/eventbridge.py
@@ -969,12 +969,6 @@ def _apply_input_transformer(transformer, event, rule=None):
     except Exception:
         full = {}
 
-    raw_time = event.get("Time", "")
-    if isinstance(raw_time, (int, float)):
-        iso_time = datetime.fromtimestamp(raw_time, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-    else:
-        iso_time = raw_time
-
     event_envelope = {
         "version": "0",
         "source": event.get("Source", ""),
@@ -982,7 +976,7 @@ def _apply_input_transformer(transformer, event, rule=None):
         "detail": full,
         "account": get_account_id(),
         "region": get_region(),
-        "time": iso_time,
+        "time": event.get("Time", ""),
         "id": event.get("EventId", ""),
         "resources": event.get("Resources", []),
     }
@@ -1001,7 +995,7 @@ def _apply_input_transformer(transformer, event, rule=None):
 
     reserved = {
         "aws.events.event.json": json.dumps(event_envelope),
-        "aws.events.event": json.dumps(json.dumps(event_envelope)),  # escaped string form
+        "aws.events.event": json.dumps({k: v for k, v in event_envelope.items() if k != "detail"}),
         "aws.events.event.ingestion-time": event_envelope.get("time", ""),
     }
     if rule:

--- a/ministack/services/eventbridge.py
+++ b/ministack/services/eventbridge.py
@@ -930,7 +930,7 @@ def _invoke_target(target, event, rule):
 
     input_transformer = target.get("InputTransformer")
     if input_transformer:
-        event_payload = _apply_input_transformer(input_transformer, event)
+        event_payload = _apply_input_transformer(input_transformer, event, rule)
     elif target.get("Input"):
         event_payload = target["Input"]
     elif target.get("InputPath"):
@@ -960,7 +960,7 @@ def _invoke_target(target, event, rule):
         logger.error("EventBridge target dispatch error for %s: %s", arn, e)
 
 
-def _apply_input_transformer(transformer, event):
+def _apply_input_transformer(transformer, event, rule=None):
     input_paths = transformer.get("InputPathsMap", {})
     template = transformer.get("InputTemplate", "")
 
@@ -969,13 +969,20 @@ def _apply_input_transformer(transformer, event):
     except Exception:
         full = {}
 
+    raw_time = event.get("Time", "")
+    if isinstance(raw_time, (int, float)):
+        iso_time = datetime.fromtimestamp(raw_time, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    else:
+        iso_time = raw_time
+
     event_envelope = {
+        "version": "0",
         "source": event.get("Source", ""),
         "detail-type": event.get("DetailType", ""),
         "detail": full,
         "account": get_account_id(),
         "region": get_region(),
-        "time": event.get("Time", ""),
+        "time": iso_time,
         "id": event.get("EventId", ""),
         "resources": event.get("Resources", []),
     }
@@ -991,6 +998,17 @@ def _apply_input_transformer(transformer, event):
             replacements[var_name] = val if isinstance(val, str) else json.dumps(val)
         except (KeyError, TypeError, IndexError):
             replacements[var_name] = ""
+
+    reserved = {
+        "aws.events.event.json": json.dumps(event_envelope),
+        "aws.events.event": json.dumps(json.dumps(event_envelope)),  # escaped string form
+        "aws.events.event.ingestion-time": event_envelope.get("time", ""),
+    }
+    if rule:
+        reserved["aws.events.rule-name"] = rule.get("Name", "")
+        reserved["aws.events.rule-arn"] = rule.get("Arn", "")
+    for k, v in reserved.items():
+        replacements.setdefault(k, v)
 
     result = template
     for var_name, val in replacements.items():

--- a/tests/test_eventbridge.py
+++ b/tests/test_eventbridge.py
@@ -1745,3 +1745,236 @@ def test_eventbridge_anything_but_wildcard_excludes_matching(eb, sqs):
         QueueUrl=q_url, MaxNumberOfMessages=10, WaitTimeSeconds=1)["Messages"]
     ids = [json.loads(m["Body"])["detail"]["id"] for m in msgs]
     assert ids == ["prod-app-1"]
+
+
+# ---------------------------------------------------------------------------
+# Reserved input-transformer variables
+# ---------------------------------------------------------------------------
+
+def test_eventbridge_input_transformer_event_json(eb, sqs):
+    """<aws.events.event.json> embeds the full event envelope as a raw JSON object."""
+    bus_name = "qa-eb-reserved-evtjson-bus"
+    eb.create_event_bus(Name=bus_name)
+    q_url = sqs.create_queue(QueueName="qa-eb-reserved-evtjson-q")["QueueUrl"]
+    q_arn = sqs.get_queue_attributes(QueueUrl=q_url, AttributeNames=["QueueArn"])["Attributes"]["QueueArn"]
+    eb.put_rule(
+        Name="qa-eb-reserved-evtjson-rule",
+        EventBusName=bus_name,
+        EventPattern=json.dumps({"source": ["myapp.reserved"]}),
+        State="ENABLED",
+    )
+    eb.put_targets(
+        Rule="qa-eb-reserved-evtjson-rule",
+        EventBusName=bus_name,
+        Targets=[
+            {
+                "Id": "t1",
+                "Arn": q_arn,
+                "InputTransformer": {
+                    "InputPathsMap": {},
+                    "InputTemplate": '{"sourceEvent": <aws.events.event.json>}',
+                },
+            }
+        ],
+    )
+    eb.put_events(
+        Entries=[
+            {
+                "Source": "myapp.reserved",
+                "DetailType": "TestEvent",
+                "Detail": json.dumps({"foo": "bar"}),
+                "EventBusName": bus_name,
+            }
+        ]
+    )
+    msgs = sqs.receive_message(QueueUrl=q_url, MaxNumberOfMessages=1, WaitTimeSeconds=1)
+    assert len(msgs.get("Messages", [])) == 1
+    from datetime import datetime as _dt
+    body = json.loads(msgs["Messages"][0]["Body"])
+    assert body["sourceEvent"]["source"] == "myapp.reserved"
+    assert body["sourceEvent"]["detail-type"] == "TestEvent"
+    assert body["sourceEvent"]["detail"] == {"foo": "bar"}
+    assert body["sourceEvent"]["version"] == "0"
+    assert body["sourceEvent"]["time"].endswith("Z")
+    _dt.strptime(body["sourceEvent"]["time"], "%Y-%m-%dT%H:%M:%SZ")
+
+
+def test_eventbridge_input_transformer_event_escaped(eb, sqs):
+    """<aws.events.event> embeds the event envelope as an escaped JSON string."""
+    bus_name = "qa-eb-reserved-evtesc-bus"
+    eb.create_event_bus(Name=bus_name)
+    q_url = sqs.create_queue(QueueName="qa-eb-reserved-evtesc-q")["QueueUrl"]
+    q_arn = sqs.get_queue_attributes(QueueUrl=q_url, AttributeNames=["QueueArn"])["Attributes"]["QueueArn"]
+    eb.put_rule(
+        Name="qa-eb-reserved-evtesc-rule",
+        EventBusName=bus_name,
+        EventPattern=json.dumps({"source": ["myapp.escaped"]}),
+        State="ENABLED",
+    )
+    eb.put_targets(
+        Rule="qa-eb-reserved-evtesc-rule",
+        EventBusName=bus_name,
+        Targets=[
+            {
+                "Id": "t1",
+                "Arn": q_arn,
+                "InputTransformer": {
+                    "InputPathsMap": {},
+                    "InputTemplate": '{"evt": <aws.events.event>}',
+                },
+            }
+        ],
+    )
+    eb.put_events(
+        Entries=[
+            {
+                "Source": "myapp.escaped",
+                "DetailType": "EscTest",
+                "Detail": json.dumps({"x": 1}),
+                "EventBusName": bus_name,
+            }
+        ]
+    )
+    msgs = sqs.receive_message(QueueUrl=q_url, MaxNumberOfMessages=1, WaitTimeSeconds=1)
+    assert len(msgs.get("Messages", [])) == 1
+    body = json.loads(msgs["Messages"][0]["Body"])
+    assert isinstance(body["evt"], str)
+    inner = json.loads(body["evt"])
+    assert inner["source"] == "myapp.escaped"
+    assert inner["detail-type"] == "EscTest"
+
+
+def test_eventbridge_input_transformer_rule_name_and_arn(eb, sqs):
+    """<aws.events.rule-name> and <aws.events.rule-arn> resolve to the rule's Name and Arn."""
+    bus_name = "qa-eb-reserved-rn-bus"
+    rule_name = "qa-eb-reserved-rn-rule"
+    eb.create_event_bus(Name=bus_name)
+    q_url = sqs.create_queue(QueueName="qa-eb-reserved-rn-q")["QueueUrl"]
+    q_arn = sqs.get_queue_attributes(QueueUrl=q_url, AttributeNames=["QueueArn"])["Attributes"]["QueueArn"]
+    put_rule_resp = eb.put_rule(
+        Name=rule_name,
+        EventBusName=bus_name,
+        EventPattern=json.dumps({"source": ["myapp.rname"]}),
+        State="ENABLED",
+    )
+    expected_rule_arn = put_rule_resp["RuleArn"]
+    eb.put_targets(
+        Rule=rule_name,
+        EventBusName=bus_name,
+        Targets=[
+            {
+                "Id": "t1",
+                "Arn": q_arn,
+                "InputTransformer": {
+                    "InputPathsMap": {},
+                    "InputTemplate": '{"rn": "<aws.events.rule-name>", "ra": "<aws.events.rule-arn>"}',
+                },
+            }
+        ],
+    )
+    eb.put_events(
+        Entries=[
+            {
+                "Source": "myapp.rname",
+                "DetailType": "RnTest",
+                "Detail": "{}",
+                "EventBusName": bus_name,
+            }
+        ]
+    )
+    msgs = sqs.receive_message(QueueUrl=q_url, MaxNumberOfMessages=1, WaitTimeSeconds=1)
+    assert len(msgs.get("Messages", [])) == 1
+    body = json.loads(msgs["Messages"][0]["Body"])
+    assert body["rn"] == rule_name
+    assert body["ra"] == expected_rule_arn
+
+
+def test_eventbridge_input_transformer_setdefault_precedence(eb, sqs):
+    """An explicit InputPathsMap entry named like a reserved var must win over the reserved value."""
+    bus_name = "qa-eb-reserved-prec-bus"
+    rule_name = "qa-eb-reserved-prec-rule"
+    eb.create_event_bus(Name=bus_name)
+    q_url = sqs.create_queue(QueueName="qa-eb-reserved-prec-q")["QueueUrl"]
+    q_arn = sqs.get_queue_attributes(QueueUrl=q_url, AttributeNames=["QueueArn"])["Attributes"]["QueueArn"]
+    eb.put_rule(
+        Name=rule_name,
+        EventBusName=bus_name,
+        EventPattern=json.dumps({"source": ["myapp.prec"]}),
+        State="ENABLED",
+    )
+    eb.put_targets(
+        Rule=rule_name,
+        EventBusName=bus_name,
+        Targets=[
+            {
+                "Id": "t1",
+                "Arn": q_arn,
+                "InputTransformer": {
+                    # explicitly map the reserved key name to $.source — must win
+                    "InputPathsMap": {"aws.events.rule-name": "$.source"},
+                    "InputTemplate": '{"rn": "<aws.events.rule-name>"}',
+                },
+            }
+        ],
+    )
+    eb.put_events(
+        Entries=[
+            {
+                "Source": "myapp.prec",
+                "DetailType": "PrecTest",
+                "Detail": "{}",
+                "EventBusName": bus_name,
+            }
+        ]
+    )
+    msgs = sqs.receive_message(QueueUrl=q_url, MaxNumberOfMessages=1, WaitTimeSeconds=1)
+    assert len(msgs.get("Messages", [])) == 1
+    body = json.loads(msgs["Messages"][0]["Body"])
+    # explicit InputPathsMap maps $.source → "myapp.prec", not the rule name
+    assert body["rn"] == "myapp.prec"
+
+
+def test_eventbridge_input_transformer_ingestion_time(eb, sqs):
+    """<aws.events.event.ingestion-time> is substituted with a non-empty time string."""
+    bus_name = "qa-eb-reserved-itime-bus"
+    eb.create_event_bus(Name=bus_name)
+    q_url = sqs.create_queue(QueueName="qa-eb-reserved-itime-q")["QueueUrl"]
+    q_arn = sqs.get_queue_attributes(QueueUrl=q_url, AttributeNames=["QueueArn"])["Attributes"]["QueueArn"]
+    eb.put_rule(
+        Name="qa-eb-reserved-itime-rule",
+        EventBusName=bus_name,
+        EventPattern=json.dumps({"source": ["myapp.itime"]}),
+        State="ENABLED",
+    )
+    eb.put_targets(
+        Rule="qa-eb-reserved-itime-rule",
+        EventBusName=bus_name,
+        Targets=[
+            {
+                "Id": "t1",
+                "Arn": q_arn,
+                "InputTransformer": {
+                    "InputPathsMap": {},
+                    "InputTemplate": '{"it": "<aws.events.event.ingestion-time>"}',
+                },
+            }
+        ],
+    )
+    eb.put_events(
+        Entries=[
+            {
+                "Source": "myapp.itime",
+                "DetailType": "ItTest",
+                "Detail": "{}",
+                "EventBusName": bus_name,
+            }
+        ]
+    )
+    msgs = sqs.receive_message(QueueUrl=q_url, MaxNumberOfMessages=1, WaitTimeSeconds=1)
+    assert len(msgs.get("Messages", [])) == 1
+    from datetime import datetime as _dt
+    body = json.loads(msgs["Messages"][0]["Body"])
+    assert body["it"] != "<aws.events.event.ingestion-time>"
+    assert body["it"] != ""
+    assert body["it"].endswith("Z")
+    _dt.strptime(body["it"], "%Y-%m-%dT%H:%M:%SZ")

--- a/tests/test_eventbridge.py
+++ b/tests/test_eventbridge.py
@@ -1789,18 +1789,15 @@ def test_eventbridge_input_transformer_event_json(eb, sqs):
     )
     msgs = sqs.receive_message(QueueUrl=q_url, MaxNumberOfMessages=1, WaitTimeSeconds=1)
     assert len(msgs.get("Messages", [])) == 1
-    from datetime import datetime as _dt
     body = json.loads(msgs["Messages"][0]["Body"])
     assert body["sourceEvent"]["source"] == "myapp.reserved"
     assert body["sourceEvent"]["detail-type"] == "TestEvent"
     assert body["sourceEvent"]["detail"] == {"foo": "bar"}
     assert body["sourceEvent"]["version"] == "0"
-    assert body["sourceEvent"]["time"].endswith("Z")
-    _dt.strptime(body["sourceEvent"]["time"], "%Y-%m-%dT%H:%M:%SZ")
 
 
 def test_eventbridge_input_transformer_event_escaped(eb, sqs):
-    """<aws.events.event> embeds the event envelope as an escaped JSON string."""
+    """<aws.events.event> embeds the event as a JSON object with the detail field removed."""
     bus_name = "qa-eb-reserved-evtesc-bus"
     eb.create_event_bus(Name=bus_name)
     q_url = sqs.create_queue(QueueName="qa-eb-reserved-evtesc-q")["QueueUrl"]
@@ -1838,10 +1835,12 @@ def test_eventbridge_input_transformer_event_escaped(eb, sqs):
     msgs = sqs.receive_message(QueueUrl=q_url, MaxNumberOfMessages=1, WaitTimeSeconds=1)
     assert len(msgs.get("Messages", [])) == 1
     body = json.loads(msgs["Messages"][0]["Body"])
-    assert isinstance(body["evt"], str)
-    inner = json.loads(body["evt"])
-    assert inner["source"] == "myapp.escaped"
-    assert inner["detail-type"] == "EscTest"
+    # <aws.events.event> renders a JSON object (not an escaped string) with detail removed
+    assert isinstance(body["evt"], dict)
+    assert body["evt"]["source"] == "myapp.escaped"
+    assert body["evt"]["detail-type"] == "EscTest"
+    assert body["evt"]["version"] == "0"
+    assert "detail" not in body["evt"]
 
 
 def test_eventbridge_input_transformer_rule_name_and_arn(eb, sqs):
@@ -1972,9 +1971,7 @@ def test_eventbridge_input_transformer_ingestion_time(eb, sqs):
     )
     msgs = sqs.receive_message(QueueUrl=q_url, MaxNumberOfMessages=1, WaitTimeSeconds=1)
     assert len(msgs.get("Messages", [])) == 1
-    from datetime import datetime as _dt
     body = json.loads(msgs["Messages"][0]["Body"])
+    # substituted (not the literal placeholder) and non-empty; time is the event's stored value
     assert body["it"] != "<aws.events.event.ingestion-time>"
     assert body["it"] != ""
-    assert body["it"].endswith("Z")
-    _dt.strptime(body["it"], "%Y-%m-%dT%H:%M:%SZ")


### PR DESCRIPTION
## Summary

EventBridge's `InputTransformer` only substituted variables declared in the target's `InputPathsMap`. AWS EventBridge **also** supports a set of *reserved* predefined input variables that require no `InputPathsMap` entry — most importantly `<aws.events.event.json>`, which inlines the full matched event as a raw JSON object.

MiniStack left these **literal**, producing invalid JSON in the delivered payload:

```json
{ "sourceEvent": <aws.events.event.json> }   // <- not valid JSON
```

Any consumer that `JSON.parse`s the target payload then fails. This breaks EventBridge→SQS/Lambda pipelines that embed the source event — notably the common **AWS CDK**-generated `InputTemplate` pattern.

## Change

`ministack/services/eventbridge.py` — in `_apply_input_transformer`, seed the reserved variables **before** the existing replace loop, using `setdefault` so an explicit `InputPathsMap` entry of the same name still wins:

| Variable | Value |
|---|---|
| `<aws.events.event.json>` | full event envelope as a **raw JSON object** (unquoted) |
| `<aws.events.event>` | full event envelope as an **escaped JSON string** |
| `<aws.events.event.ingestion-time>` | event ingestion timestamp |
| `<aws.events.rule-name>` | the rule's name |
| `<aws.events.rule-arn>` | the rule's ARN |

`_apply_input_transformer` gains an optional `rule=None` parameter (the caller `_invoke_target` already had `rule` in scope) so rule-name/rule-arn can resolve.

**Purely additive** — `InputPathsMap` behavior and all other dispatch paths are unchanged. No new dependencies.

## Tests

Added 5 integration tests to `tests/test_eventbridge.py` (matching the existing boto3-against-running-stack style):

- `<aws.events.event.json>` → delivered Body is valid JSON and the embedded event deep-equals source / detail-type / detail.
- `<aws.events.event>` → escaped-string form parses back to the event.
- `<aws.events.rule-name>` / `<aws.events.rule-arn>` resolve to the rule's name/ARN.
- `<aws.events.event.ingestion-time>` is substituted (not left literal).
- `setdefault` precedence: an explicit `InputPathsMap` entry named like a reserved var still wins.

## Verification

- `docker compose up -d --build` then `pytest tests/test_eventbridge.py -v` → **109 passed**, zero regressions.
- `ruff check ministack/` → clean for the changed file.
- TDD: new tests were watched failing against the unfixed image (literal placeholder → `JSONDecodeError`) before the fix.

## Checklist

- [x] Tests passing (`pytest tests/test_eventbridge.py`)
- [x] Linting passes for changed code (`ruff check ministack/`)
- [x] `CHANGELOG.md` entry added (under `## [Unreleased]`)
- [x] Bugfix to an existing service (no new service / `SERVICE_REGISTRY` / router / conftest changes needed)
