### PR TITLE
fix(stepfunctions): unwrap Payload for lambda:invoke.waitForTaskToken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,6 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 - **API Gateway v1 — literal path segments resolve ahead of a `{param}` sibling regardless of creation order** — a literal path (e.g. `/users/verifyUserEmail`) returned 405 when a `{id}` sibling under the same parent was registered first, because resolution followed resource-creation order instead of AWS specificity. Resolution now orders literal > `{param}` > `{proxy+}`. Reported by @ethan-dyas438.
 - **RDS Data API — `:name` placeholders are substituted by whole token** — the earlier substring replacement could corrupt an unrelated longer token (a `:id` parameter ate into a literal `:identity`) and was fragile around `::type` casts. Substitution is now a single token-aware pass, keeping `:1`/`:10` distinct, leaving `::jsonb` casts intact, and passing through any `:word` that is not a supplied parameter. Reported by @awilson9.
 
-### Fixed
-- **Step Functions — `lambda:invoke.waitForTaskToken` now delivers the unwrapped `Payload` to the handler** — the callback path forwarded the whole service-integration envelope (`{"FunctionName": ..., "Payload": {...}}`) to the Lambda instead of just the `Payload`, mirroring the synchronous `lambda:invoke` path. Handlers reading their task token / input from the top level (the standard `.waitForTaskToken` pattern) saw them nested under `Payload`, never resumed the task, and the execution hung until timeout.
-
 ---
 
 ## [1.3.66] — 2026-06-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 ### Added
 - **CloudFormation / API Gateway — `AWS::ApiGateway::RestApi` partially supports the OpenAPI `Body` property** — This implementation is very incomplete. See #928.
 
+### Fixed
+- **Step Functions — `lambda:invoke.waitForTaskToken` now delivers the unwrapped `Payload` to the handler** — the callback path forwarded the whole service-integration envelope (`{"FunctionName": ..., "Payload": {...}}`) to the Lambda instead of just the `Payload`, mirroring the synchronous `lambda:invoke` path. Handlers reading their task token / input from the top level (the standard `.waitForTaskToken` pattern) saw them nested under `Payload`, never resumed the task, and the execution hung until timeout.
+
 ---
 
 ## [1.3.66] — 2026-06-22

--- a/ministack/services/stepfunctions.py
+++ b/ministack/services/stepfunctions.py
@@ -1566,8 +1566,16 @@ def _invoke_with_callback(resource, input_data, token, state_def):
             func_name = func_name.split(":function:")[-1].split(":")[0]
 
     if func_name:
+        # For lambda:invoke[.waitForTaskToken] the resolved Parameters wrap the
+        # Lambda event under "Payload" (alongside "FunctionName"). Deliver only
+        # the Payload, mirroring the synchronous lambda:invoke path
+        # (_invoke_resource). Otherwise the handler receives the integration
+        # envelope ({"FunctionName": ..., "Payload": {...}}) instead of its
+        # input and fails to find the task token / its arguments.
+        lambda_payload = input_data.get("Payload", input_data) \
+            if isinstance(input_data, dict) else input_data
         try:
-            _call_lambda(func_name, input_data)
+            _call_lambda(func_name, lambda_payload)
         except _ExecutionError:
             pass
     else:

--- a/tests/test_stepfunctions.py
+++ b/tests/test_stepfunctions.py
@@ -1581,6 +1581,82 @@ def test_sfn_integration_sqs_send_message_wait_for_task_token(sfn, sqs):
     desc = _wait_sfn(sfn, ex["executionArn"])
     assert desc["status"] == "SUCCEEDED"
 
+def test_sfn_integration_lambda_invoke_wait_for_task_token(sfn, lam):
+    """lambda:invoke.waitForTaskToken must deliver the *unwrapped* Payload to
+    the handler, exactly like the synchronous lambda:invoke path.
+
+    Regression: the callback path forwarded the whole service-integration
+    envelope ({"FunctionName": ..., "Payload": {...}}) to the Lambda, so a
+    handler reading top-level keys (e.g. ``event["taskToken"]`` /
+    ``event["input"]``) saw them nested under ``Payload`` and could neither
+    find its task token nor its arguments, hanging the execution forever.
+    """
+    import uuid as _uuid
+
+    fn = f"intg-sfn-wfett-{_uuid.uuid4().hex[:8]}"
+    # The handler reads the token + input from the TOP LEVEL (as AWS delivers
+    # them) and completes the task itself, echoing back what it received.
+    code = (
+        "import json, os, boto3\n"
+        "def handler(event, context):\n"
+        "    token = event['taskToken']\n"
+        "    sfn = boto3.client('stepfunctions', endpoint_url=os.environ['AWS_ENDPOINT_URL'])\n"
+        "    sfn.send_task_success(\n"
+        "        taskToken=token,\n"
+        "        output=json.dumps({'top_keys': sorted(event.keys()), 'echo_input': event['input']}),\n"
+        "    )\n"
+        "    return {}\n"
+    )
+    lam.create_function(
+        FunctionName=fn,
+        Runtime="python3.12",
+        Role=_LAMBDA_ROLE,
+        Handler="index.handler",
+        Code={"ZipFile": _make_zip(code)},
+    )
+    func_arn = f"arn:aws:lambda:us-east-1:000000000000:function:{fn}"
+
+    definition = json.dumps(
+        {
+            "StartAt": "CallbackTask",
+            "States": {
+                "CallbackTask": {
+                    "Type": "Task",
+                    "Resource": "arn:aws:states:::lambda:invoke.waitForTaskToken",
+                    "Parameters": {
+                        "FunctionName": func_arn,
+                        "Payload": {
+                            "taskToken.$": "$$.Task.Token",
+                            "id.$": "$$.Execution.Name",
+                            "input.$": "$",
+                        },
+                    },
+                    "TimeoutSeconds": 30,
+                    "End": True,
+                },
+            },
+        }
+    )
+    sm = sfn.create_state_machine(
+        name=f"sfn-wfett-{_uuid.uuid4().hex[:8]}",
+        definition=definition,
+        roleArn="arn:aws:iam::000000000000:role/R",
+    )
+    ex = sfn.start_execution(
+        stateMachineArn=sm["stateMachineArn"],
+        input=json.dumps({"hello": "world"}),
+    )
+    desc = _wait_sfn(sfn, ex["executionArn"], timeout=30)
+    assert desc["status"] == "SUCCEEDED", (
+        f"execution did not succeed ({desc['status']}); the handler could not "
+        f"read its top-level taskToken/input — Payload was not unwrapped"
+    )
+    output = json.loads(desc["output"])
+    # The handler must have seen the unwrapped Payload: top-level taskToken/id/
+    # input, and NOT the service-integration wrapper keys.
+    assert output["top_keys"] == ["id", "input", "taskToken"], output["top_keys"]
+    assert output["echo_input"] == {"hello": "world"}
+
 def test_sfn_integration_sns_publish(sfn, sns):
     """Task state publishes to SNS via arn:aws:states:::sns:publish."""
     topic = sns.create_topic(Name="sfn-integ-sns-test")


### PR DESCRIPTION
## Problem

A Step Functions Task using `arn:aws:states:::lambda:invoke.waitForTaskToken` forwards the **whole service-integration envelope** to the Lambda:

```json
{ "FunctionName": "...", "Payload": { "taskToken": "...", "id": "...", "input": { ... } } }
```

instead of the unwrapped `Payload`. The synchronous `lambda:invoke` path (`_invoke_resource`) already unwraps it (`input_data.get("Payload", input_data)`), but the callback path (`_invoke_with_callback`) passed `input_data` straight through.

Handlers following the standard `.waitForTaskToken` pattern read their task token and input from the **top level** of the event (e.g. `event["taskToken"]`, `event["input"]`). With the envelope delivered instead, those keys are nested under `Payload`, so the handler never calls `SendTaskSuccess`/`SendTaskFailure` and the execution hangs until the task times out.

This surfaced migrating a CDK app (Lambda `waitForTaskToken` with `Payload: { taskToken.$: "$$.Task.Token", input.$: "$" }`) from LocalStack to MiniStack — the handler crashed destructuring `input` (undefined) and the workflow never progressed.

## Fix

Unwrap `Payload` before invoking the Lambda in `_invoke_with_callback`, mirroring `_invoke_resource`. Non-Lambda callback integrations (sqs/sns/aws-sdk) are unchanged — they still receive the resolved parameters as before.

## Test

Adds `test_sfn_integration_lambda_invoke_wait_for_task_token`: drives a `lambda:invoke.waitForTaskToken` task whose handler reads the **top-level** `taskToken`/`input` and completes the token via `SendTaskSuccess`, echoing back the keys it received. It asserts the execution succeeds and the handler saw `["id", "input", "taskToken"]` (not the `FunctionName`/`Payload` wrapper).

- On `main` (before the fix) the handler can't find its top-level token, never resumes, and the test fails (execution stays `RUNNING`).
- With the fix it passes in ~1s.

## Checklist
- [x] Tests added and passing (`pytest tests/ -v -k wait_for_task_token`)
- [x] Linting passes (`ruff check ministack/`)
- [x] Entry added to `CHANGELOG.md`

(New-service checklist items don't apply — this is a bug fix to an existing service.
EOF
)