### PR TITLE
fix(cognito): allow public base URL for SAML ACS / OIDC federation callback

### DIFF
--- a/ministack/services/cognito.py
+++ b/ministack/services/cognito.py
@@ -1138,14 +1138,42 @@ def _invoke_verify_auth_challenge_trigger(pool_id: str, client_id: str, username
 # SAML / OAuth2 helpers
 # ---------------------------------------------------------------------------
 
+def _external_base_url() -> str:
+    """
+    Public base URL the OUTSIDE world uses to reach this MiniStack.
+
+    The SAML ACS URL and the OIDC federation callback are handed to an *external* IdP
+    (Google, Okta, a SAML provider, ...) which validates them as an exact string and then
+    redirects the user's browser back to them. When MiniStack runs behind a reverse proxy
+    that terminates TLS on a different host/port (e.g. nginx on :443), the internal
+    ``http://{host}:{port}`` form never round-trips:
+
+      * public IdPs reject ``http://`` (and non-standard ports) for non-localhost hosts, and
+      * the browser cannot reach ``:4566`` from outside.
+
+    Set ``MINISTACK_COGNITO_HOSTED_UI_URL`` to the externally reachable base (e.g.
+    ``https://account.example.com``) to override. When unset, falls back to
+    ``http(s)://{MINISTACK_HOST}:{GATEWAY_PORT}``, where the scheme honors ``USE_SSL`` so it
+    stays consistent with the listener.
+
+    With no env set and ``USE_SSL`` unset this returns ``http://localhost:4566`` - identical
+    to the previous hardcoded behaviour, so existing setups are unaffected.
+    """
+    base = os.environ.get("MINISTACK_COGNITO_HOSTED_UI_URL")
+    if base:
+        return base.rstrip("/")
+    scheme = "https" if os.environ.get("USE_SSL", "").strip().lower() in ("1", "true", "yes") else "http"
+    return f"{scheme}://{_MINISTACK_HOST}:{_MINISTACK_PORT}"
+
+
 def _acs_url() -> str:
     """Assertion Consumer Service URL for SAML responses."""
-    return f"http://{_MINISTACK_HOST}:{_MINISTACK_PORT}/saml2/idpresponse"
+    return f"{_external_base_url()}/saml2/idpresponse"
 
 
 def _oidc_callback_url() -> str:
     """OIDC callback URL — external OIDC IdPs redirect back here with `code`+`state`."""
-    return f"http://{_MINISTACK_HOST}:{_MINISTACK_PORT}/oauth2/idpresponse"
+    return f"{_external_base_url()}/oauth2/idpresponse"
 
 
 def _build_saml_authn_request(pool_id: str, destination: str) -> str:


### PR DESCRIPTION
## Problem

The SAML ACS URL and the OIDC federation callback are built with a hardcoded
`http://{MINISTACK_HOST}:{GATEWAY_PORT}/...`:

```python
def _acs_url() -> str:
    return f"http://{_MINISTACK_HOST}:{_MINISTACK_PORT}/saml2/idpresponse"

def _oidc_callback_url() -> str:
    return f"http://{_MINISTACK_HOST}:{_MINISTACK_PORT}/oauth2/idpresponse"
```

`_oidc_callback_url()` is sent to the external IdP as the `redirect_uri` (and reused on the
back-channel token exchange). External IdPs (Google, OIDC, SAML) validate it as an exact
string, so when MiniStack runs behind a reverse proxy that terminates TLS on a different
host/port (e.g. nginx on `:443`), the value never round-trips:

* public IdPs reject `http://` and non-standard ports for non-localhost hosts, and
* the browser cannot reach `:4566` from outside.

Only the host is configurable today (`MINISTACK_HOST`, #797); the scheme and port are not,
so setting `MINISTACK_HOST=account.example.com` still yields
`http://account.example.com:4566/oauth2/idpresponse` — still rejected.

### Repro
1. `cognito-idp create-identity-provider --provider-type Google ...` on a pool + app client.
2. Put MiniStack behind nginx on https, proxying `/oauth2/authorize` and `/oauth2/idpresponse`
   to `127.0.0.1:4566`.
3. Hit `/oauth2/authorize?identity_provider=Google&...`.
4. The redirect to `accounts.google.com` carries
   `redirect_uri=http://localhost:4566/oauth2/idpresponse`.

## Solution

Introduce `_external_base_url()`, honored by both `_acs_url()` and `_oidc_callback_url()`,
following the precedent of `MINISTACK_COGNITO_ISSUER_BASE_URL` (#815):

- `MINISTACK_COGNITO_HOSTED_UI_URL` — externally reachable base (e.g.
  `https://account.example.com`) to override; when unset, fall back to
  `http(s)://{MINISTACK_HOST}:{GATEWAY_PORT}`, scheme honoring `USE_SSL`.

This lets the federation callback be `https://account.example.com/oauth2/idpresponse` (no
forced port, correct scheme) so it round-trips through a public IdP.

## Backward compatibility

Fully backward compatible: with no env set and `USE_SSL` unset the output is byte-for-byte the
previous `http://localhost:4566/...`. `USE_SSL=1` (already used for the listener) makes the
internal default `https://...` consistently.

Closes the gap left by #797 for federated sign-in behind an HTTPS proxy.
