### PR TITLE
Validate Bedrock tag ARNs

### DIFF
--- a/ministack/services/bedrock.py
+++ b/ministack/services/bedrock.py
@@ -35,6 +35,7 @@ import uuid
 from datetime import datetime, timezone
 from urllib.parse import unquote
 
+from ministack.core.arn import ArnParseError, parse_arn
 from ministack.core.persistence import load_state
 from ministack.core.responses import (
     AccountRegionScopedDict,
@@ -171,6 +172,71 @@ def _now_iso() -> str:
 def _arn(resource_type: str, resource_path: str) -> str:
     return (f"arn:aws:bedrock:{get_region()}:{get_account_id()}:"
             f"{resource_type}/{resource_path}")
+
+
+def _validate_resource_arn_for_tags(arn: str) -> tuple | None:
+    try:
+        spec = parse_arn(arn)
+    except ArnParseError:
+        return _validation(f"Invalid resourceARN: {arn}")
+    if spec.service != "bedrock":
+        return _validation(f"Invalid resourceARN: {arn}")
+    if spec.account_id != get_account_id():
+        return _not_found(f"Resource {arn} not found.")
+    if spec.region != get_region():
+        return _not_found(f"Resource {arn} not found.")
+
+    parts = spec.resource.split("/")
+    if len(parts) != 2 or not parts[0] or not parts[1]:
+        return _validation(f"Invalid resourceARN: {arn}")
+
+    resource_type, resource_id = parts
+    if resource_type == "application-inference-profile":
+        profile_id = resource_id
+        rec = _inference_profiles_apps.get(profile_id)
+        if rec and rec.get("InferenceProfileArn") == arn:
+            return None
+    elif resource_type == "guardrail":
+        guardrail_id = resource_id
+        rec = _guardrails.get(guardrail_id)
+        if rec and rec.get("GuardrailArn") == arn:
+            return None
+    elif resource_type == "custom-model":
+        if arn in _custom_models:
+            return None
+    elif resource_type == "imported-model":
+        if arn in _imported_models:
+            return None
+    elif resource_type == "provisioned-model":
+        provisioned_id = resource_id
+        rec = _provisioned_throughputs.get(provisioned_id)
+        if rec and rec.get("ProvisionedModelArn") == arn:
+            return None
+    elif resource_type == "model-customization-job":
+        if arn in _model_customization_jobs:
+            return None
+    elif resource_type == "model-import-job":
+        if arn in _model_import_jobs:
+            return None
+    elif resource_type == "model-copy-job":
+        if arn in _model_copy_jobs:
+            return None
+    elif resource_type == "model-invocation-job":
+        if arn in _model_invocation_jobs:
+            return None
+    elif resource_type == "evaluation-job":
+        if arn in _evaluation_jobs:
+            return None
+    elif resource_type == "marketplace-model-endpoint":
+        if arn in _marketplace_endpoints:
+            return None
+    elif resource_type == "prompt-router":
+        if arn in _prompt_routers:
+            return None
+    else:
+        return _validation(f"Invalid resourceARN: {arn}")
+
+    return _not_found(f"Resource {arn} not found.")
 
 
 def _parse_body(body) -> tuple:
@@ -374,8 +440,9 @@ def _delete_foundation_model_agreement(body) -> tuple:
 # ===========================================================================
 
 
-def _inference_profile_arn(profile_id: str) -> str:
-    return _arn("inference-profile", profile_id)
+def _inference_profile_arn(profile_id: str, *, application: bool = False) -> str:
+    resource_type = "application-inference-profile" if application else "inference-profile"
+    return _arn(resource_type, profile_id)
 
 
 def _list_inference_profiles(query_params) -> tuple:
@@ -439,7 +506,7 @@ def _create_inference_profile(body) -> tuple:
     rec = {
         "InferenceProfileName": name,
         "InferenceProfileId": pid,
-        "InferenceProfileArn": _inference_profile_arn(pid),
+        "InferenceProfileArn": _inference_profile_arn(pid, application=True),
         "Models": [{"ModelArn": models}],
         "Status": "ACTIVE",
         "Type": "APPLICATION",
@@ -1264,6 +1331,9 @@ def _tag_resource(body) -> tuple:
     tags = body_obj.get("tags", [])
     if not arn:
         return _validation("resourceARN is required.")
+    validation_error = _validate_resource_arn_for_tags(arn)
+    if validation_error:
+        return validation_error
     if not isinstance(tags, list):
         return _validation("tags must be an array.")
     current = dict(_tags.get(arn, {}))
@@ -1284,6 +1354,9 @@ def _untag_resource(body) -> tuple:
     keys = body_obj.get("tagKeys", [])
     if not arn:
         return _validation("resourceARN is required.")
+    validation_error = _validate_resource_arn_for_tags(arn)
+    if validation_error:
+        return validation_error
     current = dict(_tags.get(arn, {}))
     for k in keys:
         current.pop(k, None)
@@ -1298,6 +1371,9 @@ def _list_tags_for_resource(body) -> tuple:
     arn = body_obj.get("resourceARN")
     if not arn:
         return _validation("resourceARN is required.")
+    validation_error = _validate_resource_arn_for_tags(arn)
+    if validation_error:
+        return validation_error
     tags = [{"Key": k, "Value": v} for k, v in _tags.get(arn, {}).items()]
     return _json({"Tags": tags})
 

--- a/tests/test_bedrock_control_plane.py
+++ b/tests/test_bedrock_control_plane.py
@@ -487,3 +487,91 @@ def test_bedrock_tag_list_untag_resource():
     keys2 = {t["key"] for t in resp2["tags"]}
     assert "env" not in keys2
     assert "team" in keys2
+
+
+def test_bedrock_tag_resource_rejects_malformed_arn():
+    try:
+        _bedrock().tag_resource(
+            resourceARN="not-an-arn-but-long-enough",
+            tags=[{"key": "team", "value": "ml"}],
+        )
+    except botocore.exceptions.ClientError as exc:
+        assert exc.response["Error"]["Code"] == "ValidationException"
+    else:
+        raise AssertionError("expected ValidationException")
+
+
+def test_bedrock_tag_resource_rejects_wrong_scope_arn():
+    gr = _bedrock().create_guardrail(
+        name="gr-tag-scope", blockedInputMessaging="x", blockedOutputsMessaging="y",
+    )
+    wrong_region = gr["guardrailArn"].replace(":us-east-1:", ":us-west-2:")
+    try:
+        _bedrock().tag_resource(
+            resourceARN=wrong_region,
+            tags=[{"key": "team", "value": "ml"}],
+        )
+    except botocore.exceptions.ClientError as exc:
+        assert exc.response["Error"]["Code"] == "ResourceNotFoundException"
+    else:
+        raise AssertionError("expected ResourceNotFoundException")
+
+
+def test_bedrock_tag_resource_rejects_noncanonical_partition_arn():
+    gr = _bedrock().create_guardrail(
+        name="gr-tag-partition", blockedInputMessaging="x", blockedOutputsMessaging="y",
+    )
+    wrong_partition = gr["guardrailArn"].replace("arn:aws:", "arn:aws-cn:", 1)
+    try:
+        _bedrock().tag_resource(
+            resourceARN=wrong_partition,
+            tags=[{"key": "team", "value": "ml"}],
+        )
+    except botocore.exceptions.ClientError as exc:
+        assert exc.response["Error"]["Code"] == "ResourceNotFoundException"
+    else:
+        raise AssertionError("expected ResourceNotFoundException")
+
+
+def test_bedrock_tag_resource_rejects_wrong_service_arn():
+    gr = _bedrock().create_guardrail(
+        name="gr-tag-service", blockedInputMessaging="x", blockedOutputsMessaging="y",
+    )
+    wrong_service = gr["guardrailArn"].replace(":bedrock:", ":lambda:")
+    try:
+        _bedrock().tag_resource(
+            resourceARN=wrong_service,
+            tags=[{"key": "team", "value": "ml"}],
+        )
+    except botocore.exceptions.ClientError as exc:
+        assert exc.response["Error"]["Code"] == "ValidationException"
+    else:
+        raise AssertionError("expected ValidationException")
+
+
+def test_bedrock_tag_resource_accepts_application_inference_profile_arn():
+    create = _bedrock().create_inference_profile(
+        inferenceProfileName="aip-tag",
+        modelSource={
+            "copyFrom": "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-haiku-20240307-v1:0"
+        },
+    )
+    arn = create["inferenceProfileArn"]
+    assert ":application-inference-profile/" in arn
+
+    _bedrock().tag_resource(
+        resourceARN=arn,
+        tags=[{"key": "team", "value": "ml"}],
+    )
+    resp = _bedrock().list_tags_for_resource(resourceARN=arn)
+    assert {"key": "team", "value": "ml"} in resp["tags"]
+
+
+def test_bedrock_list_tags_rejects_unknown_resource_arn():
+    arn = "arn:aws:bedrock:us-east-1:000000000000:guardrail/gr-missing"
+    try:
+        _bedrock().list_tags_for_resource(resourceARN=arn)
+    except botocore.exceptions.ClientError as exc:
+        assert exc.response["Error"]["Code"] == "ResourceNotFoundException"
+    else:
+        raise AssertionError("expected ResourceNotFoundException")


### PR DESCRIPTION
## Why
Continue ARN parser adoption by making Bedrock tag APIs validate resource ARNs instead of accepting arbitrary strings.

## What
- Validate Bedrock tag/list/untag `resourceARN` values with the shared ARN parser
- Enforce account, region, service, resource shape, existence, and canonical stored ARN checks
- Support application inference profile tag ARNs and add regression coverage for invalid ARN cases

## Validation
- `uv run --extra dev ruff check ministack/services/bedrock.py tests/test_bedrock_control_plane.py`
- `uv run --extra dev pytest tests/test_bedrock_control_plane.py -q` with local MiniStack server (`36 passed`)
