### PR TITLE
fix(bedrock): parse model identifier ARNs

### DIFF
--- a/ministack/services/bedrock.py
+++ b/ministack/services/bedrock.py
@@ -358,13 +358,39 @@ def _model_summary(model_id, model_name, provider, inputs, outputs, streaming) -
     }
 
 
-def _find_model(identifier: str):
+def _foundation_model_id_from_identifier(identifier: str) -> str | None:
+    if not isinstance(identifier, str):
+        return None
+    model_id = identifier
     if identifier.startswith("arn:"):
-        identifier = identifier.rsplit("/", 1)[-1]
+        try:
+            spec = parse_arn(identifier)
+        except ArnParseError:
+            return None
+        if (
+            spec.partition != "aws"
+            or spec.service != "bedrock"
+            or spec.region != get_region()
+            or spec.account_id != ""
+        ):
+            return None
+        prefix = "foundation-model/"
+        if not spec.resource.startswith(prefix):
+            return None
+        model_id = spec.resource[len(prefix):]
+        if not model_id or "/" in model_id:
+            return None
     for prefix in _INFERENCE_PROFILE_PREFIXES:
-        if identifier.startswith(f"{prefix}."):
-            identifier = identifier[len(prefix) + 1:]
+        if model_id.startswith(f"{prefix}."):
+            model_id = model_id[len(prefix) + 1:]
             break
+    return model_id
+
+
+def _find_model(identifier: str):
+    identifier = _foundation_model_id_from_identifier(identifier)
+    if not identifier:
+        return None
     for entry in _CATALOG:
         if entry[0] == identifier:
             return entry

--- a/ministack/services/bedrock_runtime.py
+++ b/ministack/services/bedrock_runtime.py
@@ -47,6 +47,7 @@ import zlib
 from datetime import datetime, timezone
 from urllib.parse import unquote
 
+from ministack.core.arn import ArnParseError, parse_arn
 from ministack.core.persistence import load_state
 from ministack.core.responses import (
     AccountRegionScopedDict,
@@ -89,12 +90,67 @@ _FAMILY_PATTERNS = [
     ("deepseek", re.compile(r"(^|[./])deepseek\.", re.I)),
 ]
 
+_BEDROCK_RUNTIME_MODEL_RESOURCE_TYPES = {
+    "application-inference-profile",
+    "custom-model",
+    "custom-model-deployment",
+    "default-prompt-router",
+    "imported-model",
+    "inference-profile",
+    "prompt",
+    "prompt-router",
+    "provisioned-model",
+}
+
 
 def _family(model_id: str) -> str:
     for name, pat in _FAMILY_PATTERNS:
         if pat.search(model_id):
             return name
     return "generic"
+
+
+def _foundation_model_arn(model_id: str) -> str:
+    return f"arn:aws:bedrock:{get_region()}::foundation-model/{model_id}"
+
+
+def _normalize_model_id(model_id: str) -> tuple[str, str, tuple | None]:
+    if not isinstance(model_id, str) or not model_id:
+        return "", "", _error("ValidationException", "modelId is required.", 400)
+    if not model_id.startswith("arn:"):
+        return model_id, _foundation_model_arn(model_id), None
+
+    try:
+        spec = parse_arn(model_id)
+    except ArnParseError:
+        return "", "", _error("ValidationException", f"Invalid modelId ARN: {model_id}", 400)
+    if spec.partition != "aws" or spec.region != get_region():
+        return "", "", _error("ValidationException", f"Invalid modelId ARN: {model_id}", 400)
+    if spec.service == "sagemaker":
+        endpoint_prefix = "endpoint/"
+        if (
+            spec.account_id != get_account_id()
+            or not spec.resource.startswith(endpoint_prefix)
+            or not spec.resource[len(endpoint_prefix):]
+            or "/" in spec.resource[len(endpoint_prefix):]
+        ):
+            return "", "", _error("ValidationException", f"Invalid modelId ARN: {model_id}", 400)
+        return model_id, model_id, None
+    if spec.service != "bedrock":
+        return "", "", _error("ValidationException", f"Invalid modelId ARN: {model_id}", 400)
+
+    resource_type, sep, resource_id = spec.resource.partition("/")
+    if not sep or not resource_id:
+        return "", "", _error("ValidationException", f"Invalid modelId ARN: {model_id}", 400)
+    if resource_type == "foundation-model":
+        if spec.account_id != "" or "/" in resource_id:
+            return "", "", _error("ValidationException", f"Invalid modelId ARN: {model_id}", 400)
+        return model_id, model_id, None
+    if resource_type in _BEDROCK_RUNTIME_MODEL_RESOURCE_TYPES:
+        if spec.account_id != get_account_id():
+            return "", "", _error("ValidationException", f"Invalid modelId ARN: {model_id}", 400)
+        return model_id, model_id, None
+    return "", "", _error("ValidationException", f"Invalid modelId ARN: {model_id}", 400)
 
 
 # ---------------------------------------------------------------------------
@@ -260,6 +316,9 @@ def _validate_converse_request(body_obj) -> tuple | None:
 
 
 def _converse(model_id: str, headers, body) -> tuple:
+    model_id, _model_arn, err = _normalize_model_id(model_id)
+    if err:
+        return err
     try:
         body_obj = json.loads(body or b"{}")
     except json.JSONDecodeError:
@@ -357,6 +416,9 @@ def _build_converse_stream(model_id: str, messages, system, started_at_ms: int, 
 
 
 def _converse_stream(model_id: str, headers, body) -> tuple:
+    model_id, _model_arn, err = _normalize_model_id(model_id)
+    if err:
+        return err
     try:
         body_obj = json.loads(body or b"{}")
     except json.JSONDecodeError:
@@ -497,6 +559,9 @@ def _build_invoke_response_body(family: str, model_id: str, prompt: str, reply: 
 
 def _invoke_model(model_id: str, headers, body) -> tuple:
     """POST /model/{modelId}/invoke — body is raw JSON in model-family shape."""
+    model_id, _model_arn, err = _normalize_model_id(model_id)
+    if err:
+        return err
     if not body:
         return _error("ValidationException", "Request body is required.", 400)
     try:
@@ -629,6 +694,9 @@ def _es_event_chunk(inner: dict) -> bytes:
 
 
 def _invoke_model_with_response_stream(model_id: str, headers, body) -> tuple:
+    model_id, _model_arn, err = _normalize_model_id(model_id)
+    if err:
+        return err
     if not body:
         return _error("ValidationException", "Request body is required.", 400)
     try:
@@ -737,6 +805,9 @@ def _start_async_invoke(body) -> tuple:
         return _error("ValidationException", "Body must be a JSON object.", 400)
     if not body_obj.get("modelId"):
         return _error("ValidationException", "modelId is required.", 400)
+    _model_id, model_arn, err = _normalize_model_id(body_obj["modelId"])
+    if err:
+        return err
     if "modelInput" not in body_obj:
         return _error("ValidationException", "modelInput is required.", 400)
     if "outputDataConfig" not in body_obj:
@@ -746,7 +817,7 @@ def _start_async_invoke(body) -> tuple:
     now = datetime.now(timezone.utc).isoformat()
     record = {
         "invocationArn": arn,
-        "modelArn": f"arn:aws:bedrock:{get_region()}::foundation-model/{body_obj['modelId']}",
+        "modelArn": model_arn,
         "clientRequestToken": body_obj.get("clientRequestToken", uuid.uuid4().hex),
         "status": "Completed",
         "submitTime": now,

--- a/tests/test_bedrock.py
+++ b/tests/test_bedrock.py
@@ -8,10 +8,10 @@ on presence and ordering, not absolute values.
 
 import json
 import urllib.error
+import urllib.parse
 import urllib.request
 
 from conftest import ENDPOINT, make_client
-
 
 # ---------------------------------------------------------------------------
 # Control plane
@@ -215,6 +215,27 @@ def test_bedrock_get_foundation_model_by_arn():
     assert resp["modelDetails"]["modelId"] == "anthropic.claude-3-haiku-20240307-v1:0"
 
 
+def test_bedrock_get_foundation_model_arn_parser_does_not_tail_match_invalid_arns():
+    import botocore.exceptions
+
+    client = make_client("bedrock")
+    valid_tail = "foundation-model/anthropic.claude-3-haiku-20240307-v1:0"
+    bad_refs = [
+        f"arn:aws:lambda:us-east-1::{valid_tail}",
+        f"arn:aws:bedrock:us-west-2::{valid_tail}",
+        f"arn:aws:bedrock:us-east-1:000000000000:{valid_tail}",
+        "arn:aws:bedrock:us-east-1::custom-model/anthropic.claude-3-haiku-20240307-v1:0",
+        "arn:aws:bedrock:us-east-1",
+    ]
+    for model_identifier in bad_refs:
+        try:
+            client.get_foundation_model(modelIdentifier=model_identifier)
+        except botocore.exceptions.ClientError as exc:
+            assert exc.response["Error"]["Code"] == "ResourceNotFoundException"
+        else:
+            raise AssertionError(f"expected ResourceNotFoundException for {model_identifier}")
+
+
 def test_bedrock_model_arn_reflects_request_region():
     import boto3
     from botocore.config import Config
@@ -302,6 +323,7 @@ def test_bedrock_converse_multiple_content_blocks_in_message():
 
 def test_bedrock_converse_token_count_headers_present_in_http_response():
     import urllib.request
+
     from conftest import ENDPOINT
 
     body = json.dumps({
@@ -420,8 +442,9 @@ def test_bedrock_converse_inference_config_stop_sequences_accepted():
 
 def _raw_converse(body: dict) -> tuple:
     """Return (status, body_dict) from a raw POST to /model/.../converse."""
-    import urllib.request
     import urllib.error
+    import urllib.request
+
     from conftest import ENDPOINT
 
     req = urllib.request.Request(
@@ -465,8 +488,9 @@ def test_bedrock_converse_validation_empty_content():
 
 
 def test_bedrock_converse_validation_malformed_body():
-    import urllib.request
     import urllib.error
+    import urllib.request
+
     from conftest import ENDPOINT
 
     req = urllib.request.Request(
@@ -523,6 +547,66 @@ def test_bedrock_converse_stream_via_inference_profile_id():
     names = [list(e.keys())[0] for e in resp["stream"]]
     assert names[0] == "messageStart"
     assert names[-1] == "metadata"
+
+
+def test_bedrock_runtime_accepts_foundation_model_arn_model_id():
+    client = make_client("bedrock-runtime")
+    arn = "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-haiku-20240307-v1:0"
+    resp = client.converse(
+        modelId=arn,
+        messages=[{"role": "user", "content": [{"text": "hello via arn"}]}],
+    )
+    assert resp["output"]["message"]["role"] == "assistant"
+
+
+def test_bedrock_runtime_accepts_custom_model_arn_with_path_segments():
+    client = make_client("bedrock-runtime")
+    arn = "arn:aws:bedrock:us-east-1:000000000000:custom-model/my-model/123456789012"
+    resp = client.converse(
+        modelId=arn,
+        messages=[{"role": "user", "content": [{"text": "hello via custom arn"}]}],
+    )
+    assert resp["output"]["message"]["role"] == "assistant"
+
+
+def test_bedrock_runtime_accepts_additional_model_arn_shapes():
+    client = make_client("bedrock-runtime")
+    arns = [
+        "arn:aws:bedrock:us-east-1:000000000000:custom-model-deployment/my-deployment",
+        "arn:aws:bedrock:us-east-1:000000000000:prompt-router/my-router",
+        "arn:aws:sagemaker:us-east-1:000000000000:endpoint/my-bedrock-endpoint",
+    ]
+    for arn in arns:
+        resp = client.converse(
+            modelId=arn,
+            messages=[{"role": "user", "content": [{"text": "hello via arn"}]}],
+        )
+        assert resp["output"]["message"]["role"] == "assistant"
+
+
+def test_bedrock_runtime_model_id_arn_parser_does_not_tail_match_invalid_arns():
+    model_id = "arn:aws:lambda:us-east-1::foundation-model/anthropic.claude-3-haiku-20240307-v1:0"
+    encoded_model_id = urllib.parse.quote(model_id, safe="")
+    req = urllib.request.Request(
+        f"{ENDPOINT}/model/{encoded_model_id}/converse",
+        data=json.dumps({
+            "messages": [{"role": "user", "content": [{"text": "x"}]}],
+        }).encode(),
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": ("AWS4-HMAC-SHA256 "
+                              "Credential=test/20260605/us-east-1/bedrock/aws4_request, "
+                              "SignedHeaders=host;x-amz-date, Signature=x"),
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req):
+            raise AssertionError("expected ValidationException")
+    except urllib.error.HTTPError as exc:
+        assert exc.code == 400
+        body = json.loads(exc.read())
+        assert body["__type"] == "ValidationException"
 
 
 # ---------------------------------------------------------------------------
@@ -604,6 +688,7 @@ def test_bedrock_invoke_model_cohere_shape():
 
 def test_bedrock_invoke_model_returns_token_count_headers():
     import urllib.request
+
     from conftest import ENDPOINT
 
     req = urllib.request.Request(
@@ -748,6 +833,34 @@ def test_bedrock_start_async_invoke_then_get():
     assert get_resp["status"] == "Completed"
     assert "modelArn" in get_resp
     assert "submitTime" in get_resp
+
+
+def test_bedrock_start_async_invoke_accepts_foundation_model_arn_model_id():
+    client = make_client("bedrock-runtime")
+    arn = "arn:aws:bedrock:us-east-1::foundation-model/amazon.nova-pro-v1:0"
+    start = client.start_async_invoke(
+        modelId=arn,
+        modelInput={"messages": [{"role": "user", "content": [{"text": "x"}]}]},
+        outputDataConfig={"s3OutputDataConfig": {"s3Uri": "s3://bucket/prefix/"}},
+    )
+    get_resp = client.get_async_invoke(invocationArn=start["invocationArn"])
+    assert get_resp["modelArn"] == arn
+
+
+def test_bedrock_start_async_invoke_rejects_invalid_model_id_arn():
+    import botocore.exceptions
+
+    client = make_client("bedrock-runtime")
+    try:
+        client.start_async_invoke(
+            modelId="arn:aws:sqs:us-east-1::foundation-model/amazon.nova-pro-v1:0",
+            modelInput={"messages": [{"role": "user", "content": [{"text": "x"}]}]},
+            outputDataConfig={"s3OutputDataConfig": {"s3Uri": "s3://bucket/prefix/"}},
+        )
+    except botocore.exceptions.ClientError as exc:
+        assert exc.response["Error"]["Code"] == "ValidationException"
+    else:
+        raise AssertionError("expected ValidationException")
 
 
 def test_bedrock_list_async_invokes_includes_started_ones():


### PR DESCRIPTION
## Why
Bedrock model identifiers can be supplied as ARNs, but the existing foundation-model lookup stripped the resource tail before validating the ARN shape. That allowed malformed or wrong-service ARNs with a matching tail to resolve like a local model.

## What
- Parse Bedrock control-plane foundation-model ARNs before catalog lookup
- Validate Bedrock Runtime `modelId` ARNs before mock Converse/Invoke handling
- Preserve supported runtime ARN shapes, including custom-model path ARNs and SageMaker endpoint ARNs
- Add no-tail-fallback coverage for invalid model identifier ARNs

## Validation
- `python3 -m py_compile ministack/services/bedrock.py ministack/services/bedrock_runtime.py tests/test_bedrock.py`
- `uv run --extra dev ruff check ministack/services/bedrock.py ministack/services/bedrock_runtime.py tests/test_bedrock.py`
- `uv run --extra dev pytest tests/test_bedrock.py -q` (`72 passed`)
- `uv run --extra dev pytest tests/test_bedrock_control_plane.py -q` (`36 passed`)
