### PR TITLE
Validate OpenSearch tag ARNs

### DIFF
--- a/ministack/services/opensearch.py
+++ b/ministack/services/opensearch.py
@@ -26,6 +26,7 @@ import re
 import threading
 import time
 
+from ministack.core.arn import ArnParseError, parse_arn
 from ministack.core.responses import (
     AccountScopedDict,
     apply_image_prefix,
@@ -147,6 +148,31 @@ def _error(status, code, message):
 
 def _arn(name):
     return f"arn:aws:es:{get_region()}:{get_account_id()}:domain/{name}"
+
+
+def _resolve_taggable_opensearch_arn(arn):
+    try:
+        spec = parse_arn(arn)
+    except ArnParseError:
+        return None, _error(400, "ValidationException", f"Invalid ARN: {arn}")
+
+    if (
+        spec.partition != "aws"
+        or spec.service != "es"
+        or spec.region != get_region()
+        or spec.account_id != get_account_id()
+    ):
+        return None, _error(400, "ValidationException", f"Invalid ARN: {arn}")
+
+    prefix = "domain/"
+    if not spec.resource.startswith(prefix):
+        return None, _error(400, "ValidationException", f"Invalid ARN: {arn}")
+
+    name = spec.resource[len(prefix):]
+    rec = _domains.get(name)
+    if not rec or rec.get("ARN") != arn:
+        return None, _error(404, "ResourceNotFoundException", f"Domain not found: {name}")
+    return arn, None
 
 
 def _engine_type(version: str) -> str:
@@ -651,6 +677,9 @@ def _add_tags(payload):
     tag_list = payload.get("TagList") or []
     if not arn:
         return _error(400, "ValidationException", "ARN is required")
+    arn, err = _resolve_taggable_opensearch_arn(arn)
+    if err:
+        return err
     existing = _tags.get(arn) or []
     by_key = {t["Key"]: t for t in existing}
     for t in tag_list:
@@ -663,6 +692,9 @@ def _list_tags(query_params):
     arn = _qp(query_params, "arn")
     if not arn:
         return _error(400, "ValidationException", "arn query parameter is required")
+    arn, err = _resolve_taggable_opensearch_arn(arn)
+    if err:
+        return err
     return _json(200, {"TagList": list(_tags.get(arn) or [])})
 
 
@@ -671,6 +703,9 @@ def _remove_tags(payload):
     keys = set(payload.get("TagKeys") or [])
     if not arn:
         return _error(400, "ValidationException", "ARN is required")
+    arn, err = _resolve_taggable_opensearch_arn(arn)
+    if err:
+        return err
     existing = _tags.get(arn) or []
     _tags[arn] = [t for t in existing if t["Key"] not in keys]
     return _json(200, {})

--- a/tests/test_opensearch.py
+++ b/tests/test_opensearch.py
@@ -325,6 +325,22 @@ def test_opensearch_tag_lifecycle(os_client):
         os_client.delete_domain(DomainName=name)
 
 
+@pytest.mark.parametrize(
+    ("arn", "code"),
+    [
+        ("arn:aws:es:us-east-1:000000000000", "ValidationException"),
+        ("arn:aws:sqs:us-east-1:000000000000:domain/missing", "ValidationException"),
+        ("arn:aws:es:us-west-2:000000000000:domain/missing", "ValidationException"),
+        ("arn:aws:es:us-east-1:000000000000:domain/missing", "ResourceNotFoundException"),
+    ],
+)
+def test_opensearch_tags_require_local_domain_arn(os_client, arn, code):
+    with pytest.raises(ClientError) as exc:
+        os_client.add_tags(ARN=arn, TagList=[{"Key": "Env", "Value": "Test"}])
+
+    assert exc.value.response["Error"]["Code"] == code
+
+
 def test_opensearch_create_with_tag_list(os_client):
     name = f"ctag-{_uid()}"
     rec = os_client.create_domain(


### PR DESCRIPTION
## Summary
- Add parser-backed validation for OpenSearch AddTags, ListTags, and RemoveTags.
- Validate es domain ARNs by partition, service, account, Region, resource shape, and local domain existence.
- Reject malformed, wrong-scope, and missing-domain ARNs before reading or mutating tags.

## Validation
- `uv run --extra dev pytest tests/test_opensearch.py -q` (25 passed, 1 skipped)
