### PR TITLE
feat(sqs): reject XML 1.0 forbidden characters in message bodies

### DIFF
--- a/ministack/services/sqs.py
+++ b/ministack/services/sqs.py
@@ -28,6 +28,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import struct
 import threading
 import time
@@ -38,6 +39,9 @@ from ministack.core.persistence import PERSIST_STATE, load_state
 from ministack.core.responses import AccountScopedDict, get_account_id, get_region, md5_hash, new_uuid, now_iso
 
 logger = logging.getLogger("sqs")
+
+# XML 1.0 forbidden characters: everything below #x20 except #x9/#xA/#xD, plus #xFFFE and #xFFFF
+_INVALID_SQS_CHARS_RE = re.compile("[\x00-\x08\x0b\x0c\x0e-\x1f\ufffe\uffff]")
 
 # ── Module-level state ──────────────────────────────────────
 
@@ -331,6 +335,11 @@ def _act_send_message(data: dict, qurl: str) -> dict:
     if not body_text:
         raise _Err("MissingParameter",
                     "The request must contain the parameter MessageBody.")
+    if _INVALID_SQS_CHARS_RE.search(body_text):
+        raise _Err(
+            "InvalidMessageContents",
+            "The message contains characters outside the allowed set.",
+        )
 
     # AWS SQS rejects messages exceeding the queue's MaximumMessageSize attribute
     # (default 262144 bytes; configurable up to 1 MiB / 1048576). Real AWS error

--- a/tests/test_sqs.py
+++ b/tests/test_sqs.py
@@ -1084,3 +1084,53 @@ def test_sqs_create_queue_rejects_non_numeric_visibility_timeout(sqs):
         assert exc.response["Error"]["Code"] == "InvalidAttributeValue"
     else:
         raise AssertionError("expected InvalidAttributeValue for non-numeric")
+
+
+def test_sqs_send_message_rejects_control_chars(sqs):
+    """SendMessage must reject message bodies containing XML 1.0 forbidden characters.
+
+    AWS SQS only allows: #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]
+    Control characters like NULL, BEL, VT, etc. must result in InvalidMessageContents (400).
+    See: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/quotas-messages.html
+    """
+    url = sqs.create_queue(QueueName="intg-sqs-invalid-chars")["QueueUrl"]
+
+    forbidden = [
+        "\x00",        # NULL
+        "\x01",        # SOH
+        "\x08",        # BS (last before tab)
+        "\x0b",        # VT (vertical tab)
+        "\x0c",        # FF (form feed)
+        "\x0e",        # SO (first after CR)
+        "\x1f",        # US (last C0 control char)
+        "hello\x00world",  # control char embedded in normal text
+        "\ufffe",      # non-character
+        "\uffff",      # non-character
+    ]
+    for body in forbidden:
+        with pytest.raises(ClientError) as exc:
+            sqs.send_message(QueueUrl=url, MessageBody=body)
+        code = exc.value.response["Error"]["Code"]
+        assert code == "InvalidMessageContents", (
+            f"expected InvalidMessageContents for {repr(body)}, got {code}"
+        )
+        assert exc.value.response["ResponseMetadata"]["HTTPStatusCode"] == 400
+
+
+def test_sqs_send_message_allows_valid_chars(sqs):
+    """SendMessage must allow all XML 1.0 valid characters including tab, LF, CR, and Unicode."""
+    url = sqs.create_queue(QueueName="intg-sqs-valid-chars")["QueueUrl"]
+
+    allowed = [
+        "hello world",
+        "tab\there",
+        "newline\nhere",
+        "cr\rhere",
+        "こんにちは世界",
+        "héllo wörld",
+        "emoji \U0001f600",
+        "!@#$%^&*()",
+    ]
+    for body in allowed:
+        resp = sqs.send_message(QueueUrl=url, MessageBody=body)
+        assert "MessageId" in resp, f"send failed for {repr(body)}"


### PR DESCRIPTION
## Problem

AWS SQS only accepts message bodies containing characters valid in XML 1.0.
The following are forbidden...

- `#x00`–`#x08` (NUL and other C0 control characters)
- `#x0B` (vertical tab), `#x0C` (form feed)
- `#x0E`–`#x1F` (remaining C0 control characters)
- `#xFFFE`, `#xFFFF` (non-characters)

Tab (`#x9`), LF (`#xA`), and CR (`#xD`) remain allowed.
See: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/quotas-messages.html

MiniStack was silently accepting messages containing these characters instead of returning `InvalidMessageContents` (400). Code that sends such payloads passes locally against MiniStack but fails against real AWS, masking a class of client-side bugs.
See: https://docs.aws.amazon.com/ja_jp/AWSSimpleQueueService/latest/APIReference/API_SendMessage.html#API_SendMessage_Errors

## Fix

Added a forbidden-character check in `_act_send_message`, immediately after the empty-body guard. Messages containing any disallowed character now raise `InvalidMessageContents` (400), matching real AWS behavior.

The regex is compiled once at module level as a deny-list (`[\x00-\x08\x0b\x0c\x0e-\x1f\ufffe\uffff]`) to avoid per-request recompilation.