### PR TITLE
Parse KMS key and alias ARNs

### DIFF
--- a/ministack/services/cloudformation/provisioners.py
+++ b/ministack/services/cloudformation/provisioners.py
@@ -2390,12 +2390,14 @@ def _kms_key_delete(physical_id, props):
 def _kms_alias_create(logical_id, props, stack_name):
     alias_name = props.get("AliasName", f"alias/{stack_name}-{logical_id}")
     target_key = props.get("TargetKeyId", "")
-    _kms._aliases[alias_name] = target_key
+    rec = _kms._resolve_key(target_key)
+    alias_arn = _kms._alias_arn(alias_name)
+    _kms._aliases[alias_arn] = rec["KeyId"] if rec else target_key
     return alias_name, {}
 
 
 def _kms_alias_delete(physical_id, props):
-    _kms._aliases.pop(physical_id, None)
+    _kms._aliases.pop(_kms._alias_arn(physical_id), None)
 
 
 # --- EC2 resource provisioners ---

--- a/ministack/services/kms.py
+++ b/ministack/services/kms.py
@@ -13,6 +13,7 @@ import logging
 import os
 import time
 
+from ministack.core.arn import ArnParseError, parse_arn
 from ministack.core.responses import (
     AccountScopedDict,
     error_response_json,
@@ -50,7 +51,22 @@ _keys = AccountScopedDict()
 #     _public_key_der (bytes, RSA/ECC only),
 #     _symmetric_key (bytes, SYMMETRIC_DEFAULT only),
 # }
-_aliases = AccountScopedDict()  # alias_name -> key_id (e.g. "alias/my-key" -> "uuid")
+_aliases = AccountScopedDict()  # alias ARN -> key_id
+
+
+def _alias_arn(alias_name):
+    return f"arn:aws:kms:{get_region()}:{get_account_id()}:{alias_name}"
+
+
+def _alias_arn_from_key_record(alias_name, rec, account_id=None):
+    if rec and rec.get("Arn"):
+        try:
+            spec = parse_arn(rec["Arn"])
+            if spec.service == "kms" and spec.region and spec.account_id:
+                return f"arn:{spec.partition}:kms:{spec.region}:{spec.account_id}:{alias_name}"
+        except ArnParseError:
+            pass
+    return f"arn:aws:kms:{get_region()}:{account_id or get_account_id()}:{alias_name}"
 
 
 # ── Persistence ────────────────────────────────────────────
@@ -105,7 +121,21 @@ def restore_state(data):
             for kid, entry in keys_data.items():
                 _restore_key_entry(entry)
                 _keys[kid] = entry
-        _aliases.update(data.get("aliases", {}))
+        aliases_data = data.get("aliases", {})
+        if isinstance(aliases_data, AccountScopedDict):
+            for scoped_key, target_id in aliases_data._data.items():
+                account_id, alias_key = scoped_key
+                storage_key = alias_key
+                if not str(alias_key).startswith("arn:"):
+                    rec = _keys._data.get((account_id, target_id))
+                    storage_key = _alias_arn_from_key_record(alias_key, rec, account_id)
+                _aliases._data[(account_id, storage_key)] = target_id
+        else:
+            for alias_key, target_id in aliases_data.items():
+                storage_key = alias_key
+                if not str(alias_key).startswith("arn:"):
+                    storage_key = _alias_arn_from_key_record(alias_key, _keys.get(target_id))
+                _aliases[storage_key] = target_id
 
 
 try:
@@ -141,22 +171,46 @@ def _key_metadata(rec):
     }
 
 
+def _key_ref_from_arn(key_id_or_arn):
+    try:
+        spec = parse_arn(key_id_or_arn)
+    except ArnParseError:
+        return None
+    if (
+        spec.partition != "aws"
+        or spec.service != "kms"
+        or spec.region != get_region()
+        or spec.account_id != get_account_id()
+    ):
+        return None
+    if spec.resource.startswith("key/"):
+        key_id = spec.resource[len("key/"):]
+        return ("key", key_id) if key_id else None
+    if spec.resource.startswith("alias/"):
+        alias_name = spec.resource
+        return ("alias", key_id_or_arn) if alias_name != "alias/" else None
+    return None
+
+
 def _resolve_key(key_id_or_arn):
     if not key_id_or_arn:
         return None
+    if key_id_or_arn.startswith("arn:"):
+        key_ref = _key_ref_from_arn(key_id_or_arn)
+        if not key_ref:
+            return None
+        ref_type, key_ref_value = key_ref
+        if ref_type == "key":
+            rec = _keys.get(key_ref_value)
+            return rec if rec and rec.get("Arn") == key_id_or_arn else None
+        key_id_or_arn = key_ref_value
     # Direct key ID lookup
     if key_id_or_arn in _keys:
         return _keys[key_id_or_arn]
-    # ARN lookup
-    for rec in _keys.values():
-        if rec["Arn"] == key_id_or_arn:
-            return rec
-    # Alias lookup: "alias/my-key" or "arn:aws:kms:...:alias/my-key"
-    alias_name = key_id_or_arn
-    if ":alias/" in alias_name:
-        alias_name = "alias/" + alias_name.split(":alias/")[-1]
-    if alias_name in _aliases:
-        return _keys.get(_aliases[alias_name])
+    # Alias lookup: "alias/my-key"
+    alias_arn = key_id_or_arn if key_id_or_arn.startswith("arn:") else _alias_arn(key_id_or_arn)
+    if alias_arn in _aliases:
+        return _keys.get(_aliases[alias_arn])
     return None
 
 
@@ -833,32 +887,40 @@ def _create_alias(data):
     rec = _resolve_key(target_key_id)
     if not rec:
         return error_response_json("NotFoundException", f"Key {target_key_id} not found", 400)
-    if alias_name in _aliases:
+    alias_arn = _alias_arn(alias_name)
+    if alias_arn in _aliases:
         return error_response_json("AlreadyExistsException", f"Alias {alias_name} already exists", 400)
-    _aliases[alias_name] = rec["KeyId"]
+    _aliases[alias_arn] = rec["KeyId"]
     logger.info("Created alias %s -> %s", alias_name, rec["KeyId"])
     return json_response({})
 
 
 def _delete_alias(data):
     alias_name = data.get("AliasName", "")
-    if alias_name not in _aliases:
+    alias_arn = _alias_arn(alias_name)
+    if alias_arn not in _aliases:
         return error_response_json("NotFoundException", f"Alias {alias_name} not found", 400)
-    del _aliases[alias_name]
+    del _aliases[alias_arn]
     return json_response({})
 
 
 def _list_aliases(data):
     key_id = data.get("KeyId")
     items = []
-    for alias_name, target_id in _aliases.items():
+    for alias_arn, target_id in _aliases.items():
+        try:
+            spec = parse_arn(alias_arn)
+        except ArnParseError:
+            continue
+        if spec.service != "kms" or spec.region != get_region() or spec.account_id != get_account_id():
+            continue
         if key_id and target_id != key_id:
             rec = _resolve_key(key_id)
             if not rec or rec["KeyId"] != target_id:
                 continue
         items.append({
-            "AliasName": alias_name,
-            "AliasArn": f"arn:aws:kms:{get_region()}:{get_account_id()}:{alias_name}",
+            "AliasName": spec.resource,
+            "AliasArn": alias_arn,
             "TargetKeyId": target_id,
         })
     return json_response({"Aliases": items, "Truncated": False})
@@ -867,12 +929,13 @@ def _list_aliases(data):
 def _update_alias(data):
     alias_name = data.get("AliasName", "")
     target_key_id = data.get("TargetKeyId", "")
-    if alias_name not in _aliases:
+    alias_arn = _alias_arn(alias_name)
+    if alias_arn not in _aliases:
         return error_response_json("NotFoundException", f"Alias {alias_name} not found", 400)
     rec = _resolve_key(target_key_id)
     if not rec:
         return error_response_json("NotFoundException", f"Key {target_key_id} not found", 400)
-    _aliases[alias_name] = rec["KeyId"]
+    _aliases[alias_arn] = rec["KeyId"]
     return json_response({})
 
 

--- a/tests/test_kms.py
+++ b/tests/test_kms.py
@@ -6,8 +6,23 @@ import uuid as _uuid_mod
 import zipfile
 from urllib.parse import urlparse
 
+import boto3
 import pytest
+from botocore.config import Config
 from botocore.exceptions import ClientError
+
+ENDPOINT = os.environ.get("MINISTACK_ENDPOINT", "http://localhost:4566")
+
+
+def _regional_kms(region):
+    return boto3.client(
+        "kms",
+        endpoint_url=ENDPOINT,
+        aws_access_key_id="test",
+        aws_secret_access_key="test",
+        region_name=region,
+        config=Config(region_name=region, retries={"mode": "standard"}),
+    )
 
 
 def test_kms_create_symmetric_key(kms_client):
@@ -74,6 +89,34 @@ def test_kms_describe_key_by_arn(kms_client):
     arn = created["KeyMetadata"]["Arn"]
     resp = kms_client.describe_key(KeyId=arn)
     assert resp["KeyMetadata"]["Arn"] == arn
+
+
+def test_kms_key_arn_resolution_rejects_wrong_scope(kms_client):
+    created = kms_client.create_key(KeySpec="SYMMETRIC_DEFAULT")
+    arn = created["KeyMetadata"]["Arn"]
+    invalid_cases = [
+        arn.replace(":000000000000:", ":111111111111:"),
+        arn.replace(":us-east-1:", ":us-west-2:"),
+        arn.replace(":kms:", ":sqs:"),
+        arn.replace(":key/", ":alias/"),
+    ]
+
+    for key_id in invalid_cases:
+        with pytest.raises(ClientError) as exc:
+            kms_client.describe_key(KeyId=key_id)
+        assert exc.value.response["Error"]["Code"] == "NotFoundException"
+
+
+def test_kms_key_arn_resolution_rejects_forged_request_region(kms_client):
+    created = kms_client.create_key(KeySpec="SYMMETRIC_DEFAULT")
+    arn = created["KeyMetadata"]["Arn"]
+    west_arn = arn.replace(":us-east-1:", ":us-west-2:")
+    west_kms = _regional_kms("us-west-2")
+
+    with pytest.raises(ClientError) as exc:
+        west_kms.describe_key(KeyId=west_arn)
+    assert exc.value.response["Error"]["Code"] == "NotFoundException"
+
 
 def test_kms_describe_nonexistent_key(kms_client):
     with pytest.raises(ClientError) as exc_info:
@@ -321,6 +364,64 @@ def test_kms_describe_key_by_alias(kms_client):
     resp = kms_client.describe_key(KeyId="alias/desc-alias")
     assert resp["KeyMetadata"]["KeyId"] == key_id
 
+
+def test_kms_describe_key_by_alias_arn(kms_client):
+    key = kms_client.create_key(KeySpec="SYMMETRIC_DEFAULT")
+    key_id = key["KeyMetadata"]["KeyId"]
+    kms_client.create_alias(AliasName="alias/desc-alias-arn", TargetKeyId=key_id)
+
+    resp = kms_client.describe_key(
+        KeyId="arn:aws:kms:us-east-1:000000000000:alias/desc-alias-arn",
+    )
+
+    assert resp["KeyMetadata"]["KeyId"] == key_id
+
+
+def test_kms_alias_arn_resolution_rejects_forged_request_region(kms_client):
+    key = kms_client.create_key(KeySpec="SYMMETRIC_DEFAULT")
+    key_id = key["KeyMetadata"]["KeyId"]
+    kms_client.create_alias(AliasName="alias/forged-region-alias", TargetKeyId=key_id)
+    west_kms = _regional_kms("us-west-2")
+
+    with pytest.raises(ClientError) as exc:
+        west_kms.describe_key(
+            KeyId="arn:aws:kms:us-west-2:000000000000:alias/forged-region-alias",
+        )
+    assert exc.value.response["Error"]["Code"] == "NotFoundException"
+
+
+def test_kms_cloudformation_alias_resolves_by_name_and_arn(cfn, kms_client):
+    alias_name = f"alias/cfn-kms-alias-{_uuid_mod.uuid4().hex[:8]}"
+    template = {
+        "Resources": {
+            "Key": {"Type": "AWS::KMS::Key", "Properties": {"Description": "cfn alias key"}},
+            "Alias": {
+                "Type": "AWS::KMS::Alias",
+                "Properties": {"AliasName": alias_name, "TargetKeyId": {"Ref": "Key"}},
+            },
+        },
+    }
+    stack_name = f"kms-cfn-alias-{_uuid_mod.uuid4().hex[:8]}"
+    cfn.create_stack(StackName=stack_name, TemplateBody=json.dumps(template))
+
+    by_name = kms_client.describe_key(KeyId=alias_name)["KeyMetadata"]
+    alias_arn = f"arn:aws:kms:us-east-1:000000000000:{alias_name}"
+    by_arn = kms_client.describe_key(KeyId=alias_arn)["KeyMetadata"]
+    assert by_arn["KeyId"] == by_name["KeyId"]
+
+
+def test_kms_wrong_service_alias_arn_does_not_tail_match(kms_client):
+    key = kms_client.create_key(KeySpec="SYMMETRIC_DEFAULT")
+    kms_client.create_alias(AliasName="alias/wrong-service-tail", TargetKeyId=key["KeyMetadata"]["KeyId"])
+
+    with pytest.raises(ClientError) as exc:
+        kms_client.describe_key(
+            KeyId="arn:aws:sqs:us-east-1:000000000000:alias/wrong-service-tail",
+        )
+
+    assert exc.value.response["Error"]["Code"] == "NotFoundException"
+
+
 def test_kms_update_alias(kms_client):
     key1 = kms_client.create_key(KeySpec="SYMMETRIC_DEFAULT")
     key2 = kms_client.create_key(KeySpec="SYMMETRIC_DEFAULT")
@@ -380,6 +481,18 @@ def test_kms_tag_untag_list_v2(kms_client):
     assert len(tags["Tags"]) == 1
     assert tags["Tags"][0]["TagKey"] == "env"
     kms_client.schedule_key_deletion(KeyId=key_id, PendingWindowInDays=7)
+
+
+def test_kms_tag_resource_accepts_key_arn(kms_client):
+    key = kms_client.create_key()
+    arn = key["KeyMetadata"]["Arn"]
+
+    kms_client.tag_resource(KeyId=arn, Tags=[{"TagKey": "env", "TagValue": "test"}])
+
+    tags = kms_client.list_resource_tags(KeyId=arn)
+    tag_map = {t["TagKey"]: t["TagValue"] for t in tags["Tags"]}
+    assert tag_map["env"] == "test"
+    kms_client.schedule_key_deletion(KeyId=arn, PendingWindowInDays=7)
 
 def test_kms_enable_disable_key(kms_client):
     """EnableKey / DisableKey."""


### PR DESCRIPTION
## Why
KMS key and alias ARN inputs should be validated by parsed request scope instead of falling back to raw equality or tail-matching alias names.

## What
- Add parser-backed KMS key and alias ARN resolution with exact key ARN checks
- Store aliases by AliasArn so alias lookups and list output stay region-scoped
- Migrate persisted alias-name state from target key ARNs and update CloudFormation alias provisioning

## Validation
- `python3 -m py_compile ministack/services/kms.py ministack/services/cloudformation/provisioners.py tests/test_kms.py`
- `uv run ruff check ministack/services/kms.py ministack/services/cloudformation/provisioners.py tests/test_kms.py`
- `uv run --extra dev pytest tests/test_kms.py -q` (`58 passed`)
- `uv run --extra dev pytest tests/test_cfn.py::test_cfn_cdk_bootstrap_resources -q` (`1 passed`)