### PR TITLE
Parse Cognito IDP user pool tag ARNs

### DIFF
--- a/ministack/services/cognito.py
+++ b/ministack/services/cognito.py
@@ -392,6 +392,28 @@ class _InvalidCognitoIdentityArn(ValueError):
     pass
 
 
+class _InvalidCognitoIdpArn(ValueError):
+    pass
+
+
+def _user_pool_id_from_arn(resource_arn: str) -> str | None:
+    try:
+        spec = parse_arn(resource_arn)
+    except ArnParseError as exc:
+        raise _InvalidCognitoIdpArn("Invalid Cognito IDP resource ARN.") from exc
+    if spec.service != "cognito-idp":
+        raise _InvalidCognitoIdpArn("Invalid Cognito IDP resource ARN.")
+    if spec.region != get_region() or spec.account_id != get_account_id():
+        return None
+    prefix = "userpool/"
+    if not spec.resource.startswith(prefix):
+        raise _InvalidCognitoIdpArn("Invalid Cognito IDP resource ARN.")
+    pool_id = spec.resource[len(prefix):]
+    if not pool_id:
+        raise _InvalidCognitoIdpArn("Invalid Cognito IDP resource ARN.")
+    return pool_id
+
+
 def _identity_pool_id_from_arn(resource_arn: str) -> str | None:
     try:
         spec = parse_arn(resource_arn)
@@ -3547,30 +3569,41 @@ def _verify_software_token(data):
 def _idp_tag_resource(data):
     arn = data.get("ResourceArn", "")
     tags = data.get("Tags", {})
-    # Find pool by ARN
-    for pool in _user_pools.values():
-        if pool["Arn"] == arn:
-            pool["UserPoolTags"].update(tags)
-            return json_response({})
+    try:
+        pid = _user_pool_id_from_arn(arn)
+    except _InvalidCognitoIdpArn as exc:
+        return error_response_json("InvalidParameterException", str(exc), 400)
+    pool = _user_pools.get(pid) if pid else None
+    if pool and pool.get("Arn") == arn:
+        pool["UserPoolTags"].update(tags)
+        return json_response({})
     return error_response_json("ResourceNotFoundException", f"Resource {arn} not found.", 400)
 
 
 def _idp_untag_resource(data):
     arn = data.get("ResourceArn", "")
     tag_keys = data.get("TagKeys", [])
-    for pool in _user_pools.values():
-        if pool["Arn"] == arn:
-            for k in tag_keys:
-                pool["UserPoolTags"].pop(k, None)
-            return json_response({})
+    try:
+        pid = _user_pool_id_from_arn(arn)
+    except _InvalidCognitoIdpArn as exc:
+        return error_response_json("InvalidParameterException", str(exc), 400)
+    pool = _user_pools.get(pid) if pid else None
+    if pool and pool.get("Arn") == arn:
+        for k in tag_keys:
+            pool["UserPoolTags"].pop(k, None)
+        return json_response({})
     return error_response_json("ResourceNotFoundException", f"Resource {arn} not found.", 400)
 
 
 def _idp_list_tags_for_resource(data):
     arn = data.get("ResourceArn", "")
-    for pool in _user_pools.values():
-        if pool["Arn"] == arn:
-            return json_response({"Tags": pool.get("UserPoolTags", {})})
+    try:
+        pid = _user_pool_id_from_arn(arn)
+    except _InvalidCognitoIdpArn as exc:
+        return error_response_json("InvalidParameterException", str(exc), 400)
+    pool = _user_pools.get(pid) if pid else None
+    if pool and pool.get("Arn") == arn:
+        return json_response({"Tags": pool.get("UserPoolTags", {})})
     return error_response_json("ResourceNotFoundException", f"Resource {arn} not found.", 400)
 
 

--- a/tests/test_cognito.py
+++ b/tests/test_cognito.py
@@ -26,6 +26,10 @@ def _identity_pool_arn(identity_pool_id, region="us-east-1", account="0000000000
     return f"arn:aws:cognito-identity:{region}:{account}:identitypool/{identity_pool_id}"
 
 
+def _user_pool_arn(user_pool_id, region="us-east-1", account="000000000000"):
+    return f"arn:aws:cognito-idp:{region}:{account}:userpool/{user_pool_id}"
+
+
 def test_cognito_create_and_describe_user_pool(cognito_idp):
     resp = cognito_idp.create_user_pool(PoolName="TestPool")
     pool = resp["UserPool"]
@@ -331,6 +335,37 @@ def test_cognito_tags(cognito_idp):
     cognito_idp.untag_resource(ResourceArn=arn, TagKeys=["project"])
     tags = cognito_idp.list_tags_for_resource(ResourceArn=arn)["Tags"]
     assert "project" not in tags
+
+
+def test_cognito_user_pool_tag_apis_reject_invalid_arns(cognito_idp):
+    pid = cognito_idp.create_user_pool(PoolName="InvalidIdpArnTagPool")["UserPool"]["Id"]
+    valid_arn = _user_pool_arn(pid)
+    invalid_cases = [
+        ("not-an-arn-but-long-enough", "InvalidParameterException"),
+        ("arn:aws:cognito-idp:us-east-1", "InvalidParameterException"),
+        (f"arn:aws:cognito-identity:us-east-1:000000000000:userpool/{pid}", "InvalidParameterException"),
+        (f"arn:aws:cognito-idp:us-east-1:000000000000:identitypool/{pid}", "InvalidParameterException"),
+        (_user_pool_arn(pid, region="us-west-2"), "ResourceNotFoundException"),
+        (_user_pool_arn(pid, account="111111111111"), "ResourceNotFoundException"),
+    ]
+
+    for bad_arn, expected_code in invalid_cases:
+        with pytest.raises(ClientError) as exc:
+            cognito_idp.tag_resource(ResourceArn=bad_arn, Tags={"bad": "value"})
+        assert exc.value.response["Error"]["Code"] == expected_code
+
+    assert cognito_idp.list_tags_for_resource(ResourceArn=valid_arn)["Tags"] == {}
+
+
+def test_cognito_user_pool_list_and_untag_reject_invalid_arns(cognito_idp):
+    for operation, kwargs in [
+        (cognito_idp.list_tags_for_resource, {}),
+        (cognito_idp.untag_resource, {"TagKeys": ["missing"]}),
+    ]:
+        with pytest.raises(ClientError) as exc:
+            operation(ResourceArn="arn:aws:sqs:us-east-1:000000000000:userpool/not-a-pool", **kwargs)
+        assert exc.value.response["Error"]["Code"] == "InvalidParameterException"
+
 
 def test_cognito_get_user_from_token(cognito_idp):
     pid = cognito_idp.create_user_pool(PoolName="GetUserPool")["UserPool"]["Id"]


### PR DESCRIPTION
## Why
Cognito IDP user-pool tag APIs should validate ARN-shaped ResourceArn inputs by service, account, region, and resource shape instead of relying on raw ARN comparison.

## What
- Add parser-backed Cognito IDP user-pool ARN resolution for tag APIs
- Preserve ResourceNotFound behavior for well-formed foreign account or region ARNs
- Add invalid ARN coverage for tag, untag, and list-tags paths

## Validation
- `python3 -m py_compile ministack/services/cognito.py tests/test_cognito.py`
- `uv run ruff check ministack/services/cognito.py tests/test_cognito.py`
- `uv run --extra dev pytest tests/test_cognito.py -q` (`130 passed`)