### PR TITLE
Parse SNS topic tag ARNs

### DIFF
--- a/ministack/services/sns.py
+++ b/ministack/services/sns.py
@@ -88,6 +88,33 @@ def _validate_subscription_endpoint(protocol: str, endpoint: str):
         return _invalid_subscription_endpoint(protocol, endpoint)
     return None
 
+
+def _resolve_topic_tag_arn(arn: str):
+    arn = _normalize_arn(arn)
+    try:
+        spec = parse_arn(arn)
+    except ArnParseError:
+        return arn, None, _error("InvalidParameterException", f"Invalid SNS topic ARN: {arn}", 400)
+
+    if (
+        spec.partition != "aws"
+        or spec.service != "sns"
+        or not spec.region
+        or not spec.account_id
+        or not spec.resource
+        or ":" in spec.resource
+        or "/" in spec.resource
+    ):
+        return arn, None, _error("InvalidParameterException", f"Invalid SNS topic ARN: {arn}", 400)
+
+    if spec.region != get_region() or spec.account_id != get_account_id():
+        return arn, None, _error("ResourceNotFoundException", "Resource not found", 404)
+
+    topic = _topics.get(arn)
+    if not topic:
+        return arn, None, _error("ResourceNotFoundException", "Resource not found", 404)
+    return arn, topic, None
+
 from ministack.core.persistence import PERSIST_STATE, load_state
 
 _topics = AccountScopedDict()
@@ -1051,21 +1078,20 @@ async def _send_subscription_confirmation(topic_arn: str, sub: dict):
 # ---------------------------------------------------------------------------
 
 def _list_tags_for_resource(params):
-    arn = _normalize_arn(_p(params, "ResourceArn"))
-    topic = _topics.get(arn)
+    arn, topic, err = _resolve_topic_tag_arn(_p(params, "ResourceArn"))
+    if err:
+        return err
     tags_xml = ""
-    if topic:
-        for k, v in topic.get("tags", {}).items():
-            tags_xml += f"<member><Key>{k}</Key><Value>{v}</Value></member>"
+    for k, v in topic.get("tags", {}).items():
+        tags_xml += f"<member><Key>{k}</Key><Value>{v}</Value></member>"
     return _xml(200, "ListTagsForResourceResponse",
                 f"<ListTagsForResourceResult><Tags>{tags_xml}</Tags></ListTagsForResourceResult>")
 
 
 def _tag_resource(params):
-    arn = _normalize_arn(_p(params, "ResourceArn"))
-    topic = _topics.get(arn)
-    if not topic:
-        return _error("ResourceNotFoundException", "Resource not found", 404)
+    _arn, topic, err = _resolve_topic_tag_arn(_p(params, "ResourceArn"))
+    if err:
+        return err
     i = 1
     while _p(params, f"Tags.member.{i}.Key"):
         key = _p(params, f"Tags.member.{i}.Key")
@@ -1076,13 +1102,13 @@ def _tag_resource(params):
 
 
 def _untag_resource(params):
-    arn = _normalize_arn(_p(params, "ResourceArn"))
-    topic = _topics.get(arn)
-    if topic:
-        i = 1
-        while _p(params, f"TagKeys.member.{i}"):
-            topic.get("tags", {}).pop(_p(params, f"TagKeys.member.{i}"), None)
-            i += 1
+    _arn, topic, err = _resolve_topic_tag_arn(_p(params, "ResourceArn"))
+    if err:
+        return err
+    i = 1
+    while _p(params, f"TagKeys.member.{i}"):
+        topic.get("tags", {}).pop(_p(params, f"TagKeys.member.{i}"), None)
+        i += 1
     return _xml(200, "UntagResourceResponse", "<UntagResourceResult/>")
 
 

--- a/tests/test_sns.py
+++ b/tests/test_sns.py
@@ -248,6 +248,48 @@ def test_sns_tags(sns):
     assert "team" not in tags
     assert tags["env"] == "staging"
 
+
+def test_sns_tag_resource_accepts_empty_account_topic_arn(sns):
+    arn = sns.create_topic(Name=f"intg-sns-empty-account-{_uuid_mod.uuid4().hex[:8]}")["TopicArn"]
+    empty_account_arn = arn.replace(":000000000000:", "::")
+
+    sns.tag_resource(ResourceArn=empty_account_arn, Tags=[{"Key": "env", "Value": "test"}])
+
+    resp = sns.list_tags_for_resource(ResourceArn=arn)
+    tags = {t["Key"]: t["Value"] for t in resp["Tags"]}
+    assert tags["env"] == "test"
+
+
+def test_sns_topic_tag_apis_reject_invalid_arns(sns):
+    arn = sns.create_topic(Name=f"intg-sns-invalid-tags-{_uuid_mod.uuid4().hex[:8]}")["TopicArn"]
+    invalid_cases = [
+        ("not-an-arn", "InvalidParameterException"),
+        ("arn:aws:sns:us-east-1", "InvalidParameterException"),
+        (arn.replace(":sns:", ":sqs:"), "InvalidParameterException"),
+        (arn.replace(":000000000000:", ":111111111111:"), "ResourceNotFoundException"),
+        (arn.replace(":us-east-1:", ":us-west-2:"), "ResourceNotFoundException"),
+        ("arn:aws:sns:us-east-1:000000000000:app/APNS/example", "InvalidParameterException"),
+    ]
+
+    for bad_arn, expected_code in invalid_cases:
+        with pytest.raises(ClientError) as exc:
+            sns.tag_resource(ResourceArn=bad_arn, Tags=[{"Key": "bad", "Value": "value"}])
+        assert exc.value.response["Error"]["Code"] == expected_code
+
+    resp = sns.list_tags_for_resource(ResourceArn=arn)
+    assert resp["Tags"] == []
+
+
+def test_sns_topic_list_and_untag_reject_invalid_arns(sns):
+    for operation, kwargs in [
+        (sns.list_tags_for_resource, {}),
+        (sns.untag_resource, {"TagKeys": ["missing"]}),
+    ]:
+        with pytest.raises(ClientError) as exc:
+            operation(ResourceArn="arn:aws:sqs:us-east-1:000000000000:not-a-topic", **kwargs)
+        assert exc.value.response["Error"]["Code"] == "InvalidParameterException"
+
+
 def test_sns_subscription_attributes(sns):
     arn = sns.create_topic(Name="intg-sns-subattr")["TopicArn"]
     sub = sns.subscribe(


### PR DESCRIPTION
## Why
SNS topic tag APIs should validate topic ARNs by parsed service, account, region, and topic resource shape before mutating tag state.

## What
- Add parser-backed topic ARN resolution for direct SNS tag APIs
- Preserve empty-account topic ARN normalization for supported clients
- Add invalid ARN coverage for tag, untag, and list-tags paths

## Validation
- `python3 -m py_compile ministack/services/sns.py tests/test_sns.py`
- `uv run ruff check ministack/services/sns.py tests/test_sns.py`
- `uv run --extra dev pytest tests/test_sns.py -q` (`66 passed`)