### PR TITLE
Fix: mock Throw now routes through Catch (mirrors real execution path)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to MiniStack will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Versioning follows [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- **Step Functions — mock `Throw` now routes through `Catch` instead of failing the execution** — when `SFN_MOCK_CONFIG` was active and a mock response contained `"Throw"`, the error was raised immediately inside `_execute_task` before the `Catch`/`Retry` processing loop, so the entire execution was unconditionally marked `FAILED` even when the Task state had a matching `Catch` block. The mock Throw path now mirrors the real execution path: it checks for a matching `Catch` entry (including JSONata `Output`/`Assign` evaluation), routes to the catcher's `Next` state on a match, and only propagates `_ExecutionError` when no catcher matches. `Retry` handling in the mock path is intentionally not replicated (a future enhancement).
+
+---
+
 ## [1.3.62] — 2026-06-11
 
 ### Added

--- a/ministack/services/stepfunctions.py
+++ b/ministack/services/stepfunctions.py
@@ -1357,9 +1357,27 @@ def _execute_task(state_def, raw_input, execution, ctx):
         if mock is not None:
             attempts[state_name] = attempt + 1
             if "Throw" in mock:
-                raise _ExecutionError(
-                    mock["Throw"].get("Error", "MockError"),
-                    mock["Throw"].get("Cause", "Mocked failure"))
+                error_code = mock["Throw"].get("Error", "MockError")
+                cause = mock["Throw"].get("Cause", "Mocked failure")
+                catchers = state_def.get("Catch", [])
+                catcher = _find_matching_catcher(catchers, error_code)
+                if catcher:
+                    error_output = {"Error": error_code, "Cause": cause}
+                    if query_language == "JSONata" and "Output" in catcher:
+                        output = _apply_jsonata_output(
+                            catcher,
+                            raw_input,
+                            ctx,
+                            error_output=error_output,
+                            default=error_output,
+                        )
+                    else:
+                        output = _apply_result_path_raw(
+                            catcher.get("ResultPath", "$"), raw_input, error_output)
+                    if query_language == "JSONata":
+                        _apply_state_assign(catcher, raw_input, ctx, error_output=error_output)
+                    return output, catcher["Next"]
+                raise _ExecutionError(error_code, cause)
             mock_result = mock.get("Return", {})
             if query_language == "JSONata":
                 output = _apply_jsonata_output(

--- a/tests/test_stepfunctions.py
+++ b/tests/test_stepfunctions.py
@@ -2593,6 +2593,144 @@ def test_sfn_mock_config_throw(sfn):
     assert desc["status"] == "FAILED"
     _ministack_config({"stepfunctions._sfn_mock_config": {}})
 
+def test_sfn_mock_config_throw_with_catch(sfn):
+    """SFN_MOCK_CONFIG Throw routes through Catch when a matching Catch block exists.
+
+    Bug: previously the mock Throw raised _ExecutionError immediately, bypassing
+    Catch processing, so the entire execution failed even when the state had a
+    matching Catch handler. Fixed in fix/sfn-mock-throw-catch-jsonata.
+    """
+    from conftest import _ministack_config
+
+    mock_cfg = {
+        "StateMachines": {
+            "qa-sfn-mock-throw-catch": {
+                "TestCases": {
+                    "ThrowAndCatch": {
+                        "StateA": "StateAThrows",
+                    }
+                }
+            }
+        },
+        "MockedResponses": {
+            "StateAThrows": {
+                "0": {"Throw": {"Error": "MyError", "Cause": "test cause"}},
+            }
+        },
+    }
+    _ministack_config({"stepfunctions._sfn_mock_config": mock_cfg})
+
+    definition = json.dumps({
+        "QueryLanguage": "JSONata",
+        "StartAt": "StateA",
+        "States": {
+            "StateA": {
+                "Type": "Task",
+                "Resource": "arn:aws:lambda:us-east-1:000000000000:function:dummy",
+                "Catch": [
+                    {
+                        "ErrorEquals": ["States.ALL"],
+                        "Assign": {"caught_error": "{% $states.errorOutput %}"},
+                        "Next": "StateB",
+                    }
+                ],
+                "End": True,
+            },
+            "StateB": {
+                "Type": "Pass",
+                "Output": {
+                    "recovered": True,
+                    "error_code": "{% $caught_error.Error %}",
+                },
+                "End": True,
+            },
+        },
+    })
+    sm_arn = sfn.create_state_machine(
+        name="qa-sfn-mock-throw-catch",
+        definition=definition,
+        roleArn="arn:aws:iam::000000000000:role/r",
+    )["stateMachineArn"]
+
+    exec_arn = sfn.start_execution(
+        stateMachineArn=sm_arn + "#ThrowAndCatch", input="{}",
+    )["executionArn"]
+    for _ in range(20):
+        time.sleep(0.3)
+        desc = sfn.describe_execution(executionArn=exec_arn)
+        if desc["status"] != "RUNNING":
+            break
+
+    assert desc["status"] == "SUCCEEDED", f"Expected SUCCEEDED, got {desc['status']}: {desc.get('cause')}"
+    output = json.loads(desc["output"])
+    assert output["recovered"] is True
+    assert output["error_code"] == "MyError"
+
+    _ministack_config({"stepfunctions._sfn_mock_config": {}})
+
+def test_sfn_mock_config_throw_no_matching_catch_still_fails(sfn):
+    """SFN_MOCK_CONFIG Throw with no matching Catch still fails the execution."""
+    from conftest import _ministack_config
+
+    mock_cfg = {
+        "StateMachines": {
+            "qa-sfn-mock-throw-no-catch": {
+                "TestCases": {
+                    "ThrowNoCatch": {
+                        "StateA": "StateAThrowsNoCatch",
+                    }
+                }
+            }
+        },
+        "MockedResponses": {
+            "StateAThrowsNoCatch": {
+                "0": {"Throw": {"Error": "UnhandledError", "Cause": "no catcher"}},
+            }
+        },
+    }
+    _ministack_config({"stepfunctions._sfn_mock_config": mock_cfg})
+
+    definition = json.dumps({
+        "QueryLanguage": "JSONata",
+        "StartAt": "StateA",
+        "States": {
+            "StateA": {
+                "Type": "Task",
+                "Resource": "arn:aws:lambda:us-east-1:000000000000:function:dummy",
+                "Catch": [
+                    {
+                        "ErrorEquals": ["SpecificError"],
+                        "Next": "StateB",
+                    }
+                ],
+                "End": True,
+            },
+            "StateB": {
+                "Type": "Pass",
+                "End": True,
+            },
+        },
+    })
+    sm_arn = sfn.create_state_machine(
+        name="qa-sfn-mock-throw-no-catch",
+        definition=definition,
+        roleArn="arn:aws:iam::000000000000:role/r",
+    )["stateMachineArn"]
+
+    exec_arn = sfn.start_execution(
+        stateMachineArn=sm_arn + "#ThrowNoCatch", input="{}",
+    )["executionArn"]
+    for _ in range(20):
+        time.sleep(0.3)
+        desc = sfn.describe_execution(executionArn=exec_arn)
+        if desc["status"] != "RUNNING":
+            break
+
+    assert desc["status"] == "FAILED"
+    assert desc.get("error") == "UnhandledError"
+
+    _ministack_config({"stepfunctions._sfn_mock_config": {}})
+
 def test_sfn_test_state_pass(sfn_sync):
     """TestState API — Pass state returns transformed output."""
     resp = sfn_sync.test_state(


### PR DESCRIPTION
Fixes #903.

## Root Cause

In `_execute_task`, when `SFN_MOCK_CONFIG` is active and a mock has `"Throw"`, the error was raised immediately **before** the `while True:` loop where `Retry`/`Catch` processing lives:

```python
# Before (buggy):
if "Throw" in mock:
    raise _ExecutionError(
        mock["Throw"].get("Error", "MockError"),
        mock["Throw"].get("Cause", "Mocked failure"))
```

This `_ExecutionError` propagated out of `_execute_task` entirely, reaching the outer engine's `except _ExecutionError` handler which unconditionally calls `_fail_execution` — the entire execution failed even when the Task state had a matching `Catch` block.

## Change

One function changed: `_execute_task` in `ministack/services/stepfunctions.py`.

The mock Throw path now mirrors the real execution path — it resolves a matching `Catch` entry (including JSONata `Output`/`Assign` evaluation on the catcher), routes to `catcher["Next"]` on a match, and only propagates `_ExecutionError` when no catcher matches:

```python
# After (fixed):
if "Throw" in mock:
    error_code = mock["Throw"].get("Error", "MockError")
    cause = mock["Throw"].get("Cause", "Mocked failure")
    catchers = state_def.get("Catch", [])
    catcher = _find_matching_catcher(catchers, error_code)
    if catcher:
        error_output = {"Error": error_code, "Cause": cause}
        if query_language == "JSONata" and "Output" in catcher:
            output = _apply_jsonata_output(catcher, raw_input, ctx,
                                           error_output=error_output, default=error_output)
        else:
            output = _apply_result_path_raw(
                catcher.get("ResultPath", "$"), raw_input, error_output)
        if query_language == "JSONata":
            _apply_state_assign(catcher, raw_input, ctx, error_output=error_output)
        return output, catcher["Next"]
    raise _ExecutionError(error_code, cause)
```

`Retry` handling is intentionally not replicated in the mock path (mocked states are typically used in unit tests where the caller controls which attempt throws; a future PR could add mock Retry support).

## Tests Added

- `test_sfn_mock_config_throw_with_catch` — JSONata state machine with a `Catch: [ErrorEquals: ["States.ALL"]]` and downstream `Pass` state; asserts execution `SUCCEEDED` and output reflects the caught error code.
- `test_sfn_mock_config_throw_no_matching_catch_still_fails` — same shape but the `Catch` block only matches `"SpecificError"` while the mock throws `"UnhandledError"`; asserts execution still `FAILED` with the correct error code (existing behaviour preserved).

Made with [Cursor](https://cursor.com)