### PR TITLE
feat(eks/lambda): instance-scoped container cleanup for concurrent MiniStack instances

### DIFF
--- a/ministack/app.py
+++ b/ministack/app.py
@@ -1844,10 +1844,16 @@ def _stop_docker_containers():
         client = docker.from_env()
     except Exception:
         return
+    # Instance-scoped cleanup: when MINISTACK_INSTANCE_ID is set, only reap
+    # containers spawned by THIS instance (tagged ministack_instance=<id>), so
+    # multiple MiniStack instances can share one Docker host without evicting
+    # each other's k3s/RDS/etc. at boot. Unset → original global behaviour.
+    _instance = os.environ.get("MINISTACK_INSTANCE_ID")
     for label in ("ministack=rds", "ministack=ecs", "ministack=elasticache", "ministack=eks", "ministack=lambda"):
         try:
+            _flt = [label] + ([f"ministack_instance={_instance}"] if _instance else [])
             # all=True so exited-but-not-removed orphans get cleaned at boot.
-            for c in client.containers.list(all=True, filters={"label": label}):
+            for c in client.containers.list(all=True, filters={"label": _flt}):
                 try:
                     c.stop(timeout=5)
                     c.remove(v=True)

--- a/ministack/services/eks.py
+++ b/ministack/services/eks.py
@@ -233,6 +233,14 @@ def _get_docker():
         return None
 
 
+def _instance_labels():
+    """Per-instance label for spawned containers so concurrent MiniStack
+    instances don't reap each other's containers at boot (see
+    MINISTACK_INSTANCE_ID and _stop_all_k3s). Empty when the env is unset."""
+    iid = os.environ.get("MINISTACK_INSTANCE_ID")
+    return {"ministack_instance": iid} if iid else {}
+
+
 def _get_ministack_network(client):
     """Detect the Docker network MiniStack is running on."""
     if DOCKER_NETWORK:
@@ -343,7 +351,7 @@ def _k3s_run_kwargs(name: str, port: int, ms_network: str | None = None, oidc_ar
         devices=["/dev/fuse"],
         ports={"6443/tcp": port},
         name=f"ministack-eks-{name}",
-        labels={"ministack": "eks", "cluster_name": name},
+        labels={"ministack": "eks", "cluster_name": name, **_instance_labels()},
         environment={"K3S_KUBECONFIG_MODE": "644"},
         volumes={"/lib/modules": {"bind": "/lib/modules", "mode": "ro"}},
         tmpfs={"/run": "", "/var/run": "", "/tmp": ""},
@@ -360,7 +368,10 @@ def _stop_all_k3s():
     if not client:
         return
     try:
-        for c in client.containers.list(filters={"label": "ministack=eks"}):
+        # Instance-scoped: only this instance's k3s (see MINISTACK_INSTANCE_ID).
+        _inst = os.environ.get("MINISTACK_INSTANCE_ID")
+        _flt = ["ministack=eks"] + ([f"ministack_instance={_inst}"] if _inst else [])
+        for c in client.containers.list(filters={"label": _flt}):
             try:
                 c.stop(timeout=5)
                 c.remove(v=True, force=True)

--- a/ministack/services/lambda_svc.py
+++ b/ministack/services/lambda_svc.py
@@ -213,6 +213,15 @@ def _get_docker_client():
     except Exception:
         return None
 
+
+def _instance_labels():
+    """Per-instance label for spawned containers so concurrent MiniStack
+    instances don't reap each other's containers at boot (see
+    MINISTACK_INSTANCE_ID). Empty when the env is unset."""
+    iid = os.environ.get("MINISTACK_INSTANCE_ID")
+    return {"ministack_instance": iid} if iid else {}
+
+
 _functions = AccountScopedDict()  # function_name -> FunctionRecord
 _layers = AccountScopedDict()  # layer_name -> {"versions": [...], "next_version": int}
 _esms = AccountScopedDict()  # uuid -> esm dict
@@ -2742,7 +2751,7 @@ def _spawn_lambda_container(config: dict, code_zip: bytes | None):
         "ports": {"8080/tcp": None},
         "detach": True,
         "stdin_open": False,
-        "labels": {"ministack": "lambda"},
+        "labels": {"ministack": "lambda", **_instance_labels()},
     }
     if package_type == "Image":
         # User image brings its own entrypoint. ImageConfig can override.

--- a/tests/test_instance_scoped_cleanup.py
+++ b/tests/test_instance_scoped_cleanup.py
@@ -1,0 +1,96 @@
+"""Instance-scoped container cleanup (MINISTACK_INSTANCE_ID).
+
+When MINISTACK_INSTANCE_ID is set, spawned containers are tagged with a
+`ministack_instance=<id>` label and the boot/teardown cleanup filters on it,
+so multiple MiniStack instances can share one Docker host without reaping each
+other's containers. When unset, behaviour is the original host-global cleanup.
+"""
+import os
+
+from ministack.services import eks as _eks
+from ministack.services import lambda_svc as _lambda
+from ministack import app as _app
+
+
+# --- _instance_labels() helper (eks + lambda) -------------------------------
+
+def test_instance_labels_empty_when_unset(monkeypatch):
+    monkeypatch.delenv("MINISTACK_INSTANCE_ID", raising=False)
+    assert _eks._instance_labels() == {}
+    assert _lambda._instance_labels() == {}
+
+
+def test_instance_labels_set_when_present(monkeypatch):
+    monkeypatch.setenv("MINISTACK_INSTANCE_ID", "inst-x")
+    assert _eks._instance_labels() == {"ministack_instance": "inst-x"}
+    assert _lambda._instance_labels() == {"ministack_instance": "inst-x"}
+
+
+# --- k3s spawn kwargs carry the instance label ------------------------------
+
+def test_k3s_run_kwargs_labels_global_when_unset(monkeypatch):
+    monkeypatch.delenv("MINISTACK_INSTANCE_ID", raising=False)
+    kwargs = _eks._k3s_run_kwargs("mycluster", 16443)
+    assert kwargs["labels"] == {"ministack": "eks", "cluster_name": "mycluster"}
+
+
+def test_k3s_run_kwargs_labels_scoped_when_set(monkeypatch):
+    monkeypatch.setenv("MINISTACK_INSTANCE_ID", "inst-x")
+    kwargs = _eks._k3s_run_kwargs("mycluster", 16443)
+    assert kwargs["labels"] == {
+        "ministack": "eks",
+        "cluster_name": "mycluster",
+        "ministack_instance": "inst-x",
+    }
+
+
+# --- boot cleanup filters are instance-scoped -------------------------------
+
+class _FakeContainers:
+    def __init__(self, sink):
+        self._sink = sink
+
+    def list(self, all=False, filters=None):
+        self._sink.append(filters)
+        return []
+
+
+class _FakeClient:
+    def __init__(self, sink):
+        self.containers = _FakeContainers(sink)
+
+
+def _patch_docker(monkeypatch, sink):
+    import docker
+    # _stop_docker_containers bails early unless the socket path exists.
+    monkeypatch.setattr(os.path, "exists", lambda _p: True)
+    monkeypatch.setattr(docker, "from_env", lambda: _FakeClient(sink))
+
+
+def test_stop_docker_containers_global_when_unset(monkeypatch):
+    monkeypatch.delenv("MINISTACK_INSTANCE_ID", raising=False)
+    captured = []
+    _patch_docker(monkeypatch, captured)
+
+    _app._stop_docker_containers()
+
+    assert captured, "containers.list was never called"
+    for f in captured:
+        # exactly one service label, no instance scoping
+        assert len(f["label"]) == 1
+        assert f["label"][0].startswith("ministack=")
+        assert all(not l.startswith("ministack_instance") for l in f["label"])
+
+
+def test_stop_docker_containers_scoped_when_set(monkeypatch):
+    monkeypatch.setenv("MINISTACK_INSTANCE_ID", "inst-x")
+    captured = []
+    _patch_docker(monkeypatch, captured)
+
+    _app._stop_docker_containers()
+
+    assert captured, "containers.list was never called"
+    for f in captured:
+        # every reap is scoped to this instance AND a single service label
+        assert "ministack_instance=inst-x" in f["label"]
+        assert any(l.startswith("ministack=") for l in f["label"])


### PR DESCRIPTION
## Summary

Make MiniStack's container cleanup **instance-scoped** via an optional `MINISTACK_INSTANCE_ID` environment variable, so that **multiple MiniStack instances can run concurrently on the same Docker host** without evicting each other's containers.

## The problem

MiniStack reaps containers by their `ministack=<service>` label in two places:

- `_stop_docker_containers()` at boot (`app.py`) — reaps `ministack=rds|ecs|elasticache|eks|lambda`
- `_stop_all_k3s()` (`services/eks.py`)

Both filter **only** on the `ministack=<service>` label, which is global across the host. That's correct for the common single-instance case, but it means that **starting a second MiniStack instance tears down the first one's containers** — the boot-time cleanup of instance B matches and removes instance A's k3s clusters, RDS, Lambda containers, etc.

This makes it impossible to run more than one isolated MiniStack at a time on a shared host — e.g. several feature branches / worktrees side by side, a CI matrix with parallel jobs on one runner, or multiple independent test environments.

## The change

Introduce an **opt-in** `MINISTACK_INSTANCE_ID` env var:

- When set, every container MiniStack spawns (k3s, Lambda) gets an extra label `ministack_instance=<id>` in addition to the existing `ministack=<service>` label.
- The boot-time and teardown cleanup paths add `ministack_instance=<id>` to their label filter, so each instance only reaps the containers **it** spawned.
- When **unset**, behaviour is byte-for-byte identical to today (global cleanup) — fully backward compatible, no migration needed.

A small `_instance_labels()` helper centralizes reading the env var and producing the label dict, kept next to the other module-level docker helpers in each service.

Combined with the existing per-instance port knobs (e.g. `EKS_BASE_PORT` for the k3s API port, distinct published ports), this is enough to run N fully isolated MiniStack instances on one host: each gets a unique `MINISTACK_INSTANCE_ID` and unique ports, and they no longer collide at boot.

## Files

- `ministack/app.py` — `_stop_docker_containers()`: scope boot cleanup to the instance when the env is set.
- `ministack/services/eks.py` — label spawned k3s containers; scope `_stop_all_k3s()`.
- `ministack/services/lambda_svc.py` — label spawned Lambda containers.

30 insertions, 4 deletions across 3 files. No public API or default-behaviour changes.

## Reproduce / verify

```bash
# Instance A — its own gateway + k3s API port + instance id
docker run -d --name ministack-a -p 4566:4566 \
  -v /var/run/docker.sock:/var/run/docker.sock \
  -e MINISTACK_INSTANCE_ID=a -e EKS_BASE_PORT=16443 \
  ministackorg/ministack
# create a cluster in A: aws --endpoint http://localhost:4566 eks create-cluster ...

# Instance B — distinct gateway port, k3s API port, instance id
docker run -d --name ministack-b -p 4577:4566 \
  -v /var/run/docker.sock:/var/run/docker.sock \
  -e MINISTACK_INSTANCE_ID=b -e EKS_BASE_PORT=26443 \
  ministackorg/ministack
# create a cluster in B as well

# Booting B must NOT remove A's k3s container; each is scoped to its instance:
docker ps --filter label=ministack=eks         --format '{{.Names}}'   # both A's and B's
docker ps --filter label=ministack_instance=a   --format '{{.Names}}'   # only A's
docker ps --filter label=ministack_instance=b   --format '{{.Names}}'   # only B's
```

With the env **unset**, both instances share the global label space and the second boot reaps the first's containers — the behaviour this PR fixes.

## Testing

- **Single-instance (env unset):** boot cleanup still reaps all `ministack=*` containers as before — confirmed behaviour is unchanged.
- **Two instances, distinct `MINISTACK_INSTANCE_ID` + ports:** brought both up concurrently, each creating its own k3s cluster + workloads; confirmed the second instance's boot does **not** evict the first, that each spawned container carries the correct `ministack_instance` label, and that both stayed healthy across repeated start/stop cycles.
- **Unit tests** (`tests/test_instance_scoped_cleanup.py`, no Docker required) cover all three change sites with the env set vs. unset: the `_instance_labels()` helper, the `_k3s_run_kwargs` spawn-label builder, and `_stop_docker_containers` (the boot cleanup filter is asserted via a fake docker client). 6 tests, all passing.
