### PR TITLE
feat(sns): complete mobile-push endpoint lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,13 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- **SNS — mobile-push endpoint lifecycle: `GetEndpointAttributes`, `SetEndpointAttributes`, `DeleteEndpoint`, `DeletePlatformApplication`** — completes the platform-endpoint flow on top of the existing `CreatePlatformApplication`/`CreatePlatformEndpoint`. `CreatePlatformEndpoint` now dedups by device token within a platform application (AWS behavior): re-requesting the same `Token` returns the existing endpoint ARN when `CustomUserData` matches, and raises `InvalidParameter` `"Endpoint <arn> already exists with the same Token, but different attributes."` when it differs — so callers can parse the ARN and reconcile. `Publish` to a platform-endpoint `TargetArn` now succeeds (stub delivery) instead of returning `Topic does not exist`, and `DeletePlatformApplication` is idempotent and drops the application's endpoints. This lets app push-token registration flows (register → read/update attributes → delete) run end-to-end against MiniStack. Contributed by @sjincho.
+
 ### Fixed
 - **S3 — S3 → EventBridge events use AWS-conformant `detail-type`, `reason`, and `deletion-type`** — S3 → EventBridge delivery built the `detail-type` by string-mangling the granular notification event name (`Object ObjectCreated Put` instead of AWS's fixed `Object Created`), hardcoded `detail.reason` to `PutObject` for every event, and omitted `detail.deletion-type` on deletes. Because EventBridge rules match on `detail-type`, any rule written to the AWS-documented type (e.g. `["Object Created"]`) silently never matched. Each S3 event family now maps to its fixed EventBridge `detail-type`, with the per-API `reason` (`PutObject`/`POST Object`/`CopyObject`/`CompleteMultipartUpload`/`DeleteObject`) and a `deletion-type` on `Object Deleted`. Fixes #1005.
+
+---
 
 ## [1.3.69] — 2026-06-27
 

--- a/ministack/services/sns.py
+++ b/ministack/services/sns.py
@@ -6,7 +6,9 @@ Supports: CreateTopic, DeleteTopic, ListTopics, GetTopicAttributes, SetTopicAttr
           GetSubscriptionAttributes, SetSubscriptionAttributes,
           Publish, PublishBatch,
           ListTagsForResource, TagResource, UntagResource,
-          CreatePlatformApplication, CreatePlatformEndpoint.
+          CreatePlatformApplication, DeletePlatformApplication,
+          CreatePlatformEndpoint, GetEndpointAttributes, SetEndpointAttributes,
+          DeleteEndpoint.
 SNS → Lambda fanout dispatches via _execute_function (synchronous).
 FIFO topics: .fifo naming validation, MessageGroupId/MessageDeduplicationId enforcement,
              5-minute deduplication window, sequence numbers, content-based deduplication,
@@ -113,6 +115,10 @@ async def handle_request(method: str, path: str, headers: dict, body: bytes, que
         "UntagResource": _untag_resource,
         "CreatePlatformApplication": _create_platform_application,
         "CreatePlatformEndpoint": _create_platform_endpoint,
+        "DeletePlatformApplication": _delete_platform_application,
+        "GetEndpointAttributes": _get_endpoint_attributes,
+        "SetEndpointAttributes": _set_endpoint_attributes,
+        "DeleteEndpoint": _delete_endpoint,
     }
 
     handler = handlers.get(action)
@@ -552,6 +558,14 @@ def _publish(params):
                       "TopicArn, TargetArn, or PhoneNumber is required", 400)
 
     if topic_arn not in _topics:
+        # Publishing directly to a mobile-push platform endpoint (TargetArn) is
+        # valid in AWS — https://docs.aws.amazon.com/sns/latest/api/API_Publish.html
+        # We don't deliver anything, but the call must succeed.
+        if topic_arn in _platform_endpoints:
+            msg_id = new_uuid()
+            logger.info("SNS platform-endpoint publish stub to %s", topic_arn)
+            return _xml(200, "PublishResponse",
+                        f"<PublishResult><MessageId>{msg_id}</MessageId></PublishResult>")
         return _error("NotFound", f"Topic does not exist: {topic_arn}", 404)
 
     topic = _topics[topic_arn]
@@ -1077,7 +1091,8 @@ def _create_platform_endpoint(params):
     if not token:
         return _error("InvalidParameterException", "Token is required", 400)
 
-    endpoint_arn = f"{app_arn}/{new_uuid()}"
+    # CustomUserData is a top-level request param (not an Attributes entry).
+    custom_user_data = _p(params, "CustomUserData")
 
     attrs = {"Enabled": "true", "Token": token}
     i = 1
@@ -1086,7 +1101,34 @@ def _create_platform_endpoint(params):
         val = _p(params, f"Attributes.entry.{i}.value")
         attrs[key] = val
         i += 1
+    if custom_user_data:
+        attrs["CustomUserData"] = custom_user_data
 
+    # AWS dedups by Token within a platform application: re-requesting the same
+    # Token returns the existing endpoint when CustomUserData matches, but
+    # raises if it differs — so callers know to Get/Set the existing endpoint.
+    # Idempotency per https://docs.aws.amazon.com/sns/latest/api/API_CreatePlatformEndpoint.html
+    # ("if the requester already owns an endpoint with the same device token and
+    # attributes, that endpoint's ARN is returned"); duplicate-token error string
+    # + parse-the-ARN guidance per
+    # https://aws.amazon.com/blogs/mobile/mobile-token-management-with-amazon-sns
+    for existing in _platform_endpoints.values():
+        if (existing["application_arn"] == app_arn
+                and existing["attributes"].get("Token") == token):
+            if (existing["attributes"].get("CustomUserData", "")
+                    == attrs.get("CustomUserData", "")):
+                return _xml(200, "CreatePlatformEndpointResponse",
+                            f"<CreatePlatformEndpointResult>"
+                            f"<EndpointArn>{existing['arn']}</EndpointArn>"
+                            f"</CreatePlatformEndpointResult>")
+            return _error(
+                "InvalidParameter",
+                f"Endpoint {existing['arn']} already exists with the same Token, "
+                f"but different attributes.",
+                400,
+            )
+
+    endpoint_arn = f"{app_arn}/{new_uuid()}"
     _platform_endpoints[endpoint_arn] = {
         "arn": endpoint_arn,
         "application_arn": app_arn,
@@ -1096,6 +1138,56 @@ def _create_platform_endpoint(params):
                 f"<CreatePlatformEndpointResult>"
                 f"<EndpointArn>{endpoint_arn}</EndpointArn>"
                 f"</CreatePlatformEndpointResult>")
+
+
+def _delete_platform_application(params):
+    # Idempotent in AWS. Also drop the application's endpoints.
+    # https://docs.aws.amazon.com/sns/latest/api/API_DeletePlatformApplication.html
+    arn = _p(params, "PlatformApplicationArn")
+    _platform_applications.pop(arn, None)
+    stale = [e["arn"] for e in _platform_endpoints.values()
+             if e["application_arn"] == arn]
+    for ep_arn in stale:
+        _platform_endpoints.pop(ep_arn, None)
+    return _xml(200, "DeletePlatformApplicationResponse", "")
+
+
+def _get_endpoint_attributes(params):
+    # https://docs.aws.amazon.com/sns/latest/api/API_GetEndpointAttributes.html
+    arn = _p(params, "EndpointArn")
+    endpoint = _platform_endpoints.get(arn)
+    if endpoint is None:
+        return _error("NotFound", f"Endpoint does not exist: {arn}", 404)
+    entries = "".join(
+        f"<entry><key>{_xml_escape(k)}</key><value>{_xml_escape(v)}</value></entry>"
+        for k, v in endpoint["attributes"].items()
+    )
+    return _xml(200, "GetEndpointAttributesResponse",
+                f"<GetEndpointAttributesResult><Attributes>{entries}</Attributes>"
+                f"</GetEndpointAttributesResult>")
+
+
+def _set_endpoint_attributes(params):
+    # https://docs.aws.amazon.com/sns/latest/api/API_SetEndpointAttributes.html
+    arn = _p(params, "EndpointArn")
+    endpoint = _platform_endpoints.get(arn)
+    if endpoint is None:
+        return _error("NotFound", f"Endpoint does not exist: {arn}", 404)
+    i = 1
+    while _p(params, f"Attributes.entry.{i}.key"):
+        key = _p(params, f"Attributes.entry.{i}.key")
+        val = _p(params, f"Attributes.entry.{i}.value")
+        endpoint["attributes"][key] = val
+        i += 1
+    return _xml(200, "SetEndpointAttributesResponse", "")
+
+
+def _delete_endpoint(params):
+    # AWS DeleteEndpoint is idempotent — succeeds even if already gone.
+    # https://docs.aws.amazon.com/sns/latest/api/API_DeleteEndpoint.html
+    arn = _p(params, "EndpointArn")
+    _platform_endpoints.pop(arn, None)
+    return _xml(200, "DeleteEndpointResponse", "")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sns.py
+++ b/tests/test_sns.py
@@ -1351,3 +1351,132 @@ def test_sns_publish_batch_rejects_oversized_entry_per_entry(sns):
     assert "too-big" in failed_ids
     failed = next(r for r in resp["Failed"] if r["Id"] == "too-big")
     assert failed["Code"] == "InvalidParameter"
+
+
+def _create_gcm_app(sns, name):
+    return sns.create_platform_application(
+        Name=name, Platform="GCM", Attributes={"PlatformCredential": ""},
+    )["PlatformApplicationArn"]
+
+
+def test_sns_create_platform_application(sns):
+    app_arn = _create_gcm_app(sns, "intg-sns-pe-create-app")
+    assert ":app/GCM/intg-sns-pe-create-app" in app_arn
+
+
+def test_sns_create_platform_endpoint_stores_token_and_enabled(sns):
+    app_arn = _create_gcm_app(sns, "intg-sns-pe-token")
+    token = _uuid_mod.uuid4().hex
+    arn = sns.create_platform_endpoint(
+        PlatformApplicationArn=app_arn, Token=token,
+    )["EndpointArn"]
+    attrs = sns.get_endpoint_attributes(EndpointArn=arn)["Attributes"]
+    assert attrs["Token"] == token
+    assert attrs["Enabled"] == "true"  # AWS default when unspecified
+
+
+def test_sns_create_platform_endpoint_stores_custom_user_data(sns):
+    app_arn = _create_gcm_app(sns, "intg-sns-pe-cud")
+    arn = sns.create_platform_endpoint(
+        PlatformApplicationArn=app_arn, Token=_uuid_mod.uuid4().hex,
+        CustomUserData="u-42",
+    )["EndpointArn"]
+    attrs = sns.get_endpoint_attributes(EndpointArn=arn)["Attributes"]
+    assert attrs["CustomUserData"] == "u-42"
+
+
+def test_sns_create_platform_endpoint_idempotent_when_attributes_match(sns):
+    app_arn = _create_gcm_app(sns, "intg-sns-pe-idem")
+    token = _uuid_mod.uuid4().hex
+    a1 = sns.create_platform_endpoint(
+        PlatformApplicationArn=app_arn, Token=token, CustomUserData="same",
+    )["EndpointArn"]
+    a2 = sns.create_platform_endpoint(
+        PlatformApplicationArn=app_arn, Token=token, CustomUserData="same",
+    )["EndpointArn"]
+    assert a1 == a2
+
+
+def test_sns_create_platform_endpoint_duplicate_token_different_attrs_raises(sns):
+    app_arn = _create_gcm_app(sns, "intg-sns-pe-dup")
+    token = _uuid_mod.uuid4().hex
+    existing = sns.create_platform_endpoint(
+        PlatformApplicationArn=app_arn, Token=token, CustomUserData="first",
+    )["EndpointArn"]
+    with pytest.raises(ClientError) as exc:
+        sns.create_platform_endpoint(
+            PlatformApplicationArn=app_arn, Token=token, CustomUserData="second",
+        )
+    msg = exc.value.response["Error"]["Message"]
+    # AWS-style message; consumers parse the existing endpoint ARN out of it.
+    assert "already exists with the same Token" in msg
+    assert existing in msg
+
+
+def test_sns_get_endpoint_attributes_not_found(sns):
+    app_arn = _create_gcm_app(sns, "intg-sns-pe-getmiss")
+    with pytest.raises(ClientError) as exc:
+        sns.get_endpoint_attributes(EndpointArn=f"{app_arn}/does-not-exist")
+    assert exc.value.response["Error"]["Code"] == "NotFound"
+
+
+def test_sns_set_endpoint_attributes_merges(sns):
+    app_arn = _create_gcm_app(sns, "intg-sns-pe-set")
+    arn = sns.create_platform_endpoint(
+        PlatformApplicationArn=app_arn, Token=_uuid_mod.uuid4().hex,
+    )["EndpointArn"]
+    new_token = _uuid_mod.uuid4().hex
+    sns.set_endpoint_attributes(
+        EndpointArn=arn,
+        Attributes={"Token": new_token, "Enabled": "false", "CustomUserData": "x"},
+    )
+    attrs = sns.get_endpoint_attributes(EndpointArn=arn)["Attributes"]
+    assert attrs["Token"] == new_token
+    assert attrs["Enabled"] == "false"
+    assert attrs["CustomUserData"] == "x"
+
+
+def test_sns_set_endpoint_attributes_not_found(sns):
+    app_arn = _create_gcm_app(sns, "intg-sns-pe-setmiss")
+    with pytest.raises(ClientError) as exc:
+        sns.set_endpoint_attributes(
+            EndpointArn=f"{app_arn}/nope", Attributes={"Enabled": "false"},
+        )
+    assert exc.value.response["Error"]["Code"] == "NotFound"
+
+
+def test_sns_delete_endpoint_then_get_not_found(sns):
+    app_arn = _create_gcm_app(sns, "intg-sns-pe-del")
+    arn = sns.create_platform_endpoint(
+        PlatformApplicationArn=app_arn, Token=_uuid_mod.uuid4().hex,
+    )["EndpointArn"]
+    sns.delete_endpoint(EndpointArn=arn)
+    with pytest.raises(ClientError) as exc:
+        sns.get_endpoint_attributes(EndpointArn=arn)
+    assert exc.value.response["Error"]["Code"] == "NotFound"
+
+
+def test_sns_delete_endpoint_is_idempotent(sns):
+    app_arn = _create_gcm_app(sns, "intg-sns-pe-delidem")
+    # Deleting a non-existent endpoint succeeds in AWS (no error).
+    sns.delete_endpoint(EndpointArn=f"{app_arn}/never-existed")
+
+
+def test_sns_delete_platform_application_removes_endpoints(sns):
+    app_arn = _create_gcm_app(sns, "intg-sns-pe-delapp")
+    arn = sns.create_platform_endpoint(
+        PlatformApplicationArn=app_arn, Token=_uuid_mod.uuid4().hex,
+    )["EndpointArn"]
+    sns.delete_platform_application(PlatformApplicationArn=app_arn)
+    with pytest.raises(ClientError) as exc:
+        sns.get_endpoint_attributes(EndpointArn=arn)
+    assert exc.value.response["Error"]["Code"] == "NotFound"
+
+
+def test_sns_publish_to_platform_endpoint(sns):
+    app_arn = _create_gcm_app(sns, "intg-sns-pe-publish")
+    arn = sns.create_platform_endpoint(
+        PlatformApplicationArn=app_arn, Token=_uuid_mod.uuid4().hex,
+    )["EndpointArn"]
+    resp = sns.publish(TargetArn=arn, Message="hi")
+    assert resp["MessageId"]


### PR DESCRIPTION
Build on the existing CreatePlatformApplication/CreatePlatformEndpoint with the operations needed to register and manage mobile-push endpoints end-to-end.

- CreatePlatformEndpoint:
  - Dedups by device token within a platform application
  - Re-requesting the same Token returns the existing endpoint ARN when CustomUserData matches.
  - Raises InvalidParameter when it differs (matches AWS response error).
- GetEndpointAttributes / SetEndpointAttributes:
  - Read and merge endpoint attributes
- DeleteEndpoint / DeletePlatformApplication:
  - Made idempotent to match AWS behavior.
  - DeletePlatformApplication also drops the application's endpoints.
- Publish to a platform-endpoint TargetArn now succeeds (stub delivery) instead of returning "Topic does not exist".

Adds 12 integration tests in tests/test_sns.py covering register -> read/update -> delete and the dedup/idempotency edges. 

Checked:
- ruff clean
- pytest tests/test_sns.py green
