### PR TITLE
Validate ElastiCache tag ARNs

### DIFF
--- a/ministack/services/elasticache.py
+++ b/ministack/services/elasticache.py
@@ -26,6 +26,7 @@ import os
 import time
 from urllib.parse import parse_qs
 
+from ministack.core.arn import ArnParseError, parse_arn
 from ministack.core.persistence import load_state
 from ministack.core.responses import AccountScopedDict, apply_image_prefix, get_account_id, get_region, new_uuid
 
@@ -554,6 +555,59 @@ def _arn_param_group(name):
 
 def _arn_snapshot(name):
     return f"arn:aws:elasticache:{get_region()}:{get_account_id()}:snapshot:{name}"
+
+
+def _resolve_taggable_elasticache_arn(arn):
+    try:
+        spec = parse_arn(arn)
+    except ArnParseError:
+        return None, _error("InvalidParameterValue", f"Invalid resource ARN: {arn}", 400)
+
+    if (
+        spec.partition != "aws"
+        or spec.service != "elasticache"
+        or spec.region != get_region()
+        or spec.account_id != get_account_id()
+    ):
+        return None, _error("InvalidParameterValue", f"Invalid resource ARN: {arn}", 400)
+
+    resource_type, sep, name = spec.resource.partition(":")
+    if not sep or not name:
+        return None, _error("InvalidParameterValue", f"Invalid resource ARN: {arn}", 400)
+
+    resources = {
+        "cluster": (_clusters, "CacheClusterNotFound", f"Cluster {name} not found", "CacheClusterArn"),
+        "replicationgroup": (
+            _replication_groups,
+            "ReplicationGroupNotFoundFault",
+            f"Replication group {name} not found",
+            "ARN",
+        ),
+        "subnetgroup": (
+            _subnet_groups,
+            "CacheSubnetGroupNotFoundFault",
+            f"Cache subnet group {name} not found.",
+            "ARN",
+        ),
+        "parametergroup": (
+            _param_groups,
+            "CacheParameterGroupNotFound",
+            f"Cache parameter group {name} not found.",
+            "ARN",
+        ),
+        "snapshot": (_snapshots, "SnapshotNotFoundFault", f"Snapshot {name} not found", "ARN"),
+        "user": (_users, "UserNotFoundFault", f"User {name} not found", "ARN"),
+        "usergroup": (_user_groups, "UserGroupNotFoundFault", f"User group {name} not found", "ARN"),
+    }
+    entry = resources.get(resource_type)
+    if not entry:
+        return None, _error("InvalidParameterValue", f"Invalid resource ARN: {arn}", 400)
+
+    store, code, message, arn_key = entry
+    record = store.get(name)
+    if not record or record.get(arn_key) != arn:
+        return None, _error(code, message, 404)
+    return arn, None
 
 
 def _record_event(source_id, source_type, message):
@@ -1330,6 +1384,9 @@ def _extract_tags(p):
 
 def _list_tags(p):
     arn = _p(p, "ResourceName")
+    arn, err = _resolve_taggable_elasticache_arn(arn)
+    if err:
+        return err
     tags = _tags.get(arn, [])
     # TagList.member.locationName = "Tag"
     tag_xml = "".join(f"<Tag><Key>{t['Key']}</Key><Value>{t['Value']}</Value></Tag>" for t in tags)
@@ -1339,6 +1396,9 @@ def _list_tags(p):
 
 def _add_tags(p):
     arn = _p(p, "ResourceName")
+    arn, err = _resolve_taggable_elasticache_arn(arn)
+    if err:
+        return err
     new_tags = _extract_tags(p)
     existing = _tags.setdefault(arn, [])
     existing_keys = {t["Key"] for t in existing}
@@ -1359,6 +1419,9 @@ def _add_tags(p):
 
 def _remove_tags(p):
     arn = _p(p, "ResourceName")
+    arn, err = _resolve_taggable_elasticache_arn(arn)
+    if err:
+        return err
     keys_to_remove = set()
     idx = 1
     while _p(p, f"TagKeys.member.{idx}"):

--- a/tests/test_elasticache.py
+++ b/tests/test_elasticache.py
@@ -178,6 +178,53 @@ def test_elasticache_tags(ec):
     assert "env" in tag_keys
     assert "team" not in tag_keys
 
+
+def test_elasticache_tag_arns_must_parse_to_local_resources(ec):
+    name = f"tag-pg-{_uuid_mod.uuid4().hex[:8]}"
+    ec.create_cache_parameter_group(
+        CacheParameterGroupName=name,
+        CacheParameterGroupFamily="redis7.0",
+        Description="tag parser test",
+    )
+    arn = f"arn:aws:elasticache:us-east-1:000000000000:parametergroup:{name}"
+
+    ec.add_tags_to_resource(ResourceName=arn, Tags=[{"Key": "env", "Value": "test"}])
+    tags = ec.list_tags_for_resource(ResourceName=arn)["TagList"]
+    assert {t["Key"]: t["Value"] for t in tags} == {"env": "test"}
+
+    with pytest.raises(ClientError) as exc:
+        ec.add_tags_to_resource(
+            ResourceName=f"arn:aws:elasticache:us-west-2:000000000000:parametergroup:{name}",
+            Tags=[{"Key": "env", "Value": "test"}],
+        )
+    assert exc.value.response["Error"]["Code"] == "InvalidParameterValue"
+
+    with pytest.raises(ClientError) as exc:
+        ec.list_tags_for_resource(
+            ResourceName="arn:aws:elasticache:us-east-1:000000000000:parametergroup:missing"
+        )
+    assert exc.value.response["Error"]["Code"] == "CacheParameterGroupNotFound"
+
+    ec.delete_cache_parameter_group(CacheParameterGroupName=name)
+
+
+def test_elasticache_cluster_tag_arn_uses_cache_cluster_arn_field(ec):
+    cluster_id = f"tag-cluster-{_uuid_mod.uuid4().hex[:8]}"
+    ec.create_cache_cluster(
+        CacheClusterId=cluster_id,
+        Engine="redis",
+        CacheNodeType="cache.t3.micro",
+        NumCacheNodes=1,
+    )
+    arn = ec.describe_cache_clusters(CacheClusterId=cluster_id)["CacheClusters"][0]["ARN"]
+
+    ec.add_tags_to_resource(ResourceName=arn, Tags=[{"Key": "env", "Value": "test"}])
+    tags = ec.list_tags_for_resource(ResourceName=arn)["TagList"]
+    assert {t["Key"]: t["Value"] for t in tags} == {"env": "test"}
+
+    ec.delete_cache_cluster(CacheClusterId=cluster_id)
+
+
 # Migrated from test_ec.py
 @requires_docker
 def test_elasticache_create_cluster_v2(ec):


### PR DESCRIPTION
## Summary
- Add parser-backed validation for ElastiCache ListTagsForResource, AddTagsToResource, and RemoveTagsFromResource.
- Validate currently modeled ElastiCache ARN shapes for clusters, replication groups, subnet groups, parameter groups, snapshots, users, and user groups.
- Preserve valid cache cluster tagging by checking the stored CacheClusterArn field for cluster resources.

## Validation
- `uv run --extra dev pytest tests/test_elasticache.py -q` (5 passed, 35 skipped)
