### PR TITLE
ci: reduce buildx cache pressure and clean up PR caches

### DIFF
--- a/.github/workflows/cache-cleanup-on-pr-close.yml
+++ b/.github/workflows/cache-cleanup-on-pr-close.yml
@@ -1,0 +1,41 @@
+name: Cleanup PR caches
+
+on:
+  pull_request_target:
+    types: [closed]
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+
+    steps:
+      - name: Delete caches for closed PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          ref="refs/pull/${PR_NUMBER}/merge"
+
+          cache_ids=$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${REPO}/actions/caches?per_page=100" \
+            --jq ".actions_caches[] | select(.ref == \"${ref}\") | .id")
+
+          if [ -z "${cache_ids}" ]; then
+            echo "No caches found for ${ref}"
+            exit 0
+          fi
+
+          for id in $cache_ids; do
+            echo "Deleting cache id ${id} for ${ref}"
+            gh api \
+              --method DELETE \
+              -H "Accept: application/vnd.github+json" \
+              "/repos/${REPO}/actions/caches/${id}"
+          done

--- a/.github/workflows/docker-publish-on-pr.yml
+++ b/.github/workflows/docker-publish-on-pr.yml
@@ -99,7 +99,7 @@ jobs:
           build-args: |
             MINISTACK_VERSION=pr-${{ github.event.pull_request.number }}-${{ steps.short_sha.outputs.short_sha }}
           cache-from: type=gha,scope=regular-pr
-          cache-to: type=gha,mode=max,scope=regular-pr
+          cache-to: type=gha,mode=min,scope=regular-pr
 
       # ── Full (Debian/glibc) image — DuckDB-backed Athena, psycopg2, pymysql.
       # Only built when the PR carries the `full-preview` label (opt-in to keep
@@ -130,7 +130,7 @@ jobs:
           build-args: |
             MINISTACK_VERSION=pr-${{ github.event.pull_request.number }}-${{ steps.short_sha.outputs.short_sha }}
           cache-from: type=gha,scope=full-pr
-          cache-to: type=gha,mode=max,scope=full-pr
+          cache-to: type=gha,mode=min,scope=full-pr
 
       - name: Comment on PR with Docker image info
         if: steps.guard.outputs.skip != 'true'


### PR DESCRIPTION
## Summary
Reduces GitHub Actions cache pressure for PR preview image builds and adds automatic cleanup of stale PR caches on close.

## Changes
- change Docker Buildx GHA cache export from `mode=max` to `mode=min` in `.github/workflows/docker-publish-on-pr.yml`
- add `.github/workflows/cleanup-pr-caches.yml` to delete caches associated with closed pull requests
- keep existing shared cache scopes (`regular-pr` / `full-pr`) while lowering cache export size

## Why
A recent PR preview build failed during Buildx cache export with:

- `error writing layer blob: failed to reserve cache`

The failure happened while exporting to the GitHub Actions cache, which suggests cache reservation/quota contention rather than an application build problem.

Using `mode=min` should reduce cache export size and lower the chance of reservation failures. Cleaning up PR-specific caches on PR close should also reduce stale cache accumulation over time.

## Expected impact
- fewer cache reservation failures in Docker preview builds
- less stale PR cache buildup
- slightly less aggressive cache reuse than `mode=max`, but better reliability

## Notes
- this does not change image contents or publish behavior
- if cache pressure continues, a follow-up could move from shared scopes to PR-specific scopes or further tune cache strategy