### PR TITLE
Parse CloudFront KVS data-plane ARNs

### DIFF
--- a/ministack/services/cloudfront_keyvaluestore.py
+++ b/ministack/services/cloudfront_keyvaluestore.py
@@ -16,8 +16,9 @@ import re
 from datetime import datetime
 from urllib.parse import unquote
 
+from ministack.core.arn import ArnParseError, parse_arn
 from ministack.core.persistence import load_state
-from ministack.core.responses import AccountScopedDict, json_response, new_uuid
+from ministack.core.responses import AccountScopedDict, get_account_id, json_response, new_uuid
 
 logger = logging.getLogger("cloudfront-keyvaluestore")
 
@@ -70,21 +71,45 @@ def _error(code: str, message: str, status: int) -> tuple:
     return status, {"Content-Type": "application/json"}, body
 
 
+def _kvs_name_from_arn(arn: str):
+    try:
+        spec = parse_arn(arn)
+    except ArnParseError:
+        return None, _error("ValidationException", f"Invalid KvsARN: {arn}", 400)
+    if (
+        spec.partition != "aws"
+        or spec.service != "cloudfront"
+        or spec.region
+        or spec.account_id != get_account_id()
+    ):
+        return None, _error("ValidationException", f"Invalid KvsARN: {arn}", 400)
+
+    prefix = "key-value-store/"
+    if not spec.resource.startswith(prefix):
+        return None, _error("ValidationException", f"Invalid KvsARN: {arn}", 400)
+    name = spec.resource[len(prefix):]
+    if not name or "/" in name:
+        return None, _error("ValidationException", f"Invalid KvsARN: {arn}", 400)
+    return name, None
+
+
 def _get_store(arn: str):
+    name, err = _kvs_name_from_arn(arn)
+    if err:
+        return None, err
+
     store = _stores.get(arn)
     if store is None:
         from ministack.services.cloudfront import _kvstores
 
-        kvs = None
-        for v in _kvstores.values():
-            if v["ARN"] == arn:
-                kvs = v
-                break
+        kvs = _kvstores.get(name)
+        if kvs and kvs.get("ARN") != arn:
+            kvs = None
         if kvs is None:
-            return None
+            return None, _error("ResourceNotFoundException", f"Key value store {arn} was not found.", 404)
         store = {"etag": new_uuid(), "items": {}}
         _stores[arn] = store
-    return store
+    return store, None
 
 
 def _compute_size(items: dict) -> int:
@@ -136,9 +161,9 @@ async def handle_request(method, path, headers, body, query_params):
 
 
 def _describe_store(arn: str):
-    store = _get_store(arn)
-    if store is None:
-        return _error("ResourceNotFoundException", f"Key value store {arn} was not found.", 404)
+    store, err = _get_store(arn)
+    if err:
+        return err
 
     from ministack.services.cloudfront import _kvstores
 
@@ -177,9 +202,9 @@ def _qp_first(query_params, key):
 
 
 def _list_keys(arn: str, query_params):
-    store = _get_store(arn)
-    if store is None:
-        return _error("ResourceNotFoundException", f"Key value store {arn} was not found.", 404)
+    store, err = _get_store(arn)
+    if err:
+        return err
 
     raw_max = _qp_first(query_params, "MaxResults")
     try:
@@ -217,9 +242,9 @@ def _list_keys(arn: str, query_params):
 
 
 def _get_key(arn: str, key: str):
-    store = _get_store(arn)
-    if store is None:
-        return _error("ResourceNotFoundException", f"Key value store {arn} was not found.", 404)
+    store, err = _get_store(arn)
+    if err:
+        return err
 
     value = store["items"].get(key)
     if value is None:
@@ -235,9 +260,9 @@ def _get_key(arn: str, key: str):
 
 
 def _put_key(arn: str, key: str, headers, body):
-    store = _get_store(arn)
-    if store is None:
-        return _error("ResourceNotFoundException", f"Key value store {arn} was not found.", 404)
+    store, err = _get_store(arn)
+    if err:
+        return err
 
     if_match = headers.get("if-match")
     if not if_match:
@@ -265,9 +290,9 @@ def _put_key(arn: str, key: str, headers, body):
 
 
 def _delete_key(arn: str, key: str, headers):
-    store = _get_store(arn)
-    if store is None:
-        return _error("ResourceNotFoundException", f"Key value store {arn} was not found.", 404)
+    store, err = _get_store(arn)
+    if err:
+        return err
 
     if_match = headers.get("if-match")
     if not if_match:
@@ -290,9 +315,9 @@ def _delete_key(arn: str, key: str, headers):
 
 
 def _update_keys(arn: str, headers, body):
-    store = _get_store(arn)
-    if store is None:
-        return _error("ResourceNotFoundException", f"Key value store {arn} was not found.", 404)
+    store, err = _get_store(arn)
+    if err:
+        return err
 
     if_match = headers.get("if-match")
     if not if_match:

--- a/tests/test_cloudfront_kvs.py
+++ b/tests/test_cloudfront_kvs.py
@@ -1,8 +1,20 @@
 import json
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
 import uuid as _uuid_mod
 
 import pytest
 from botocore.exceptions import ClientError
+
+ENDPOINT = os.environ.get("MINISTACK_ENDPOINT", "http://localhost:4566")
+
+
+def _describe_store_raw(kvs_arn):
+    url = f"{ENDPOINT}/key-value-stores/{urllib.parse.quote(kvs_arn, safe='')}"
+    req = urllib.request.Request(url, method="GET")
+    return urllib.request.urlopen(req, timeout=10)
 
 
 def test_kvs_dataplane_describe(cloudfront, cloudfront_kvs):
@@ -153,6 +165,26 @@ def test_kvs_dataplane_not_found(cloudfront_kvs):
         cloudfront_kvs.describe_key_value_store(KvsARN=fake_arn)
     assert exc.value.response["Error"]["Code"] == "ResourceNotFoundException"
     assert exc.value.response["ResponseMetadata"]["HTTPStatusCode"] == 404
+
+
+def test_kvs_dataplane_rejects_invalid_kvs_arns(cloudfront):
+    name = f"dp-invalid-arn-{_uuid_mod.uuid4().hex[:8]}"
+    create_resp = cloudfront.create_key_value_store(Name=name, Comment="invalid arn test")
+    arn = create_resp["KeyValueStore"]["ARN"]
+    invalid_cases = [
+        "arn:aws:cloudfront::000000000000:distribution/example",
+        arn.replace(":cloudfront:", ":sqs:"),
+        arn.replace(":000000000000:", ":111111111111:"),
+        arn.replace("cloudfront::", "cloudfront:us-east-1:"),
+        f"{arn}/extra",
+    ]
+
+    for bad_arn in invalid_cases:
+        with pytest.raises(urllib.error.HTTPError) as exc:
+            _describe_store_raw(bad_arn)
+        assert exc.value.code == 400
+        body = json.loads(exc.value.read().decode("utf-8"))
+        assert body["__type"] == "ValidationException"
 
 
 def test_kvs_dataplane_list_keys_pagination(cloudfront, cloudfront_kvs):


### PR DESCRIPTION
## Why
CloudFront KeyValueStore data-plane requests carry `KvsARN` through path routing, and the service should validate those ARNs with the shared parser before store lookup.

## What
- Add parser-backed CloudFront KVS ARN validation for data-plane handlers
- Preserve valid KVS data-plane behavior and not-found handling
- Add server-side invalid ARN coverage using raw HTTP for cases botocore rejects before sending

## Validation
- `python3 -m py_compile ministack/services/cloudfront_keyvaluestore.py tests/test_cloudfront_kvs.py`
- `uv run ruff check ministack/services/cloudfront_keyvaluestore.py tests/test_cloudfront_kvs.py`
- `uv run --extra dev pytest tests/test_cloudfront_kvs.py -q` (`10 passed`)