### PR TITLE
Region-scope SQS state

### DIFF
--- a/ministack/app.py
+++ b/ministack/app.py
@@ -760,8 +760,9 @@ async def _handle_sqs_messages_request(method: str, path: str, headers: dict, qu
 
     Filters:
       ?account=<12-digit-id>   restrict to one account
+      ?region=<aws-region>     restrict to one region
       ?QueueUrl=<url>          restrict to one queue (within whatever
-                               accounts pass the account filter)
+                               accounts/regions pass the filters)
     """
     if path != "/_ministack/sqs/messages" or method != "GET":
         return None
@@ -786,20 +787,34 @@ async def _handle_sqs_messages_request(method: str, path: str, headers: dict, qu
     if "QueueUrl" in query_params:
         raw_qurl = query_params["QueueUrl"]
         queue_url_filter = raw_qurl[0] if isinstance(raw_qurl, (list, tuple)) else raw_qurl
+    region_filter = None
+    if "region" in query_params:
+        raw_region = query_params["region"]
+        region_filter = raw_region[0] if isinstance(raw_region, (list, tuple)) else raw_region
 
     try:
         mod = _get_module("sqs")
         now = time.time()
 
-        # AccountScopedDict._data is keyed by (account_id, queue_url).
-        per_account: dict[str, dict[str, list]] = {}
+        # Legacy AccountScopedDict state is keyed by (account_id, queue_url);
+        # AccountRegionScopedDict state is keyed by (account_id, region, queue_url).
+        per_account: dict[str, dict[str, dict[str, list]]] = {}
         try:
             all_data = mod._queues.to_dict()
         except Exception:
             all_data = {}
 
-        for (acct, qurl), queue in all_data.items():
+        for scoped_key, queue in all_data.items():
+            if len(scoped_key) == 3:
+                acct, region, qurl = scoped_key
+            elif len(scoped_key) == 2:
+                acct, qurl = scoped_key
+                region = os.environ.get("MINISTACK_REGION", "us-east-1")
+            else:
+                continue
             if account_id is not None and acct != account_id:
+                continue
+            if region_filter is not None and region != region_filter:
                 continue
             if queue_url_filter is not None and qurl != queue_url_filter:
                 continue
@@ -826,7 +841,7 @@ async def _handle_sqs_messages_request(method: str, path: str, headers: dict, qu
                     "MessageDeduplicationId": m.get("dedup_id"),
                     "SequenceNumber": m.get("seq"),
                 })
-            per_account.setdefault(acct, {})[qurl] = rendered
+            per_account.setdefault(acct, {}).setdefault(region, {})[qurl] = rendered
 
         response = {"messages": per_account}
     except Exception as e:

--- a/ministack/services/eventbridge.py
+++ b/ministack/services/eventbridge.py
@@ -1275,8 +1275,7 @@ def _dispatch_to_sqs(spec, payload, sqs_parameters=None):
     from ministack.services import sqs as _sqs
 
     queue_name = spec.resource
-    queue_url = _sqs._queue_url(queue_name)
-    queue = _sqs._queues.get(queue_url)
+    queue = _sqs._queue_by_arn(str(spec))
     if not queue:
         logger.warning("EventBridge → SQS: queue %s not found", queue_name)
         return

--- a/ministack/services/lambda_svc.py
+++ b/ministack/services/lambda_svc.py
@@ -2934,11 +2934,7 @@ def _route_async_failure(target_arn: str, func_name: str, event: dict, result: d
             if not qname:
                 logger.warning("Lambda %s DLQ target is not a valid SQS ARN: %s", func_name, target_arn)
                 return
-            target_q = None
-            for url, q in _sqs._queues.items():
-                if q.get("attributes", {}).get("QueueArn") == target_arn:
-                    target_q = q
-                    break
+            target_q = _sqs._queue_by_arn(target_arn)
             if target_q is not None:
                 now = time.time()
                 target_q["messages"].append({

--- a/ministack/services/s3.py
+++ b/ministack/services/s3.py
@@ -23,9 +23,9 @@ Storage: In-memory (optionally backed by S3_DATA_DIR).
 """
 
 import base64
+import contextvars
 import copy
 import datetime as _dt
-import contextvars
 import hashlib
 import json
 import logging
@@ -1988,8 +1988,7 @@ def _deliver_event_to_sqs(arn: str, event_payload: dict, bucket_region: str) -> 
     if not queue_name:
         logger.warning("S3 notification: invalid SQS queue ARN %s", arn)
         return
-    queue_url = _sqs._queue_url(queue_name)
-    queue = _sqs._queues.get(queue_url)
+    queue = _sqs._queue_by_arn(str(spec))
     if not queue:
         logger.warning("S3 notification: SQS queue %s not found", queue_name)
         return

--- a/ministack/services/sns.py
+++ b/ministack/services/sns.py
@@ -952,14 +952,7 @@ def _deliver_to_sqs(endpoint: str, envelope: str, raw: bool, raw_message: str,
     if spec.account_id != get_account_id():
         logger.warning("SNS fanout: SQS queue %s is outside the current account scope", queue_name)
         return
-    queue = next(
-        (
-            q
-            for q in _sqs._queues.values()
-            if q.get("attributes", {}).get("QueueArn") == str(spec)
-        ),
-        None,
-    )
+    queue = _sqs._queue_by_arn(str(spec))
     if not queue:
         logger.warning("SNS fanout: SQS queue %s not found", queue_name)
         return
@@ -1024,7 +1017,7 @@ def _http_post_sync(endpoint: str, payload: str, sns_message_type: str) -> int:
     which silently skipped every HTTP subscription confirmation (#460).
 
     Handles `http://user:pass@host/path` userinfo by stripping it from the URL
-    and promoting to an Authorization: Basic header, matching real AWS SNS
+    and promoting it to the HTTP auth header, matching real AWS SNS
     behaviour for HTTP(S) endpoints with embedded credentials. urllib leaves
     userinfo in the URL by default, which would break the Host header."""
     import base64 as _b64

--- a/ministack/services/sqs.py
+++ b/ministack/services/sqs.py
@@ -32,11 +32,12 @@ import re
 import struct
 import threading
 import time
-from urllib.parse import parse_qs
+from urllib.parse import parse_qs, urlparse
 from xml.sax.saxutils import escape as _esc
 
+from ministack.core.arn import ArnParseError, parse_arn
 from ministack.core.persistence import PERSIST_STATE, load_state
-from ministack.core.responses import AccountScopedDict, get_account_id, get_region, md5_hash, new_uuid, now_iso
+from ministack.core.responses import AccountRegionScopedDict, get_account_id, get_region, md5_hash, new_uuid, now_iso
 
 logger = logging.getLogger("sqs")
 
@@ -44,11 +45,12 @@ logger = logging.getLogger("sqs")
 # #x9 | #xA | #xD | #x20-#xD7FF | #xE000-#xFFFD | #x10000-#x10FFFF):
 # everything below #x20 except #x9/#xA/#xD, the surrogate block #xD800-#xDFFF, and #xFFFE/#xFFFF.
 _INVALID_SQS_CHARS_RE = re.compile("[\x00-\x08\x0b\x0c\x0e-\x1f\ud800-\udfff\ufffe\uffff]")
+_ACCOUNT_ID_RE = re.compile(r"^\d{12}$")
 
 # ── Module-level state ──────────────────────────────────────
 
-_queues = AccountScopedDict()
-_queue_name_to_url = AccountScopedDict()
+_queues = AccountRegionScopedDict()
+_queue_name_to_url = AccountRegionScopedDict()
 _queues_lock = threading.Lock()
 
 
@@ -56,8 +58,8 @@ _queues_lock = threading.Lock()
 
 def get_state():
     # Both must be deepcopy(asd): dict(asd) iterates only the current
-    # request's tenant via AccountScopedDict.__iter__, so other tenants'
-    # name→url mappings would silently disappear at shutdown
+    # request's account/region via AccountRegionScopedDict.__iter__, so other
+    # tenants' name→url mappings would silently disappear at shutdown
     # serialisation. Same bug family as #492.
     return {
         "queues": copy.deepcopy(_queues),
@@ -68,7 +70,8 @@ def get_state():
 def restore_state(data):
     if data:
         _queues.update(data.get("queues", {}))
-        _queue_name_to_url.update(data.get("queue_name_to_url", {}))
+        _queue_name_to_url.clear()
+        _rebuild_queue_name_index()
 
 
 try:
@@ -100,7 +103,91 @@ class _Err(Exception):
 # ── Queue URL ───────────────────────────────────────────────
 
 def _queue_url(name: str) -> str:
-    return f"http://{DEFAULT_HOST}:{DEFAULT_PORT}/{get_account_id()}/{name}"
+    return _queue_url_for_account(get_account_id(), name)
+
+
+def _queue_url_for_account(account_id: str, name: str) -> str:
+    return f"http://{DEFAULT_HOST}:{DEFAULT_PORT}/{account_id}/{name}"
+
+
+def _queue_name_from_arn_spec(spec) -> str | None:
+    if (
+        spec.partition != "aws"
+        or spec.service != "sqs"
+        or not spec.region
+        or not spec.account_id
+        or not spec.resource
+        or ":" in spec.resource
+        or "/" in spec.resource
+    ):
+        return None
+    return spec.resource
+
+
+def _queue_by_arn(arn: str) -> dict | None:
+    try:
+        spec = parse_arn(arn)
+    except ArnParseError:
+        return None
+    name = _queue_name_from_arn_spec(spec)
+    if not name:
+        return None
+    canonical_url = _queue_name_to_url.get_scoped(spec.account_id, spec.region, name)
+    if not canonical_url:
+        canonical_url = _queue_url_for_account(spec.account_id, name)
+    q = _queues.get_scoped(spec.account_id, spec.region, canonical_url)
+    if q and q.get("attributes", {}).get("QueueArn") == arn:
+        return q
+    return None
+
+
+def _queue_ref_from_urlish(url: str) -> tuple[str | None, str]:
+    if not url:
+        return None, ""
+    if "://" in url:
+        parts = urlparse(url).path.strip("/").split("/")
+    else:
+        parts = url.strip("/").split("/")
+    if len(parts) >= 2:
+        return parts[-2], parts[-1]
+    return None, parts[-1] if parts else url
+
+
+def _queue_scope_from_record(scoped_key, queue: dict) -> tuple[str, str, str, str] | None:
+    if len(scoped_key) == 3:
+        account_id, region, url = scoped_key
+    elif len(scoped_key) == 2:
+        account_id, url = scoped_key
+        region = get_region()
+    else:
+        return None
+
+    name = queue.get("name") if isinstance(queue, dict) else None
+    arn = queue.get("attributes", {}).get("QueueArn", "") if isinstance(queue, dict) else ""
+    try:
+        spec = parse_arn(arn)
+    except ArnParseError:
+        spec = None
+    if spec:
+        parsed_name = _queue_name_from_arn_spec(spec)
+        if parsed_name:
+            account_id = spec.account_id
+            region = spec.region
+            name = parsed_name
+    if not name:
+        _account_from_url, name = _queue_ref_from_urlish(url)
+    if not name:
+        return None
+    return account_id, region, name, url
+
+
+def _rebuild_queue_name_index() -> None:
+    for scoped_key, queue in _queues.all_items():
+        scope = _queue_scope_from_record(scoped_key, queue)
+        if not scope:
+            continue
+        account_id, region, name, url = scope
+        _queue_name_to_url.set_scoped(account_id, region, name, url)
 
 
 # ────────────────────────────────────────────────────────────
@@ -203,6 +290,18 @@ def _validate_redrive_policy(rp_str: str) -> None:
     except (TypeError, ValueError):
         raise _Err("InvalidAttributeValue", err_msg, 400)
     if mrc_int < 1 or mrc_int > 1000:
+        raise _Err("InvalidAttributeValue", err_msg, 400)
+    try:
+        dlq_spec = parse_arn(dlta)
+    except ArnParseError:
+        raise _Err("InvalidAttributeValue", err_msg, 400)
+    if (
+        _queue_name_from_arn_spec(dlq_spec) is None
+        or dlq_spec.account_id != get_account_id()
+        or dlq_spec.region != get_region()
+    ):
+        raise _Err("InvalidAttributeValue", err_msg, 400)
+    if _queue_by_arn(dlta) is None:
         raise _Err("InvalidAttributeValue", err_msg, 400)
 
 
@@ -854,8 +953,10 @@ def _get_q(url: str) -> dict:
         # This handles cases where the hostname differs (e.g. docker-compose
         # service name "ministack" vs "localhost"), or when a bare queue name
         # is passed instead of a full URL (supported by AWS and some SDKs).
-        parts = url.rstrip("/").split("/")
-        name = parts[-1] if len(parts) >= 2 else url
+        account_id, name = _queue_ref_from_urlish(url)
+        if account_id and _ACCOUNT_ID_RE.match(account_id) and account_id != get_account_id():
+            raise _Err("QueueDoesNotExist",
+                        "The specified queue does not exist for this wsdl version.")
         canonical_url = _queue_name_to_url.get(name)
         if canonical_url:
             q = _queues.get(canonical_url)
@@ -986,8 +1087,7 @@ def _dlq_sweep(q: dict) -> None:
     if not max_rc or not arn:
         return
 
-    dlq = next((qq for qq in _queues.values()
-                if qq["attributes"].get("QueueArn") == arn), None)
+    dlq = _queue_by_arn(arn)
     if dlq is None:
         return
 

--- a/tests/test_sqs.py
+++ b/tests/test_sqs.py
@@ -6,7 +6,9 @@ import uuid as _uuid_mod
 import zipfile
 from urllib.parse import urlparse
 
+import boto3
 import pytest
+from botocore.config import Config
 from botocore.exceptions import ClientError
 
 
@@ -17,6 +19,19 @@ def _make_zip(code: str) -> bytes:
     return buf.getvalue()
 
 _LAMBDA_ROLE = "arn:aws:iam::000000000000:role/lambda-role"
+
+
+def _regional_sqs(region_name):
+    endpoint = os.environ.get("MINISTACK_ENDPOINT", "http://localhost:4566")
+    return boto3.client(
+        "sqs",
+        endpoint_url=endpoint,
+        aws_access_key_id="test",
+        aws_secret_access_key="test",
+        region_name=region_name,
+        config=Config(region_name=region_name, retries={"mode": "standard"}),
+    )
+
 
 def test_sqs_create_queue(sqs):
     resp = sqs.create_queue(QueueName="intg-sqs-create")
@@ -50,6 +65,43 @@ def test_sqs_get_queue_url(sqs):
     sqs.create_queue(QueueName="intg-sqs-geturl")
     resp = sqs.get_queue_url(QueueName="intg-sqs-geturl")
     assert "intg-sqs-geturl" in resp["QueueUrl"]
+
+
+def test_sqs_queues_are_region_scoped_by_name(sqs):
+    name = f"mr-sqs-same-name-{_uuid_mod.uuid4().hex[:8]}"
+    west = _regional_sqs("us-west-2")
+
+    east_url = sqs.create_queue(QueueName=name)["QueueUrl"]
+    west_url = west.create_queue(QueueName=name)["QueueUrl"]
+
+    east_arn = sqs.get_queue_attributes(
+        QueueUrl=east_url, AttributeNames=["QueueArn"]
+    )["Attributes"]["QueueArn"]
+    west_arn = west.get_queue_attributes(
+        QueueUrl=west_url, AttributeNames=["QueueArn"]
+    )["Attributes"]["QueueArn"]
+    assert east_arn == f"arn:aws:sqs:us-east-1:000000000000:{name}"
+    assert west_arn == f"arn:aws:sqs:us-west-2:000000000000:{name}"
+
+    sqs.send_message(QueueUrl=east_url, MessageBody="east")
+    west.send_message(QueueUrl=west_url, MessageBody="west")
+
+    east_msgs = sqs.receive_message(
+        QueueUrl=east_url, MaxNumberOfMessages=1, WaitTimeSeconds=0
+    )
+    west_msgs = west.receive_message(
+        QueueUrl=west_url, MaxNumberOfMessages=1, WaitTimeSeconds=0
+    )
+    assert [m["Body"] for m in east_msgs["Messages"]] == ["east"]
+    assert [m["Body"] for m in west_msgs["Messages"]] == ["west"]
+
+    west.delete_queue(QueueUrl=west_url)
+    with pytest.raises(ClientError):
+        west.get_queue_attributes(QueueUrl=west_url, AttributeNames=["QueueArn"])
+    assert sqs.get_queue_attributes(
+        QueueUrl=east_url, AttributeNames=["QueueArn"]
+    )["Attributes"]["QueueArn"] == east_arn
+
 
 def test_sqs_queue_url_reflects_env_host(sqs):
     """QueueUrl host must come from MINISTACK_HOST env var, not hardcoded localhost."""
@@ -377,7 +429,8 @@ def test_sqs_tag_queue_rejects_null_tag_value(sqs):
     stored as Python None then serialised back as the literal string "null".
     Real AWS rejects at intake.
     """
-    import urllib.request, json as _json
+    import json as _json
+    import urllib.request
     url = sqs.create_queue(QueueName="intg-sqs-tag-null")["QueueUrl"]
 
     endpoint = os.environ.get("MINISTACK_ENDPOINT", "http://localhost:4566")
@@ -707,6 +760,17 @@ def test_sqs_bare_queue_name_as_url(sqs):
     assert bodies == ["via-name", "via-url"]
 
 
+def test_sqs_localstack_queue_path_alias(sqs):
+    queue_name = "intg-sqs-localstack-alias"
+    sqs.create_queue(QueueName=queue_name)
+    alias_url = f"http://localhost:4566/queue/{queue_name}"
+
+    sqs.send_message(QueueUrl=alias_url, MessageBody="via-alias")
+
+    resp = sqs.receive_message(QueueUrl=queue_name, MaxNumberOfMessages=1)
+    assert resp["Messages"][0]["Body"] == "via-alias"
+
+
 # -- AWS-parity gaps from competitor audit ------------------------------
 # Three regressions, all surfaced when comparing MS behaviour against the
 # AWS SQS API reference: SendMessage size enforcement, AddPermission,
@@ -868,6 +932,26 @@ def test_sqs_create_queue_redrive_policy_accepts_int_max_receive_count(sqs):
     )
 
 
+def test_sqs_redrive_policy_rejects_cross_region_dlq(sqs):
+    west = _regional_sqs("us-west-2")
+    west_dlq_url = west.create_queue(
+        QueueName=f"rp-west-dlq-{_uuid_mod.uuid4().hex[:8]}"
+    )["QueueUrl"]
+    west_dlq_arn = west.get_queue_attributes(
+        QueueUrl=west_dlq_url, AttributeNames=["QueueArn"]
+    )["Attributes"]["QueueArn"]
+
+    with pytest.raises(ClientError) as exc:
+        sqs.create_queue(
+            QueueName=f"rp-east-src-{_uuid_mod.uuid4().hex[:8]}",
+            Attributes={"RedrivePolicy": json.dumps({
+                "deadLetterTargetArn": west_dlq_arn,
+                "maxReceiveCount": "2",
+            })},
+        )
+    assert exc.value.response["Error"]["Code"] == "InvalidAttributeValue"
+
+
 def test_sqs_set_queue_attributes_validates_redrive_policy(sqs):
     """SetQueueAttributes runs the same validator — otherwise CreateQueue
     rejects the bad value but SetQueueAttributes would let it through and
@@ -963,8 +1047,8 @@ def test_sqs_messages_endpoint_basic(sqs):
     # One account, one queue, two messages.
     accts = list(data["messages"].keys())
     assert len(accts) == 1
-    assert qurl in data["messages"][accts[0]]
-    msgs = data["messages"][accts[0]][qurl]
+    assert qurl in data["messages"][accts[0]]["us-east-1"]
+    msgs = data["messages"][accts[0]]["us-east-1"][qurl]
     bodies = sorted(m["Body"] for m in msgs)
     assert bodies == ["hello-peek-1", "hello-peek-2"]
     # Peek must not have receive-counted the messages.
@@ -981,6 +1065,27 @@ def test_sqs_messages_endpoint_basic(sqs):
     sqs.delete_queue(QueueUrl=qurl)
 
 
+def test_sqs_messages_endpoint_separates_same_url_regions(sqs):
+    """QueueUrl peeks keep same-name regional queues separate."""
+    import urllib.request
+
+    name = f"intg-peek-region-{_uuid_mod.uuid4().hex[:8]}"
+    west = _regional_sqs("us-west-2")
+    east_url = sqs.create_queue(QueueName=name)["QueueUrl"]
+    west_url = west.create_queue(QueueName=name)["QueueUrl"]
+    sqs.send_message(QueueUrl=east_url, MessageBody="east-peek")
+    west.send_message(QueueUrl=west_url, MessageBody="west-peek")
+    endpoint = os.environ.get("MINISTACK_ENDPOINT", "http://localhost:4566")
+
+    with urllib.request.urlopen(f"{endpoint}/_ministack/sqs/messages?QueueUrl={east_url}") as r:
+        data = json.loads(r.read())
+
+    acct = next(iter(data["messages"]))
+    by_region = data["messages"][acct]
+    assert [m["Body"] for m in by_region["us-east-1"][east_url]] == ["east-peek"]
+    assert [m["Body"] for m in by_region["us-west-2"][west_url]] == ["west-peek"]
+
+
 def test_sqs_messages_endpoint_invalid_account_rejected(sqs):
     """?account=<not-12-digit> returns 400 InvalidAccountID."""
     import urllib.error
@@ -993,6 +1098,57 @@ def test_sqs_messages_endpoint_invalid_account_rejected(sqs):
         assert e.code == 400
         body = json.loads(e.read())
         assert body["__type"] == "InvalidAccountID"
+
+
+def test_sqs_restore_rebuilds_legacy_name_index_from_queue_arn():
+    import ministack.services.sqs as _sqs
+    from ministack.core.responses import (
+        AccountScopedDict,
+        get_account_id,
+        get_region,
+        set_request_account_id,
+        set_request_region,
+    )
+
+    original_account = get_account_id()
+    original_region = get_region()
+    original_queues = dict(_sqs._queues._data)
+    original_names = dict(_sqs._queue_name_to_url._data)
+    try:
+        _sqs._queues.clear()
+        _sqs._queue_name_to_url.clear()
+        set_request_account_id("000000000000")
+        set_request_region("us-east-1")
+
+        legacy_queues = AccountScopedDict()
+        legacy_names = AccountScopedDict()
+        queue_name = f"legacy-west-{_uuid_mod.uuid4().hex[:8]}"
+        queue_url = f"http://localhost:4566/000000000000/{queue_name}"
+        legacy_queues[queue_url] = {
+            "name": queue_name,
+            "url": queue_url,
+            "attributes": {"QueueArn": f"arn:aws:sqs:us-west-2:000000000000:{queue_name}"},
+            "messages": [],
+            "tags": {},
+            "is_fifo": False,
+            "dedup_cache": {},
+            "fifo_seq": 0,
+        }
+        legacy_names[queue_name] = queue_url
+
+        _sqs.restore_state({"queues": legacy_queues, "queue_name_to_url": legacy_names})
+
+        assert _sqs._queue_name_to_url.get(queue_name) is None
+        set_request_region("us-west-2")
+        assert _sqs._queue_name_to_url.get(queue_name) == queue_url
+        assert _sqs._get_q(queue_url)["attributes"]["QueueArn"].endswith(queue_name)
+    finally:
+        _sqs._queues.clear()
+        _sqs._queues._data.update(original_queues)
+        _sqs._queue_name_to_url.clear()
+        _sqs._queue_name_to_url._data.update(original_names)
+        set_request_account_id(original_account)
+        set_request_region(original_region)
 
 
 # ── Numeric attribute range validation (#841) ────────────────────────


### PR DESCRIPTION
## Why
Continue region-state isolation for services that need to deliver to SQS queues without relying on current-region QueueUrl lookup.

## What
- Store SQS queues by account and region, including persisted name-index rebuilds
- Keep `/queue/<name>` URL aliases while preserving account mismatch rejection
- Route S3, SNS, EventBridge, and Lambda SQS delivery through QueueArn resolution
- Add message endpoint region scoping and coverage for same-name regional queues

## Risk Assessment
Medium - this changes SQS state layout and in-process integrations on the multi-region feature branch, with full service regression coverage for the modified integration services.

## References
Validation:
- `uv run --extra dev ruff check ministack/app.py ministack/services/sqs.py ministack/services/s3.py ministack/services/sns.py ministack/services/eventbridge.py ministack/services/lambda_svc.py tests/test_sqs.py`
- `uv run --extra dev pytest tests/test_sqs.py tests/test_s3.py tests/test_sns.py tests/test_eventbridge.py tests/test_lambda.py -v -n 4 --dist=loadfile -m "not serial"`
- `uv run --extra dev pytest tests/test_sqs.py tests/test_s3.py tests/test_sns.py tests/test_eventbridge.py tests/test_lambda.py -v -m serial`
