### PR TITLE
Fix: apply Assign in mock path for JSONata Task states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to MiniStack will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Versioning follows [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- **Step Functions — `Assign` is now applied in the mock execution path for JSONata Task states** — when `SFN_MOCK_CONFIG` was active, `_apply_state_assign` was never called on the mock return branch, so any `Assign` block in a JSONata Task state was silently skipped; downstream states referencing the assigned variables failed with `States.QueryEvaluationError: Undefined variable`. The mock branch now mirrors the real execution path by calling `_apply_state_assign` after `_apply_jsonata_output`.
+
+---
+
 ## [1.3.62] — 2026-06-11
 
 ### Added

--- a/ministack/services/stepfunctions.py
+++ b/ministack/services/stepfunctions.py
@@ -1369,6 +1369,7 @@ def _execute_task(state_def, raw_input, execution, ctx):
                     result=mock_result,
                     default=mock_result,
                 )
+                _apply_state_assign(state_def, raw_input, ctx, result=mock_result)
             else:
                 result = _apply_result_selector(state_def, mock_result)
                 output = _apply_result_path(state_def, raw_input, result)

--- a/tests/test_stepfunctions.py
+++ b/tests/test_stepfunctions.py
@@ -2593,6 +2593,73 @@ def test_sfn_mock_config_throw(sfn):
     assert desc["status"] == "FAILED"
     _ministack_config({"stepfunctions._sfn_mock_config": {}})
 
+def test_sfn_mock_config_jsonata_assign_applied(sfn):
+    """SFN_MOCK_CONFIG + JSONata Task with Assign — variable must be visible downstream.
+
+    Regression: the mock execution path called _apply_jsonata_output but never
+    called _apply_state_assign, so any Assign block was silently skipped.
+    A downstream state reading the assigned variable would fail with
+    States.QueryEvaluationError: Undefined variable.
+    """
+    from conftest import _ministack_config
+
+    mock_cfg = {
+        "StateMachines": {
+            "qa-sfn-mock-jsonata-assign": {
+                "TestCases": {
+                    "HappyPath": {
+                        "FetchData": "MockedData",
+                    }
+                }
+            }
+        },
+        "MockedResponses": {
+            "MockedData": {
+                "0": {"Return": {"value": 99}},
+            }
+        },
+    }
+    _ministack_config({"stepfunctions._sfn_mock_config": mock_cfg})
+
+    definition = json.dumps({
+        "QueryLanguage": "JSONata",
+        "StartAt": "FetchData",
+        "States": {
+            "FetchData": {
+                "Type": "Task",
+                "Resource": "arn:aws:lambda:us-east-1:000000000000:function:nonexistent",
+                "Assign": {"fetchedValue": "{% $states.result.value %}"},
+                "Next": "UseValue",
+            },
+            "UseValue": {
+                "Type": "Pass",
+                "Output": {"result": "{% $fetchedValue %}"},
+                "End": True,
+            },
+        },
+    })
+    sm_arn = sfn.create_state_machine(
+        name="qa-sfn-mock-jsonata-assign",
+        definition=definition,
+        roleArn="arn:aws:iam::000000000000:role/r",
+    )["stateMachineArn"]
+
+    exec_arn = sfn.start_execution(
+        stateMachineArn=sm_arn + "#HappyPath", input="{}",
+    )["executionArn"]
+    for _ in range(20):
+        time.sleep(0.3)
+        desc = sfn.describe_execution(executionArn=exec_arn)
+        if desc["status"] != "RUNNING":
+            break
+
+    assert desc["status"] == "SUCCEEDED", (
+        f"Execution failed — Assign likely not applied in mock path: {desc.get('cause')}"
+    )
+    output = json.loads(desc["output"])
+    assert output["result"] == 99, f"Expected 99 from assigned variable, got: {output}"
+    _ministack_config({"stepfunctions._sfn_mock_config": {}})
+
 def test_sfn_test_state_pass(sfn_sync):
     """TestState API — Pass state returns transformed output."""
     resp = sfn_sync.test_state(


### PR DESCRIPTION
Fixes #901

## Root Cause

In `_execute_task`, the mock path (active when `SFN_MOCK_CONFIG` is set) and the real execution path diverge after calling `_apply_jsonata_output`:

- **Real path** calls `_apply_state_assign` → `Assign` variables are set correctly.
- **Mock path** does **not** call `_apply_state_assign` → all `Assign` blocks are silently skipped.

Any downstream state that reads a variable set via `Assign` on a mocked Task will fail with `States.QueryEvaluationError: Undefined variable`.

## Change

One line added to the mock path in `_execute_task`, mirroring the real execution path:

```diff
             if query_language == "JSONata":
                 output = _apply_jsonata_output(
                     state_def,
                     raw_input,
                     ctx,
                     result=mock_result,
                     default=mock_result,
                 )
+                _apply_state_assign(state_def, raw_input, ctx, result=mock_result)
             else:
```

## Reproduction

See issue #901 for a minimal reproduction script that fails on 1.3.62 and passes with this fix applied.

Made with [Cursor](https://cursor.com)