### PR TITLE
Validate Amazon MQ tag ARNs

### DIFF
--- a/ministack/services/mq.py
+++ b/ministack/services/mq.py
@@ -27,6 +27,7 @@ import re
 import time
 from urllib.parse import unquote
 
+from ministack.core.arn import ArnParseError, parse_arn
 from ministack.core.persistence import load_state
 from ministack.core.responses import AccountScopedDict, get_account_id, get_region, new_uuid
 
@@ -402,6 +403,30 @@ def _resource_exists(resource_arn: str) -> bool:
     return any(b.get("brokerArn") == resource_arn for b in _brokers.values())
 
 
+def _resolve_broker_arn(resource_arn: str):
+    try:
+        spec = parse_arn(resource_arn)
+    except ArnParseError:
+        return None, _err(404, "ResourceArn", ERROR_MESSAGES["RESOURCE_NOT_FOUND"].format(resource_arn))
+
+    if (
+        spec.partition != "aws"
+        or spec.service != "mq"
+        or spec.region != get_region()
+        or spec.account_id != get_account_id()
+    ):
+        return None, _err(404, "ResourceArn", ERROR_MESSAGES["RESOURCE_NOT_FOUND"].format(resource_arn))
+
+    resource_type, sep, broker_id = spec.resource.partition(":")
+    if resource_type != "broker" or not sep or not broker_id:
+        return None, _err(404, "ResourceArn", ERROR_MESSAGES["RESOURCE_NOT_FOUND"].format(resource_arn))
+
+    broker = _brokers.get(broker_id)
+    if not broker or broker.get("brokerArn") != resource_arn:
+        return None, _err(404, "ResourceArn", ERROR_MESSAGES["RESOURCE_NOT_FOUND"].format(resource_arn))
+    return resource_arn, None
+
+
 def _get_broker_or_404(broker_id: str):
     """Retrieve broker or return 404 error tuple."""
     broker = _brokers.get(broker_id)
@@ -682,15 +707,17 @@ def _list_broker_instance_options(query_params: dict) -> tuple:
 
 def _list_tags(resource_arn: str) -> tuple:
     """List all tags for a broker resource."""
-    if not _resource_exists(resource_arn):
-        return _err(404, "ResourceArn", ERROR_MESSAGES["RESOURCE_NOT_FOUND"].format(resource_arn))
+    resource_arn, err = _resolve_broker_arn(resource_arn)
+    if err:
+        return err
     return _ok({"tags": dict(_tags.get(resource_arn, {}))})
 
 
 def _create_tags(resource_arn: str, body: dict) -> tuple:
     """Add or update tags on a broker resource."""
-    if not _resource_exists(resource_arn):
-        return _err(404, "ResourceArn", ERROR_MESSAGES["RESOURCE_NOT_FOUND"].format(resource_arn))
+    resource_arn, err = _resolve_broker_arn(resource_arn)
+    if err:
+        return err
     tags = body.get("tags") if isinstance(body, dict) else None
     if not isinstance(tags, dict):
         return _err(400, "Tags", ERROR_MESSAGES["TAGS_INVALID"])
@@ -700,8 +727,9 @@ def _create_tags(resource_arn: str, body: dict) -> tuple:
 
 def _delete_tags(resource_arn: str, query_params: dict) -> tuple:
     """Delete specific tags from a broker resource."""
-    if not _resource_exists(resource_arn):
-        return _err(404, "ResourceArn", ERROR_MESSAGES["RESOURCE_NOT_FOUND"].format(resource_arn))
+    resource_arn, err = _resolve_broker_arn(resource_arn)
+    if err:
+        return err
     tag_keys = query_params.get("tagKeys")
     if not tag_keys:
         return _err(400, "TagKeys", ERROR_MESSAGES["TAG_KEYS_REQUIRED"])

--- a/tests/test_mq.py
+++ b/tests/test_mq.py
@@ -644,6 +644,26 @@ def test_mq_list_tags_with_non_existent_arn(mq):
     assert exc.value.response["ResponseMetadata"]["HTTPStatusCode"] == 404
     assert exc.value.response["Error"]["Code"] == "NotFoundException"
 
+
+@pytest.mark.parametrize(
+    "arn_template",
+    [
+        "arn:aws:sqs:us-east-1:000000000000:broker:{broker_id}",
+        "arn:aws:mq:us-west-2:000000000000:broker:{broker_id}",
+        "arn:aws:mq:us-east-1:111111111111:broker:{broker_id}",
+    ],
+)
+def test_mq_tag_arns_must_parse_to_local_broker(mq, arn_template):
+    broker = _create(mq, BrokerName=_name("tag-arn"))
+    arn = arn_template.format(broker_id=broker["BrokerId"])
+
+    with pytest.raises(ClientError) as exc:
+        mq.create_tags(ResourceArn=arn, Tags={"env": "dev"})
+
+    assert exc.value.response["ResponseMetadata"]["HTTPStatusCode"] == 404
+    assert exc.value.response["Error"]["Code"] == "NotFoundException"
+
+
 def test_mq_list_tags_multiple_times_consistent(mq):
     """Test that ListTags returns consistent results across multiple calls."""
     broker = _create(mq, BrokerName=_name("tags-consistency"))


### PR DESCRIPTION
## Summary
- Replace raw exact-string broker ARN existence checks with parser-backed Amazon MQ broker ARN validation.
- Validate broker tag ARNs by partition, service, account, Region, resource shape, and local broker existence.
- Keep existing NotFoundException behavior for malformed, wrong-scope, and missing-resource tag operations.

## Validation
- `uv run --extra dev pytest tests/test_mq.py -q` (99 passed)
