### PR TITLE
Region-scope Secrets Manager state

### DIFF
--- a/ministack/services/rds_data.py
+++ b/ministack/services/rds_data.py
@@ -266,29 +266,31 @@ def _get_secret_credentials(secret_arn):
     """
     from ministack.services import secretsmanager
 
-    for _name, secret in secretsmanager._secrets.items():
-        if secret.get("ARN") == secret_arn or _name == secret_arn:
-            # Find the AWSCURRENT version
-            for _vid, ver in secret.get("Versions", {}).items():
-                if "AWSCURRENT" in ver.get("Stages", []):
-                    secret_string = ver.get("SecretString")
-                    if secret_string:
-                        try:
-                            parsed = json.loads(secret_string)
-                            return (parsed.get("username"),
-                                    parsed.get("password", secret_string))
-                        except (json.JSONDecodeError, TypeError):
-                            return None, secret_string
-            # Fallback to any version
-            for _vid, ver in secret.get("Versions", {}).items():
-                secret_string = ver.get("SecretString")
-                if secret_string:
-                    try:
-                        parsed = json.loads(secret_string)
-                        return (parsed.get("username"),
-                                parsed.get("password", secret_string))
-                    except (json.JSONDecodeError, TypeError):
-                        return None, secret_string
+    _name, secret = secretsmanager._resolve(secret_arn, use_arn_scope=True)
+    if not secret:
+        return None, None
+
+    # Find the AWSCURRENT version
+    for _vid, ver in secret.get("Versions", {}).items():
+        if "AWSCURRENT" in ver.get("Stages", []):
+            secret_string = ver.get("SecretString")
+            if secret_string:
+                try:
+                    parsed = json.loads(secret_string)
+                    return (parsed.get("username"),
+                            parsed.get("password", secret_string))
+                except (json.JSONDecodeError, TypeError):
+                    return None, secret_string
+    # Fallback to any version
+    for _vid, ver in secret.get("Versions", {}).items():
+        secret_string = ver.get("SecretString")
+        if secret_string:
+            try:
+                parsed = json.loads(secret_string)
+                return (parsed.get("username"),
+                        parsed.get("password", secret_string))
+            except (json.JSONDecodeError, TypeError):
+                return None, secret_string
     return None, None
 
 

--- a/ministack/services/secretsmanager.py
+++ b/ministack/services/secretsmanager.py
@@ -21,7 +21,7 @@ import time
 
 from ministack.core.arn import ArnParseError, parse_arn
 from ministack.core.responses import (
-    AccountScopedDict,
+    AccountRegionScopedDict,
     error_response_json,
     get_account_id,
     get_region,
@@ -35,8 +35,8 @@ REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 
 from ministack.core.persistence import PERSIST_STATE, load_state
 
-_secrets = AccountScopedDict()
-_resource_policies = AccountScopedDict()
+_secrets = AccountRegionScopedDict()
+_resource_policies = AccountRegionScopedDict()
 # name -> {
 #   ARN, Name, Description, Tags: [{Key, Value}],
 #   CreatedDate, LastChangedDate, LastAccessedDate,
@@ -77,7 +77,7 @@ except Exception:
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _secret_name_from_arn(secret_id):
+def _secret_scope_from_arn(secret_id):
     try:
         spec = parse_arn(secret_id)
     except ArnParseError:
@@ -85,18 +85,36 @@ def _secret_name_from_arn(secret_id):
     if (
         spec.partition != "aws"
         or spec.service != "secretsmanager"
-        or spec.region != get_region()
-        or spec.account_id != get_account_id()
     ):
         return None
     prefix = "secret:"
     if not spec.resource.startswith(prefix):
         return None
     name = spec.resource[len(prefix):]
-    return name or None
+    if not name:
+        return None
+    return spec, name
 
 
-def _resolve(secret_id):
+def _secret_name_from_arn(secret_id):
+    scope = _secret_scope_from_arn(secret_id)
+    if not scope:
+        return None
+    spec, name = scope
+    if spec.region != get_region() or spec.account_id != get_account_id():
+        return None
+    return name
+
+
+def _secret_arn_for_region(secret, region):
+    try:
+        spec = parse_arn(secret["ARN"])
+    except ArnParseError:
+        return f"arn:aws:secretsmanager:{region}:{get_account_id()}:secret:{secret['Name']}-{new_uuid()[:6]}"
+    return f"arn:{spec.partition}:secretsmanager:{region}:{spec.account_id}:{spec.resource}"
+
+
+def _resolve(secret_id, *, use_arn_scope=False):
     """Look up a secret by name or ARN.  Returns (storage_key, record) or (None, None).
 
     Supports three lookup modes (matching real AWS behaviour):
@@ -107,12 +125,22 @@ def _resolve(secret_id):
     if not secret_id:
         return None, None
     if secret_id.startswith("arn:"):
-        if not _secret_name_from_arn(secret_id):
+        scope = _secret_scope_from_arn(secret_id)
+        if not scope:
             return None, None
-        for key, s in _secrets.items():
+        spec, _ = scope
+        if spec.account_id != get_account_id():
+            return None, None
+        if use_arn_scope:
+            candidates = _secrets.items_scoped(spec.account_id, spec.region)
+        else:
+            if spec.region != get_region():
+                return None, None
+            candidates = _secrets.items()
+        for key, s in candidates:
             if s["ARN"] == secret_id:
                 return key, s
-        for key, s in _secrets.items():
+        for key, s in candidates:
             if s["ARN"].startswith(secret_id):
                 return key, s
         return None, None
@@ -139,7 +167,7 @@ def resolve_secret_string(secret_id, version_stage="AWSCURRENT"):
     in-process without going through the HTTP API. Returns None if the secret
     does not exist, is scheduled for deletion, or has no value for the stage.
     """
-    _, secret = _resolve(secret_id)
+    _, secret = _resolve(secret_id, use_arn_scope=True)
     if not secret or secret.get("DeletedDate"):
         return None
     _, ver = _find_stage_version(secret, version_stage)
@@ -188,6 +216,115 @@ def _apply_current_promotion(secret, new_vid):
 
 def _vid_to_stages(secret):
     return {vid: list(ver["Stages"]) for vid, ver in secret["Versions"].items() if ver["Stages"]}
+
+
+def _sync_replicas(secret):
+    source_scope = _secret_scope_from_arn(secret["ARN"])
+    account_id = source_scope[0].account_id if source_scope else get_account_id()
+    source_region = source_scope[0].region if source_scope else get_region()
+    for status in secret.get("ReplicationStatus", []):
+        region = status.get("Region")
+        if not region:
+            continue
+        if region == source_region:
+            continue
+        replica = _secrets.get_scoped(account_id, region, secret["Name"])
+        if not replica:
+            continue
+        if replica.get("ARN") != _secret_arn_for_region(secret, region):
+            continue
+        replica_arn = replica["ARN"]
+        replica_kms_key_id = replica.get("KmsKeyId")
+        updated = copy.deepcopy(secret)
+        updated["ARN"] = replica_arn
+        updated["ReplicationStatus"] = []
+        updated["_PrimarySecretArn"] = secret["ARN"]
+        updated["_PrimaryRegion"] = source_region
+        if replica_kms_key_id:
+            updated["KmsKeyId"] = replica_kms_key_id
+        else:
+            updated.pop("KmsKeyId", None)
+        _secrets.set_scoped(account_id, region, secret["Name"], updated)
+
+
+def _is_replica(secret):
+    return bool(secret.get("_PrimarySecretArn"))
+
+
+def _replica_mutation_error():
+    return error_response_json(
+        "InvalidRequestException",
+        "You can't perform this operation on a replica secret.",
+        400,
+    )
+
+
+def _delete_replicas(secret):
+    source_scope = _secret_scope_from_arn(secret["ARN"])
+    account_id = source_scope[0].account_id if source_scope else get_account_id()
+    source_region = source_scope[0].region if source_scope else get_region()
+    for status in secret.get("ReplicationStatus", []):
+        region = status.get("Region")
+        if not region:
+            continue
+        if region == source_region:
+            continue
+        replica = _secrets.get_scoped(account_id, region, secret["Name"])
+        if replica and replica.get("ARN") == _secret_arn_for_region(secret, region):
+            _resource_policies.pop_scoped(account_id, region, replica["ARN"], None)
+            _secrets.pop_scoped(account_id, region, secret["Name"], None)
+
+
+def _replica_policy_targets(secret):
+    source_scope = _secret_scope_from_arn(secret["ARN"])
+    account_id = source_scope[0].account_id if source_scope else get_account_id()
+    source_region = source_scope[0].region if source_scope else get_region()
+    for status in secret.get("ReplicationStatus", []):
+        region = status.get("Region")
+        if not region:
+            continue
+        if region == source_region:
+            continue
+        replica = _secrets.get_scoped(account_id, region, secret["Name"])
+        if replica and replica.get("ARN") == _secret_arn_for_region(secret, region):
+            yield account_id, region, replica["ARN"]
+
+
+def _sync_replica_resource_policy(secret, policy):
+    for account_id, region, replica_arn in _replica_policy_targets(secret):
+        _resource_policies.set_scoped(account_id, region, replica_arn, copy.deepcopy(policy))
+
+
+def _delete_replica_resource_policies(secret):
+    for account_id, region, replica_arn in _replica_policy_targets(secret):
+        _resource_policies.pop_scoped(account_id, region, replica_arn, None)
+
+
+def _unlink_from_primary(replica):
+    primary_arn = replica.get("_PrimarySecretArn")
+    if not primary_arn:
+        return
+    primary_scope = _secret_scope_from_arn(primary_arn)
+    replica_scope = _secret_scope_from_arn(replica["ARN"])
+    if not primary_scope or not replica_scope:
+        return
+    primary_spec, _ = primary_scope
+    replica_spec, _ = replica_scope
+    for _name, candidate in _secrets.items_scoped(primary_spec.account_id, primary_spec.region):
+        if candidate.get("ARN") != primary_arn:
+            continue
+        candidate["ReplicationStatus"] = [
+            status
+            for status in candidate.get("ReplicationStatus", [])
+            if status.get("Region") != replica_spec.region
+        ]
+        return
+
+
+def _cleanup_overwritten_secret(secret):
+    _delete_replicas(secret)
+    if _is_replica(secret):
+        _unlink_from_primary(secret)
 
 
 def _remove_stage(secret, version_id, stage):
@@ -421,6 +558,8 @@ def _list_secrets(data):
         }
         if s.get("DeletedDate"):
             entry["DeletedDate"] = s["DeletedDate"]
+        if s.get("_PrimaryRegion"):
+            entry["PrimaryRegion"] = s["_PrimaryRegion"]
         secret_list.append(entry)
 
     resp: dict = {"SecretList": secret_list}
@@ -443,6 +582,8 @@ def _delete_secret(data):
             "InvalidRequestException",
             "You can't perform this operation on the secret because it was already scheduled for deletion.", 400,
         )
+    if _is_replica(secret):
+        return _replica_mutation_error()
 
     force = data.get("ForceDeleteWithoutRecovery", False)
     window = data.get("RecoveryWindowInDays")
@@ -465,6 +606,7 @@ def _delete_secret(data):
 
     if force:
         arn, sname = secret["ARN"], secret["Name"]
+        _delete_replicas(secret)
         del _secrets[key]
         # Clean up any associated resource policy too — otherwise it
         # lingers as an orphan keyed by the now-deleted ARN, invisible
@@ -474,6 +616,7 @@ def _delete_secret(data):
         return json_response({"ARN": arn, "Name": sname, "DeletionDate": deletion_date})
 
     secret["DeletedDate"] = deletion_date
+    _sync_replicas(secret)
     return json_response({"ARN": secret["ARN"], "Name": secret["Name"], "DeletionDate": deletion_date})
 
 
@@ -490,7 +633,10 @@ def _restore_secret(data):
             "InvalidRequestException",
             "Secret is not scheduled for deletion.", 400,
         )
+    if _is_replica(secret):
+        return _replica_mutation_error()
     secret["DeletedDate"] = None
+    _sync_replicas(secret)
     return json_response({"ARN": secret["ARN"], "Name": secret["Name"]})
 
 
@@ -507,6 +653,8 @@ def _update_secret(data):
             "InvalidRequestException",
             "You can't perform this operation on the secret because it was marked for deletion.", 400,
         )
+    if _is_replica(secret):
+        return _replica_mutation_error()
 
     if "Description" in data:
         secret["Description"] = data["Description"]
@@ -516,6 +664,7 @@ def _update_secret(data):
     has_new_value = "SecretString" in data or "SecretBinary" in data
     if not has_new_value:
         secret["LastChangedDate"] = int(time.time())
+        _sync_replicas(secret)
         return json_response({"ARN": secret["ARN"], "Name": secret["Name"]})
 
     vid = new_uuid()
@@ -528,6 +677,7 @@ def _update_secret(data):
     }
     _apply_current_promotion(secret, vid)
     secret["LastChangedDate"] = now
+    _sync_replicas(secret)
     return json_response({"ARN": secret["ARN"], "Name": secret["Name"], "VersionId": vid})
 
 
@@ -553,6 +703,8 @@ def _describe_secret(data):
     }
     if secret.get("DeletedDate"):
         result["DeletedDate"] = secret["DeletedDate"]
+    if secret.get("_PrimaryRegion"):
+        result["PrimaryRegion"] = secret["_PrimaryRegion"]
     if secret.get("KmsKeyId"):
         result["KmsKeyId"] = secret["KmsKeyId"]
     if secret.get("RotationLambdaARN"):
@@ -577,6 +729,8 @@ def _put_secret_value(data):
             "InvalidRequestException",
             "You can't perform this operation on the secret because it was marked for deletion.", 400,
         )
+    if _is_replica(secret):
+        return _replica_mutation_error()
 
     vid = data.get("ClientRequestToken", new_uuid())
     stages = data.get("VersionStages", ["AWSCURRENT"])
@@ -595,6 +749,7 @@ def _put_secret_value(data):
         secret["Versions"][vid]["Stages"] = list(stages)
 
     secret["LastChangedDate"] = now
+    _sync_replicas(secret)
     return json_response({
         "ARN": secret["ARN"],
         "Name": secret["Name"],
@@ -616,6 +771,8 @@ def _update_secret_version_stage(data):
             "InvalidRequestException",
             "You can't perform this operation on the secret because it was marked for deletion.", 400,
         )
+    if _is_replica(secret):
+        return _replica_mutation_error()
 
     version_stage = data.get("VersionStage")
     move_to_vid = data.get("MoveToVersionId")
@@ -684,6 +841,7 @@ def _update_secret_version_stage(data):
             _add_stage(secret, old_current_vid, "AWSPREVIOUS")
 
     secret["LastChangedDate"] = int(time.time())
+    _sync_replicas(secret)
     return json_response({"ARN": secret["ARN"], "Name": secret["Name"]})
 
 
@@ -695,10 +853,18 @@ def _tag_resource(data):
             "ResourceNotFoundException",
             "Secrets Manager can't find the specified secret.", 400,
         )
+    if secret.get("DeletedDate"):
+        return error_response_json(
+            "InvalidRequestException",
+            "You can't perform this operation on the secret because it was marked for deletion.", 400,
+        )
+    if _is_replica(secret):
+        return _replica_mutation_error()
     existing = {t["Key"]: t for t in secret.get("Tags", [])}
     for t in data.get("Tags", []):
         existing[t["Key"]] = t
     secret["Tags"] = list(existing.values())
+    _sync_replicas(secret)
     return json_response({})
 
 
@@ -710,8 +876,16 @@ def _untag_resource(data):
             "ResourceNotFoundException",
             "Secrets Manager can't find the specified secret.", 400,
         )
+    if secret.get("DeletedDate"):
+        return error_response_json(
+            "InvalidRequestException",
+            "You can't perform this operation on the secret because it was marked for deletion.", 400,
+        )
+    if _is_replica(secret):
+        return _replica_mutation_error()
     keys_to_remove = set(data.get("TagKeys", []))
     secret["Tags"] = [t for t in secret.get("Tags", []) if t["Key"] not in keys_to_remove]
+    _sync_replicas(secret)
     return json_response({})
 
 
@@ -769,6 +943,8 @@ def _rotate_secret(data):
             "InvalidRequestException",
             "You can't perform this operation on the secret because it was marked for deletion.", 400,
         )
+    if _is_replica(secret):
+        return _replica_mutation_error()
 
     lambda_arn = data.get("RotationLambdaARN") or secret.get("RotationLambdaARN")
     rotation_rules = data.get("RotationRules") or secret.get("RotationRules")
@@ -794,6 +970,7 @@ def _rotate_secret(data):
 
     _apply_current_promotion(secret, vid)
     secret["LastChangedDate"] = now
+    _sync_replicas(secret)
 
     return json_response({"ARN": secret["ARN"], "Name": secret["Name"], "VersionId": vid})
 
@@ -868,19 +1045,88 @@ def _replicate_secret_to_regions(data):
             "ResourceNotFoundException",
             "Secrets Manager can't find the specified secret.", 400,
         )
+    if secret.get("DeletedDate"):
+        return error_response_json(
+            "InvalidRequestException",
+            "You can't perform this operation on the secret because it was marked for deletion.", 400,
+        )
+    if _is_replica(secret):
+        return _replica_mutation_error()
 
+    force_overwrite = bool(data.get("ForceOverwriteReplicaSecret", False))
+    existing_status = {
+        status.get("Region"): status
+        for status in secret.get("ReplicationStatus", [])
+        if status.get("Region")
+    }
+    new_statuses = []
+    source_scope = _secret_scope_from_arn(secret["ARN"])
+    source_region = source_scope[0].region if source_scope else get_region()
+    replica_updates = []
     for r in data.get("AddReplicaRegions", []):
         region = r.get("Region")
-        secret["ReplicationStatus"].append({
+        if not region:
+            continue
+        if region == source_region:
+            return error_response_json(
+                "InvalidParameterException",
+                "The replica region can't be the same as the primary secret region.",
+                400,
+            )
+        replica_arn = _secret_arn_for_region(secret, region)
+        existing = _secrets.get_scoped(get_account_id(), region, secret["Name"])
+        if existing and existing.get("ARN") != replica_arn and not force_overwrite:
+            return error_response_json(
+                "ResourceExistsException",
+                f"The operation failed because the secret {secret['Name']} already exists.",
+                400,
+            )
+        existing_replica_kms = None
+        if existing and existing.get("ARN") == replica_arn:
+            existing_replica_kms = existing.get("KmsKeyId")
+        kms_key_id = r.get("KmsKeyId") or existing_replica_kms
+        old_policy_arn = None
+        old_secret = None
+        if existing and existing.get("ARN") != replica_arn:
+            old_policy_arn = existing.get("ARN")
+            old_secret = existing
+        replica_updates.append((region, replica_arn, kms_key_id, old_policy_arn, old_secret))
+
+        status = {
             "Region": region,
             "Status": "InSync",
             "StatusMessage": "Replication succeeded (stub).",
-        })
+        }
+        if kms_key_id:
+            status["KmsKeyId"] = kms_key_id
+        existing_status[region] = status
+        new_statuses.append(status)
+
+    for region, replica_arn, kms_key_id, old_policy_arn, old_secret in replica_updates:
+        replica = copy.deepcopy(secret)
+        replica["ARN"] = replica_arn
+        replica["ReplicationStatus"] = []
+        replica["_PrimarySecretArn"] = secret["ARN"]
+        replica["_PrimaryRegion"] = source_region
+        if kms_key_id:
+            replica["KmsKeyId"] = kms_key_id
+        else:
+            replica.pop("KmsKeyId", None)
+        if old_policy_arn:
+            _resource_policies.pop_scoped(get_account_id(), region, old_policy_arn, None)
+        if old_secret:
+            _cleanup_overwritten_secret(old_secret)
+        _secrets.set_scoped(get_account_id(), region, secret["Name"], replica)
+        policy = _resource_policies.get(secret["ARN"])
+        if policy is not None:
+            _resource_policies.set_scoped(get_account_id(), region, replica_arn, copy.deepcopy(policy))
+
+    secret["ReplicationStatus"] = list(existing_status.values())
 
     logger.info(
         "ReplicateSecretToRegions stub for %s, regions=%s",
         secret["Name"],
-        [r.get("Region") for r in data.get("AddReplicaRegions", [])],
+        [status.get("Region") for status in new_statuses],
     )
 
     return json_response({
@@ -903,6 +1149,7 @@ def _put_resource_policy(data):
         )
     policy = data.get("ResourcePolicy", "{}")
     _resource_policies[secret["ARN"]] = policy
+    _sync_replica_resource_policy(secret, policy)
     return json_response({"ARN": secret["ARN"], "Name": secret["Name"]})
 
 
@@ -930,6 +1177,7 @@ def _delete_resource_policy(data):
             "Secrets Manager can't find the specified secret.", 400,
         )
     _resource_policies.pop(secret["ARN"], None)
+    _delete_replica_resource_policies(secret)
     return json_response({"ARN": secret["ARN"], "Name": secret["Name"]})
 
 

--- a/tests/test_rds_data.py
+++ b/tests/test_rds_data.py
@@ -765,3 +765,67 @@ def test_rds_data_secret_credentials_no_username():
     assert user is None
     assert pw == "just-a-password"
     del secretsmanager._secrets["pw-only-secret"]
+
+
+def test_rds_data_secret_credentials_use_secret_arn_region():
+    """_get_secret_credentials resolves ARN-scoped secrets outside the request region."""
+    from ministack.core.responses import get_region, set_request_account_id, set_request_region
+    from ministack.services import rds_data, secretsmanager
+
+    original_region = get_region()
+    set_request_account_id("test")
+    set_request_region("us-east-1")
+    secretsmanager._secrets["cross-region-cred"] = {
+        "ARN": "arn:aws:secretsmanager:us-east-1:000000000000:secret:cross-region-cred",
+        "Name": "cross-region-cred",
+        "Versions": {
+            "v1": {
+                "Stages": ["AWSCURRENT"],
+                "SecretString": '{"username":"app_rw","password":"p@ss123"}',
+            }
+        },
+    }
+    try:
+        set_request_region("us-west-2")
+        user, pw = rds_data._get_secret_credentials(
+            "arn:aws:secretsmanager:us-east-1:000000000000:secret:cross-region-cred"
+        )
+        assert user == "app_rw"
+        assert pw == "p@ss123"
+    finally:
+        set_request_region("us-east-1")
+        secretsmanager._secrets.pop("cross-region-cred", None)
+        set_request_region(original_region)
+
+
+def test_rds_data_secret_credentials_reject_cross_account_secret_arn():
+    from ministack.core.responses import (
+        get_account_id,
+        get_region,
+        set_request_account_id,
+        set_request_region,
+    )
+    from ministack.services import rds_data, secretsmanager
+
+    original_account = get_account_id()
+    original_region = get_region()
+    set_request_account_id("000000000000")
+    set_request_region("us-east-1")
+    secretsmanager._secrets.set_scoped("111111111111", "us-east-1", "cross-account-cred", {
+        "ARN": "arn:aws:secretsmanager:us-east-1:111111111111:secret:cross-account-cred",
+        "Name": "cross-account-cred",
+        "Versions": {
+            "v1": {
+                "Stages": ["AWSCURRENT"],
+                "SecretString": '{"username":"app_rw","password":"p@ss123"}',
+            }
+        },
+    })
+    try:
+        assert rds_data._get_secret_credentials(
+            "arn:aws:secretsmanager:us-east-1:111111111111:secret:cross-account-cred"
+        ) == (None, None)
+    finally:
+        secretsmanager._secrets.pop_scoped("111111111111", "us-east-1", "cross-account-cred", None)
+        set_request_account_id(original_account)
+        set_request_region(original_region)

--- a/tests/test_secretsmanager.py
+++ b/tests/test_secretsmanager.py
@@ -72,6 +72,416 @@ def test_secretsmanager_create_get(sm):
     resp = sm.get_secret_value(SecretId="test-secret-1")
     assert json.loads(resp["SecretString"])["user"] == "admin"
 
+
+def test_secretsmanager_secrets_are_region_scoped_by_name(sm):
+    name = f"sm-region-scope-{_uuid_mod.uuid4().hex[:8]}"
+    west = _regional_sm("us-west-2")
+
+    east_arn = sm.create_secret(Name=name, SecretString="east")["ARN"]
+    west_arn = west.create_secret(Name=name, SecretString="west")["ARN"]
+
+    assert east_arn.startswith("arn:aws:secretsmanager:us-east-1:000000000000:secret:")
+    assert west_arn.startswith("arn:aws:secretsmanager:us-west-2:000000000000:secret:")
+    assert sm.get_secret_value(SecretId=name)["SecretString"] == "east"
+    assert west.get_secret_value(SecretId=name)["SecretString"] == "west"
+
+    east_names = {entry["Name"] for entry in sm.list_secrets()["SecretList"]}
+    west_names = {entry["Name"] for entry in west.list_secrets()["SecretList"]}
+    assert name in east_names
+    assert name in west_names
+
+    with pytest.raises(ClientError) as exc:
+        sm.get_secret_value(SecretId=west_arn)
+    assert exc.value.response["Error"]["Code"] == "ResourceNotFoundException"
+
+
+def test_secretsmanager_resource_policies_are_region_scoped(sm):
+    name = f"sm-region-policy-{_uuid_mod.uuid4().hex[:8]}"
+    west = _regional_sm("us-west-2")
+    sm.create_secret(Name=name, SecretString="east")
+    west.create_secret(Name=name, SecretString="west")
+
+    east_policy = json.dumps({"Version": "2012-10-17", "Statement": [{"Sid": "east"}]})
+    west_policy = json.dumps({"Version": "2012-10-17", "Statement": [{"Sid": "west"}]})
+    sm.put_resource_policy(SecretId=name, ResourcePolicy=east_policy)
+    west.put_resource_policy(SecretId=name, ResourcePolicy=west_policy)
+
+    assert sm.get_resource_policy(SecretId=name)["ResourcePolicy"] == east_policy
+    assert west.get_resource_policy(SecretId=name)["ResourcePolicy"] == west_policy
+
+
+def test_secretsmanager_replicate_secret_to_regions_creates_target_region_secret(sm):
+    name = f"sm-region-replica-{_uuid_mod.uuid4().hex[:8]}"
+    west = _regional_sm("us-west-2")
+
+    east_arn = sm.create_secret(Name=name, SecretString="primary")["ARN"]
+    resp = sm.replicate_secret_to_regions(
+        SecretId=name,
+        AddReplicaRegions=[{"Region": "us-west-2", "KmsKeyId": "alias/west-key"}],
+    )
+    assert resp["ARN"] == east_arn
+    assert resp["ReplicationStatus"] == [{
+        "Region": "us-west-2",
+        "Status": "InSync",
+        "StatusMessage": "Replication succeeded (stub).",
+        "KmsKeyId": "alias/west-key",
+    }]
+
+    replica_value = west.get_secret_value(SecretId=name)
+    assert replica_value["SecretString"] == "primary"
+    assert replica_value["ARN"].startswith(
+        "arn:aws:secretsmanager:us-west-2:000000000000:secret:"
+    )
+    assert west.describe_secret(SecretId=name)["KmsKeyId"] == "alias/west-key"
+    replica_description = west.describe_secret(SecretId=name)
+    assert replica_description["PrimaryRegion"] == "us-east-1"
+    replica_entries = {
+        entry["Name"]: entry
+        for entry in west.list_secrets()["SecretList"]
+    }
+    assert replica_entries[name]["PrimaryRegion"] == "us-east-1"
+
+
+def test_secretsmanager_replicate_secret_to_regions_requires_force_for_existing_target(sm):
+    name = f"sm-region-replica-conflict-{_uuid_mod.uuid4().hex[:8]}"
+    west = _regional_sm("us-west-2")
+    sm.create_secret(Name=name, SecretString="primary")
+    west.create_secret(Name=name, SecretString="independent")
+
+    with pytest.raises(ClientError) as exc:
+        sm.replicate_secret_to_regions(
+            SecretId=name,
+            AddReplicaRegions=[{"Region": "us-west-2"}],
+        )
+    assert exc.value.response["Error"]["Code"] == "ResourceExistsException"
+    assert west.get_secret_value(SecretId=name)["SecretString"] == "independent"
+
+    sm.replicate_secret_to_regions(
+        SecretId=name,
+        AddReplicaRegions=[{"Region": "us-west-2"}],
+        ForceOverwriteReplicaSecret=True,
+    )
+    assert west.get_secret_value(SecretId=name)["SecretString"] == "primary"
+
+
+def test_secretsmanager_replicate_secret_to_regions_rejects_source_region(sm):
+    name = f"sm-region-replica-source-{_uuid_mod.uuid4().hex[:8]}"
+    sm.create_secret(Name=name, SecretString="primary")
+
+    with pytest.raises(ClientError) as exc:
+        sm.replicate_secret_to_regions(
+            SecretId=name,
+            AddReplicaRegions=[{"Region": "us-east-1"}],
+        )
+    assert exc.value.response["Error"]["Code"] == "InvalidParameterException"
+    assert "ReplicationStatus" not in sm.describe_secret(SecretId=name)
+
+
+def test_secretsmanager_replicate_secret_to_regions_does_not_partially_write(sm):
+    name = f"sm-region-replica-partial-{_uuid_mod.uuid4().hex[:8]}"
+    west = _regional_sm("us-west-2")
+    sm.create_secret(Name=name, SecretString="primary")
+
+    with pytest.raises(ClientError) as exc:
+        sm.replicate_secret_to_regions(
+            SecretId=name,
+            AddReplicaRegions=[
+                {"Region": "us-west-2"},
+                {"Region": "us-east-1"},
+            ],
+        )
+    assert exc.value.response["Error"]["Code"] == "InvalidParameterException"
+    assert "ReplicationStatus" not in sm.describe_secret(SecretId=name)
+    with pytest.raises(ClientError) as missing:
+        west.get_secret_value(SecretId=name)
+    assert missing.value.response["Error"]["Code"] == "ResourceNotFoundException"
+
+
+def test_secretsmanager_replicate_secret_to_regions_does_not_copy_primary_kms(sm):
+    name = f"sm-region-replica-kms-{_uuid_mod.uuid4().hex[:8]}"
+    west = _regional_sm("us-west-2")
+    sm.create_secret(Name=name, SecretString="primary", KmsKeyId="alias/source-key")
+
+    sm.replicate_secret_to_regions(
+        SecretId=name,
+        AddReplicaRegions=[{"Region": "us-west-2"}],
+    )
+
+    assert "KmsKeyId" not in west.describe_secret(SecretId=name)
+
+
+def test_secretsmanager_replicated_secret_versions_stay_in_sync(sm):
+    name = f"sm-region-replica-sync-{_uuid_mod.uuid4().hex[:8]}"
+    west = _regional_sm("us-west-2")
+    sm.create_secret(Name=name, SecretString="primary")
+    sm.replicate_secret_to_regions(
+        SecretId=name,
+        AddReplicaRegions=[{"Region": "us-west-2"}],
+    )
+
+    sm.update_secret(SecretId=name, SecretString="updated")
+    assert west.get_secret_value(SecretId=name)["SecretString"] == "updated"
+
+    sm.put_secret_value(SecretId=name, SecretString="put-value")
+    assert west.get_secret_value(SecretId=name)["SecretString"] == "put-value"
+
+    token = _uuid_mod.uuid4().hex
+    sm.rotate_secret(SecretId=name, ClientRequestToken=token)
+    replica_stages = west.describe_secret(SecretId=name)["VersionIdsToStages"]
+    assert replica_stages[token] == ["AWSCURRENT"]
+
+
+def test_secretsmanager_replica_rejects_direct_mutation(sm):
+    name = f"sm-region-replica-readonly-{_uuid_mod.uuid4().hex[:8]}"
+    west = _regional_sm("us-west-2")
+    sm.create_secret(Name=name, SecretString="primary")
+    sm.replicate_secret_to_regions(
+        SecretId=name,
+        AddReplicaRegions=[{"Region": "us-west-2"}],
+    )
+
+    with pytest.raises(ClientError) as exc:
+        west.put_secret_value(SecretId=name, SecretString="west-only")
+    assert exc.value.response["Error"]["Code"] == "InvalidRequestException"
+    assert west.get_secret_value(SecretId=name)["SecretString"] == "primary"
+
+
+def test_secretsmanager_primary_force_delete_removes_replicas(sm):
+    name = f"sm-region-replica-delete-{_uuid_mod.uuid4().hex[:8]}"
+    west = _regional_sm("us-west-2")
+    sm.create_secret(Name=name, SecretString="primary")
+    sm.replicate_secret_to_regions(
+        SecretId=name,
+        AddReplicaRegions=[{"Region": "us-west-2"}],
+    )
+
+    sm.delete_secret(SecretId=name, ForceDeleteWithoutRecovery=True)
+
+    with pytest.raises(ClientError) as exc:
+        west.get_secret_value(SecretId=name)
+    assert exc.value.response["Error"]["Code"] == "ResourceNotFoundException"
+
+
+def test_secretsmanager_primary_force_delete_removes_replica_policy(sm):
+    from ministack.services import secretsmanager as _sm
+
+    name = f"sm-region-replica-policy-delete-{_uuid_mod.uuid4().hex[:8]}"
+    west = _regional_sm("us-west-2")
+    sm.create_secret(Name=name, SecretString="primary")
+    sm.replicate_secret_to_regions(
+        SecretId=name,
+        AddReplicaRegions=[{"Region": "us-west-2"}],
+    )
+    west_arn = west.describe_secret(SecretId=name)["ARN"]
+    west.put_resource_policy(
+        SecretId=name,
+        ResourcePolicy=json.dumps({"Version": "2012-10-17", "Statement": []}),
+    )
+
+    sm.delete_secret(SecretId=name, ForceDeleteWithoutRecovery=True)
+
+    assert _sm._resource_policies.get_scoped("000000000000", "us-west-2", west_arn) is None
+
+
+def test_secretsmanager_replica_cannot_be_replicated(sm):
+    name = f"sm-region-replica-chain-{_uuid_mod.uuid4().hex[:8]}"
+    west = _regional_sm("us-west-2")
+    east_2 = _regional_sm("us-east-2")
+    sm.create_secret(Name=name, SecretString="primary")
+    sm.replicate_secret_to_regions(
+        SecretId=name,
+        AddReplicaRegions=[{"Region": "us-west-2"}],
+    )
+
+    with pytest.raises(ClientError) as exc:
+        west.replicate_secret_to_regions(
+            SecretId=name,
+            AddReplicaRegions=[{"Region": "us-east-2"}],
+        )
+    assert exc.value.response["Error"]["Code"] == "InvalidRequestException"
+    with pytest.raises(ClientError) as missing:
+        east_2.get_secret_value(SecretId=name)
+    assert missing.value.response["Error"]["Code"] == "ResourceNotFoundException"
+
+
+def test_secretsmanager_deleted_secret_cannot_be_replicated(sm):
+    name = f"sm-region-replica-deleted-{_uuid_mod.uuid4().hex[:8]}"
+    west = _regional_sm("us-west-2")
+    sm.create_secret(Name=name, SecretString="primary")
+    sm.delete_secret(SecretId=name, RecoveryWindowInDays=7)
+
+    with pytest.raises(ClientError) as exc:
+        sm.replicate_secret_to_regions(
+            SecretId=name,
+            AddReplicaRegions=[{"Region": "us-west-2"}],
+        )
+    assert exc.value.response["Error"]["Code"] == "InvalidRequestException"
+    with pytest.raises(ClientError) as missing:
+        west.get_secret_value(SecretId=name)
+    assert missing.value.response["Error"]["Code"] == "ResourceNotFoundException"
+
+
+def test_secretsmanager_force_overwrite_removes_target_policy(sm):
+    from ministack.services import secretsmanager as _sm
+
+    name = f"sm-region-replica-overwrite-policy-{_uuid_mod.uuid4().hex[:8]}"
+    west = _regional_sm("us-west-2")
+    sm.create_secret(Name=name, SecretString="primary")
+    old_west_arn = west.create_secret(Name=name, SecretString="independent")["ARN"]
+    west.put_resource_policy(
+        SecretId=name,
+        ResourcePolicy=json.dumps({"Version": "2012-10-17", "Statement": []}),
+    )
+
+    sm.replicate_secret_to_regions(
+        SecretId=name,
+        AddReplicaRegions=[{"Region": "us-west-2"}],
+        ForceOverwriteReplicaSecret=True,
+    )
+
+    assert _sm._resource_policies.get_scoped("000000000000", "us-west-2", old_west_arn) is None
+
+
+def test_secretsmanager_replicate_secret_to_regions_copies_resource_policy(sm):
+    name = f"sm-region-replica-policy-{_uuid_mod.uuid4().hex[:8]}"
+    west = _regional_sm("us-west-2")
+    policy = json.dumps({"Version": "2012-10-17", "Statement": [{"Sid": "source"}]})
+    sm.create_secret(Name=name, SecretString="primary")
+    sm.put_resource_policy(SecretId=name, ResourcePolicy=policy)
+
+    sm.replicate_secret_to_regions(
+        SecretId=name,
+        AddReplicaRegions=[{"Region": "us-west-2"}],
+    )
+
+    assert west.get_resource_policy(SecretId=name)["ResourcePolicy"] == policy
+
+
+def test_secretsmanager_replica_resource_policy_stays_in_sync(sm):
+    name = f"sm-region-replica-policy-sync-{_uuid_mod.uuid4().hex[:8]}"
+    west = _regional_sm("us-west-2")
+    sm.create_secret(Name=name, SecretString="primary")
+    sm.replicate_secret_to_regions(
+        SecretId=name,
+        AddReplicaRegions=[{"Region": "us-west-2"}],
+    )
+
+    first_policy = json.dumps({"Version": "2012-10-17", "Statement": [{"Sid": "first"}]})
+    second_policy = json.dumps({"Version": "2012-10-17", "Statement": [{"Sid": "second"}]})
+    sm.put_resource_policy(SecretId=name, ResourcePolicy=first_policy)
+    assert west.get_resource_policy(SecretId=name)["ResourcePolicy"] == first_policy
+
+    sm.put_resource_policy(SecretId=name, ResourcePolicy=second_policy)
+    assert west.get_resource_policy(SecretId=name)["ResourcePolicy"] == second_policy
+
+    sm.delete_resource_policy(SecretId=name)
+    assert "ResourcePolicy" not in west.get_resource_policy(SecretId=name)
+
+
+def test_secretsmanager_replicate_secret_to_regions_preserves_replica_kms(sm):
+    name = f"sm-region-replica-kms-repeat-{_uuid_mod.uuid4().hex[:8]}"
+    west = _regional_sm("us-west-2")
+    sm.create_secret(Name=name, SecretString="primary")
+    sm.replicate_secret_to_regions(
+        SecretId=name,
+        AddReplicaRegions=[{"Region": "us-west-2", "KmsKeyId": "alias/west-key"}],
+    )
+
+    resp = sm.replicate_secret_to_regions(
+        SecretId=name,
+        AddReplicaRegions=[{"Region": "us-west-2"}],
+    )
+
+    assert west.describe_secret(SecretId=name)["KmsKeyId"] == "alias/west-key"
+    assert resp["ReplicationStatus"] == [{
+        "Region": "us-west-2",
+        "Status": "InSync",
+        "StatusMessage": "Replication succeeded (stub).",
+        "KmsKeyId": "alias/west-key",
+    }]
+
+
+def test_secretsmanager_force_overwrite_transfers_replica_ownership(sm):
+    name = f"sm-region-replica-owner-{_uuid_mod.uuid4().hex[:8]}"
+    east_2 = _regional_sm("us-east-2")
+    west = _regional_sm("us-west-2")
+    sm.create_secret(Name=name, SecretString="east-primary")
+    east_2.create_secret(Name=name, SecretString="east2-primary")
+    sm.replicate_secret_to_regions(
+        SecretId=name,
+        AddReplicaRegions=[{"Region": "us-west-2"}],
+    )
+    east_2.replicate_secret_to_regions(
+        SecretId=name,
+        AddReplicaRegions=[{"Region": "us-west-2"}],
+        ForceOverwriteReplicaSecret=True,
+    )
+    assert not sm.describe_secret(SecretId=name).get("ReplicationStatus")
+
+    sm.update_secret(SecretId=name, SecretString="old-primary-update")
+    assert west.get_secret_value(SecretId=name)["SecretString"] == "east2-primary"
+
+    sm.delete_secret(SecretId=name, ForceDeleteWithoutRecovery=True)
+    assert west.get_secret_value(SecretId=name)["SecretString"] == "east2-primary"
+
+    east_2.update_secret(SecretId=name, SecretString="new-primary-update")
+    assert west.get_secret_value(SecretId=name)["SecretString"] == "new-primary-update"
+
+
+def test_secretsmanager_force_overwrite_cleans_up_overwritten_primary_replicas(sm):
+    name = f"sm-region-replica-overwrite-primary-{_uuid_mod.uuid4().hex[:8]}"
+    west = _regional_sm("us-west-2")
+    eu_west_1 = _regional_sm("eu-west-1")
+    sm.create_secret(Name=name, SecretString="east-primary")
+    west.create_secret(Name=name, SecretString="west-primary")
+    west.replicate_secret_to_regions(
+        SecretId=name,
+        AddReplicaRegions=[{"Region": "eu-west-1"}],
+    )
+
+    sm.replicate_secret_to_regions(
+        SecretId=name,
+        AddReplicaRegions=[{"Region": "us-west-2"}],
+        ForceOverwriteReplicaSecret=True,
+    )
+
+    with pytest.raises(ClientError) as missing:
+        eu_west_1.get_secret_value(SecretId=name)
+    assert missing.value.response["Error"]["Code"] == "ResourceNotFoundException"
+
+
+def test_secretsmanager_self_region_replication_status_does_not_mark_primary_replica():
+    from ministack.core.responses import get_region, set_request_region
+    from ministack.services import secretsmanager as _sm
+
+    original_region = get_region()
+    name = f"sm-region-replica-self-status-{_uuid_mod.uuid4().hex[:8]}"
+    _sm.reset()
+    set_request_region("us-east-1")
+    try:
+        _sm._create_secret({"Name": name, "SecretString": "primary"})
+        secret = _sm._secrets.get(name)
+        secret["ReplicationStatus"] = [{
+            "Region": "us-east-1",
+            "Status": "InSync",
+            "StatusMessage": "legacy self-region status",
+        }]
+
+        _sm._update_secret({"SecretId": name, "SecretString": "updated"})
+
+        secret = _sm._secrets.get(name)
+        assert "_PrimarySecretArn" not in secret
+        status, _, body = _sm._describe_secret({"SecretId": name})
+        assert status == 200
+        assert "PrimaryRegion" not in json.loads(body)
+        status, _, body = _sm._get_secret_value({"SecretId": name})
+        assert status == 200
+        assert json.loads(body)["SecretString"] == "updated"
+    finally:
+        _sm.reset()
+        set_request_region(original_region)
+
+
 def test_secretsmanager_update_list(sm):
     sm.create_secret(Name="test-secret-2", SecretString="original")
     sm.update_secret(SecretId="test-secret-2", SecretString="updated")


### PR DESCRIPTION
## Why
Continue region-state isolation for Secrets Manager and its in-process RDS Data consumer on the multi-region feature branch.

## What
- Store Secrets Manager secrets and resource policies by account and region
- Resolve RDS Data secret credentials by the secret ARN region while rejecting cross-account secret ARNs
- Materialize `ReplicateSecretToRegions` replicas with primary/replica metadata, KMS handling, policy sync, and version sync
- Add replica mutation guards plus overwrite and deletion cleanup behavior

## Risk Assessment
Medium - this changes Secrets Manager state layout and replica handling on the multi-region feature branch, with focused service regression coverage.

## References
Validation:
- `uv run --extra dev ruff check ministack/services/secretsmanager.py ministack/services/rds_data.py tests/test_secretsmanager.py tests/test_rds_data.py`
- `uv run --extra dev pytest tests/test_secretsmanager.py tests/test_rds_data.py -v`
