### PR TITLE
fix(glue): GetUserDefinedFunctions treats Pattern as RE2 regex, not glob

### DIFF
--- a/ministack/services/glue.py
+++ b/ministack/services/glue.py
@@ -17,6 +17,7 @@ import fnmatch
 import json
 import logging
 import os
+import re
 import subprocess
 import tempfile
 import threading
@@ -1894,7 +1895,19 @@ def _get_user_defined_functions(data):
     else:
         items = list(_user_defined_functions.values())
     if pattern:
-        items = [u for u in items if _simple_glob_match(pattern, u.get("FunctionName", ""))]
+        # Real AWS Glue treats Pattern as a regular expression matched against the
+        # function name (not a glob). e.g. Trino's Glue connector resolves a UDF
+        # with a regex like `trino__<name>__.*`. An invalid regex (e.g. a bare
+        # `*`) raises InvalidInputException, mirroring Glue's RE2 parse error.
+        try:
+            compiled = re.compile(pattern)
+        except re.error as exc:
+            return error_response_json(
+                "InvalidInputException",
+                f"Invalid pattern syntax: error parsing regexp: {exc}",
+                400,
+            )
+        items = [u for u in items if compiled.search(u.get("FunctionName", ""))]
     return json_response({"UserDefinedFunctions": items})
 
 
@@ -1940,5 +1953,6 @@ def reset():
     _triggers.clear()
     _workflows.clear()
     _workflow_runs.clear()
+    _user_defined_functions.clear()
     _table_column_statistics.clear()
     _partition_column_statistics.clear()

--- a/tests/test_glue.py
+++ b/tests/test_glue.py
@@ -1201,8 +1201,8 @@ def test_glue_user_defined_function_crud(glue):
     got2 = glue.get_user_defined_function(DatabaseName="udf_db", FunctionName="upper_clean")["UserDefinedFunction"]
     assert got2["ClassName"] == "com.example.UpperClean2"
 
-    # Pattern is a required AWS field (botocore enforces) — "*" matches everything.
-    listed = glue.get_user_defined_functions(DatabaseName="udf_db", Pattern="*")["UserDefinedFunctions"]
+    # Pattern is a regex (RE2) over the function name in real Glue — ".*" matches all.
+    listed = glue.get_user_defined_functions(DatabaseName="udf_db", Pattern=".*")["UserDefinedFunctions"]
     names = [u["FunctionName"] for u in listed]
     assert "upper_clean" in names
 
@@ -1210,6 +1210,38 @@ def test_glue_user_defined_function_crud(glue):
     with pytest.raises(ClientError) as exc2:
         glue.get_user_defined_function(DatabaseName="udf_db", FunctionName="upper_clean")
     assert exc2.value.response["Error"]["Code"] == "EntityNotFoundException"
+
+
+def test_glue_get_user_defined_functions_pattern_is_regex(glue):
+    """GetUserDefinedFunctions treats Pattern as an RE2 regex over the function
+    name, not a glob — matches real AWS Glue (the semantics Trino's Glue connector
+    relies on when resolving a UDF via `trino__<name>__.*`)."""
+    glue.create_database(DatabaseInput={"Name": "regex_db"})
+    func_name = "trino__dw_clean_text__abc123"
+    glue.create_user_defined_function(
+        DatabaseName="regex_db",
+        FunctionInput={"FunctionName": func_name, "ClassName": "com.example.Clean"},
+    )
+
+    def names(**kwargs):
+        return [u["FunctionName"] for u in glue.get_user_defined_functions(**kwargs)["UserDefinedFunctions"]]
+
+    # `.*` matches everything (real Glue: 1; old glob behaviour: 0).
+    assert func_name in names(DatabaseName="regex_db", Pattern=".*")
+    # A Trino-style anchored regex matches the function (real Glue: 1; old glob: 0).
+    assert func_name in names(DatabaseName="regex_db", Pattern="trino__dw_clean_text__.*")
+    # A regex that cannot match returns nothing.
+    assert names(DatabaseName="regex_db", Pattern="nope__.*") == []
+
+    # A bare `*` is an INVALID regex and must raise InvalidInputException
+    # (real Glue: matched 1 under the old glob behaviour — now an error).
+    with pytest.raises(ClientError) as exc:
+        glue.get_user_defined_functions(DatabaseName="regex_db", Pattern="*")
+    assert exc.value.response["Error"]["Code"] == "InvalidInputException"
+    assert "Invalid pattern syntax" in exc.value.response["Error"]["Message"]
+
+    # DatabaseName omitted searches across all databases in the catalog.
+    assert func_name in names(Pattern="trino__.*")
 
 
 def test_glue_resolve_script_account_scoped(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

The Glue stub in `ministack/services/glue.py` matched the `GetUserDefinedFunctions` `Pattern` argument as a **glob** (`fnmatch`), but real AWS Glue treats `Pattern` as an **RE2 regular expression** applied to the function name.

This broke Trino: Trino's Hive/Glue connector resolves a UDF by calling `GetUserDefinedFunctions` with a regex like `trino__<name>__.*`. Against MiniStack that returned 0 matches, so Trino reported `Function 'x' not registered` on every call even though `CREATE FUNCTION` had persisted the object correctly.

This PR:

- Compiles `Pattern` as a regex (`re.compile`) and matches it (`re.search`) against `FunctionName` in `_get_user_defined_functions`. `.*` matches all; `trino__dw_clean_text__.*` matches that function.
- Raises `InvalidInputException` with a Glue-like message (`Invalid pattern syntax: error parsing regexp: ...`) when `Pattern` is not a valid regex (e.g. a bare `*`), instead of silently matching everything.
- Leaves the `DatabaseName` omitted/`*` "search all databases" behaviour and pagination untouched, and does **not** touch Create/Get/Update/Delete (already correct).
- `GetTables` keeps its own `_simple_glob_match` helper — its glob semantics are correct and unchanged.
- Also clears `_user_defined_functions` in `reset()`, which the original UDF PR (#817) omitted — UDF state leaked across resets.

Fixes #923.

## Behaviour parity

Reproduced against MiniStack from this branch with a UDF named `trino__dw_clean_text__abc`:

| Pattern                       | Real AWS Glue          | This branch |
|-------------------------------|------------------------|-------------|
| `.*`                          | matches (1)            | 1 ✅        |
| `trino__dw_clean_text__.*`    | matches (1)            | 1 ✅        |
| `*`                           | `InvalidInputException`| `InvalidInputException` ✅ |

Invalid-pattern response message: `Invalid pattern syntax: error parsing regexp: nothing to repeat at position 0` (RE2's inner text differs from Go's, but the `Invalid pattern syntax: error parsing regexp:` prefix matches Glue).

## Test plan

Verified locally against MiniStack running on a fresh `.venv` (Python 3.13), endpoint on a private port.

- **`pytest tests/test_glue.py`** — 56 passed.
  - Updated `test_glue_user_defined_function_crud` to list with `Pattern=".*"` (a `*` glob is now an invalid regex).
  - New `test_glue_get_user_defined_functions_pattern_is_regex` covers: `.*` matches all; a Trino-style anchored regex matches; a non-matching regex returns `[]`; a bare `*` raises `InvalidInputException`; and `DatabaseName` omitted searches across all databases.
- Manually reproduced the behaviour-parity table above end-to-end with boto3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
