### PR TITLE
Validate EventBridge tag ARNs

### DIFF
--- a/ministack/services/eventbridge.py
+++ b/ministack/services/eventbridge.py
@@ -779,6 +779,83 @@ def _archive_name_from_ref(source_arn):
     return _events_resource_name_from_ref(source_arn, "archive/", "EventSourceArn")
 
 
+def _resolve_taggable_events_arn(arn):
+    try:
+        spec = parse_arn(arn)
+    except ArnParseError:
+        return None, error_response_json(
+            "ValidationException",
+            "Parameter ResourceARN is not valid. Reason: Provided Arn is not in correct format.",
+            400,
+        )
+
+    if spec.partition != "aws" or spec.service != "events":
+        return None, error_response_json(
+            "ValidationException",
+            "Parameter ResourceARN is not valid. Reason: Provided Arn is not an EventBridge ResourceARN.",
+            400,
+        )
+    if spec.region != get_region() or spec.account_id != get_account_id():
+        return None, error_response_json(
+            "ResourceNotFoundException",
+            f"EventBridge resource {arn} does not exist.",
+            400,
+        )
+
+    resource = spec.resource
+    if resource.startswith("event-bus/"):
+        name = resource.split("/", 1)[1]
+        if name == "default":
+            exists = arn == f"arn:aws:events:{get_region()}:{get_account_id()}:event-bus/default"
+        else:
+            record = _event_buses.get(name)
+            exists = bool(record) and record.get("Arn") == arn
+    elif resource.startswith("rule/"):
+        parts = resource.split("/")
+        if len(parts) == 2:
+            bus, rule = "default", parts[1]
+        elif len(parts) == 3:
+            _, bus, rule = parts
+        else:
+            bus, rule = "", ""
+        record = _rules.get(_rule_key(rule, bus)) if rule else None
+        exists = bool(record) and record.get("Arn") == arn
+    elif resource.startswith("archive/"):
+        name = resource.split("/", 1)[1]
+        record = _archives.get(name)
+        exists = bool(record) and record.get("ArchiveArn") == arn
+    elif resource.startswith("replay/"):
+        name = resource.split("/", 1)[1]
+        record = _replays.get(name)
+        exists = bool(record) and record.get("ReplayArn") == arn
+    elif resource.startswith("endpoint/"):
+        name = resource.split("/", 1)[1]
+        record = _endpoints.get(name)
+        exists = bool(record) and record.get("Arn") == arn
+    elif resource.startswith("connection/"):
+        name = resource.split("/", 1)[1]
+        record = _connections.get(name)
+        exists = bool(record) and record.get("ConnectionArn") == arn
+    elif resource.startswith("api-destination/"):
+        name = resource.split("/", 1)[1]
+        record = _api_destinations.get(name)
+        exists = bool(record) and record.get("ApiDestinationArn") == arn
+    else:
+        return None, error_response_json(
+            "ValidationException",
+            "Parameter ResourceARN is not valid. Reason: Provided Arn is not a taggable EventBridge resource.",
+            400,
+        )
+
+    if not exists:
+        return None, error_response_json(
+            "ResourceNotFoundException",
+            f"EventBridge resource {arn} does not exist.",
+            400,
+        )
+    return arn, None
+
+
 def _put_events(data):
     entries = data.get("Entries", [])
     # AWS spec: PutEvents.Entries list min=1 max=10. Real AWS rejects with
@@ -1272,6 +1349,9 @@ def _dispatch_to_stepfunctions(arn, payload):
 
 def _tag_resource(data):
     arn = data.get("ResourceARN", "")
+    arn, err = _resolve_taggable_events_arn(arn)
+    if err:
+        return err
     tags = data.get("Tags", [])
     if arn not in _tags:
         _tags[arn] = {}
@@ -1282,6 +1362,9 @@ def _tag_resource(data):
 
 def _untag_resource(data):
     arn = data.get("ResourceARN", "")
+    arn, err = _resolve_taggable_events_arn(arn)
+    if err:
+        return err
     keys = data.get("TagKeys", [])
     if arn in _tags:
         for k in keys:
@@ -1291,6 +1374,9 @@ def _untag_resource(data):
 
 def _list_tags_for_resource(data):
     arn = data.get("ResourceARN", "")
+    arn, err = _resolve_taggable_events_arn(arn)
+    if err:
+        return err
     tag_dict = _tags.get(arn, {})
     tag_list = [{"Key": k, "Value": v} for k, v in tag_dict.items()]
     return json_response({"Tags": tag_list})

--- a/tests/test_eventbridge.py
+++ b/tests/test_eventbridge.py
@@ -6,6 +6,7 @@ import uuid as _uuid_mod
 import zipfile
 from urllib.parse import urlparse
 
+import boto3
 import pytest
 from botocore.exceptions import ClientError
 
@@ -850,6 +851,60 @@ def test_eventbridge_tags_v2(eb):
     tags2 = eb.list_tags_for_resource(ResourceARN=arn)["Tags"]
     assert not any(t["Key"] == "stage" for t in tags2)
     assert any(t["Key"] == "team" for t in tags2)
+
+
+@pytest.mark.parametrize(
+    ("arn", "code"),
+    [
+        ("not-an-arn", "ValidationException"),
+        ("arn:aws:sqs:us-east-1:000000000000:rule/missing", "ValidationException"),
+        ("arn:aws:events:us-west-2:000000000000:rule/missing", "ResourceNotFoundException"),
+        ("arn:aws:events:us-east-1:000000000000:rule/missing", "ResourceNotFoundException"),
+    ],
+)
+def test_eventbridge_tag_resource_requires_local_eventbridge_arn(eb, arn, code):
+    with pytest.raises(ClientError) as exc:
+        eb.tag_resource(ResourceARN=arn, Tags=[{"Key": "env", "Value": "test"}])
+
+    assert exc.value.response["Error"]["Code"] == code
+
+
+def test_eventbridge_tag_resource_rejects_same_name_other_region_bus(eb):
+    name = f"eb-tag-region-{_uuid_mod.uuid4().hex[:8]}"
+    eb.create_event_bus(Name=name)
+    west = boto3.client(
+        "events",
+        endpoint_url=os.environ.get("MINISTACK_ENDPOINT", "http://localhost:4566"),
+        aws_access_key_id="test",
+        aws_secret_access_key="test",
+        region_name="us-west-2",
+    )
+    west_arn = f"arn:aws:events:us-west-2:000000000000:event-bus/{name}"
+
+    with pytest.raises(ClientError) as exc:
+        west.tag_resource(ResourceARN=west_arn, Tags=[{"Key": "env", "Value": "test"}])
+
+    assert exc.value.response["Error"]["Code"] == "ResourceNotFoundException"
+
+
+def test_eventbridge_tag_resource_accepts_default_bus_in_secondary_region(eb):
+    eb.list_tags_for_resource(
+        ResourceARN="arn:aws:events:us-east-1:000000000000:event-bus/default",
+    )
+    west = boto3.client(
+        "events",
+        endpoint_url=os.environ.get("MINISTACK_ENDPOINT", "http://localhost:4566"),
+        aws_access_key_id="test",
+        aws_secret_access_key="test",
+        region_name="us-west-2",
+    )
+    west_arn = "arn:aws:events:us-west-2:000000000000:event-bus/default"
+
+    west.tag_resource(ResourceARN=west_arn, Tags=[{"Key": "env", "Value": "west"}])
+    tags = west.list_tags_for_resource(ResourceARN=west_arn)["Tags"]
+
+    assert {t["Key"]: t["Value"] for t in tags} == {"env": "west"}
+
 
 def test_eventbridge_archive(eb):
     import uuid as _uuid


### PR DESCRIPTION
## Summary
- Add parser-backed validation for EventBridge TagResource, UntagResource, and ListTagsForResource.
- Validate implemented taggable resources against exact stored ARNs, including event buses, rules, archives, replays, endpoints, connections, and API destinations.
- Preserve per-Region default event bus tag behavior while rejecting same-name custom resources that do not exist in the request Region.

## Validation
- `uv run --extra dev pytest tests/test_eventbridge.py -q` (127 passed)
