### PR TITLE
test(persistence): restore cold-imported module to fix cross-module desync flake

### DIFF
--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -674,22 +674,43 @@ def test_module_cold_import_with_typical_snapshot_does_not_log_restore_failure(
     # importlib.reload() won't work because it merges into the
     # existing namespace; the late-declared symbol stays bound from
     # the prior import.
+    import ministack.services as _services_pkg
+
     full_name = f"ministack.services.{mod_name}"
+    # The cold-import swaps a brand-new module object into BOTH sys.modules and
+    # the `ministack.services` package attribute. Other already-imported modules
+    # that did `from ministack.services import <mod>` keep a reference to the
+    # ORIGINAL object, so we must restore it afterwards. Otherwise the fresh
+    # module (with empty, reset state) leaks into later tests on the same xdist
+    # worker and desyncs cross-module references — e.g. cold-importing `ecs`
+    # then `secretsmanager` leaves the fresh `ecs` pointing at a stale
+    # `secretsmanager`, so ECS RunTask can no longer resolve Secrets Manager
+    # secrets created via the live module. Both the sys.modules entry and the
+    # package attribute must be restored: `from ministack.services import <mod>`
+    # reads the package attribute, not sys.modules directly.
+    original_mod = sys.modules.get(full_name)
     sys.modules.pop(full_name, None)
 
-    caplog.clear()
-    with caplog.at_level("WARNING"):
-        mod = importlib.import_module(full_name)
+    try:
+        caplog.clear()
+        with caplog.at_level("WARNING"):
+            mod = importlib.import_module(full_name)
 
-    bad = [
-        r for r in caplog.records
-        if r.levelno >= 30  # WARNING+
-        and any(needle in r.getMessage().lower()
-                for needle in ("failed to restore", "restore failed",
-                               "continuing fresh", "continuing with fresh"))
-    ]
-    if hasattr(mod, "reset"):
-        mod.reset()
+        bad = [
+            r for r in caplog.records
+            if r.levelno >= 30  # WARNING+
+            and any(needle in r.getMessage().lower()
+                    for needle in ("failed to restore", "restore failed",
+                                   "continuing fresh", "continuing with fresh"))
+        ]
+        if hasattr(mod, "reset"):
+            mod.reset()
+    finally:
+        # Re-register the original module so references bound before this test
+        # (e.g. `ecs.secretsmanager`) stay valid for subsequent tests.
+        if original_mod is not None:
+            sys.modules[full_name] = original_mod
+            setattr(_services_pkg, mod_name, original_mod)
 
     assert not bad, (
         f"Cold import of `{mod_name}` (state-key `{svc_key}`) emitted "


### PR DESCRIPTION
A flaky test that fails depending on pytest-xdist file→worker distribution under `--dist=loadfile`.

## Symptom
`tests/test_ecs.py::test_ecs_run_task_injects_secrets_manager_secrets` intermittently fails with `KeyError: 'SECRET_VAL'` and warnings:
```
WARNING ecs:ecs.py:1023 ECS: could not resolve secret arn:aws:secretsmanager:...:secret:ecs-secret-plain-... for env var SECRET_VAL
```

## Root cause
`test_module_cold_import_with_typical_snapshot_does_not_log_restore_failure` pops a service module from `sys.modules` and re-imports it fresh to catch the NameError-at-import regression — but never restores the original module. Since the test is parametrized over every persisted service:

1. Cold-importing `ecs` (alphabetically first) creates a fresh `ecs` whose `from ministack.services import secretsmanager` binds the then-current `secretsmanager`.
2. Cold-importing `secretsmanager` later swaps that module out, leaving the leaked `ecs` pointing at a **stale** `secretsmanager`.
3. A later test that creates a secret via the live `secretsmanager` and resolves it through `ecs.resolve_secret_string` reads the stale module → secret not found → `KeyError`.

The bug only surfaces when `--dist=loadfile` schedules `test_persistence.py` and `test_ecs.py` onto the same worker with the cold-imports running first — which is why `main` is green by scheduling luck rather than correctness.

## Fix
Restore the original module object in **both** `sys.modules` and the `ministack.services` package attribute (the latter is what `from ministack.services import <mod>` actually reads) once the cold-import assertion has run.

## Verification
Reproduced locally:
```
pytest \
  "tests/test_persistence.py::...[ecs-ecs]" \
  "tests/test_persistence.py::...[secretsmanager-secretsmanager]" \
  "tests/test_ecs.py::test_ecs_run_task_injects_secrets_manager_secrets"
# before: 1 failed, 2 passed   after: 3 passed
```
Full `tests/test_persistence.py` (133 params) passes, and `test_persistence.py` + the ECS secrets test together pass (134).