### PR TITLE
fix(cloudformation): GetTemplateSummary now returns capabilities info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to MiniStack will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Versioning follows [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- **CloudFormation — `GetTemplateSummary` now returns `Capabilities` and `CapabilitiesReason`** — the handler already accepted `TemplateBody` and returned `Parameters` / `ResourceTypes` correctly, but omitted the `Capabilities` and `CapabilitiesReason` fields. These are now computed from the template: `CAPABILITY_NAMED_IAM` for IAM resources with explicit name properties (`RoleName`, `UserName`, etc.), `CAPABILITY_IAM` for unnamed IAM resources, and `CAPABILITY_AUTO_EXPAND` for templates with a `Transform`. `CapabilitiesReason` uses the format confirmed against the AWS API: `"The following resource(s) require capabilities: [<type>]"`. Contributed by @maximoosemine.
+
 ## [1.3.63] — 2026-06-13
 
 ### Fixed

--- a/ministack/services/cloudformation/handlers.py
+++ b/ministack/services/cloudformation/handlers.py
@@ -627,11 +627,61 @@ def _get_template_summary(params):
             "</member>"
         )
 
+    _NAMED_IAM_PROPS = {
+        "AWS::IAM::Role": "RoleName",
+        "AWS::IAM::User": "UserName",
+        "AWS::IAM::Group": "GroupName",
+        "AWS::IAM::Policy": "PolicyName",
+        "AWS::IAM::ManagedPolicy": "ManagedPolicyName",
+        "AWS::IAM::InstanceProfile": "InstanceProfileName",
+    }
+    named_iam_ids = []
+    unnamed_iam_ids = []
+    for logical_id, res in resources.items():
+        rtype = res.get("Type", "")
+        if not rtype.startswith("AWS::IAM::"):
+            continue
+        name_prop = _NAMED_IAM_PROPS.get(rtype)
+        if name_prop and res.get("Properties", {}).get(name_prop):
+            named_iam_ids.append(logical_id)
+        else:
+            unnamed_iam_ids.append(logical_id)
+
+    capabilities = []
+    caps_reason_types = []
+    if named_iam_ids:
+        capabilities.append("CAPABILITY_NAMED_IAM")
+        caps_reason_types.extend(
+            sorted(set(resources[lid].get("Type", "") for lid in named_iam_ids))
+        )
+    elif unnamed_iam_ids:
+        capabilities.append("CAPABILITY_IAM")
+        caps_reason_types.extend(
+            sorted(set(resources[lid].get("Type", "") for lid in unnamed_iam_ids))
+        )
+    if template.get("Transform"):
+        capabilities.append("CAPABILITY_AUTO_EXPAND")
+
+    caps_xml = "".join(f"<member>{c}</member>" for c in capabilities)
+    # AWS'es behavior here is very inconsistent with their docs. AWS doesn't necessarily return
+    # all of the types it should every time. We're doing the best we can here.
+    caps_reason = (
+        "The following resource(s) require capabilities: [" + ", ".join(caps_reason_types) + "]"
+        if caps_reason_types else ""
+    )
+
+    caps_block = (
+        f"<Capabilities>{caps_xml}</Capabilities>"
+        f"<CapabilitiesReason>{_esc(caps_reason)}</CapabilitiesReason>"
+        if capabilities else ""
+    )
+
     return _xml(200, "GetTemplateSummaryResponse",
                 f"<GetTemplateSummaryResult>"
                 f"<Description>{_esc(description)}</Description>"
                 f"<ResourceTypes>{types_xml}</ResourceTypes>"
                 f"<Parameters>{params_xml}</Parameters>"
+                f"{caps_block}"
                 f"</GetTemplateSummaryResult>")
 
 

--- a/tests/test_cfn.py
+++ b/tests/test_cfn.py
@@ -463,6 +463,67 @@ def test_cfn_validate_template(cfn):
     with pytest.raises(ClientError):
         cfn.validate_template(TemplateBody=json.dumps(invalid_template))
 
+def test_cfn_get_template_summary(cfn):
+    # Basic template: parameters and resource types surfaced, no capabilities
+    basic = {
+        "AWSTemplateFormatVersion": "2010-09-09",
+        "Description": "summary test",
+        "Parameters": {
+            "Env": {"Type": "String", "Default": "dev", "Description": "env"},
+        },
+        "Resources": {
+            "Bucket": {"Type": "AWS::S3::Bucket"},
+        },
+    }
+    result = cfn.get_template_summary(TemplateBody=json.dumps(basic))
+    assert result["Description"] == "summary test"
+    assert "AWS::S3::Bucket" in result["ResourceTypes"]
+    assert any(p["ParameterKey"] == "Env" for p in result["Parameters"])
+    assert result.get("Capabilities", []) == []
+
+    # IAM role with explicit RoleName → CAPABILITY_NAMED_IAM
+    named_iam = {
+        "AWSTemplateFormatVersion": "2010-09-09",
+        "Resources": {
+            "Role": {
+                "Type": "AWS::IAM::Role",
+                "Properties": {
+                    "RoleName": "my-role",
+                    "AssumeRolePolicyDocument": {"Version": "2012-10-17", "Statement": []},
+                },
+            }
+        },
+    }
+    result = cfn.get_template_summary(TemplateBody=json.dumps(named_iam))
+    assert "CAPABILITY_NAMED_IAM" in result["Capabilities"]
+    assert result.get("CapabilitiesReason") == "The following resource(s) require capabilities: [AWS::IAM::Role]"
+
+    # IAM role without explicit name → CAPABILITY_IAM
+    unnamed_iam = {
+        "AWSTemplateFormatVersion": "2010-09-09",
+        "Resources": {
+            "Role": {
+                "Type": "AWS::IAM::Role",
+                "Properties": {
+                    "AssumeRolePolicyDocument": {"Version": "2012-10-17", "Statement": []},
+                },
+            }
+        },
+    }
+    result = cfn.get_template_summary(TemplateBody=json.dumps(unnamed_iam))
+    assert result["Capabilities"] == ["CAPABILITY_IAM"]
+
+    # Template with Transform → CAPABILITY_AUTO_EXPAND
+    transform_tpl = {
+        "AWSTemplateFormatVersion": "2010-09-09",
+        "Transform": "AWS::Serverless-2016-10-31",
+        "Resources": {
+            "Fn": {"Type": "AWS::Serverless::Function", "Properties": {}},
+        },
+    }
+    result = cfn.get_template_summary(TemplateBody=json.dumps(transform_tpl))
+    assert "CAPABILITY_AUTO_EXPAND" in result["Capabilities"]
+
 def test_cfn_list_stacks(cfn):
     for name in ("cfn-t12-a", "cfn-t12-b"):
         template = {


### PR DESCRIPTION
## What

The response from `GetTemplateSummary` was missing the `Capabilities` and `CapabilitiesReason` fields. This meant the `aws cloudformation deploy` CLI and any SDK caller could not determine what capabilities a template requires before creating a change set, inconsistent with the [AWS API](https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_GetTemplateSummary.html).

The handler now computes and returns `Capabilities` and `CapabilitiesReason` matching AWS behavior:

- `CAPABILITY_NAMED_IAM` — any `AWS::IAM::*` resource with an explicit name property.
- `CAPABILITY_IAM` — any other `AWS::IAM::*` resource.
- `CAPABILITY_AUTO_EXPAND` — template contains a `Transform` key.

`CapabilitiesReason` uses the format derived from the AWS API.

## Shape

The fix is contained to `_get_template_summary` in `services/cloudformation/handlers.py`.

## Behavior Notes

* Templates with no IAM resources and no `Transform` receive no `Capabilities` or `CapabilitiesReason` in the response, unchanged from before.

## Test Plan

* New `test_cfn_get_template_summary`: four sub-cases — no capabilities (S3-only template), `CAPABILITY_NAMED_IAM` (role with explicit `RoleName`), `CAPABILITY_IAM` (role without explicit name), and `CAPABILITY_AUTO_EXPAND` (template with `Transform`). Asserts exact `CapabilitiesReason` string for the named IAM case.
* Full `tests/test_cfn.py` passes.
* `ruff check` clean on the changed file.
* Tested against `aws cloudformation deploy`