### PR TITLE
Validate Bedrock Agent Runtime tag ARNs

### DIFF
--- a/ministack/core/router.py
+++ b/ministack/core/router.py
@@ -10,6 +10,9 @@ Routes incoming requests to the correct service handler based on:
 import logging
 import os
 import re
+from urllib.parse import unquote
+
+from ministack.core.arn import ArnParseError, parse_arn
 
 logger = logging.getLogger("ministack")
 
@@ -477,13 +480,33 @@ def detect_service(method: str, path: str, headers: dict, query_params: dict) ->
                     or (method == "POST" and re.match(r"^/flows/[^/]+/aliases/[^/]+$", path))
                     or re.match(r"^/knowledgebases/[^/]+/retrieve$", path)):
                     return "bedrock-agent-runtime"
+                if path.startswith("/tags/"):
+                    decoded_path = unquote(path)
+                    tag_arn = decoded_path.removeprefix("/tags/")
+                    try:
+                        tag_spec = parse_arn(tag_arn)
+                    except ArnParseError:
+                        return "bedrock-agent-runtime"
+                    if tag_spec.service != "bedrock":
+                        return "bedrock-agent-runtime"
+                    if (":session/" in decoded_path
+                        or tag_spec.resource == "session"
+                        or tag_spec.resource.startswith("session/")
+                        or tag_spec.resource.startswith("session:")
+                        or (":flow/" in decoded_path
+                            and "/aliases/" in decoded_path
+                            and "/executions/" in decoded_path)
+                        or (tag_spec.resource.startswith("flow/")
+                            and "/aliases/" in tag_spec.resource
+                            and "/executions/" in tag_spec.resource)):
+                        return "bedrock-agent-runtime"
+                    return "bedrock-agent"
                 # bedrock-agent control-plane paths
                 if (path.startswith("/agents/")
                     or path.startswith("/agents")
                     or path.startswith("/knowledgebases")
                     or path.startswith("/flows")
-                    or path.startswith("/prompts")
-                    or path.startswith("/tags/")):
+                    or path.startswith("/prompts")):
                     return "bedrock-agent"
                 # bedrock-runtime data plane paths
                 if (path.startswith("/model/")

--- a/ministack/services/bedrock_agent_runtime.py
+++ b/ministack/services/bedrock_agent_runtime.py
@@ -33,6 +33,7 @@ import zlib
 from datetime import datetime, timezone
 from urllib.parse import unquote
 
+from ministack.core.arn import ArnParseError, parse_arn
 from ministack.core.persistence import load_state
 from ministack.core.responses import (
     AccountRegionScopedDict,
@@ -104,6 +105,29 @@ def _now_iso() -> str:
 
 def _arn(rt: str, path: str) -> str:
     return f"arn:aws:bedrock:{get_region()}:{get_account_id()}:{rt}/{path}"
+
+
+def _validate_tag_resource_arn(arn: str) -> tuple | None:
+    try:
+        spec = parse_arn(arn)
+    except ArnParseError:
+        return _validation(f"Invalid resourceArn: {arn}")
+    if spec.service != "bedrock":
+        return _validation(f"Invalid resourceArn: {arn}")
+    if spec.account_id != get_account_id() or spec.region != get_region():
+        return _not_found(f"Resource {arn} not found.")
+
+    resource = spec.resource
+    parts = resource.split("/")
+    if len(parts) == 2 and parts[0] == "session" and parts[1]:
+        session_id = parts[1]
+        rec = _sessions.get(session_id)
+        if rec and rec.get("SessionArn") == arn:
+            return None
+    else:
+        return _validation(f"Invalid resourceArn: {arn}")
+
+    return _not_found(f"Resource {arn} not found.")
 
 
 def _parse_body(body) -> tuple:
@@ -608,6 +632,9 @@ def _stop_flow_execution(flow_id: str, alias_id: str, exec_id: str) -> tuple:
 
 
 def _tag_resource(arn: str, body) -> tuple:
+    validation_error = _validate_tag_resource_arn(arn)
+    if validation_error:
+        return validation_error
     body_obj, err = _parse_body(body)
     if err:
         return err
@@ -619,6 +646,9 @@ def _tag_resource(arn: str, body) -> tuple:
 
 
 def _untag_resource(arn: str, query_params) -> tuple:
+    validation_error = _validate_tag_resource_arn(arn)
+    if validation_error:
+        return validation_error
     keys = query_params.get("tagKeys", []) if isinstance(query_params, dict) else []
     if isinstance(keys, str):
         keys = [keys]
@@ -630,6 +660,9 @@ def _untag_resource(arn: str, query_params) -> tuple:
 
 
 def _list_tags(arn: str) -> tuple:
+    validation_error = _validate_tag_resource_arn(arn)
+    if validation_error:
+        return validation_error
     return 200, {"Content-Type": "application/json"}, json.dumps({
         "tags": dict(_tags.get(arn, {})),
     }).encode()

--- a/tests/test_bedrock_agent_runtime.py
+++ b/tests/test_bedrock_agent_runtime.py
@@ -21,7 +21,7 @@ def _ar():
 
 def test_bedrock_ar_retrieve_returns_results_envelope():
     resp = _ar().retrieve(
-        knowledgeBaseId="kb-test",
+        knowledgeBaseId="KBTEST1234",
         retrievalQuery={"text": "what is AWS?"},
     )
     assert "retrievalResults" in resp
@@ -288,3 +288,79 @@ def test_bedrock_ar_tag_resource():
     _ar().untag_resource(resourceArn=arn, tagKeys=["env"])
     lst2 = _ar().list_tags_for_resource(resourceArn=arn)
     assert "env" not in lst2["tags"]
+
+
+def test_bedrock_ar_tag_resource_rejects_malformed_arn():
+    try:
+        _ar().tag_resource(resourceArn="not-an-arn-but-long-enough", tags={"env": "prod"})
+    except botocore.exceptions.ClientError as exc:
+        assert exc.response["Error"]["Code"] == "ValidationException"
+    else:
+        raise AssertionError("expected ValidationException")
+
+
+def test_bedrock_ar_tag_resource_rejects_malformed_session_arn():
+    arn = "arn:aws:bedrock:us-east-1:000000000000:session"
+    try:
+        _ar().tag_resource(resourceArn=arn, tags={"env": "prod"})
+    except botocore.exceptions.ClientError as exc:
+        assert exc.response["Error"]["Code"] == "ValidationException"
+    else:
+        raise AssertionError("expected ValidationException")
+
+
+def test_bedrock_ar_tag_resource_rejects_wrong_scope_arn():
+    session = _ar().create_session()
+    wrong_region = session["sessionArn"].replace(":us-east-1:", ":us-west-2:")
+    try:
+        _ar().tag_resource(resourceArn=wrong_region, tags={"env": "prod"})
+    except botocore.exceptions.ClientError as exc:
+        assert exc.response["Error"]["Code"] == "ResourceNotFoundException"
+    else:
+        raise AssertionError("expected ResourceNotFoundException")
+
+
+def test_bedrock_ar_tag_resource_rejects_noncanonical_partition_arn():
+    session = _ar().create_session()
+    wrong_partition = session["sessionArn"].replace("arn:aws:", "arn:aws-cn:", 1)
+    try:
+        _ar().tag_resource(resourceArn=wrong_partition, tags={"env": "prod"})
+    except botocore.exceptions.ClientError as exc:
+        assert exc.response["Error"]["Code"] == "ResourceNotFoundException"
+    else:
+        raise AssertionError("expected ResourceNotFoundException")
+
+
+def test_bedrock_ar_tag_resource_rejects_wrong_service_arn():
+    session = _ar().create_session()
+    wrong_service = session["sessionArn"].replace(":bedrock:", ":lambda:")
+    try:
+        _ar().tag_resource(resourceArn=wrong_service, tags={"env": "prod"})
+    except botocore.exceptions.ClientError as exc:
+        assert exc.response["Error"]["Code"] == "ValidationException"
+    else:
+        raise AssertionError("expected ValidationException")
+
+
+def test_bedrock_ar_tag_resource_rejects_flow_execution_arn():
+    execution = _ar().start_flow_execution(
+        flowIdentifier="FLTAG",
+        flowAliasIdentifier="FATAG",
+        inputs=[{"content": {"document": "input"}, "nodeName": "InputNode", "nodeOutputName": "document"}],
+    )
+    try:
+        _ar().tag_resource(resourceArn=execution["executionArn"], tags={"env": "prod"})
+    except botocore.exceptions.ClientError as exc:
+        assert exc.response["Error"]["Code"] == "ValidationException"
+    else:
+        raise AssertionError("expected ValidationException")
+
+
+def test_bedrock_ar_list_tags_rejects_unknown_resource_arn():
+    arn = "arn:aws:bedrock:us-east-1:000000000000:session/SESSIONMISSING"
+    try:
+        _ar().list_tags_for_resource(resourceArn=arn)
+    except botocore.exceptions.ClientError as exc:
+        assert exc.response["Error"]["Code"] == "ResourceNotFoundException"
+    else:
+        raise AssertionError("expected ResourceNotFoundException")


### PR DESCRIPTION
## Why
Continue ARN parser adoption by making Bedrock Agent Runtime tag APIs validate session ARNs consistently on the shared localhost endpoint.

## What
- Validate Bedrock Agent Runtime tag/list/untag `resourceArn` values with the shared ARN parser
- Route ambiguous shared-endpoint tag requests to the runtime validator when needed
- Reject malformed, wrong-service, wrong-scope, unknown, and non-session runtime tag ARNs

## Validation
- `uv run --extra dev ruff check ministack/core/router.py ministack/services/bedrock_agent_runtime.py tests/test_bedrock_agent_runtime.py`
- `uv run --extra dev pytest tests/test_bedrock_agent_runtime.py -q` with local MiniStack server (`23 passed`)
