### PR TITLE
Add region-scoped SSM parameter state

### DIFF
--- a/ministack/services/cloudformation/provisioners.py
+++ b/ministack/services/cloudformation/provisioners.py
@@ -726,8 +726,7 @@ def _ssm_create(logical_id, props, stack_name):
     ptype = props.get("Type", "String")
     value = props.get("Value", "")
     description = props.get("Description", "")
-    # ARN: no extra slash if name starts with /
-    param_arn = f"arn:aws:ssm:{get_region()}:{get_account_id()}:parameter{name}"
+    param_arn = _ssm._param_arn(name)
 
     _ssm._parameters[name] = {
         "Name": name,

--- a/ministack/services/ssm.py
+++ b/ministack/services/ssm.py
@@ -15,7 +15,9 @@ import os
 import time
 from datetime import datetime, timezone
 
+from ministack.core.arn import ArnParseError, parse_arn
 from ministack.core.responses import (
+    AccountRegionScopedDict,
     AccountScopedDict,
     error_response_json,
     get_account_id,
@@ -31,9 +33,9 @@ DEFAULT_PAGE_SIZE = 10
 
 from ministack.core.persistence import PERSIST_STATE, load_state
 
-_parameters = AccountScopedDict()
-_parameter_history = AccountScopedDict()
-_tags = AccountScopedDict()
+_parameters = AccountRegionScopedDict()
+_parameter_history = AccountRegionScopedDict()
+_tags = AccountRegionScopedDict()
 
 
 # ── Persistence ────────────────────────────────────────────
@@ -46,11 +48,155 @@ def get_state():
     }
 
 
+def _legacy_region_for_parameter_history(account_id: str, name: str) -> str:
+    exact_regions = {
+        region
+        for (stored_account_id, region, stored_name), _param in _parameters.all_items()
+        if stored_account_id == account_id and stored_name == name
+    }
+    if len(exact_regions) == 1:
+        return next(iter(exact_regions))
+
+    candidates = set(_parameter_name_candidates(name))
+    regions = {
+        region
+        for (stored_account_id, region, stored_name), _param in _parameters.all_items()
+        if stored_account_id == account_id and stored_name in candidates
+    }
+    if len(regions) == 1:
+        return next(iter(regions))
+    return get_region()
+
+
+def _restore_parameter_history(data) -> None:
+    if isinstance(data, AccountRegionScopedDict):
+        _parameter_history.update(data)
+        return
+    if isinstance(data, AccountScopedDict):
+        for (account_id, name), history in data._data.items():
+            region = _legacy_region_for_parameter_history(account_id, name)
+            _parameter_history.set_scoped(account_id, region, name, history)
+        return
+    if isinstance(data, dict):
+        for key, history in data.items():
+            if isinstance(key, tuple) and len(key) == 3:
+                account_id, region, name = key
+            elif isinstance(key, tuple) and len(key) == 2:
+                account_id, name = key
+                region = _legacy_region_for_parameter_history(account_id, name)
+            else:
+                account_id = get_account_id()
+                name = key
+                region = _legacy_region_for_parameter_history(account_id, name)
+            _parameter_history.set_scoped(account_id, region, name, history)
+
+
 def restore_state(data):
     if data:
         _parameters.update(data.get("parameters", {}))
-        _parameter_history.update(data.get("parameter_history", {}))
+        _restore_parameter_history(data.get("parameter_history", {}))
         _tags.update(data.get("tags", {}))
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+
+
+def _now_epoch() -> float:
+    return datetime.now(timezone.utc).timestamp()
+
+
+def _parameter_resource(name: str) -> str:
+    return f"parameter/{name.lstrip('/')}"
+
+
+def _param_arn(name: str) -> str:
+    return f"arn:aws:ssm:{get_region()}:{get_account_id()}:{_parameter_resource(name)}"
+
+
+def _parameter_name_candidates(name: str) -> list[str]:
+    if not name:
+        return []
+    candidates = [name]
+    alternate = name.lstrip("/") if name.startswith("/") else f"/{name}"
+    if alternate and alternate not in candidates:
+        candidates.append(alternate)
+    return candidates
+
+
+def _parameter_name_from_arn(value: str) -> tuple[str, str, str, bool] | None:
+    try:
+        spec = parse_arn(value)
+    except ArnParseError:
+        return None
+    if spec.partition != "aws" or spec.service != "ssm" or not spec.region:
+        return None
+    if spec.resource.startswith("parameter/"):
+        name = spec.resource[len("parameter/"):]
+        legacy_no_slash = False
+    elif spec.resource.startswith("parameter"):
+        name = spec.resource[len("parameter"):]
+        legacy_no_slash = True
+    else:
+        return None
+    if not name:
+        return None
+    return spec.account_id, spec.region or get_region(), name, legacy_no_slash
+
+
+def _lookup_parameter(name_or_arn: str, *, allow_arn_region: bool = False, flexible_name: bool = False):
+    if not name_or_arn:
+        return None, None
+    if name_or_arn.startswith("arn:"):
+        parsed = _parameter_name_from_arn(name_or_arn)
+        if not parsed:
+            return None, None
+        account_id, region, arn_name, legacy_no_slash = parsed
+        if account_id != get_account_id() or (not allow_arn_region and region != get_region()):
+            return None, None
+        matches = []
+        candidates = [arn_name] if legacy_no_slash else _parameter_name_candidates(arn_name)
+        for candidate in candidates:
+            param = _parameters.get_scoped(account_id, region, candidate)
+            if param:
+                matches.append((candidate, param))
+        for candidate, param in matches:
+            if param.get("ARN") == name_or_arn:
+                return candidate, param
+        if legacy_no_slash:
+            return None, None
+        if matches:
+            return matches[0]
+        return None, None
+
+    candidates = _parameter_name_candidates(name_or_arn) if flexible_name else [name_or_arn]
+    for candidate in candidates:
+        param = _parameters.get(candidate)
+        if param:
+            return candidate, param
+    return None, None
+
+
+def _parameter_tag_arn(resource_type: str, resource_id: str) -> str | None:
+    if resource_type != "Parameter":
+        return resource_id
+    if resource_id.startswith("arn:"):
+        _, param = _lookup_parameter(resource_id)
+        if not param:
+            return None
+        if resource_id in _tags:
+            return resource_id
+        return param["ARN"]
+    _, param = _lookup_parameter(resource_id, flexible_name=True)
+    if param:
+        normalized_id = resource_id if resource_id.startswith("/") else f"/{resource_id}"
+        slash_normalized_arn = _param_arn(normalized_id)
+        if slash_normalized_arn in _tags:
+            return slash_normalized_arn
+        return param["ARN"]
+    if not resource_id.startswith("/"):
+        resource_id = "/" + resource_id
+    return _param_arn(resource_id)
 
 
 try:
@@ -62,18 +208,6 @@ except Exception:
     logging.getLogger(__name__).exception(
         "Failed to restore persisted state; continuing with fresh store"
     )
-
-
-def _now_iso() -> str:
-    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
-
-
-def _now_epoch() -> float:
-    return datetime.now(timezone.utc).timestamp()
-
-
-def _param_arn(name: str) -> str:
-    return f"arn:aws:ssm:{get_region()}:{get_account_id()}:parameter{name}"
 
 
 def _encode_next_token(index: int) -> str:
@@ -126,15 +260,27 @@ def _put_parameter(data):
     value = data.get("Value", "")
     overwrite = data.get("Overwrite", False)
 
-    if name in _parameters and not overwrite:
+    existing = _parameters.get(name)
+    alternate_existing = [
+        candidate
+        for candidate in _parameter_name_candidates(name)
+        if candidate != name and candidate in _parameters
+    ]
+    if alternate_existing and not existing:
+        return error_response_json(
+            "ParameterAlreadyExists",
+            "The parameter already exists. To overwrite this value, set the overwrite option in the request to true.",
+            400,
+        )
+    if existing and not overwrite:
         return error_response_json(
             "ParameterAlreadyExists",
             "The parameter already exists. To overwrite this value, set the overwrite option in the request to true.",
             400,
         )
 
-    version = (_parameters[name]["Version"] + 1) if name in _parameters else 1
-    arn = _param_arn(name)
+    version = (existing["Version"] + 1) if existing else 1
+    arn = existing.get("ARN") if existing else _param_arn(name)
     now = _now_epoch()
 
     stored_value = value
@@ -154,7 +300,7 @@ def _put_parameter(data):
         "ARN": arn,
         "LastModifiedDate": now,
         "DataType": data.get("DataType", "text"),
-        "Description": data.get("Description", _parameters.get(name, {}).get("Description", "")),
+        "Description": data.get("Description", existing.get("Description", "") if existing else ""),
         "Tier": data.get("Tier", "Standard"),
         "AllowedPattern": data.get("AllowedPattern", ""),
         "Policies": data.get("Policies", []),
@@ -201,18 +347,13 @@ def resolve_parameter_value(name_or_arn):
     """
     if not name_or_arn:
         return None
-    name = name_or_arn
-    if name_or_arn.startswith("arn:") and ":parameter" in name_or_arn:
-        name = name_or_arn.split(":parameter", 1)[1]   # -> "/path/name"
-    param = (_parameters.get(name)
-             or _parameters.get("/" + name.lstrip("/"))
-             or _parameters.get(name.lstrip("/")))
+    _, param = _lookup_parameter(name_or_arn, allow_arn_region=True, flexible_name=True)
     return param.get("Value") if param else None
 
 
 def _get_parameter(data):
     name = data.get("Name")
-    param = _parameters.get(name)
+    _, param = _lookup_parameter(name)
     if not param:
         return error_response_json("ParameterNotFound", f"Parameter {name} not found", 400)
     with_decryption = data.get("WithDecryption", False)
@@ -225,7 +366,7 @@ def _get_parameters(data):
     params = []
     invalid = []
     for name in names:
-        p = _parameters.get(name)
+        _, p = _lookup_parameter(name)
         if p:
             params.append(_param_out(p, with_decryption))
         else:
@@ -274,12 +415,17 @@ def _get_parameters_by_path(data):
 
 def _delete_parameter(data):
     name = data.get("Name")
-    if name not in _parameters:
+    if isinstance(name, str) and name.startswith("arn:"):
+        return error_response_json("ValidationException", "Parameter name must not be an ARN", 400)
+    key, param = _lookup_parameter(name)
+    if not param:
         return error_response_json("ParameterNotFound", f"Parameter {name} not found", 400)
-    del _parameters[name]
-    _parameter_history.pop(name, None)
-    arn = _param_arn(name)
-    _tags.pop(arn, None)
+    tag_arn = _parameter_tag_arn("Parameter", key)
+    del _parameters[key]
+    _parameter_history.pop(key, None)
+    for arn in {param["ARN"], tag_arn}:
+        if arn:
+            _tags.pop(arn, None)
     return json_response({})
 
 
@@ -288,10 +434,17 @@ def _delete_parameters(data):
     deleted = []
     invalid = []
     for name in names:
-        if name in _parameters:
-            del _parameters[name]
-            _parameter_history.pop(name, None)
-            _tags.pop(_param_arn(name), None)
+        if isinstance(name, str) and name.startswith("arn:"):
+            invalid.append(name)
+            continue
+        key, param = _lookup_parameter(name)
+        if param:
+            tag_arn = _parameter_tag_arn("Parameter", key)
+            del _parameters[key]
+            _parameter_history.pop(key, None)
+            for arn in {param["ARN"], tag_arn}:
+                if arn:
+                    _tags.pop(arn, None)
             deleted.append(name)
         else:
             invalid.append(name)
@@ -474,12 +627,9 @@ def _add_tags_to_resource(data):
     resource_id = data.get("ResourceId", "")
     new_tags = data.get("Tags", [])
 
-    if resource_type == "Parameter":
-        if not resource_id.startswith("/"):
-            resource_id = "/" + resource_id
-        arn = _param_arn(resource_id)
-    else:
-        arn = resource_id
+    arn = _parameter_tag_arn(resource_type, resource_id)
+    if arn is None:
+        return error_response_json("ParameterNotFound", f"Parameter {resource_id} not found", 400)
 
     if arn not in _tags:
         _tags[arn] = {}
@@ -494,12 +644,9 @@ def _remove_tags_from_resource(data):
     resource_id = data.get("ResourceId", "")
     tag_keys = data.get("TagKeys", [])
 
-    if resource_type == "Parameter":
-        if not resource_id.startswith("/"):
-            resource_id = "/" + resource_id
-        arn = _param_arn(resource_id)
-    else:
-        arn = resource_id
+    arn = _parameter_tag_arn(resource_type, resource_id)
+    if arn is None:
+        return error_response_json("ParameterNotFound", f"Parameter {resource_id} not found", 400)
 
     if arn in _tags:
         for key in tag_keys:
@@ -512,12 +659,9 @@ def _list_tags_for_resource(data):
     resource_type = data.get("ResourceType", "Parameter")
     resource_id = data.get("ResourceId", "")
 
-    if resource_type == "Parameter":
-        if not resource_id.startswith("/"):
-            resource_id = "/" + resource_id
-        arn = _param_arn(resource_id)
-    else:
-        arn = resource_id
+    arn = _parameter_tag_arn(resource_type, resource_id)
+    if arn is None:
+        return error_response_json("ParameterNotFound", f"Parameter {resource_id} not found", 400)
 
     tag_dict = _tags.get(arn, {})
     tag_list = [{"Key": k, "Value": v} for k, v in tag_dict.items()]

--- a/tests/test_ecs.py
+++ b/tests/test_ecs.py
@@ -1138,3 +1138,53 @@ def test_ecs_cfn_taskdef_populates_registered_fields(ecs, cfn):
             f"compatibilities missing/empty: {td.get('compatibilities')!r}"
     finally:
         cfn.delete_stack(StackName=stack_name)
+
+def test_ecs_container_secret_ssm_valuefrom_is_region_scoped():
+    """ECS ``secrets[].valueFrom`` SSM references honor the parameter's region.
+
+    A bare parameter name resolves only in the task's request region — a
+    same-name parameter in another region is not visible, and a missing one
+    fails the launch. A full ARN resolves by the ARN's embedded region
+    regardless of the request region."""
+    from ministack.core.responses import (
+        get_account_id,
+        get_region,
+        set_request_account_id,
+        set_request_region,
+    )
+    from ministack.services import ssm as ssm_service
+
+    original_account = get_account_id()
+    original_region = get_region()
+    account_id = "000000000000"
+    name = f"/ecs/secret/{_uuid_mod.uuid4().hex[:8]}"
+    name_cdef = {"secrets": [{"name": "DB_PASS", "valueFrom": name}]}
+
+    try:
+        set_request_account_id(account_id)
+        ssm_service.reset()
+
+        # Parameter created in us-east-1 only.
+        set_request_region("us-east-1")
+        ssm_service._put_parameter({"Name": name, "Type": "String", "Value": "east-secret"})
+        east_arn = ssm_service._parameters.get_scoped(account_id, "us-east-1", name)["ARN"]
+
+        # Same request region → bare-name valueFrom resolves.
+        assert ecs_service._resolve_container_secrets(name_cdef) == {"DB_PASS": "east-secret"}
+
+        # Different request region, no same-name parameter → launch fails.
+        set_request_region("us-west-2")
+        with pytest.raises(ecs_service._SecretResolutionError):
+            ecs_service._resolve_container_secrets(name_cdef)
+
+        # A same-name parameter in the other region is isolated (west, not east).
+        ssm_service._put_parameter({"Name": name, "Type": "String", "Value": "west-secret"})
+        assert ecs_service._resolve_container_secrets(name_cdef) == {"DB_PASS": "west-secret"}
+
+        # Full ARN resolves by the ARN's region regardless of request region.
+        arn_cdef = {"secrets": [{"name": "DB_PASS", "valueFrom": east_arn}]}
+        assert ecs_service._resolve_container_secrets(arn_cdef) == {"DB_PASS": "east-secret"}
+    finally:
+        ssm_service.reset()
+        set_request_account_id(original_account)
+        set_request_region(original_region)

--- a/tests/test_ssm.py
+++ b/tests/test_ssm.py
@@ -748,3 +748,46 @@ def test_ssm_resolve_parameter_value_uses_arn_region_without_tail_fallback():
         ssm_service.reset()
         set_request_account_id(original_account)
         set_request_region(original_region)
+
+
+def test_cloudformation_ssm_parameter_is_region_scoped():
+    """A CloudFormation-created ``AWS::SSM::Parameter`` is stored under the
+    deploy request's region, so a client in another region cannot read it."""
+    from ministack.core.responses import (
+        get_account_id,
+        get_region,
+        set_request_account_id,
+        set_request_region,
+    )
+    from ministack.services import ssm as ssm_service
+    from ministack.services.cloudformation import provisioners
+
+    original_account = get_account_id()
+    original_region = get_region()
+    account_id = "000000000000"
+    name = f"cfn-region-{_uuid_mod.uuid4().hex[:8]}"
+
+    try:
+        set_request_account_id(account_id)
+        set_request_region("us-west-2")
+        ssm_service.reset()
+        provisioners._ssm_create("Param", {"Name": name, "Value": "west"}, "stack")
+
+        # Stored only under the deploy region.
+        assert ssm_service._parameters.get_scoped(account_id, "us-west-2", name) is not None
+        assert ssm_service._parameters.get_scoped(account_id, "us-east-1", name) is None
+
+        # Readable in the deploy region.
+        status, _headers, body = ssm_service._get_parameter({"Name": name})
+        assert status == 200
+        assert json.loads(body)["Parameter"]["Value"] == "west"
+
+        # Absent from another region.
+        set_request_region("us-east-1")
+        status, _headers, body = ssm_service._get_parameter({"Name": name})
+        assert status == 400
+        assert json.loads(body)["__type"] == "ParameterNotFound"
+    finally:
+        ssm_service.reset()
+        set_request_account_id(original_account)
+        set_request_region(original_region)

--- a/tests/test_ssm.py
+++ b/tests/test_ssm.py
@@ -6,8 +6,21 @@ import uuid as _uuid_mod
 import zipfile
 from urllib.parse import urlparse
 
+import boto3
 import pytest
+from botocore.config import Config
 from botocore.exceptions import ClientError
+
+
+def _regional_ssm(region_name):
+    return boto3.client(
+        "ssm",
+        endpoint_url=os.environ.get("MINISTACK_ENDPOINT", "http://localhost:4566"),
+        aws_access_key_id="test",
+        aws_secret_access_key="test",
+        region_name=region_name,
+        config=Config(region_name=region_name, retries={"mode": "standard"}),
+    )
 
 
 def test_ssm_put_get(ssm):
@@ -253,3 +266,485 @@ def test_ssm_get_parameters_by_path_root_non_recursive(ssm):
     names = [p["Name"] for p in resp["Parameters"]]
     assert "/toplevel" in names
     assert "/nested/deep" not in names
+
+
+def test_ssm_restore_legacy_parameter_history_uses_parameter_arn_region():
+    from ministack.core.responses import AccountScopedDict, set_request_account_id, set_request_region
+    from ministack.services import ssm as ssm_service
+
+    account_id = "000000000000"
+    name = f"/legacy/history/{_uuid_mod.uuid4().hex[:8]}"
+
+    set_request_account_id(account_id)
+    set_request_region("us-east-1")
+    ssm_service.reset()
+    parameters = AccountScopedDict()
+    parameters[name] = {
+        "Name": name,
+        "Type": "String",
+        "Value": "v2",
+        "Version": 2,
+        "ARN": f"arn:aws:ssm:us-west-2:{account_id}:parameter/{name.lstrip('/')}",
+    }
+    parameter_history = AccountScopedDict()
+    parameter_history[name] = [
+        {"Name": name, "Type": "String", "Value": "v1", "Version": 1},
+        {"Name": name, "Type": "String", "Value": "v2", "Version": 2},
+    ]
+
+    try:
+        ssm_service.restore_state({
+            "parameters": parameters,
+            "parameter_history": parameter_history,
+        })
+
+        assert len(ssm_service._parameter_history.get_scoped(account_id, "us-west-2", name)) == 2
+        assert ssm_service._parameter_history.get_scoped(account_id, "us-east-1", name) is None
+    finally:
+        ssm_service.reset()
+
+
+def test_ssm_restore_legacy_history_prefers_exact_parameter_name_region():
+    from ministack.core.responses import AccountScopedDict, set_request_account_id, set_request_region
+    from ministack.services import ssm as ssm_service
+
+    account_id = "000000000000"
+    suffix = _uuid_mod.uuid4().hex[:8]
+    bare_name = f"legacy-history-exact-{suffix}"
+    path_name = f"/{bare_name}"
+
+    set_request_account_id(account_id)
+    set_request_region("us-east-1")
+    ssm_service.reset()
+    parameters = AccountScopedDict()
+    parameters[bare_name] = {
+        "Name": bare_name,
+        "Type": "String",
+        "Value": "bare",
+        "Version": 1,
+        "ARN": f"arn:aws:ssm:us-west-2:{account_id}:parameter{bare_name}",
+    }
+    parameters[path_name] = {
+        "Name": path_name,
+        "Type": "String",
+        "Value": "path",
+        "Version": 1,
+        "ARN": f"arn:aws:ssm:us-east-1:{account_id}:parameter/{bare_name}",
+    }
+    parameter_history = AccountScopedDict()
+    parameter_history[bare_name] = [
+        {"Name": bare_name, "Type": "String", "Value": "bare", "Version": 1},
+    ]
+
+    try:
+        ssm_service.restore_state({
+            "parameters": parameters,
+            "parameter_history": parameter_history,
+        })
+
+        assert len(ssm_service._parameter_history.get_scoped(account_id, "us-west-2", bare_name)) == 1
+        assert ssm_service._parameter_history.get_scoped(account_id, "us-east-1", bare_name) is None
+    finally:
+        ssm_service.reset()
+
+
+def test_ssm_restore_legacy_bare_name_tags_uses_stored_parameter_arn():
+    from ministack.core.responses import AccountScopedDict, set_request_account_id, set_request_region
+    from ministack.services import ssm as ssm_service
+
+    account_id = "000000000000"
+    name = f"legacy-tag-{_uuid_mod.uuid4().hex[:8]}"
+    legacy_arn = f"arn:aws:ssm:us-west-2:{account_id}:parameter{name}"
+
+    set_request_account_id(account_id)
+    set_request_region("us-east-1")
+    ssm_service.reset()
+    parameters = AccountScopedDict()
+    parameters[name] = {
+        "Name": name,
+        "Type": "String",
+        "Value": "legacy",
+        "Version": 1,
+        "ARN": legacy_arn,
+    }
+    tags = AccountScopedDict()
+    tags[legacy_arn] = {"env": "legacy"}
+
+    try:
+        ssm_service.restore_state({
+            "parameters": parameters,
+            "tags": tags,
+        })
+        set_request_region("us-west-2")
+        assert ssm_service.resolve_parameter_value(legacy_arn) == "legacy"
+        status, _headers, body = ssm_service._list_tags_for_resource({
+            "ResourceType": "Parameter",
+            "ResourceId": name,
+        })
+        assert status == 200
+        assert json.loads(body)["TagList"] == [{"Key": "env", "Value": "legacy"}]
+
+        status, _headers, _body = ssm_service._put_parameter({
+            "Name": name,
+            "Type": "String",
+            "Value": "updated",
+            "Overwrite": True,
+        })
+        assert status == 200
+        assert ssm_service._parameters[name]["ARN"] == legacy_arn
+        status, _headers, body = ssm_service._list_tags_for_resource({
+            "ResourceType": "Parameter",
+            "ResourceId": name,
+        })
+        assert status == 200
+        assert json.loads(body)["TagList"] == [{"Key": "env", "Value": "legacy"}]
+    finally:
+        ssm_service.reset()
+
+
+def test_ssm_arn_lookup_prefers_exact_stored_arn_match():
+    from ministack.core.responses import AccountScopedDict, set_request_account_id, set_request_region
+    from ministack.services import ssm as ssm_service
+
+    account_id = "000000000000"
+    suffix = _uuid_mod.uuid4().hex[:8]
+    bare_name = f"legacy-exact-{suffix}"
+    path_name = f"/{bare_name}"
+    bare_arn = f"arn:aws:ssm:us-west-2:{account_id}:parameter{bare_name}"
+    path_arn = f"arn:aws:ssm:us-west-2:{account_id}:parameter/{bare_name}"
+
+    set_request_account_id(account_id)
+    set_request_region("us-east-1")
+    ssm_service.reset()
+    parameters = AccountScopedDict()
+    parameters[bare_name] = {
+        "Name": bare_name,
+        "Type": "String",
+        "Value": "bare",
+        "Version": 1,
+        "ARN": bare_arn,
+    }
+    parameters[path_name] = {
+        "Name": path_name,
+        "Type": "String",
+        "Value": "path",
+        "Version": 1,
+        "ARN": path_arn,
+    }
+
+    try:
+        ssm_service.restore_state({"parameters": parameters})
+        set_request_region("us-west-2")
+        assert ssm_service.resolve_parameter_value(bare_arn) == "bare"
+        assert ssm_service.resolve_parameter_value(path_arn) == "path"
+    finally:
+        ssm_service.reset()
+
+
+def test_ssm_exact_legacy_slash_twin_can_be_overwritten():
+    from ministack.core.responses import AccountScopedDict, set_request_account_id, set_request_region
+    from ministack.services import ssm as ssm_service
+
+    account_id = "000000000000"
+    suffix = _uuid_mod.uuid4().hex[:8]
+    bare_name = f"legacy-overwrite-{suffix}"
+    path_name = f"/{bare_name}"
+
+    set_request_account_id(account_id)
+    set_request_region("us-east-1")
+    ssm_service.reset()
+    parameters = AccountScopedDict()
+    parameters[bare_name] = {
+        "Name": bare_name,
+        "Type": "String",
+        "Value": "bare",
+        "Version": 1,
+        "ARN": f"arn:aws:ssm:us-west-2:{account_id}:parameter{bare_name}",
+    }
+    parameters[path_name] = {
+        "Name": path_name,
+        "Type": "String",
+        "Value": "path",
+        "Version": 1,
+        "ARN": f"arn:aws:ssm:us-west-2:{account_id}:parameter/{bare_name}",
+    }
+
+    try:
+        ssm_service.restore_state({"parameters": parameters})
+        set_request_region("us-west-2")
+        status, _headers, _body = ssm_service._put_parameter({
+            "Name": bare_name,
+            "Type": "String",
+            "Value": "updated-bare",
+            "Overwrite": True,
+        })
+        assert status == 200
+        assert ssm_service._parameters[bare_name]["Value"] == "updated-bare"
+        assert ssm_service._parameters[path_name]["Value"] == "path"
+    finally:
+        ssm_service.reset()
+
+
+def test_ssm_legacy_no_slash_arn_does_not_fallback_to_path_parameter():
+    from ministack.core.responses import AccountScopedDict, set_request_account_id, set_request_region
+    from ministack.services import ssm as ssm_service
+
+    account_id = "000000000000"
+    suffix = _uuid_mod.uuid4().hex[:8]
+    path_name = f"/legacy-stale-{suffix}"
+    path_arn = f"arn:aws:ssm:us-west-2:{account_id}:parameter/{path_name.lstrip('/')}"
+    stale_legacy_arn = f"arn:aws:ssm:us-west-2:{account_id}:parameter{path_name.lstrip('/')}"
+
+    set_request_account_id(account_id)
+    set_request_region("us-east-1")
+    ssm_service.reset()
+    parameters = AccountScopedDict()
+    parameters[path_name] = {
+        "Name": path_name,
+        "Type": "String",
+        "Value": "path",
+        "Version": 1,
+        "ARN": path_arn,
+    }
+
+    try:
+        ssm_service.restore_state({"parameters": parameters})
+        set_request_region("us-west-2")
+        assert ssm_service.resolve_parameter_value(path_arn) == "path"
+        assert ssm_service.resolve_parameter_value(stale_legacy_arn) is None
+    finally:
+        ssm_service.reset()
+
+
+def test_ssm_malformed_or_foreign_partition_arn_does_not_fallback_to_name():
+    from ministack.core.responses import AccountScopedDict, set_request_account_id, set_request_region
+    from ministack.services import ssm as ssm_service
+
+    account_id = "000000000000"
+    name = f"/invalid-arn/{_uuid_mod.uuid4().hex[:8]}"
+    canonical_arn = f"arn:aws:ssm:us-east-1:{account_id}:parameter/{name.lstrip('/')}"
+    missing_region_arn = f"arn:aws:ssm::{account_id}:parameter/{name.lstrip('/')}"
+    foreign_partition_arn = f"arn:aws-cn:ssm:us-east-1:{account_id}:parameter/{name.lstrip('/')}"
+
+    set_request_account_id(account_id)
+    set_request_region("us-east-1")
+    ssm_service.reset()
+    parameters = AccountScopedDict()
+    parameters[name] = {
+        "Name": name,
+        "Type": "String",
+        "Value": "value",
+        "Version": 1,
+        "ARN": canonical_arn,
+    }
+
+    try:
+        ssm_service.restore_state({"parameters": parameters})
+        assert ssm_service.resolve_parameter_value(canonical_arn) == "value"
+        assert ssm_service.resolve_parameter_value(missing_region_arn) is None
+        assert ssm_service.resolve_parameter_value(foreign_partition_arn) is None
+    finally:
+        ssm_service.reset()
+
+
+def test_ssm_restore_legacy_add_tags_key_for_bare_name_parameter():
+    from ministack.core.responses import AccountScopedDict, set_request_account_id, set_request_region
+    from ministack.services import ssm as ssm_service
+
+    account_id = "000000000000"
+    name = f"legacy-add-tags-{_uuid_mod.uuid4().hex[:8]}"
+    legacy_arn = f"arn:aws:ssm:us-west-2:{account_id}:parameter{name}"
+    legacy_add_tags_arn = f"arn:aws:ssm:us-west-2:{account_id}:parameter/{name}"
+
+    set_request_account_id(account_id)
+    set_request_region("us-east-1")
+    ssm_service.reset()
+    parameters = AccountScopedDict()
+    parameters[name] = {
+        "Name": name,
+        "Type": "String",
+        "Value": "legacy",
+        "Version": 1,
+        "ARN": legacy_arn,
+    }
+    tags = AccountScopedDict()
+    tags[legacy_add_tags_arn] = {"env": "legacy-add-tags"}
+
+    try:
+        ssm_service.restore_state({
+            "parameters": parameters,
+            "tags": tags,
+        })
+        set_request_region("us-west-2")
+        status, _headers, body = ssm_service._list_tags_for_resource({
+            "ResourceType": "Parameter",
+            "ResourceId": name,
+        })
+        assert status == 200
+        assert json.loads(body)["TagList"] == [{"Key": "env", "Value": "legacy-add-tags"}]
+
+        status, _headers, body = ssm_service._list_tags_for_resource({
+            "ResourceType": "Parameter",
+            "ResourceId": legacy_add_tags_arn,
+        })
+        assert status == 200
+        assert json.loads(body)["TagList"] == [{"Key": "env", "Value": "legacy-add-tags"}]
+
+        status, _headers, _body = ssm_service._delete_parameter({"Name": name})
+        assert status == 200
+        assert ssm_service._tags.get_scoped(account_id, "us-west-2", legacy_arn) is None
+        assert ssm_service._tags.get_scoped(account_id, "us-west-2", legacy_add_tags_arn) is None
+    finally:
+        ssm_service.reset()
+
+
+def test_cloudformation_ssm_parameter_uses_canonical_arn_builder():
+    from ministack.core.responses import set_request_account_id, set_request_region
+    from ministack.services import ssm as ssm_service
+    from ministack.services.cloudformation import provisioners
+
+    account_id = "000000000000"
+    name = f"cfn-param-{_uuid_mod.uuid4().hex[:8]}"
+
+    set_request_account_id(account_id)
+    set_request_region("us-west-2")
+    ssm_service.reset()
+    try:
+        provisioners._ssm_create("Param", {"Name": name, "Value": "value"}, "stack")
+        assert ssm_service._parameters[name]["ARN"] == (
+            f"arn:aws:ssm:us-west-2:{account_id}:parameter/{name}"
+        )
+    finally:
+        ssm_service.reset()
+
+
+def test_ssm_parameters_are_region_scoped_by_name(ssm):
+    west = _regional_ssm("us-west-2")
+    name = f"/mr/ssm/{_uuid_mod.uuid4().hex[:8]}"
+
+    ssm.put_parameter(Name=name, Value="east", Type="String")
+    west.put_parameter(Name=name, Value="west", Type="String")
+
+    east_param = ssm.get_parameter(Name=name)["Parameter"]
+    west_param = west.get_parameter(Name=name)["Parameter"]
+
+    assert east_param["Value"] == "east"
+    assert west_param["Value"] == "west"
+    assert ":us-east-1:" in east_param["ARN"]
+    assert ":us-west-2:" in west_param["ARN"]
+
+    ssm.delete_parameter(Name=name)
+    with pytest.raises(ClientError) as exc:
+        ssm.get_parameter(Name=name)
+    assert exc.value.response["Error"]["Code"] == "ParameterNotFound"
+    assert west.get_parameter(Name=name)["Parameter"]["Value"] == "west"
+
+
+def test_ssm_delete_rejects_parameter_arn(ssm):
+    name = f"/mr/ssm/delete-arn/{_uuid_mod.uuid4().hex[:8]}"
+    ssm.put_parameter(Name=name, Value="value", Type="String")
+    arn = ssm.get_parameter(Name=name)["Parameter"]["ARN"]
+
+    with pytest.raises(ClientError) as exc:
+        ssm.delete_parameter(Name=arn)
+    assert exc.value.response["Error"]["Code"] == "ValidationException"
+    assert ssm.get_parameter(Name=name)["Parameter"]["Value"] == "value"
+
+    resp = ssm.delete_parameters(Names=[arn])
+    assert arn in resp["InvalidParameters"]
+    assert ssm.get_parameter(Name=name)["Parameter"]["Value"] == "value"
+
+    ssm.delete_parameter(Name=name)
+
+
+def test_ssm_put_rejects_slash_variant_duplicate(ssm):
+    name = f"mr-ssm-duplicate-{_uuid_mod.uuid4().hex[:8]}"
+    ssm.put_parameter(Name=name, Value="bare", Type="String")
+
+    with pytest.raises(ClientError) as exc:
+        ssm.put_parameter(Name=f"/{name}", Value="path", Type="String")
+    assert exc.value.response["Error"]["Code"] == "ParameterAlreadyExists"
+
+    with pytest.raises(ClientError) as exc:
+        ssm.put_parameter(Name=f"/{name}", Value="path", Type="String", Overwrite=True)
+    assert exc.value.response["Error"]["Code"] == "ParameterAlreadyExists"
+
+    assert ssm.get_parameter(Name=name)["Parameter"]["Value"] == "bare"
+    ssm.delete_parameter(Name=name)
+
+
+def test_ssm_parameter_arn_lookup_is_request_region_scoped(ssm):
+    west = _regional_ssm("us-west-2")
+    name = f"/mr/ssm/arn/{_uuid_mod.uuid4().hex[:8]}"
+
+    ssm.put_parameter(Name=name, Value="east", Type="String")
+    west.put_parameter(Name=name, Value="west", Type="String")
+
+    east_arn = ssm.get_parameter(Name=name)["Parameter"]["ARN"]
+    west_arn = west.get_parameter(Name=name)["Parameter"]["ARN"]
+
+    assert ssm.get_parameter(Name=east_arn)["Parameter"]["Value"] == "east"
+    with pytest.raises(ClientError) as exc:
+        ssm.get_parameter(Name=west_arn)
+    assert exc.value.response["Error"]["Code"] == "ParameterNotFound"
+
+
+def test_ssm_tags_accept_current_region_parameter_arn(ssm):
+    west = _regional_ssm("us-west-2")
+    name = f"/mr/ssm/tag/{_uuid_mod.uuid4().hex[:8]}"
+
+    ssm.put_parameter(Name=name, Value="east", Type="String")
+    west.put_parameter(Name=name, Value="west", Type="String")
+
+    east_arn = ssm.get_parameter(Name=name)["Parameter"]["ARN"]
+    ssm.add_tags_to_resource(
+        ResourceType="Parameter",
+        ResourceId=east_arn,
+        Tags=[{"Key": "scope", "Value": "east"}],
+    )
+
+    east_tags = ssm.list_tags_for_resource(ResourceType="Parameter", ResourceId=east_arn)["TagList"]
+    west_tags = west.list_tags_for_resource(ResourceType="Parameter", ResourceId=name)["TagList"]
+
+    assert {tag["Key"]: tag["Value"] for tag in east_tags} == {"scope": "east"}
+    assert west_tags == []
+
+
+def test_ssm_resolve_parameter_value_uses_arn_region_without_tail_fallback():
+    from ministack.core.responses import (
+        get_account_id,
+        get_region,
+        set_request_account_id,
+        set_request_region,
+    )
+    from ministack.services import ssm as ssm_service
+
+    original_account = get_account_id()
+    original_region = get_region()
+    name = f"/mr/ssm/resolve/{_uuid_mod.uuid4().hex[:8]}"
+
+    try:
+        ssm_service.reset()
+        set_request_account_id("000000000000")
+        set_request_region("us-east-1")
+        ssm_service._put_parameter({"Name": name, "Value": "east", "Type": "String"})
+
+        west_arn = f"arn:aws:ssm:us-west-2:000000000000:parameter/{name.lstrip('/')}"
+        assert ssm_service.resolve_parameter_value(west_arn) is None
+
+        set_request_region("us-west-2")
+        ssm_service._put_parameter({"Name": name, "Value": "west", "Type": "String"})
+
+        set_request_region("us-east-1")
+        assert ssm_service.resolve_parameter_value(name) == "east"
+        assert ssm_service.resolve_parameter_value(west_arn) == "west"
+        assert ssm_service.resolve_parameter_value(
+            west_arn.replace(":ssm:", ":secretsmanager:", 1)
+        ) is None
+        assert ssm_service.resolve_parameter_value(
+            west_arn.replace(":000000000000:", ":111111111111:", 1)
+        ) is None
+    finally:
+        ssm_service.reset()
+        set_request_account_id(original_account)
+        set_request_region(original_region)


### PR DESCRIPTION
## Why
Continue the multi-region state migration by making SSM parameter state behave independently per account and region while preserving legacy persisted state.

## What
- Move SSM parameters, history, and tags onto account+region scoped storage
- Parse SSM parameter ARNs for lookups, tagging, and CloudFormation parameter refs
- Preserve legacy restore behavior and slash/no-slash compatibility with focused tests

## Risk Assessment
Low to medium — isolated to SSM parameter handling and CloudFormation SSM parameter outputs on the multi-region feature branch.

## References
- `uv run --extra dev ruff check ministack/services/ssm.py ministack/services/cloudformation/provisioners.py tests/test_ssm.py`
- `uv run --extra dev pytest tests/test_ssm.py -q`