### PR TITLE
fix(s3) Preserve WebsiteRedirectLocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+- **S3 — preserve WebSiteRedirectLocation ** — x-amz-website-redirect-location is now preserved
+
 ### Fixed
 - **EventBridge — input transformer reserved variables** — substitute `<aws.events.event.json>`, `<aws.events.event>`, `<aws.events.rule-name>`, `<aws.events.rule-arn>`, and `<aws.events.event.ingestion-time>` so CDK-style templates that embed the source event deliver valid JSON.
 - **CloudFormation — `GetTemplateSummary` now returns `Capabilities` and `CapabilitiesReason`** — the handler already accepted `TemplateBody` and returned `Parameters` / `ResourceTypes` correctly, but omitted the `Capabilities` and `CapabilitiesReason` fields. These are now computed from the template: `CAPABILITY_NAMED_IAM` for IAM resources with explicit name properties (`RoleName`, `UserName`, etc.), `CAPABILITY_IAM` for unnamed IAM resources, and `CAPABILITY_AUTO_EXPAND` for templates with a `Transform`. `CapabilitiesReason` uses the format confirmed against the AWS API: `"The following resource(s) require capabilities: [<type>]"`. Contributed by @maximoosemine.

--- a/ministack/services/s3.py
+++ b/ministack/services/s3.py
@@ -168,6 +168,7 @@ _PRESERVED_HEADERS = (
     "content-disposition",
     "content-language",
     "expires",
+    "x-amz-website-redirect-location",
 )
 
 # Per botocore/data/s3/2006-03-01/service-2.json (StorageClass enum).

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -306,6 +306,17 @@ def test_s3_head_object(s3):
     assert resp["ContentType"] == "application/octet-stream"
     assert "ETag" in resp
 
+def test_s3_head_object_website_redirection(s3):
+    s3.create_bucket(Bucket="intg-s3-website-redirection")
+    s3.put_object(
+        Bucket="intg-s3-website-redirection",
+        Key="redirect",
+        WebsiteRedirectLocation='http://my-redirect-website',
+    )
+    resp = s3.head_object(Bucket="intg-s3-website-redirection", Key="redirect")
+    assert resp["ContentLength"] == 0
+    assert resp["WebsiteRedirectLocation"] == "http://my-redirect-website"
+
 def test_s3_head_object_not_found(s3):
     s3.create_bucket(Bucket="intg-s3-headobj404")
     with pytest.raises(ClientError) as exc:


### PR DESCRIPTION
When uploading an object to S3 with x-amz-website-redirect-location was discarded.
A test has been added.

I will check if CloudFront Distribution will honor this information.