### PR TITLE
Negative-cache failed OIDC discovery to prevent 2hr auth outage on transient failures

### DIFF
--- a/ministack/services/apigateway.py
+++ b/ministack/services/apigateway.py
@@ -516,6 +516,8 @@ async def _fetch_oidc_jwks_uri(issuer: str) -> str | None:
         jwks_uri = (json.loads(body or b"{}") or {}).get("jwks_uri")
     except (OSError, ValueError, json.JSONDecodeError):
         jwks_uri = None
+    if not isinstance(jwks_uri, str) or not jwks_uri.strip():
+        jwks_uri = None
     if jwks_uri is not None:
         # Mirror _fetch_jwks (line ~543) which hardcodes `now + 7200`; no
         # separate env knob for OIDC discovery — it shares the JWT-auth

--- a/ministack/services/apigateway.py
+++ b/ministack/services/apigateway.py
@@ -516,9 +516,13 @@ async def _fetch_oidc_jwks_uri(issuer: str) -> str | None:
         jwks_uri = (json.loads(body or b"{}") or {}).get("jwks_uri")
     except (OSError, ValueError, json.JSONDecodeError):
         jwks_uri = None
-    # Mirror _fetch_jwks (line ~543) which hardcodes `now + 7200`; no separate
-    # env knob for OIDC discovery — it shares the JWT-auth external-fetch path.
-    _oidc_config_cache[issuer] = {"jwks_uri": jwks_uri, "expiresAt": now + 7200}
+    if jwks_uri is not None:
+        # Mirror _fetch_jwks (line ~543) which hardcodes `now + 7200`; no
+        # separate env knob for OIDC discovery — it shares the JWT-auth
+        # external-fetch path.
+        _oidc_config_cache[issuer] = {"jwks_uri": jwks_uri, "expiresAt": now + 7200}
+    else:
+        _oidc_config_cache[issuer] = {"jwks_uri": None, "expiresAt": now + 60}
     return jwks_uri
 
 

--- a/tests/test_apigatewayv2.py
+++ b/tests/test_apigatewayv2.py
@@ -1355,7 +1355,7 @@ def test_apigw_resolve_jwks_url_falls_back_when_discovery_unavailable(monkeypatc
     assert resolved == f"{issuer}/.well-known/jwks.json"
 
 
-def test_apigw_oidc_discovery_failure_is_not_cached(monkeypatch):
+def test_apigw_oidc_discovery_failure_is_negative_cached(monkeypatch):
     """A failed discovery must not poison the cache for the full 7200s TTL.
 
     Regression test: a transient discovery failure used to be cached for

--- a/tests/test_apigatewayv2.py
+++ b/tests/test_apigatewayv2.py
@@ -1355,6 +1355,55 @@ def test_apigw_resolve_jwks_url_falls_back_when_discovery_unavailable(monkeypatc
     assert resolved == f"{issuer}/.well-known/jwks.json"
 
 
+def test_apigw_oidc_discovery_failure_is_not_cached(monkeypatch):
+    """A failed discovery must not poison the cache for the full 7200s TTL.
+
+    Regression test: a transient discovery failure used to be cached for
+    7200s, making every JWT validation for that issuer fail closed for up to
+    2 hours even after the underlying network issue cleared. It should
+    instead be negative-cached briefly (60s) so a flood of requests during
+    the outage doesn't each trigger their own discovery call, but recovery
+    happens quickly once the issuer is reachable again.
+    """
+    import asyncio
+
+    from ministack.services import apigateway as apigw_mod
+
+    issuer = "https://flaky-idp.test"
+    real_jwks_uri = f"{issuer}/id/keys"
+    calls = {"count": 0}
+
+    async def _flaky_then_ok_urlopen(_request_or_url, _timeout_seconds):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            raise OSError("connection refused")
+        body = json.dumps({"jwks_uri": real_jwks_uri}).encode("utf-8")
+        return 200, {"Content-Type": "application/json"}, body
+
+    fake_now = {"value": 1_000_000.0}
+    monkeypatch.setattr(apigw_mod, "_urlopen_async", _flaky_then_ok_urlopen)
+    monkeypatch.setattr(apigw_mod, "_oidc_config_cache", apigw_mod.AccountScopedDict())
+    monkeypatch.setattr(apigw_mod.time, "time", lambda: fake_now["value"])
+
+    authorizer = {"jwtConfiguration": {"Issuer": issuer, "Audience": ["ms-client"]}}
+
+    first = asyncio.run(apigw_mod._resolve_jwks_url(authorizer))
+    assert first == f"{issuer}/.well-known/jwks.json"
+
+    # Within the 60s negative-cache window, a retry must not re-trigger
+    # discovery — it should reuse the cached failure.
+    second = asyncio.run(apigw_mod._resolve_jwks_url(authorizer))
+    assert second == f"{issuer}/.well-known/jwks.json"
+    assert calls["count"] == 1
+
+    # Once the negative-cache TTL has elapsed, discovery is retried and
+    # the now-healthy issuer resolves successfully.
+    fake_now["value"] += 61
+    third = asyncio.run(apigw_mod._resolve_jwks_url(authorizer))
+    assert third == real_jwks_uri
+    assert calls["count"] == 2
+
+
 def test_apigw_resolve_jwks_url_cognito_skips_discovery(monkeypatch):
     """Cognito issuers keep using the local pool JWKS — no discovery call."""
     import asyncio


### PR DESCRIPTION
_fetch_oidc_jwks_uri previously cached the result of OIDC discovery unconditionally, including failures. A single transient network blip during discovery would resolve jwks_uri = None and cache that for the full 7200s TTL, causing every subsequent JWT validation for that issuer to fall back to the wrong default path ({issuer}/.well-known/jwks.json) and 404/401 for up to 2 hours — even though the token, issuer, and audience were all valid. The only workaround was restarting the container.

this closes #999 

Changes:
- _fetch_oidc_jwks_uri now only writes the 7200s success cache when discovery actually resolves a jwks_uri.
- On failure, it writes a short 60s negative cache instead of caching nothing — this avoids re-running discovery on every single request during an outage, while letting auth recover within a minute once the issuer is reachable again.
- Updated test_apigw_oidc_discovery_failure_is_not_cached to cover both halves of the new behavior: a retry within the 60s window reuses the cached failure (no extra discovery call), and a retry after the TTL elapses re-attempts discovery and succeeds.