### PR TITLE
feat(eks): inject IMDS endpoint into k3s containers for in-cluster AWS SDKs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to MiniStack will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Versioning follows [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+- **EKS — IMDS endpoint injected into k3s containers so in-cluster AWS SDKs work without the metadata workaround** — the EC2 IMDS link-local address (`169.254.169.254`) is not reachable from inside the nested k3s container (the route is hypervisor-provided on real EC2 and absent in plain Docker networking), so in-cluster controllers such as Karpenter, the AWS Load Balancer Controller, and the EBS CSI driver hung on IMDS and required `AWS_EC2_METADATA_DISABLED=true` + dummy credentials. The k3s container now receives `AWS_EC2_METADATA_SERVICE_ENDPOINT=http://<ministack-host>:<gateway-port>` (and `AWS_REGION` for the cluster's region), pointing those SDKs at MiniStack's IMDS handler on the gateway. `<ministack-host>` is MiniStack's container IP when k3s shares its Docker network, otherwise `host.docker.internal` (now also resolvable on plain Linux Docker via a `host-gateway` mapping). The iptables/DNAT path for SDKs that ignore `AWS_EC2_METADATA_SERVICE_ENDPOINT` is intentionally not implemented — the env var is honoured by AWS SDK for Go v1.27+/v2, boto3, and AWS SDK for Java v2. Contributed by @b-rajesh.
+
+---
+
 ## [1.3.66] — 2026-06-22
 
 ### Added

--- a/ministack/services/eks.py
+++ b/ministack/services/eks.py
@@ -248,6 +248,37 @@ def _get_ministack_network(client):
         return None
 
 
+def _resolve_ministack_host(client, ms_network):
+    """Address k3s containers use to reach the MiniStack gateway (for IMDS).
+
+    In-cluster AWS SDKs (Karpenter, ALB controller, EBS CSI driver) cannot reach
+    the EC2 IMDS link-local address (169.254.169.254) from inside a Docker
+    container, so they are pointed at the gateway via
+    AWS_EC2_METADATA_SERVICE_ENDPOINT instead. This returns the gateway address
+    as seen from inside the k3s container:
+
+    - on a shared Docker network: MiniStack's own container IP on that network
+    - otherwise: ``host.docker.internal`` (provided by Docker Desktop, and on
+      plain Linux via the ``extra_hosts`` host-gateway mapping in
+      ``_k3s_run_kwargs``)
+
+    Docker-based and contextvar-free — safe to call from the background
+    start/restart threads (the caller resolves ``client`` and ``ms_network``).
+    """
+    if ms_network:
+        try:
+            hostname = os.environ.get("HOSTNAME", "")
+            if hostname:
+                self_container = client.containers.get(hostname)
+                networks = self_container.attrs.get("NetworkSettings", {}).get("Networks", {})
+                ip = networks.get(ms_network, {}).get("IPAddress", "")
+                if ip:
+                    return ip
+        except Exception as e:
+            logger.debug("EKS: MiniStack self-IP lookup on network %s failed: %s", ms_network, e)
+    return "host.docker.internal"
+
+
 def _wait_for_port(host, port, timeout=30):
     import socket
     deadline = time.time() + timeout
@@ -305,7 +336,7 @@ def _collect_node_labels(cluster: dict) -> list[str]:
     return [f"--node-label={k}={v}" for k, v in labels.items()]
 
 
-def _k3s_run_kwargs(name: str, port: int, ms_network: str | None = None, oidc_args: list[str] | None = None, node_labels: list[str] | None = None) -> dict:
+def _k3s_run_kwargs(name: str, port: int, ms_network: str | None = None, oidc_args: list[str] | None = None, node_labels: list[str] | None = None, region: str | None = None, ministack_host: str | None = None) -> dict:
     """Build the docker run kwargs for a k3s server container.
 
     `privileged=True` is required: k3s server mode remounts `/sys/fs/cgroup`,
@@ -326,6 +357,16 @@ def _k3s_run_kwargs(name: str, port: int, ms_network: str | None = None, oidc_ar
     if node_labels:
         command.extend(node_labels)
 
+    environment = {"K3S_KUBECONFIG_MODE": "644"}
+    # Point in-cluster AWS SDKs at the MiniStack gateway for IMDS — the EC2
+    # link-local 169.254.169.254 is unreachable from inside a Docker container —
+    # and pin the cluster's region. Both are standard AWS SDK env vars.
+    if ministack_host:
+        gateway_port = os.environ.get("GATEWAY_PORT", "4566")
+        environment["AWS_EC2_METADATA_SERVICE_ENDPOINT"] = f"http://{ministack_host}:{gateway_port}"
+    if region:
+        environment["AWS_REGION"] = region
+
     run_kwargs = dict(
         image=apply_image_prefix(EKS_K3S_IMAGE),
         command=command,
@@ -344,7 +385,8 @@ def _k3s_run_kwargs(name: str, port: int, ms_network: str | None = None, oidc_ar
         ports={"6443/tcp": port},
         name=f"ministack-eks-{name}",
         labels={"ministack": "eks", "cluster_name": name},
-        environment={"K3S_KUBECONFIG_MODE": "644"},
+        environment=environment,
+        extra_hosts={"host.docker.internal": "host-gateway"},
         volumes={"/lib/modules": {"bind": "/lib/modules", "mode": "ro"}},
         tmpfs={"/run": "", "/var/run": "", "/tmp": ""},
     )
@@ -451,6 +493,7 @@ def _create_cluster(body):
 
     oidc_args, _idp_cfg_refs = _collect_oidc_state(name)
     node_labels = _collect_node_labels(cluster)
+    region = get_region()  # request context; the bg thread has no contextvars
 
     def _bg_start():
         client = _get_docker()
@@ -460,7 +503,8 @@ def _create_cluster(body):
             return
         try:
             ms_network = _get_ministack_network(client)
-            run_kwargs = _k3s_run_kwargs(name=name, port=port, ms_network=ms_network, oidc_args=oidc_args, node_labels=node_labels)
+            ministack_host = _resolve_ministack_host(client, ms_network)
+            run_kwargs = _k3s_run_kwargs(name=name, port=port, ms_network=ms_network, oidc_args=oidc_args, node_labels=node_labels, region=region, ministack_host=ministack_host)
 
 
             container = client.containers.run(**run_kwargs)
@@ -947,6 +991,7 @@ def _restart_k3s(cluster_name, oidc_args=None, idp_cfg_refs=None):
     oidc_args = oidc_args or []
     idp_cfg_refs = idp_cfg_refs or []
     node_labels = _collect_node_labels(cluster)
+    region = get_region()  # request context; the bg thread has no contextvars
 
     def _mark_idp_active():
         for cfg in idp_cfg_refs:
@@ -966,7 +1011,8 @@ def _restart_k3s(cluster_name, oidc_args=None, idp_cfg_refs=None):
                 cluster["_docker_id"] = None
 
             ms_network = _get_ministack_network(client)
-            run_kwargs = _k3s_run_kwargs(name=cluster_name, port=port, ms_network=ms_network, oidc_args=oidc_args, node_labels=node_labels)
+            ministack_host = _resolve_ministack_host(client, ms_network)
+            run_kwargs = _k3s_run_kwargs(name=cluster_name, port=port, ms_network=ms_network, oidc_args=oidc_args, node_labels=node_labels, region=region, ministack_host=ministack_host)
 
             container = client.containers.run(**run_kwargs)
             cluster["_docker_id"] = container.id

--- a/tests/test_eks.py
+++ b/tests/test_eks.py
@@ -872,3 +872,71 @@ def test_eks_k3s_run_kwargs_appends_node_labels():
     # Existing server flags must still be present — refactor must not regress them.
     assert "server" in run_kwargs["command"]
     assert "--https-listen-port=6443" in run_kwargs["command"]
+
+
+# ---------------------------------------------------------------------------
+# IMDS endpoint injection (in-cluster AWS SDKs reach the MiniStack gateway)
+# ---------------------------------------------------------------------------
+
+class _FakeSelfContainer:
+    def __init__(self, ip, network):
+        self.attrs = {"NetworkSettings": {"Networks": {network: {"IPAddress": ip}}}}
+
+
+class _FakeClientByName:
+    def __init__(self, self_container):
+        self._self = self_container
+
+    class _Containers:
+        def __init__(self, self_container):
+            self._self = self_container
+
+        def get(self, _name):
+            return self._self
+
+    @property
+    def containers(self):
+        return self._Containers(self._self)
+
+
+def test_eks_k3s_run_kwargs_injects_aws_metadata_env(monkeypatch):
+    """region + ministack_host produce the IMDS-redirect env so in-cluster AWS SDKs
+    hit the MiniStack gateway instead of the unreachable 169.254.169.254."""
+    from ministack.services.eks import _k3s_run_kwargs
+
+    monkeypatch.setenv("GATEWAY_PORT", "4566")
+    kw = _k3s_run_kwargs(name="t", port=16443, region="us-west-2", ministack_host="10.0.0.5")
+    env = kw["environment"]
+    assert env["AWS_EC2_METADATA_SERVICE_ENDPOINT"] == "http://10.0.0.5:4566"
+    assert env["AWS_REGION"] == "us-west-2"
+    assert env["K3S_KUBECONFIG_MODE"] == "644"  # existing env must be preserved
+    # host.docker.internal must resolve on plain Linux Docker too.
+    assert kw["extra_hosts"] == {"host.docker.internal": "host-gateway"}
+
+
+def test_eks_k3s_run_kwargs_omits_aws_env_when_unresolved():
+    """Without region/ministack_host (e.g. Docker unavailable) no AWS_* env is set —
+    back-compat with callers that do not pass them."""
+    from ministack.services.eks import _k3s_run_kwargs
+
+    env = _k3s_run_kwargs(name="t", port=16443)["environment"]
+    assert "AWS_EC2_METADATA_SERVICE_ENDPOINT" not in env
+    assert "AWS_REGION" not in env
+    assert env["K3S_KUBECONFIG_MODE"] == "644"
+
+
+def test_eks_resolve_ministack_host_uses_container_ip(monkeypatch):
+    """On a shared Docker network, k3s must reach MiniStack at its own container IP
+    on that network (so IMDS is reachable from inside the cluster)."""
+    from ministack.services import eks as eks_mod
+
+    monkeypatch.setenv("HOSTNAME", "ministack-abc123")
+    client = _FakeClientByName(_FakeSelfContainer("172.20.0.4", "shared-net"))
+    assert eks_mod._resolve_ministack_host(client, "shared-net") == "172.20.0.4"
+
+
+def test_eks_resolve_ministack_host_falls_back_to_host_docker_internal():
+    """No shared network → host.docker.internal (Docker Desktop / host-gateway)."""
+    from ministack.services import eks as eks_mod
+
+    assert eks_mod._resolve_ministack_host(client=None, ms_network=None) == "host.docker.internal"


### PR DESCRIPTION
In-cluster AWS SDKs (Karpenter, AWS Load Balancer Controller, EBS CSI driver) now reach MiniStack's IMDS handler on the gateway instead of the unreachable EC2 link-local `169.254.169.254` — eliminating the
  `AWS_EC2_METADATA_DISABLED=true` + dummy-credentials workaround.
  
  ## Problem
  
  The IMDS link-local address `169.254.169.254` is hypervisor-provided on real EC2 and absent in plain Docker networking, so an AWS SDK running inside the nested k3s container hangs on IMDS and eventually fails. The documented workaround
  was to disable IMDS and supply dummy creds + region.

  ## Changes
  
  - The k3s container now receives `AWS_EC2_METADATA_SERVICE_ENDPOINT=http://<host>:<gateway-port>` (and `AWS_REGION` for the cluster's region) so in-cluster SDKs hit MiniStack's IMDS handler directly.
  - `<host>` is MiniStack's own container IP when k3s shares its Docker network, otherwise `host.docker.internal` — now also resolvable on plain Linux Docker via an `extra_hosts` `host-gateway` mapping.
  - `region` is resolved at the request boundary and passed into the background start/restart threads; the new `_resolve_ministack_host` helper is docker-based and contextvar-free, so the threads never read request-scoped state.

  ## Tests
  
  4 new deterministic tests (no Docker / no boto3): env injected, env omitted when unresolved (back-compat), host → container IP on shared network, host → `host.docker.internal` fallback. `ruff` clean; `pytest tests/test_eks.py` green
  (parallel + serial).

  ## Notes

  `AWS_EC2_METADATA_SERVICE_ENDPOINT` + `AWS_REGION` are standard AWS SDK env vars, not MiniStack-specific knobs. The iptables/DNAT path (for SDKs that ignore the env var) is intentionally not implemented — AWS SDK for Go v1.27+/v2, boto3,
  and AWS SDK for Java v2 all honour it.

  Note: independent of #966 (both branch off main) — if both merge, a trivial rebase in _bg_start/_bg_restart.