### PR TITLE
fix(cognito): use unquote instead of unquote_plus for Basic auth

### DIFF
--- a/ministack/services/cognito.py
+++ b/ministack/services/cognito.py
@@ -63,7 +63,7 @@ import string
 import time
 import zlib
 from datetime import datetime, timezone
-from urllib.parse import parse_qs, quote, unquote_plus, urlencode
+from urllib.parse import parse_qs, quote, unquote, urlencode
 from xml.etree.ElementTree import Element, SubElement
 from xml.etree.ElementTree import tostring as xml_tostring
 
@@ -1236,7 +1236,7 @@ def _authenticate_client(headers: dict, form: dict):
             # containing "/" or "+" arrives as %2F/%2B and must be decoded to
             # match the stored value. The client_secret_post path already gets
             # this via parse_qs.
-            return unquote_plus(cid), unquote_plus(csec)
+            return unquote(cid), unquote(csec)
         except Exception:
             pass
     return form.get("client_id", ""), form.get("client_secret", "")


### PR DESCRIPTION
## Summary

`_authenticate_client` was using `unquote_plus` to decode client credentials from the `Authorization: Basic` header. `unquote_plus` converts `+` to space, which corrupts base64-encoded client secrets containing `+` characters.

## Problem

`test_oauth2_token_client_auth_basic` failed non-deterministically in CI ([run](https://github.com/ministackorg/ministack/actions/runs/28226431301/job/84238862173)) depending on whether the randomly generated secret contained `+`. Since `_client_secret()` produces standard base64 (`A-Za-z0-9+/=`), roughly half of secrets contain at least one `+`.

## Fix

Switch from `unquote_plus` to `unquote` which only decodes `%XX` sequences, leaving literal `+` intact. This matches how real OAuth2 clients and AWS Cognito handle HTTP Basic auth credentials.

## Testing

- Ran `test_oauth2_token_client_auth_basic` 10 times locally, all pass
- All 9 `oauth2_token` tests pass
