### PR TITLE
Validate ELBv2 tag ARNs

### DIFF
--- a/ministack/services/alb.py
+++ b/ministack/services/alb.py
@@ -143,6 +143,45 @@ def _target_group_full_name_from_arn(arn: str) -> str:
     return _elbv2_resource_tail(arn, "targetgroup/")
 
 
+def _resolve_taggable_elbv2_arn(arn: str):
+    try:
+        spec = parse_arn(arn)
+    except ArnParseError:
+        return None, _error("ValidationError", f"Invalid resource ARN: {arn}")
+
+    if (
+        spec.partition != "aws"
+        or spec.service != "elasticloadbalancing"
+        or spec.region != get_region()
+        or spec.account_id != get_account_id()
+    ):
+        return None, _error("ValidationError", f"Invalid resource ARN: {arn}")
+
+    resources = (
+        ("loadbalancer/", _lbs, "LoadBalancerNotFound", "Load balancer"),
+        ("targetgroup/", _tgs, "TargetGroupNotFound", "Target group"),
+        ("listener/", _listeners, "ListenerNotFound", "Listener"),
+        ("listener-rule/", _rules, "RuleNotFound", "Rule"),
+    )
+    for prefix, store, code, label in resources:
+        if spec.resource.startswith(prefix):
+            if arn not in store:
+                return None, _error(code, f"{label} '{arn}' not found.")
+            return arn, None
+
+    return None, _error("ValidationError", f"Invalid resource ARN: {arn}")
+
+
+def _resolve_taggable_elbv2_arns(arns):
+    resolved = []
+    for arn in arns:
+        arn, err = _resolve_taggable_elbv2_arn(arn)
+        if err:
+            return [], err
+        resolved.append(arn)
+    return resolved, None
+
+
 def _parse_actions(params, prefix="DefaultActions"):
     actions, i = [], 1
     while True:
@@ -833,7 +872,9 @@ def _describe_target_health(params):
 # ---------------------------------------------------------------------------
 
 def _add_tags(params):
-    arns = _parse_member_list(params, "ResourceArns")
+    arns, err = _resolve_taggable_elbv2_arns(_parse_member_list(params, "ResourceArns"))
+    if err:
+        return err
     new_tags = _parse_tags(params)
     for arn in arns:
         existing = _tags.setdefault(arn, [])
@@ -848,7 +889,9 @@ def _add_tags(params):
 
 
 def _remove_tags(params):
-    arns = _parse_member_list(params, "ResourceArns")
+    arns, err = _resolve_taggable_elbv2_arns(_parse_member_list(params, "ResourceArns"))
+    if err:
+        return err
     key_set = set(_parse_member_list(params, "TagKeys"))
     for arn in arns:
         if arn in _tags:
@@ -860,6 +903,9 @@ def _describe_tags(params):
     arns = _parse_member_list(params, "ResourceArns")
     descs = ""
     for arn in arns:
+        arn, err = _resolve_taggable_elbv2_arn(arn)
+        if err:
+            return err
         tags_xml = "".join(
             f"<member><Key>{t['Key']}</Key><Value>{t['Value']}</Value></member>"
             for t in _tags.get(arn, [])

--- a/tests/test_alb.py
+++ b/tests/test_alb.py
@@ -333,6 +333,52 @@ def test_elbv2_tags(elbv2):
 
     elbv2.delete_load_balancer(LoadBalancerArn=lb_arn)
 
+
+@pytest.mark.parametrize(
+    ("arn", "code"),
+    [
+        ("not-an-arn", "ValidationError"),
+        (
+            "arn:aws:sqs:us-east-1:000000000000:loadbalancer/app/qa-alb-tags/missing",
+            "ValidationError",
+        ),
+        (
+            "arn:aws:elasticloadbalancing:us-west-2:000000000000:loadbalancer/app/qa-alb-tags/missing",
+            "ValidationError",
+        ),
+        (
+            "arn:aws:elasticloadbalancing:us-east-1:000000000000:loadbalancer/app/qa-alb-tags/missing",
+            "LoadBalancerNotFound",
+        ),
+    ],
+)
+def test_elbv2_tag_arns_must_parse_to_local_resources(elbv2, arn, code):
+    with pytest.raises(ClientError) as exc:
+        elbv2.add_tags(ResourceArns=[arn], Tags=[{"Key": "env", "Value": "test"}])
+
+    assert exc.value.response["Error"]["Code"] == code
+
+
+def test_elbv2_add_tags_validates_all_arns_before_mutating(elbv2):
+    lb_arn = elbv2.create_load_balancer(Name="qa-alb-tags-atomic")["LoadBalancers"][0]["LoadBalancerArn"]
+    missing_arn = (
+        "arn:aws:elasticloadbalancing:us-east-1:000000000000:"
+        "loadbalancer/app/qa-alb-tags-atomic/missing"
+    )
+
+    with pytest.raises(ClientError) as exc:
+        elbv2.add_tags(
+            ResourceArns=[lb_arn, missing_arn],
+            Tags=[{"Key": "team", "Value": "infra"}],
+        )
+
+    assert exc.value.response["Error"]["Code"] == "LoadBalancerNotFound"
+    desc = elbv2.describe_tags(ResourceArns=[lb_arn])
+    assert desc["TagDescriptions"][0]["Tags"] == []
+
+    elbv2.delete_load_balancer(LoadBalancerArn=lb_arn)
+
+
 # Migrated from test_alb.py
 def _alb_zip(code: str) -> bytes:
     buf = io.BytesIO()


### PR DESCRIPTION
## Summary
- Add parser-backed validation for ELBv2 tag operations across AddTags, RemoveTags, and DescribeTags.
- Validate load balancer, target group, listener, and listener-rule ARNs against the current account/Region and local resource stores.
- Resolve all requested ARNs before mutating tag state so failed multi-resource requests do not partially update tags.

## Validation
- `uv run --extra dev pytest tests/test_alb.py -q` (31 passed)
