### PR TITLE
Validate MediaConnect tag ARNs

### DIFF
--- a/ministack/services/mediaconnect.py
+++ b/ministack/services/mediaconnect.py
@@ -22,6 +22,7 @@ import re
 import time
 import urllib.parse
 
+from ministack.core.arn import ArnParseError, parse_arn
 from ministack.core.persistence import load_state
 from ministack.core.responses import (
     AccountScopedDict,
@@ -84,6 +85,26 @@ def _flow_arn(name):
 
 def _error(status, code, message):
     return error_response_json(code, message, status)
+
+
+def _resolve_flow_arn(arn):
+    try:
+        spec = parse_arn(arn)
+    except ArnParseError:
+        return None, _error(400, "BadRequestException", f"Invalid flow ARN: {arn}")
+
+    if (
+        spec.partition != "aws"
+        or spec.service != "mediaconnect"
+        or spec.region != get_region()
+        or spec.account_id != get_account_id()
+        or not spec.resource.startswith("flow:")
+    ):
+        return None, _error(400, "BadRequestException", f"Invalid flow ARN: {arn}")
+
+    if arn not in _flows:
+        return None, _error(404, "NotFoundException", f"Flow {arn} not found.")
+    return arn, None
 
 
 # Real AWS ListFlows returns a slimmer ``ListedFlow`` projection — not the
@@ -188,6 +209,9 @@ def _update_flow(arn, body):
 
 
 def _list_tags(arn):
+    arn, err = _resolve_flow_arn(arn)
+    if err:
+        return err
     return json_response({"tags": _tags.get(arn, {})})
 
 

--- a/tests/test_mediaconnect.py
+++ b/tests/test_mediaconnect.py
@@ -140,8 +140,31 @@ def test_mediaconnect_update_unknown_flow_404(mc):
 # ListTagsForResource
 # ---------------------------------------------------------------------------
 
-def test_mediaconnect_list_tags_unknown_resource_returns_empty(mc):
-    bogus = f"arn:aws:mediaconnect:{REGION}:000000000000:flow:{uuid.uuid4()}:nope"
-    resp = mc.list_tags_for_resource(ResourceArn=bogus)
+def test_mediaconnect_list_tags_for_created_flow_returns_empty_map(mc):
+    name = f"flow-tags-{_uid()}"
+    flow = mc.create_flow(Name=name, Source=_basic_source())["Flow"]
+
+    resp = mc.list_tags_for_resource(ResourceArn=flow["FlowArn"])
     # AWS returns no Tags key when the map is empty; boto3 may include {} or omit.
     assert resp.get("Tags", {}) == {}
+
+
+def test_mediaconnect_list_tags_unknown_resource_404(mc):
+    bogus = f"arn:aws:mediaconnect:{REGION}:000000000000:flow:{uuid.uuid4()}:nope"
+    with pytest.raises(ClientError) as e:
+        mc.list_tags_for_resource(ResourceArn=bogus)
+    assert e.value.response["Error"]["Code"] == "NotFoundException"
+
+
+@pytest.mark.parametrize(
+    ("arn", "code"),
+    [
+        ("not-an-arn", "BadRequestException"),
+        ("arn:aws:sqs:us-east-1:000000000000:flow:abc:nope", "BadRequestException"),
+        ("arn:aws:mediaconnect:us-west-2:000000000000:flow:abc:nope", "BadRequestException"),
+    ],
+)
+def test_mediaconnect_list_tags_requires_local_flow_arn(mc, arn, code):
+    with pytest.raises(ClientError) as e:
+        mc.list_tags_for_resource(ResourceArn=arn)
+    assert e.value.response["Error"]["Code"] == code


### PR DESCRIPTION
## Summary
- Add parser-backed MediaConnect flow ARN validation before ListTagsForResource responses.
- Require list-tags requests to reference an existing local flow ARN instead of returning empty tags for arbitrary strings.
- Cover created-flow, missing-flow, malformed, wrong-service, and wrong-Region tag ARN behavior.

## Validation
- `uv run --extra dev pytest tests/test_mediaconnect.py -q` (11 passed)
