### PR TITLE
fix(ecs): Fix ECS container command overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to MiniStack will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Versioning follows [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- **ECS — `RunTask` now applies `containerOverrides.command` to the launched Docker container** — Overridden commands (including an explicit empty command) were ignored at runtime because the Docker `containers.run(...)` call still used the task-definition command.  The effective container definition now carries the matched override command into Docker, while non-overridden containers keep their defaults.
+
+---
+
 ## [1.3.63] — 2026-06-13
 
 ### Fixed

--- a/ministack/services/ecs.py
+++ b/ministack/services/ecs.py
@@ -947,6 +947,13 @@ def _docker_binds_from_taskdef(td, cdef):
     return binds
 
 
+def _container_override_for(container_overrides, container_name):
+    for override in container_overrides:
+        if override.get("name") == container_name:
+            return override
+    return {}
+
+
 def _build_run_kwargs(cdef, td, env, port_bindings, ecs_network,
                       host_mode, task_id, task_arn, ministack_net_ip,
                       cluster_arn):
@@ -1087,14 +1094,18 @@ def _run_task(data):
                 logger.debug("ECS: could not detect Ministack network, using default")
 
             for i, cdef in enumerate(td.get("containerDefinitions", [])):
+                container_override = _container_override_for(
+                    container_overrides, cdef["name"]
+                )
                 env_override = {}
-                for ov in container_overrides:
-                    if ov.get("name") == cdef["name"]:
-                        for e in ov.get("environment", []):
-                            env_override[e["name"]] = e["value"]
+                for e in container_override.get("environment", []):
+                    env_override[e["name"]] = e["value"]
 
                 env = {e["name"]: e["value"] for e in cdef.get("environment", [])}
                 env.update(env_override)
+                effective_cdef = dict(cdef)
+                if "command" in container_override:
+                    effective_cdef["command"] = container_override["command"]
 
                 port_bindings = {}
                 for pm in cdef.get("portMappings", []):
@@ -1107,7 +1118,7 @@ def _run_task(data):
                     td, cdef, launch_type, env, host_mode, ministack_net_ip,
                 )
                 run_kwargs = _build_run_kwargs(
-                    cdef, td, env, port_bindings, ecs_network,
+                    effective_cdef, td, env, port_bindings, ecs_network,
                     host_mode, task_id, task_arn, ministack_net_ip,
                     _clusters[cluster_name]["clusterArn"],
                 )

--- a/tests/test_ecs.py
+++ b/tests/test_ecs.py
@@ -4,6 +4,7 @@ import os
 import time
 import uuid as _uuid_mod
 import zipfile
+from types import SimpleNamespace
 from urllib.parse import urlparse
 
 import pytest
@@ -209,6 +210,112 @@ def test_ecs_run_task_metadata_v4(ecs):
             success = True
             break
     assert success, "Task should transition to STOPPED"
+
+
+def test_ecs_run_task_applies_container_command_overrides(monkeypatch):
+    """RunTask containerOverrides.command should reach Docker run kwargs."""
+    from ministack.services import ecs as _ecs
+
+    class FakeContainers:
+        def __init__(self):
+            self.calls = []
+
+        def get(self, _name):
+            raise Exception("not found")
+
+        def list(self, *args, **kwargs):
+            return []
+
+        def run(self, image, **kwargs):
+            self.calls.append((image, kwargs))
+            return SimpleNamespace(id=f"container-{len(self.calls):012d}")
+
+    fake_containers = FakeContainers()
+    fake_docker = SimpleNamespace(containers=fake_containers)
+
+    monkeypatch.setattr(_ecs, "_get_docker", lambda: fake_docker)
+
+    _ecs._register_task_definition({
+        "family": "cmd-override-td",
+        "containerDefinitions": [
+            {
+                "name": "web",
+                "image": "busybox",
+                "command": ["echo", "default-web"],
+            },
+            {
+                "name": "worker",
+                "image": "busybox",
+                "command": ["echo", "default-worker"],
+            },
+        ],
+    })
+
+    _ecs._run_task({
+        "cluster": "cmd-override-c",
+        "taskDefinition": "cmd-override-td",
+        "overrides": {
+            "containerOverrides": [
+                {"name": "web", "command": ["echo", "override-web"]},
+            ],
+        },
+    })
+
+    calls_by_name = {
+        kwargs["labels"]["com.amazonaws.ecs.container-name"]: kwargs
+        for _image, kwargs in fake_containers.calls
+    }
+    assert calls_by_name["web"]["command"] == ["echo", "override-web"]
+    assert calls_by_name["worker"]["command"] == ["echo", "default-worker"]
+
+    td = _ecs._task_defs["cmd-override-td:1"]
+    assert td["containerDefinitions"][0]["command"] == ["echo", "default-web"]
+
+def test_ecs_run_task_command_override_allows_empty_command(monkeypatch):
+    """An explicit empty command override must replace the task definition command."""
+    from ministack.services import ecs as _ecs
+
+    class FakeContainers:
+        def __init__(self):
+            self.calls = []
+
+        def get(self, _name):
+            raise Exception("not found")
+
+        def list(self, *args, **kwargs):
+            return []
+
+        def run(self, image, **kwargs):
+            self.calls.append((image, kwargs))
+            return SimpleNamespace(id="container-empty-command")
+
+    fake_containers = FakeContainers()
+    fake_docker = SimpleNamespace(containers=fake_containers)
+
+    monkeypatch.setattr(_ecs, "_get_docker", lambda: fake_docker)
+
+    _ecs._register_task_definition({
+        "family": "empty-cmd-override-td",
+        "containerDefinitions": [
+            {
+                "name": "web",
+                "image": "busybox",
+                "command": ["echo", "default"],
+            },
+        ],
+    })
+
+    _ecs._run_task({
+        "cluster": "empty-cmd-override-c",
+        "taskDefinition": "empty-cmd-override-td",
+        "overrides": {
+            "containerOverrides": [
+                {"name": "web", "command": []},
+            ],
+        },
+    })
+
+    assert fake_containers.calls[0][1]["command"] == []
 
 def test_ecs_service(ecs):
     ecs.create_service(


### PR DESCRIPTION
## Why
ECS `RunTask` already applied containerOverrides.environment, but containerOverrides.command was ignored, i.e., the task definition's command was passed through unchanged.

## What
- Look up each container's override by name and, when command is present, apply it to a copy of the container definition before starting Docker. 
- Added tests for command overrides.

## Validation
- `uv run pytest tests/test_ecs.py -v`
  - `32 passed`
- `uv run ruff check ministack/services/ecs.py`
  - `All checks passed!`
- `uv run ruff check tests/test_ecs.py`
  - `All checks passed!`