### PR TITLE
Parse EFS tag resource ARNs

### DIFF
--- a/ministack/services/efs.py
+++ b/ministack/services/efs.py
@@ -24,6 +24,7 @@ import re
 import string
 import time
 
+from ministack.core.arn import ArnParseError, parse_arn
 from ministack.core.persistence import PERSIST_STATE, load_state
 from ministack.core.responses import AccountScopedDict, get_account_id, get_region
 
@@ -291,21 +292,59 @@ def _delete_access_point(ap_id):
 # Tags
 # ---------------------------------------------------------------------------
 
-def _tag_resource(resource_id, body):
-    resource = _find_resource(resource_id)
+def _tag_resource_not_found(resource_id):
+    # Per AWS EFS docs the resource-not-found error is keyed by the resource
+    # type — FileSystemNotFound for fs-* / file-system ARNs,
+    # AccessPointNotFound for fsap-* / access-point ARNs. Falling back to
+    # BadRequest for anything else matches the EFS regex on ResourceId.
+    if resource_id.startswith("fs-") or "file-system/fs-" in resource_id:
+        return _error(404, "FileSystemNotFound", f"File system '{resource_id}' does not exist.")
+    if resource_id.startswith("fsap-") or "access-point/fsap-" in resource_id:
+        return _error(404, "AccessPointNotFound", f"Access point '{resource_id}' does not exist.")
+    return _error(400, "BadRequest", f"Resource id '{resource_id}' is not a valid EFS resource.")
+
+
+def _resource_id_from_arn(resource_id):
+    try:
+        spec = parse_arn(resource_id)
+    except ArnParseError:
+        return None, _error(400, "BadRequest", f"Resource id '{resource_id}' is not a valid EFS resource.")
+
+    if spec.partition != "aws" or spec.service != "elasticfilesystem":
+        return None, _error(400, "BadRequest", f"Resource id '{resource_id}' is not a valid EFS resource.")
+
+    parts = spec.resource.split("/")
+    if len(parts) != 2 or parts[0] not in {"file-system", "access-point"} or not parts[1]:
+        return None, _error(400, "BadRequest", f"Resource id '{resource_id}' is not a valid EFS resource.")
+    resource_type, lookup_id = parts
+    if resource_type == "file-system" and not lookup_id.startswith("fs-"):
+        return None, _error(400, "BadRequest", f"Resource id '{resource_id}' is not a valid EFS resource.")
+    if resource_type == "access-point" and not lookup_id.startswith("fsap-"):
+        return None, _error(400, "BadRequest", f"Resource id '{resource_id}' is not a valid EFS resource.")
+
+    if spec.region != get_region() or spec.account_id != get_account_id():
+        return None, _tag_resource_not_found(resource_id)
+    return (resource_type, lookup_id), None
+
+
+def _resolve_tag_resource(resource_id):
+    lookup_id = resource_id
+    resource_type = None
+    if resource_id.startswith("arn:"):
+        resolved, err = _resource_id_from_arn(resource_id)
+        if err:
+            return None, err
+        resource_type, lookup_id = resolved
+    resource = _find_resource(lookup_id, resource_type)
     if resource is None:
-        # Per AWS EFS docs the resource-not-found error is keyed by the
-        # resource type — FileSystemNotFound for fs-* / file-system ARNs,
-        # AccessPointNotFound for fsap-* / access-point ARNs. Falling back
-        # to BadRequest for anything else matches the EFS regex on ResourceId.
-        if resource_id.startswith("fs-") or "file-system/fs-" in resource_id:
-            return _error(404, "FileSystemNotFound",
-                f"File system '{resource_id}' does not exist.")
-        if resource_id.startswith("fsap-") or "access-point/fsap-" in resource_id:
-            return _error(404, "AccessPointNotFound",
-                f"Access point '{resource_id}' does not exist.")
-        return _error(400, "BadRequest",
-            f"Resource id '{resource_id}' is not a valid EFS resource.")
+        return None, _tag_resource_not_found(resource_id)
+    return resource, None
+
+
+def _tag_resource(resource_id, body):
+    resource, err = _resolve_tag_resource(resource_id)
+    if err:
+        return err
     tags = body.get("Tags", [])
     existing = {t["Key"]: i for i, t in enumerate(resource.get("Tags", []))}
     tag_list = resource.setdefault("Tags", [])
@@ -319,53 +358,25 @@ def _tag_resource(resource_id, body):
 
 
 def _untag_resource(resource_id, keys):
-    resource = _find_resource(resource_id)
-    if resource is None:
-        # Per AWS EFS docs the resource-not-found error is keyed by the
-        # resource type — FileSystemNotFound for fs-* / file-system ARNs,
-        # AccessPointNotFound for fsap-* / access-point ARNs. Falling back
-        # to BadRequest for anything else matches the EFS regex on ResourceId.
-        if resource_id.startswith("fs-") or "file-system/fs-" in resource_id:
-            return _error(404, "FileSystemNotFound",
-                f"File system '{resource_id}' does not exist.")
-        if resource_id.startswith("fsap-") or "access-point/fsap-" in resource_id:
-            return _error(404, "AccessPointNotFound",
-                f"Access point '{resource_id}' does not exist.")
-        return _error(400, "BadRequest",
-            f"Resource id '{resource_id}' is not a valid EFS resource.")
+    resource, err = _resolve_tag_resource(resource_id)
+    if err:
+        return err
     resource["Tags"] = [t for t in resource.get("Tags", []) if t["Key"] not in keys]
     return _json(200, {})
 
 
 def _list_tags_for_resource(resource_id):
-    resource = _find_resource(resource_id)
-    if resource is None:
-        # Per AWS EFS docs the resource-not-found error is keyed by the
-        # resource type — FileSystemNotFound for fs-* / file-system ARNs,
-        # AccessPointNotFound for fsap-* / access-point ARNs. Falling back
-        # to BadRequest for anything else matches the EFS regex on ResourceId.
-        if resource_id.startswith("fs-") or "file-system/fs-" in resource_id:
-            return _error(404, "FileSystemNotFound",
-                f"File system '{resource_id}' does not exist.")
-        if resource_id.startswith("fsap-") or "access-point/fsap-" in resource_id:
-            return _error(404, "AccessPointNotFound",
-                f"Access point '{resource_id}' does not exist.")
-        return _error(400, "BadRequest",
-            f"Resource id '{resource_id}' is not a valid EFS resource.")
+    resource, err = _resolve_tag_resource(resource_id)
+    if err:
+        return err
     return _json(200, {"Tags": resource.get("Tags", [])})
 
 
-def _find_resource(resource_id):
-    if resource_id in _file_systems:
+def _find_resource(resource_id, resource_type=None):
+    if resource_type in (None, "file-system") and resource_id in _file_systems:
         return _file_systems[resource_id]
-    if resource_id in _access_points:
+    if resource_type in (None, "access-point") and resource_id in _access_points:
         return _access_points[resource_id]
-    for fs in _file_systems.values():
-        if fs["FileSystemArn"] == resource_id:
-            return fs
-    for ap in _access_points.values():
-        if ap["AccessPointArn"] == resource_id:
-            return ap
     return None
 
 

--- a/tests/test_efs.py
+++ b/tests/test_efs.py
@@ -99,6 +99,53 @@ def test_efs_tags(efs):
     assert "env" not in keys
     assert "team" in keys
 
+
+def test_efs_access_point_tags_accept_arn(efs):
+    fs = efs.create_file_system(CreationToken=f"ap-tags-{_uuid_mod.uuid4().hex[:8]}")
+    ap = efs.create_access_point(FileSystemId=fs["FileSystemId"])
+    ap_arn = ap["AccessPointArn"]
+
+    efs.tag_resource(ResourceId=ap_arn, Tags=[{"Key": "team", "Value": "data"}])
+
+    tags_resp = efs.list_tags_for_resource(ResourceId=ap_arn)
+    tag_map = {t["Key"]: t["Value"] for t in tags_resp["Tags"]}
+    assert tag_map["team"] == "data"
+
+
+def test_efs_tag_resource_rejects_invalid_arns(efs):
+    fs = efs.create_file_system(CreationToken=f"invalid-tags-{_uuid_mod.uuid4().hex[:8]}")
+    fs_arn = fs["FileSystemArn"]
+    ap = efs.create_access_point(FileSystemId=fs["FileSystemId"])
+    invalid_cases = [
+        ("not-an-arn", "BadRequest"),
+        (fs_arn.replace(":elasticfilesystem:", ":s3:"), "BadRequest"),
+        (fs_arn.replace(":000000000000:", ":111111111111:"), "FileSystemNotFound"),
+        (fs_arn.replace(":us-east-1:", ":us-west-2:"), "FileSystemNotFound"),
+        (f"arn:aws:elasticfilesystem:us-east-1:000000000000:mount-target/{fs['FileSystemId']}", "BadRequest"),
+        (f"arn:aws:elasticfilesystem:us-east-1:000000000000:file-system/{ap['AccessPointId']}", "BadRequest"),
+        (f"arn:aws:elasticfilesystem:us-east-1:000000000000:access-point/{fs['FileSystemId']}", "BadRequest"),
+    ]
+
+    for bad_resource_id, expected_code in invalid_cases:
+        with pytest.raises(ClientError) as exc:
+            efs.tag_resource(ResourceId=bad_resource_id, Tags=[{"Key": "bad", "Value": "value"}])
+        assert exc.value.response["Error"]["Code"] == expected_code
+
+    tags_resp = efs.list_tags_for_resource(ResourceId=fs_arn)
+    tag_map = {t["Key"]: t["Value"] for t in tags_resp["Tags"]}
+    assert "bad" not in tag_map
+
+
+def test_efs_list_and_untag_reject_invalid_arns(efs):
+    for operation, kwargs in [
+        (efs.list_tags_for_resource, {}),
+        (efs.untag_resource, {"TagKeys": ["missing"]}),
+    ]:
+        with pytest.raises(ClientError) as exc:
+            operation(ResourceId="arn:aws:s3:us-east-1:000000000000:file-system/fs-1234567890abcdef0", **kwargs)
+        assert exc.value.response["Error"]["Code"] == "BadRequest"
+
+
 def test_efs_lifecycle_configuration(efs):
     fs = efs.create_file_system()
     fs_id = fs["FileSystemId"]


### PR DESCRIPTION
## Why
EFS tag APIs accept `ResourceId` values that may be file-system or access-point ARNs, so ARN-shaped inputs should be parsed and scoped before lookup.

## What
- Add parser-backed EFS file-system and access-point ARN handling for tag APIs
- Reject malformed, wrong-service, wrong-scope, and mismatched resource-type ARNs
- Keep bare file-system and access-point ID behavior intact

## Validation
- `python3 -m py_compile ministack/services/efs.py tests/test_efs.py`
- `uv run ruff check ministack/services/efs.py tests/test_efs.py`
- `uv run --extra dev pytest tests/test_efs.py -q` (`16 passed`)