### PR TITLE
feat(persistence): on-demand state save, named checkpoints with hot restore, and shutdown durability fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to MiniStack will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Versioning follows [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+- **State — on-demand save and named checkpoints via `/_ministack/state/*` admin endpoints** — `POST /_ministack/state/save` flushes all in-memory service state to `STATE_DIR` immediately; `POST /_ministack/state/checkpoint {"name": ...}` saves a named snapshot under `${STATE_DIR}/checkpoints/<name>/` (per-service state files, Lambda code blobs as hardlinked copies so Lambda's orphan-blob prune can't corrupt a checkpoint, and S3 object data when `S3_PERSIST=1`); `POST /_ministack/state/restore {"name": ...}` hot-restores a snapshot into the running instance without a restart (in-memory reset, file swap, per-service restore, pollers/schedulers restarted — same semantics as a process restart: RUNNING Step Functions executions become `FAILED`/`States.ServiceRestart`, open API Gateway WebSocket connections are closed); `GET /_ministack/state/checkpoints` lists and `DELETE /_ministack/state/checkpoints/<name>` removes them. The endpoints work regardless of `PERSIST_STATE` — that flag keeps governing only the automatic boot-restore/shutdown-save cycle — and named checkpoints survive `/_ministack/reset`, so snapshot → reset → restore works as a test-isolation workflow.
+- **Persistence — `PERSIST_INTERVAL` periodic autosave** — opt-in (seconds, default `0` = off, requires `PERSIST_STATE=1`): a background task saves all service state every N seconds, so a crash, OOM kill, or `SIGKILL` — which no shutdown hook can catch — loses at most one interval of state instead of everything since the last clean shutdown.
+
+### Fixed
+- **Persistence — state is flushed on `SIGTERM`/`docker stop` even when the ASGI lifespan shutdown doesn't run** — the `SIGTERM` handler installed by `python -m ministack` calls `sys.exit(0)` directly, which could bypass hypercorn's graceful lifespan shutdown and silently drop all state on `docker stop`. An `atexit` safety net now performs the final save whenever `PERSIST_STATE=1` and the lifespan shutdown save hasn't already run.
+- **Reset — `/_ministack/reset` wipes persisted state files unconditionally and removes orphaned Lambda code blobs** — the file wipe was gated on `PERSIST_STATE`, so state files written by the explicit save endpoint with the gate off survived a reset and could be resurrected into a later checkpoint; and `lambda-blobs/` was never cleaned, leaking orphaned code blobs after every reset until the next Lambda save. Reset now always removes `${STATE_DIR}/*.json` and `${STATE_DIR}/lambda-blobs/` (named checkpoints under `${STATE_DIR}/checkpoints/` are preserved).
+
+---
+
 ## [1.3.70] — 2026-06-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -698,6 +698,7 @@ end-to-end without any client config.
 | `MINISTACK_OPENSEARCH_ENDPOINT` | _(unset)_ | If set (e.g. `localhost:9200`), every domain returns this endpoint instead of spawning a per-domain container — useful when you bring your own cluster |
 | `PERSIST_STATE` | `0` | Set `1` to persist service state across restarts |
 | `STATE_DIR` | `/tmp/ministack-state` | Directory for persisted state files |
+| `PERSIST_INTERVAL` | `0` | Autosave period in seconds (requires `PERSIST_STATE=1`). `0` disables. Set e.g. `300` so a crash or `SIGKILL` loses at most that much state — shutdown-time saves can't catch those |
 | `LAMBDA_EXECUTOR` | `local` | Lambda execution mode: `local` (subprocess) or `docker` (container). `provided` runtimes and `PackageType: Image` always use Docker |
 | `LAMBDA_STRICT` | `0` | Set `1` for AWS-fidelity mode: every Lambda invocation runs in a Docker container via the AWS RIE image; in-process fallbacks are disabled. Missing Docker surfaces as `Runtime.DockerUnavailable` instead of degrading to a subprocess. Opt-in because the default install doesn't require Docker |
 | `LAMBDA_DOCKER_NETWORK` | _(unset)_ | Legacy alias for `DOCKER_NETWORK` (Lambda only). Prefer `DOCKER_NETWORK` which covers all services |
@@ -794,6 +795,29 @@ docker run -p 4566:4566 \
   -v /tmp/ministack-data:/data \
   ministackorg/ministack
 ```
+
+State is flushed on graceful shutdown (including `docker stop` / `SIGTERM`, via an atexit safety net). A crash or `SIGKILL` cannot be caught — set `PERSIST_INTERVAL` (seconds) to autosave periodically, or save on demand with the endpoint below.
+
+#### On-demand save and named checkpoints
+
+Admin endpoints for saving and restoring state programmatically — useful for snapshotting a seeded environment before a test run and rolling back afterwards. These work even without `PERSIST_STATE=1` (that flag only controls the automatic save/restore cycle at shutdown/boot):
+
+```bash
+# Flush current state to STATE_DIR right now
+curl -X POST localhost:4566/_ministack/state/save
+
+# Save a named snapshot (add "overwrite": true to replace an existing one)
+curl -X POST localhost:4566/_ministack/state/checkpoint -d '{"name": "seeded"}'
+
+# Hot-restore a snapshot into the running instance — no restart needed
+curl -X POST localhost:4566/_ministack/state/restore -d '{"name": "seeded"}'
+
+# List / delete checkpoints
+curl localhost:4566/_ministack/state/checkpoints
+curl -X DELETE localhost:4566/_ministack/state/checkpoints/seeded
+```
+
+Checkpoints live under `${STATE_DIR}/checkpoints/<name>/` and include Lambda code blobs and (when `S3_PERSIST=1`) S3 object data. They survive `POST /_ministack/reset` — reset wipes live state and persisted state files (regardless of `PERSIST_STATE`), but named checkpoints stay available, so snapshot → reset → restore works as a workflow. Hot-restore caveats: open API Gateway WebSocket connections are closed, RUNNING Step Functions executions are marked `FAILED` (`States.ServiceRestart`) — the same semantics as a process restart — and new requests are briefly held while the restore swaps state.
 
 ### Lambda in Docker
 

--- a/ministack/app.py
+++ b/ministack/app.py
@@ -7,6 +7,7 @@ Compatible with AWS CLI, boto3, and any AWS SDK via --endpoint-url.
 
 import argparse
 import asyncio
+import atexit
 import base64
 import json
 import logging
@@ -980,6 +981,155 @@ async def _handle_admin_config_request(path: str, method: str, body: bytes):
     return 200, {"Content-Type": "application/json"}, json.dumps({"applied": applied}).encode()
 
 
+def _restore_checkpoint_locked(name: str) -> list[str]:
+    """Hot-restore a named checkpoint into the running process.
+
+    Caller must hold the reset lock; runs in a worker thread via
+    asyncio.to_thread. Sequence matters: reset in-memory state first
+    (restore paths merge via .update(), they don't replace), then swap the
+    on-disk files (before any lazy import, so a module whose bottom-of-file
+    load_state() fires under PERSIST_STATE=1 sees checkpoint data), then
+    explicitly apply each service's restore path — import-time self-restore
+    only runs once per process, so already-imported modules (and every
+    module when PERSIST_STATE=0) need the explicit call.
+    """
+    from ministack.core import checkpoints, persistence
+
+    # Fail before touching anything if the checkpoint doesn't exist.
+    checkpoints.require_checkpoint(name)
+
+    _reset_in_memory_state()
+    restored_keys = checkpoints.restore_checkpoint_files(name)
+
+    applied = []
+    for key in restored_keys:
+        mod_name = _state_map.get(key)
+        if mod_name is None:
+            logger.warning("restore %r: unknown state key %r — skipping", name, key)
+            continue
+        data = persistence.read_state_file(persistence.STATE_DIR, key)
+        if not data:
+            continue
+        mod = _get_module(mod_name)
+        # A freshly imported module may have already self-restored from the
+        # checkpoint files (PERSIST_STATE=1); re-applying is harmless because
+        # every restore path merges idempotently.
+        restore_fn = getattr(mod, "load_persisted_state", None) or getattr(mod, "restore_state", None)
+        if restore_fn is None:
+            logger.warning("restore %r: %s has no restore path — skipping", name, mod_name)
+            continue
+        try:
+            restore_fn(data)
+            applied.append(key)
+        except Exception as e:
+            logger.warning("restore %r: failed to restore %s: %s", name, key, e)
+
+    # Belt-and-braces: the EventBridge scheduler daemon survives reset, but
+    # start_scheduler() is idempotent and covers the case where the module
+    # was imported for the first time during this restore.
+    try:
+        from ministack.services import eventbridge as _eb_mod
+        _eb_mod.start_scheduler()
+    except Exception as e:
+        logger.warning("restore %r: EventBridge scheduler restart failed: %s", name, e)
+
+    return applied
+
+
+async def _handle_admin_state_request(method: str, path: str, body: bytes):
+    """Admin state endpoints: on-demand save, named checkpoints, hot restore.
+
+    These work regardless of PERSIST_STATE — the env gate governs only the
+    automatic boot-restore/shutdown-save cycle, while these are explicit
+    user actions. All mutating routes take the reset lock, which both
+    serializes against /_ministack/reset and gates admission of new
+    requests, giving a near-quiescent snapshot.
+    """
+    if not path.startswith("/_ministack/state/"):
+        return None
+
+    from ministack.core import checkpoints, persistence
+
+    def _json_resp(status: int, payload: dict):
+        return status, {"Content-Type": "application/json"}, json.dumps(payload).encode()
+
+    def _body_name():
+        try:
+            req = json.loads(body) if body else {}
+        except json.JSONDecodeError:
+            req = {}
+        return req if isinstance(req, dict) else {}
+
+    if path == "/_ministack/state/save" and method == "POST":
+        async with _get_reset_lock():
+            saved = await asyncio.to_thread(
+                persistence.save_all_resilient, _build_persistence_save_dict()
+            )
+        payload = {
+            "saved": True,
+            "services": saved,
+            "state_dir": persistence.STATE_DIR,
+            "autoload": persistence.PERSIST_STATE,
+        }
+        if not persistence.PERSIST_STATE:
+            payload["note"] = (
+                "PERSIST_STATE is not enabled — saved state will not be loaded "
+                "automatically at next boot. Use /_ministack/state/restore or "
+                "start with PERSIST_STATE=1."
+            )
+        return _json_resp(200, payload)
+
+    if path == "/_ministack/state/checkpoint" and method == "POST":
+        req = _body_name()
+        name = req.get("name")
+        try:
+            checkpoints.validate_name(name)
+        except checkpoints.InvalidCheckpointNameError as e:
+            return _json_resp(400, {"error": str(e)})
+        try:
+            async with _get_reset_lock():
+                manifest = await asyncio.to_thread(
+                    checkpoints.create_checkpoint,
+                    name,
+                    _build_persistence_save_dict(),
+                    overwrite=bool(req.get("overwrite", False)),
+                )
+        except checkpoints.CheckpointExistsError as e:
+            return _json_resp(409, {"error": str(e)})
+        return _json_resp(200, manifest)
+
+    if path == "/_ministack/state/restore" and method == "POST":
+        name = _body_name().get("name")
+        try:
+            checkpoints.validate_name(name)
+        except checkpoints.InvalidCheckpointNameError as e:
+            return _json_resp(400, {"error": str(e)})
+        try:
+            async with _get_reset_lock():
+                applied = await asyncio.to_thread(_restore_checkpoint_locked, name)
+        except checkpoints.CheckpointNotFoundError as e:
+            return _json_resp(404, {"error": str(e)})
+        return _json_resp(200, {"restored": True, "name": name, "services": len(applied)})
+
+    if path == "/_ministack/state/checkpoints" and method == "GET":
+        cps = await asyncio.to_thread(checkpoints.list_checkpoints)
+        return _json_resp(200, {"checkpoints": cps})
+
+    if path.startswith("/_ministack/state/checkpoints/") and method == "DELETE":
+        name = path[len("/_ministack/state/checkpoints/"):]
+        try:
+            checkpoints.validate_name(name)
+        except checkpoints.InvalidCheckpointNameError as e:
+            return _json_resp(400, {"error": str(e)})
+        try:
+            await asyncio.to_thread(checkpoints.delete_checkpoint, name)
+        except checkpoints.CheckpointNotFoundError as e:
+            return _json_resp(404, {"error": str(e)})
+        return _json_resp(200, {"deleted": True, "name": name})
+
+    return None
+
+
 async def _handle_post_body_shortcuts(method: str, path: str, headers: dict, body: bytes, query_params: dict, request_id: str):
     """Handle body-dependent routes before the generic service router."""
     # CloudFormation custom resource ResponseURL intercept
@@ -1000,6 +1150,9 @@ async def _handle_post_body_shortcuts(method: str, path: str, headers: dict, bod
     if response is not None:
         # See _handle_pre_body_request: browser-based OIDC clients need CORS.
         return _with_data_plane_headers(response, request_id)
+    response = await _handle_admin_state_request(method, path, body)
+    if response is not None:
+        return response
     return await _handle_admin_config_request(path, method, body)
 
 
@@ -1810,10 +1963,21 @@ async def _handle_lifespan(scope, receive, send):
             for svc in SERVICE_HANDLERS:
                 logger.debug("%s init completed.", svc.capitalize())
             asyncio.create_task(_run_ready_scripts())
+            _start_autosave_task()
         elif message["type"] == "lifespan.shutdown":
             logger.info("MiniStack shutting down...")
+            # Stop the autosave loop before the final save so they can't
+            # interleave.
+            if _autosave_task is not None:
+                _autosave_task.cancel()
+                try:
+                    await _autosave_task
+                except asyncio.CancelledError:
+                    pass
             if PERSIST_STATE:
                 save_all(_build_persistence_save_dict())
+                global _final_save_done
+                _final_save_done = True
             try:
                 from ministack.services import transfer
 
@@ -1876,6 +2040,77 @@ def _build_persistence_save_dict():
                 continue
         save_dict[key] = mod.get_state
     return save_dict
+
+
+# Set once the lifespan shutdown save has run, so the atexit safety net
+# below doesn't redo the work (a double save would be harmless — atomic
+# rewrite of identical content — just redundant).
+_final_save_done = False
+
+
+def _final_save():
+    """atexit safety net: flush state when the process exits without the
+    ASGI lifespan shutdown save having run. The SIGTERM handler installed
+    by main() calls sys.exit(0) directly, which raises SystemExit and runs
+    atexit handlers — but may bypass hypercorn's graceful lifespan
+    shutdown entirely, silently dropping all state on `docker stop`.
+    SIGKILL/OOM remains uncatchable; PERSIST_INTERVAL autosave covers that."""
+    global _final_save_done
+    from ministack.core import persistence
+
+    if _final_save_done or not persistence.PERSIST_STATE:
+        return
+    _final_save_done = True
+    try:
+        save_all(_build_persistence_save_dict())
+        logger.info("Final state save completed (atexit)")
+    except Exception as e:
+        logger.error("Final state save failed: %s", e)
+
+
+atexit.register(_final_save)
+
+
+_autosave_task: "asyncio.Task | None" = None
+
+
+def _persist_interval() -> float:
+    raw = os.environ.get("PERSIST_INTERVAL", "0")
+    try:
+        return float(raw or 0)
+    except ValueError:
+        logger.warning("Invalid PERSIST_INTERVAL=%r — autosave disabled", raw)
+        return 0.0
+
+
+def _start_autosave_task():
+    """Start the periodic autosave loop when PERSIST_STATE=1 and
+    PERSIST_INTERVAL > 0. Covers crash/SIGKILL, which no shutdown hook
+    can — state is at most one interval stale."""
+    global _autosave_task
+    from ministack.core import persistence
+
+    interval = _persist_interval()
+    if not (persistence.PERSIST_STATE and interval > 0):
+        return
+    _autosave_task = asyncio.create_task(_autosave_loop(interval))
+    logger.info("Autosave enabled: every %gs to %s", interval, persistence.STATE_DIR)
+
+
+async def _autosave_loop(interval: float):
+    from ministack.core import persistence
+
+    while True:
+        await asyncio.sleep(interval)
+        try:
+            async with _get_reset_lock():
+                await asyncio.to_thread(
+                    persistence.save_all_resilient, _build_persistence_save_dict()
+                )
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("Autosave failed")
 
 
 def _load_persisted_state():
@@ -2090,10 +2325,10 @@ def _run_init_scripts():
             logger.error("Failed to execute init script %s: %s", script_path, e)
 
 
-def _reset_all_state():
-    """Wipe all in-memory state across every service module, and persisted files if enabled."""
-
-    from ministack.core.persistence import PERSIST_STATE, STATE_DIR
+def _reset_in_memory_state():
+    """Run every imported service module's reset(). Shared by
+    /_ministack/reset (which also wipes persisted files) and checkpoint
+    hot-restore (which replaces the files instead)."""
 
     # Stateful modules that don't have a routing entry in SERVICE_REGISTRY but
     # still need reset() — REST API v1 (served via the apigateway module),
@@ -2122,18 +2357,44 @@ def _reset_all_state():
         except Exception as e:
             logger.warning("reset() failed for %s: %s", mod_name, e)
 
+
+def _reset_all_state():
+    """Wipe all in-memory state across every service module, and persisted files."""
+
+    from ministack.core.persistence import STATE_DIR
+
+    _reset_in_memory_state()
+
     S3_DATA_DIR = os.environ.get("S3_DATA_DIR", "/tmp/ministack-data/s3")
     S3_PERSIST = os.environ.get("S3_PERSIST", "0") == "1"
 
-    # Wipe persisted files so a subsequent restart doesn't reload old state
-    if PERSIST_STATE and os.path.isdir(STATE_DIR):
+    # Wipe persisted files so neither a restart nor a later checkpoint can
+    # resurrect pre-reset state. Deliberately NOT gated on PERSIST_STATE:
+    # the explicit /_ministack/state/save endpoint writes these files even
+    # with the gate off, and a file surviving reset gets captured into the
+    # next checkpoint by the unloaded-module fallback in
+    # checkpoints.create_checkpoint(). Named checkpoints
+    # (STATE_DIR/checkpoints/) intentionally survive reset — snapshot →
+    # reset → restore is a primary workflow; remove them via
+    # DELETE /_ministack/state/checkpoints/<name>.
+    if os.path.isdir(STATE_DIR):
+        wiped = False
         for fname in os.listdir(STATE_DIR):
             if fname.endswith(".json"):
                 try:
                     os.remove(os.path.join(STATE_DIR, fname))
+                    wiped = True
                 except Exception as e:
                     logger.warning("reset: failed to remove %s: %s", fname, e)
-        logger.info("Wiped persisted state files in %s", STATE_DIR)
+        # Lambda code blobs: with lambda.json gone every blob is an orphan.
+        # Without this they leak until the next Lambda save's orphan prune,
+        # which never runs if Lambda isn't used again.
+        blob_dir = os.path.join(STATE_DIR, "lambda-blobs")
+        if os.path.isdir(blob_dir):
+            shutil.rmtree(blob_dir, ignore_errors=True)
+            wiped = True
+        if wiped:
+            logger.info("Wiped persisted state files in %s", STATE_DIR)
 
     if S3_PERSIST and os.path.isdir(S3_DATA_DIR):
         for entry in os.listdir(S3_DATA_DIR):

--- a/ministack/core/checkpoints.py
+++ b/ministack/core/checkpoints.py
@@ -1,0 +1,282 @@
+"""Named state checkpoints for MiniStack.
+
+A checkpoint is an explicit, on-demand snapshot of all service state,
+stored under ``${STATE_DIR}/checkpoints/<name>/``:
+
+    <state_key>.json    one file per service (same format as live STATE_DIR)
+    lambda-blobs/       Lambda code blobs, hardlinked from the live blob dir
+    s3-data/            S3 object bodies (only when S3_PERSIST=1)
+    manifest.json       {version, name, created_at, services, s3_data}
+
+Checkpoints work regardless of PERSIST_STATE — that flag governs only the
+automatic boot-restore/shutdown-save cycle. Blob files are hardlinked
+(copied on cross-device failure) rather than referenced: lambda_svc's
+``_prune_orphan_code_blobs`` unlinks live directory entries on every
+``get_state()``, and a checkpoint must survive that. Content-addressed
+sha256 filenames make hardlinks safe — the same name never means
+different bytes.
+"""
+
+import json
+import logging
+import os
+import re
+import shutil
+from datetime import datetime, timezone
+
+from ministack.core import persistence
+
+logger = logging.getLogger("checkpoints")
+
+MANIFEST_VERSION = 1
+# Single path segment, no leading dot — blocks traversal and tmp-dir collisions.
+CHECKPOINT_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
+
+_BLOB_DIR_NAME = "lambda-blobs"
+_S3_DATA_DIR_NAME = "s3-data"
+_MANIFEST_NAME = "manifest.json"
+
+
+class CheckpointError(Exception):
+    pass
+
+
+class InvalidCheckpointNameError(CheckpointError):
+    pass
+
+
+class CheckpointExistsError(CheckpointError):
+    pass
+
+
+class CheckpointNotFoundError(CheckpointError):
+    pass
+
+
+def checkpoint_root() -> str:
+    return os.path.join(persistence.STATE_DIR, "checkpoints")
+
+
+def validate_name(name) -> str:
+    if not isinstance(name, str) or not CHECKPOINT_NAME_RE.match(name):
+        raise InvalidCheckpointNameError(
+            "checkpoint name must match [A-Za-z0-9][A-Za-z0-9._-]{0,63}"
+        )
+    return name
+
+
+def require_checkpoint(name: str) -> str:
+    """Validate ``name`` and return its directory, raising if absent."""
+    validate_name(name)
+    path = os.path.join(checkpoint_root(), name)
+    if not os.path.isdir(path):
+        raise CheckpointNotFoundError(f"checkpoint {name!r} not found")
+    return path
+
+
+def _link_or_copy(src: str, dst: str) -> None:
+    try:
+        os.link(src, dst)
+    except OSError:
+        shutil.copy2(src, dst)
+
+
+def _copy_blob_dir(src_dir: str, dst_dir: str) -> None:
+    os.makedirs(dst_dir, exist_ok=True)
+    for fname in os.listdir(src_dir):
+        src = os.path.join(src_dir, fname)
+        if os.path.isfile(src):
+            _link_or_copy(src, os.path.join(dst_dir, fname))
+
+
+def _dir_size(path: str) -> int:
+    total = 0
+    for dirpath, _dirnames, filenames in os.walk(path):
+        for fname in filenames:
+            try:
+                total += os.path.getsize(os.path.join(dirpath, fname))
+            except OSError:
+                pass
+    return total
+
+
+def _read_manifest(cp_dir: str) -> dict | None:
+    try:
+        with open(os.path.join(cp_dir, _MANIFEST_NAME)) as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _s3_persist_config() -> tuple[bool, str]:
+    return (
+        os.environ.get("S3_PERSIST", "0") == "1",
+        os.environ.get("S3_DATA_DIR", "/tmp/ministack-data/s3"),
+    )
+
+
+def create_checkpoint(name: str, save_dict: dict, *, overwrite: bool = False) -> dict:
+    """Snapshot all service state into a named checkpoint.
+
+    ``save_dict`` is ``{state_key: get_state_fn}`` (the caller builds it from
+    the loaded modules and should hold the reset lock so the snapshot is
+    near-quiescent). Live ``STATE_DIR/*.json`` files whose key is not in
+    ``save_dict`` are copied in as-is — they hold prior-boot state for
+    modules that were never imported this run, and skipping them would
+    silently drop those services from the checkpoint.
+
+    The checkpoint is built in a temp dir and renamed into place, so a
+    half-written checkpoint is never visible under its final name.
+    """
+    validate_name(name)
+    root = checkpoint_root()
+    final_dir = os.path.join(root, name)
+    if os.path.isdir(final_dir) and not overwrite:
+        raise CheckpointExistsError(f"checkpoint {name!r} already exists")
+
+    os.makedirs(root, exist_ok=True)
+    tmp_dir = os.path.join(root, f".tmp-{name}-{os.getpid()}")
+    if os.path.isdir(tmp_dir):
+        shutil.rmtree(tmp_dir)
+    os.makedirs(tmp_dir)
+
+    try:
+        services = []
+        for key, get_state in save_dict.items():
+            data = persistence.get_state_with_retry(key, get_state)
+            if data is None:
+                continue
+            persistence.write_state_file(tmp_dir, key, data)
+            services.append(key)
+
+        state_dir = persistence.STATE_DIR
+        if os.path.isdir(state_dir):
+            for fname in sorted(os.listdir(state_dir)):
+                if not fname.endswith(".json") or fname.endswith(".tmp"):
+                    continue
+                key = fname[: -len(".json")]
+                if key in save_dict:
+                    continue
+                shutil.copy2(os.path.join(state_dir, fname), os.path.join(tmp_dir, fname))
+                services.append(key)
+
+        live_blobs = os.path.join(state_dir, _BLOB_DIR_NAME)
+        if os.path.isdir(live_blobs):
+            _copy_blob_dir(live_blobs, os.path.join(tmp_dir, _BLOB_DIR_NAME))
+
+        s3_persist, s3_data_dir = _s3_persist_config()
+        has_s3_data = False
+        if s3_persist and os.path.isdir(s3_data_dir):
+            shutil.copytree(s3_data_dir, os.path.join(tmp_dir, _S3_DATA_DIR_NAME))
+            has_s3_data = True
+
+        manifest = {
+            "version": MANIFEST_VERSION,
+            "name": name,
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "services": sorted(services),
+            "s3_data": has_s3_data,
+        }
+        with open(os.path.join(tmp_dir, _MANIFEST_NAME), "w") as f:
+            json.dump(manifest, f)
+
+        if os.path.isdir(final_dir):
+            old_dir = os.path.join(root, f".old-{name}-{os.getpid()}")
+            os.rename(final_dir, old_dir)
+            os.rename(tmp_dir, final_dir)
+            shutil.rmtree(old_dir, ignore_errors=True)
+        else:
+            os.rename(tmp_dir, final_dir)
+    except BaseException:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+        raise
+
+    manifest["size_bytes"] = _dir_size(final_dir)
+    logger.info("Checkpoint %r created (%d services)", name, len(services))
+    return manifest
+
+
+def restore_checkpoint_files(name: str) -> list[str]:
+    """Replace live STATE_DIR contents with the checkpoint's files.
+
+    Wipes live ``*.json`` and ``lambda-blobs/`` (never ``checkpoints/``),
+    copies the checkpoint back, and returns the restored state keys. The
+    caller is responsible for resetting in-memory state first and applying
+    each service's restore path afterward.
+    """
+    cp_dir = require_checkpoint(name)
+    manifest = _read_manifest(cp_dir)
+    state_dir = persistence.STATE_DIR
+    os.makedirs(state_dir, exist_ok=True)
+
+    for fname in os.listdir(state_dir):
+        if fname.endswith(".json"):
+            try:
+                os.remove(os.path.join(state_dir, fname))
+            except OSError as e:
+                logger.warning("restore: failed to remove %s: %s", fname, e)
+    live_blobs = os.path.join(state_dir, _BLOB_DIR_NAME)
+    if os.path.isdir(live_blobs):
+        shutil.rmtree(live_blobs, ignore_errors=True)
+
+    restored = []
+    for fname in sorted(os.listdir(cp_dir)):
+        if not fname.endswith(".json") or fname == _MANIFEST_NAME:
+            continue
+        shutil.copy2(os.path.join(cp_dir, fname), os.path.join(state_dir, fname))
+        restored.append(fname[: -len(".json")])
+
+    cp_blobs = os.path.join(cp_dir, _BLOB_DIR_NAME)
+    if os.path.isdir(cp_blobs):
+        _copy_blob_dir(cp_blobs, live_blobs)
+
+    if manifest and manifest.get("s3_data"):
+        s3_persist, s3_data_dir = _s3_persist_config()
+        if s3_persist:
+            if os.path.isdir(s3_data_dir):
+                for entry in os.listdir(s3_data_dir):
+                    entry_path = os.path.join(s3_data_dir, entry)
+                    try:
+                        if os.path.isdir(entry_path):
+                            shutil.rmtree(entry_path)
+                        else:
+                            os.remove(entry_path)
+                    except OSError as e:
+                        logger.warning("restore: failed to remove S3 data %s: %s", entry, e)
+            shutil.copytree(
+                os.path.join(cp_dir, _S3_DATA_DIR_NAME), s3_data_dir, dirs_exist_ok=True
+            )
+        else:
+            logger.warning(
+                "restore: checkpoint %r contains S3 object data but S3_PERSIST is "
+                "not enabled — S3 object bodies were NOT restored",
+                name,
+            )
+
+    logger.info("Checkpoint %r files restored (%d services)", name, len(restored))
+    return restored
+
+
+def list_checkpoints() -> list[dict]:
+    root = checkpoint_root()
+    if not os.path.isdir(root):
+        return []
+    out = []
+    for entry in sorted(os.listdir(root)):
+        if entry.startswith("."):
+            continue
+        cp_dir = os.path.join(root, entry)
+        if not os.path.isdir(cp_dir):
+            continue
+        manifest = _read_manifest(cp_dir) or {"version": None, "created_at": None, "services": []}
+        manifest["name"] = entry
+        manifest["size_bytes"] = _dir_size(cp_dir)
+        out.append(manifest)
+    out.sort(key=lambda m: m.get("created_at") or "")
+    return out
+
+
+def delete_checkpoint(name: str) -> None:
+    cp_dir = require_checkpoint(name)
+    shutil.rmtree(cp_dir)
+    logger.info("Checkpoint %r deleted", name)

--- a/ministack/core/persistence.py
+++ b/ministack/core/persistence.py
@@ -105,3 +105,89 @@ def save_all(services: dict) -> None:
             save_state(name, get_state())
         except Exception as e:
             logger.error("Persistence: error getting state for %s: %s", name, e)
+
+
+# ---------------------------------------------------------------------------
+# Ungated, path-parameterized primitives. Unlike save_state/load_state these
+# do NOT check PERSIST_STATE — they back explicit, on-demand operations
+# (admin save endpoint, named checkpoints) where the user has already asked
+# for the write. STATE_DIR is intentionally not baked in so checkpoints can
+# write the same file format into their own directories.
+# ---------------------------------------------------------------------------
+
+
+def write_state_file(dir_path: str, service: str, data: dict) -> str:
+    """Atomically write ``data`` to ``<dir_path>/<service>.json``. Raises on failure."""
+    os.makedirs(dir_path, exist_ok=True)
+    path = os.path.join(dir_path, f"{service}.json")
+    tmp = path + ".tmp"
+    try:
+        with open(tmp, "w") as f:
+            json.dump(data, f, default=_json_default)
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.remove(tmp)
+        except OSError:
+            pass
+        raise
+    return path
+
+
+def read_state_file(dir_path: str, service: str) -> dict | None:
+    """Read ``<dir_path>/<service>.json``; None if absent or unreadable."""
+    path = os.path.join(dir_path, f"{service}.json")
+    if not os.path.exists(path):
+        return None
+    try:
+        with open(path) as f:
+            return json.load(f, object_hook=_json_object_hook)
+    except (json.JSONDecodeError, OSError) as e:
+        logger.error("Persistence: failed to read %s: %s", path, e)
+        return None
+
+
+_GET_STATE_ATTEMPTS = 3
+
+
+def get_state_with_retry(name: str, get_state):
+    """Call ``get_state()``, retrying on RuntimeError.
+
+    get_state() deep-copies live stores; a request mutating a store
+    mid-copy raises RuntimeError ("dictionary changed size during
+    iteration"). The stores are consistent between requests, so an
+    immediate retry almost always succeeds. Returns None when state
+    could not be captured."""
+    for attempt in range(_GET_STATE_ATTEMPTS):
+        try:
+            return get_state()
+        except RuntimeError as e:
+            if attempt == _GET_STATE_ATTEMPTS - 1:
+                logger.error(
+                    "Persistence: error getting state for %s after %d attempts: %s",
+                    name, _GET_STATE_ATTEMPTS, e,
+                )
+        except Exception as e:
+            logger.error("Persistence: error getting state for %s: %s", name, e)
+            return None
+    return None
+
+
+def save_all_resilient(services: dict) -> int:
+    """Save all service states to STATE_DIR regardless of PERSIST_STATE,
+    retrying snapshots that race with in-flight requests. Backs the
+    explicit /_ministack/state/save endpoint and the autosave loop.
+    Returns the number of services saved."""
+    saved = 0
+    for name, get_state in services.items():
+        data = get_state_with_retry(name, get_state)
+        if data is None:
+            continue
+        try:
+            path = write_state_file(STATE_DIR, name, data)
+        except Exception as e:
+            logger.error("Persistence: failed to save %s: %s", name, e)
+            continue
+        logger.info("Persistence: saved %s state to %s", name, path)
+        saved += 1
+    return saved

--- a/tests/test_checkpoints.py
+++ b/tests/test_checkpoints.py
@@ -1,0 +1,578 @@
+"""
+Tests for named state checkpoints (/_ministack/state/*), the on-demand save
+endpoint, and the durability hardening (autosave loop, atexit final save).
+
+Checkpoint semantics under test:
+  - checkpoints work regardless of PERSIST_STATE (the env gate governs only
+    the automatic boot-restore/shutdown-save cycle);
+  - checkpoints own copies of lambda code blobs, so lambda_svc's
+    per-get_state() orphan prune can never corrupt them;
+  - hot restore resets in-memory state before merging the checkpoint back
+    (restore paths .update(), they don't replace);
+  - restoring a nonexistent checkpoint fails BEFORE wiping live state.
+"""
+import asyncio
+import contextlib
+import importlib
+import json
+import os
+import signal
+import socket
+import subprocess
+import sys
+import time
+
+import pytest
+
+import ministack.app as app
+from ministack.core import checkpoints, persistence
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+@pytest.fixture(autouse=True)
+def _isolated_state(monkeypatch, tmp_path):
+    # Default the gate OFF — checkpoints must work without it. Tests that
+    # exercise the gate interaction flip it on themselves.
+    monkeypatch.setattr(persistence, "PERSIST_STATE", False)
+    monkeypatch.setattr(persistence, "STATE_DIR", str(tmp_path))
+    # Fresh reset lock per test: asyncio.Lock binds to the event loop that
+    # first acquires it, and each asyncio.run() here creates a new loop.
+    monkeypatch.setattr(app, "_reset_lock", None)
+
+
+def _module(mod_name):
+    return importlib.import_module(f"ministack.services.{mod_name}")
+
+
+# ---------------------------------------------------------------------------
+# Name validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad", ["", "../x", "a/b", ".hidden", "a" * 65, None, "a b", "-lead"])
+def test_validate_name_rejects(bad):
+    with pytest.raises(checkpoints.InvalidCheckpointNameError):
+        checkpoints.validate_name(bad)
+
+
+@pytest.mark.parametrize("good", ["a", "before-test", "v1.2_rc", "A" * 64])
+def test_validate_name_accepts(good):
+    assert checkpoints.validate_name(good) == good
+
+
+# ---------------------------------------------------------------------------
+# Checkpoint CRUD
+# ---------------------------------------------------------------------------
+
+
+def test_create_list_overwrite_delete():
+    save_dict = {"autoscaling": lambda: {"launch_configs": {"lc": {"x": 1}}}}
+    manifest = checkpoints.create_checkpoint("cp1", save_dict)
+    assert manifest["name"] == "cp1"
+    assert manifest["services"] == ["autoscaling"]
+    assert manifest["s3_data"] is False
+    assert manifest["size_bytes"] > 0
+    assert manifest["created_at"]
+
+    listed = checkpoints.list_checkpoints()
+    assert [c["name"] for c in listed] == ["cp1"]
+    assert listed[0]["services"] == ["autoscaling"]
+
+    with pytest.raises(checkpoints.CheckpointExistsError):
+        checkpoints.create_checkpoint("cp1", save_dict)
+
+    manifest2 = checkpoints.create_checkpoint(
+        "cp1", {"eks": lambda: {"clusters": {}}}, overwrite=True
+    )
+    assert manifest2["services"] == ["eks"]
+
+    checkpoints.delete_checkpoint("cp1")
+    assert checkpoints.list_checkpoints() == []
+    with pytest.raises(checkpoints.CheckpointNotFoundError):
+        checkpoints.delete_checkpoint("cp1")
+
+
+def test_create_survives_failing_get_state():
+    def boom():
+        raise ValueError("store exploded")
+
+    manifest = checkpoints.create_checkpoint(
+        "cp-partial", {"bad": boom, "good": lambda: {"k": 1}}
+    )
+    assert manifest["services"] == ["good"]
+
+
+def test_checkpoint_includes_unloaded_module_state_files():
+    """A module never imported this run has no get_state in the save dict,
+    but its prior-boot state file in live STATE_DIR must still be captured."""
+    persistence.write_state_file(persistence.STATE_DIR, "waf", {"acls": {"a": 1}})
+    manifest = checkpoints.create_checkpoint("cp-fallback", {"eks": lambda: {"clusters": {}}})
+    assert set(manifest["services"]) == {"eks", "waf"}
+    cp_dir = os.path.join(checkpoints.checkpoint_root(), "cp-fallback")
+    assert persistence.read_state_file(cp_dir, "waf") == {"acls": {"a": 1}}
+
+
+# ---------------------------------------------------------------------------
+# Lambda code blobs
+# ---------------------------------------------------------------------------
+
+
+def test_checkpoint_blobs_survive_live_prune():
+    """Simulates _prune_orphan_code_blobs deleting a live blob after the
+    checkpoint was taken — the checkpoint's hardlinked copy must survive
+    and restore must bring the live file back."""
+    blob_dir = os.path.join(persistence.STATE_DIR, "lambda-blobs")
+    os.makedirs(blob_dir)
+    blob = os.path.join(blob_dir, "a" * 64 + ".zip")
+    with open(blob, "wb") as f:
+        f.write(b"zipbytes")
+
+    checkpoints.create_checkpoint("cp-blob", {})
+    os.remove(blob)  # what the prune does to unreferenced live blobs
+
+    checkpoints.restore_checkpoint_files("cp-blob")
+    with open(blob, "rb") as f:
+        assert f.read() == b"zipbytes"
+
+
+def test_lambda_code_round_trips_through_checkpoint(monkeypatch):
+    """End-to-end through the real lambda_svc externalize/prune/internalize
+    path: function code must come back as bytes after a hot restore, even
+    when the live blob was pruned in between."""
+    lam = _module("lambda_svc")
+    monkeypatch.setattr(
+        lam, "CODE_BLOB_DIR", os.path.join(persistence.STATE_DIR, "lambda-blobs")
+    )
+    lam.reset()
+    code = b"PK\x03\x04 fake zip bytes"
+    lam._functions["fn-cp"] = {"FunctionName": "fn-cp", "code_zip": code, "versions": {}}
+    try:
+        app._get_module("lambda_svc")  # register for _build_persistence_save_dict
+        checkpoints.create_checkpoint("cp-lam", app._build_persistence_save_dict())
+
+        # Delete the function and trigger the orphan prune.
+        del lam._functions["fn-cp"]
+        lam.get_state()
+
+        app._restore_checkpoint_locked("cp-lam")
+        assert lam._functions["fn-cp"]["code_zip"] == code
+    finally:
+        lam.reset()
+
+
+# ---------------------------------------------------------------------------
+# Hot restore
+# ---------------------------------------------------------------------------
+
+
+def test_hot_restore_round_trip():
+    auto = _module("autoscaling")
+    auto.reset()
+    auto._launch_configs["lc-1"] = {"LaunchConfigurationName": "lc-1"}
+    try:
+        checkpoints.create_checkpoint("cp-hot", {"autoscaling": auto.get_state})
+
+        # Mutate after the checkpoint — restore must return to the snapshot.
+        auto._launch_configs["lc-2"] = {"LaunchConfigurationName": "lc-2"}
+
+        applied = app._restore_checkpoint_locked("cp-hot")
+        assert "autoscaling" in applied
+        assert "lc-1" in auto._launch_configs
+        assert "lc-2" not in auto._launch_configs
+    finally:
+        auto.reset()
+
+
+def test_hot_restore_works_without_persist_state():
+    assert persistence.PERSIST_STATE is False  # fixture default
+    eks = _module("eks")
+    eks.reset()
+    eks._clusters["c1"] = {"name": "c1", "status": "ACTIVE"}
+    try:
+        checkpoints.create_checkpoint("cp-nogate", {"eks": eks.get_state})
+        eks.reset()
+        applied = app._restore_checkpoint_locked("cp-nogate")
+        assert "eks" in applied
+        assert "c1" in eks._clusters
+    finally:
+        eks.reset()
+
+
+def test_restore_unknown_checkpoint_leaves_state_untouched():
+    auto = _module("autoscaling")
+    auto.reset()
+    auto._launch_configs["keep-me"] = {"x": 1}
+    try:
+        with pytest.raises(checkpoints.CheckpointNotFoundError):
+            app._restore_checkpoint_locked("does-not-exist")
+        assert "keep-me" in auto._launch_configs
+    finally:
+        auto.reset()
+
+
+def test_restore_flips_running_stepfunctions_execution_to_failed():
+    sfn = _module("stepfunctions")
+    sfn.reset()
+    exec_arn = "arn:aws:states:us-east-1:000000000000:execution:sm:e1"
+    sfn._executions[exec_arn] = {
+        "executionArn": exec_arn,
+        "stateMachineArn": "arn:aws:states:us-east-1:000000000000:stateMachine:sm",
+        "status": "RUNNING",
+        "startDate": 0,
+        "input": "{}",
+    }
+    try:
+        checkpoints.create_checkpoint("cp-sfn", {"stepfunctions": sfn.get_state})
+        app._restore_checkpoint_locked("cp-sfn")
+        restored = sfn._executions[exec_arn]
+        assert restored["status"] == "FAILED"
+        assert restored.get("error") == "States.ServiceRestart"
+    finally:
+        sfn.reset()
+
+
+# ---------------------------------------------------------------------------
+# /_ministack/reset interaction
+# ---------------------------------------------------------------------------
+
+
+def test_reset_removes_stale_lambda_blobs():
+    """With lambda.json wiped by reset, every blob is an orphan — reset must
+    remove them or they leak until a Lambda save's orphan prune, which never
+    runs if Lambda isn't used again."""
+    blob_dir = os.path.join(persistence.STATE_DIR, "lambda-blobs")
+    os.makedirs(blob_dir)
+    with open(os.path.join(blob_dir, "b" * 64 + ".zip"), "wb") as f:
+        f.write(b"orphan")
+
+    app._reset_all_state()
+    assert not os.path.isdir(blob_dir), "reset left stale lambda-blobs behind"
+
+
+def test_reset_wipes_state_files_even_without_gate():
+    """/state/save writes files with PERSIST_STATE off; reset must wipe them
+    regardless of the gate, or a later checkpoint's unloaded-module fallback
+    resurrects pre-reset state."""
+    assert persistence.PERSIST_STATE is False  # fixture default
+    persistence.write_state_file(persistence.STATE_DIR, "waf", {"acls": {"stale": 1}})
+
+    app._reset_all_state()
+    assert not os.path.exists(os.path.join(persistence.STATE_DIR, "waf.json"))
+
+    manifest = checkpoints.create_checkpoint("post-reset", {})
+    assert "waf" not in manifest["services"], (
+        "checkpoint resurrected pre-reset state from a file reset left behind"
+    )
+
+
+def test_checkpoints_survive_reset():
+    """Named checkpoints are user snapshots — snapshot → reset → restore is a
+    primary workflow, so reset must not delete them."""
+    eks = _module("eks")
+    eks.reset()
+    eks._clusters["c-reset"] = {"name": "c-reset"}
+    try:
+        checkpoints.create_checkpoint("pre-reset", {"eks": eks.get_state})
+
+        app._reset_all_state()
+        assert [c["name"] for c in checkpoints.list_checkpoints()] == ["pre-reset"]
+        assert "c-reset" not in eks._clusters  # reset really wiped live state
+
+        applied = app._restore_checkpoint_locked("pre-reset")
+        assert "eks" in applied
+        assert "c-reset" in eks._clusters
+    finally:
+        eks.reset()
+
+
+# ---------------------------------------------------------------------------
+# S3 object data
+# ---------------------------------------------------------------------------
+
+
+def test_checkpoint_captures_and_restores_s3_data(monkeypatch, tmp_path):
+    s3_dir = tmp_path / "s3data"
+    (s3_dir / "bucket").mkdir(parents=True)
+    (s3_dir / "bucket" / "obj").write_bytes(b"body-bytes")
+    monkeypatch.setenv("S3_PERSIST", "1")
+    monkeypatch.setenv("S3_DATA_DIR", str(s3_dir))
+
+    manifest = checkpoints.create_checkpoint("cp-s3", {})
+    assert manifest["s3_data"] is True
+
+    (s3_dir / "bucket" / "obj").unlink()
+    checkpoints.restore_checkpoint_files("cp-s3")
+    assert (s3_dir / "bucket" / "obj").read_bytes() == b"body-bytes"
+
+
+# ---------------------------------------------------------------------------
+# Admin endpoints
+# ---------------------------------------------------------------------------
+
+
+def _call(method, path, body=b""):
+    return asyncio.run(app._handle_admin_state_request(method, path, body))
+
+
+def test_state_endpoints_full_flow():
+    auto = _module("autoscaling")
+    auto.reset()
+    auto._launch_configs["lc-ep"] = {"x": 1}
+    app._get_module("autoscaling")  # register for _build_persistence_save_dict
+
+    async def flow():
+        results = {}
+        results["create"] = await app._handle_admin_state_request(
+            "POST", "/_ministack/state/checkpoint", json.dumps({"name": "ep1"}).encode()
+        )
+        results["dup"] = await app._handle_admin_state_request(
+            "POST", "/_ministack/state/checkpoint", b'{"name": "ep1"}'
+        )
+        results["list"] = await app._handle_admin_state_request(
+            "GET", "/_ministack/state/checkpoints", b""
+        )
+        auto._launch_configs.pop("lc-ep")
+        results["restore"] = await app._handle_admin_state_request(
+            "POST", "/_ministack/state/restore", b'{"name": "ep1"}'
+        )
+        results["restore_missing"] = await app._handle_admin_state_request(
+            "POST", "/_ministack/state/restore", b'{"name": "missing"}'
+        )
+        results["bad_name"] = await app._handle_admin_state_request(
+            "POST", "/_ministack/state/checkpoint", b'{"name": "../evil"}'
+        )
+        results["delete"] = await app._handle_admin_state_request(
+            "DELETE", "/_ministack/state/checkpoints/ep1", b""
+        )
+        results["delete_again"] = await app._handle_admin_state_request(
+            "DELETE", "/_ministack/state/checkpoints/ep1", b""
+        )
+        results["unknown"] = await app._handle_admin_state_request(
+            "GET", "/_ministack/other", b""
+        )
+        return results
+
+    try:
+        r = asyncio.run(flow())
+        status, _, body = r["create"]
+        assert status == 200
+        assert "autoscaling" in json.loads(body)["services"]
+        assert r["dup"][0] == 409
+        status, _, body = r["list"]
+        assert status == 200
+        assert [c["name"] for c in json.loads(body)["checkpoints"]] == ["ep1"]
+        assert r["restore"][0] == 200
+        assert "lc-ep" in auto._launch_configs, "hot restore did not bring state back"
+        assert r["restore_missing"][0] == 404
+        assert r["bad_name"][0] == 400
+        assert r["delete"][0] == 200
+        assert r["delete_again"][0] == 404
+        assert r["unknown"] is None
+    finally:
+        auto.reset()
+
+
+def test_state_save_endpoint_without_gate(monkeypatch):
+    eks = _module("eks")
+    eks.reset()
+    eks._clusters["c-save"] = {"name": "c-save"}
+    app._get_module("eks")
+    try:
+        status, _, body = _call("POST", "/_ministack/state/save")
+        assert status == 200
+        payload = json.loads(body)
+        assert payload["saved"] is True
+        assert payload["autoload"] is False
+        assert "note" in payload
+        # File written to STATE_DIR even with the gate off — explicit action.
+        data = persistence.read_state_file(persistence.STATE_DIR, "eks")
+        assert data is not None and "c-save" in data.get("clusters", {})
+    finally:
+        eks.reset()
+
+
+def test_state_save_endpoint_with_gate(monkeypatch):
+    monkeypatch.setattr(persistence, "PERSIST_STATE", True)
+    status, _, body = _call("POST", "/_ministack/state/save")
+    assert status == 200
+    payload = json.loads(body)
+    assert payload["autoload"] is True
+    assert "note" not in payload
+
+
+# ---------------------------------------------------------------------------
+# save_all_resilient
+# ---------------------------------------------------------------------------
+
+
+def test_save_all_resilient_retries_runtime_error():
+    attempts = {"n": 0}
+
+    def flaky():
+        attempts["n"] += 1
+        if attempts["n"] == 1:
+            raise RuntimeError("dictionary changed size during iteration")
+        return {"ok": 1}
+
+    assert persistence.save_all_resilient({"svc": flaky}) == 1
+    assert attempts["n"] == 2
+    assert persistence.read_state_file(persistence.STATE_DIR, "svc") == {"ok": 1}
+
+
+def test_save_all_resilient_gives_up_after_retries():
+    def always_racing():
+        raise RuntimeError("dictionary changed size during iteration")
+
+    assert persistence.save_all_resilient({"svc": always_racing}) == 0
+    assert persistence.read_state_file(persistence.STATE_DIR, "svc") is None
+
+
+# ---------------------------------------------------------------------------
+# Autosave
+# ---------------------------------------------------------------------------
+
+
+def test_persist_interval_parsing(monkeypatch):
+    monkeypatch.setenv("PERSIST_INTERVAL", "2.5")
+    assert app._persist_interval() == 2.5
+    monkeypatch.setenv("PERSIST_INTERVAL", "bogus")
+    assert app._persist_interval() == 0.0
+    monkeypatch.delenv("PERSIST_INTERVAL")
+    assert app._persist_interval() == 0.0
+
+
+@pytest.mark.parametrize(
+    "gate,interval", [(False, "1"), (True, "0"), (False, "0"), (True, "")]
+)
+def test_autosave_not_started_when_disabled(monkeypatch, gate, interval):
+    monkeypatch.setattr(persistence, "PERSIST_STATE", gate)
+    monkeypatch.setenv("PERSIST_INTERVAL", interval)
+    monkeypatch.setattr(app, "_autosave_task", None)
+
+    async def run():
+        app._start_autosave_task()
+        assert app._autosave_task is None
+
+    asyncio.run(run())
+
+
+def test_autosave_loop_saves_periodically(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        persistence, "save_all_resilient", lambda d: calls.append(d) or len(d)
+    )
+
+    async def run():
+        task = asyncio.create_task(app._autosave_loop(0.01))
+        for _ in range(200):
+            await asyncio.sleep(0.01)
+            if calls:
+                break
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+    asyncio.run(run())
+    assert calls, "autosave loop never invoked save_all_resilient"
+
+
+# ---------------------------------------------------------------------------
+# atexit final save
+# ---------------------------------------------------------------------------
+
+
+def test_final_save_runs_once(monkeypatch):
+    monkeypatch.setattr(persistence, "PERSIST_STATE", True)
+    monkeypatch.setattr(app, "_final_save_done", False)
+    calls = []
+    monkeypatch.setattr(app, "save_all", lambda d: calls.append(d))
+
+    app._final_save()
+    assert len(calls) == 1
+    assert app._final_save_done is True
+    app._final_save()
+    assert len(calls) == 1, "atexit save must not run twice"
+
+
+def test_final_save_noop_without_gate(monkeypatch):
+    monkeypatch.setattr(persistence, "PERSIST_STATE", False)
+    monkeypatch.setattr(app, "_final_save_done", False)
+    calls = []
+    monkeypatch.setattr(app, "save_all", lambda d: calls.append(d))
+
+    app._final_save()
+    assert not calls
+    assert app._final_save_done is False
+
+
+# ---------------------------------------------------------------------------
+# SIGTERM integration: docker-stop shaped shutdown must flush state
+# ---------------------------------------------------------------------------
+
+
+def _free_port():
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+@pytest.mark.serial
+def test_sigterm_flushes_state(tmp_path):
+    """`python -m ministack` installs a SIGTERM handler that calls
+    sys.exit(0), which may bypass the ASGI lifespan shutdown save. The
+    atexit safety net must still flush state to STATE_DIR."""
+    port = _free_port()
+    state_dir = tmp_path / "state"
+    env = {
+        **os.environ,
+        "GATEWAY_PORT": str(port),
+        "PERSIST_STATE": "1",
+        "STATE_DIR": str(state_dir),
+        "LOG_LEVEL": "WARNING",
+        "SFTP_ENABLED": "0",
+    }
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "ministack"],
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.STDOUT,
+        cwd=REPO_ROOT,
+    )
+    try:
+        import urllib.request
+
+        deadline = time.monotonic() + 30
+        while time.monotonic() < deadline:
+            try:
+                urllib.request.urlopen(f"http://127.0.0.1:{port}/_ministack/health", timeout=1)
+                break
+            except OSError:
+                time.sleep(0.2)
+        else:
+            pytest.fail("server did not become healthy")
+
+        import boto3
+
+        sqs = boto3.client(
+            "sqs",
+            endpoint_url=f"http://127.0.0.1:{port}",
+            region_name="us-east-1",
+            aws_access_key_id="test",
+            aws_secret_access_key="test",
+        )
+        sqs.create_queue(QueueName="sigterm-test-queue")
+
+        proc.send_signal(signal.SIGTERM)
+        proc.wait(timeout=15)
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=5)
+
+    sqs_file = state_dir / "sqs.json"
+    assert sqs_file.exists(), (
+        "SIGTERM shutdown did not persist SQS state — neither the lifespan "
+        "shutdown save nor the atexit safety net ran."
+    )
+    assert "sigterm-test-queue" in sqs_file.read_text()


### PR DESCRIPTION
  ## Motivation

  State kept resetting for API Gateway → Lambda setups across restarts. Two root causes in the persistence lifecycle, plus a missing capability:

  1. State is only saved on graceful ASGI lifespan shutdown — but the SIGTERM handler installed by `python -m ministack` calls `sys.exit(0)` directly, which can bypass hypercorn's lifespan
  shutdown entirely. `docker stop` could silently drop all state; crash/`SIGKILL` always did.
  2. There was no way to save or snapshot state programmatically.

  ## Added

  **`/_ministack/state/*` admin endpoints** (work regardless of `PERSIST_STATE` — that flag keeps governing only the automatic boot-restore/shutdown-save cycle):

  - `POST /_ministack/state/save` — flush all in-memory service state to `STATE_DIR` now
  - `POST /_ministack/state/checkpoint {"name": "...", "overwrite"?}` — named snapshot under `${STATE_DIR}/checkpoints/<name>/`: per-service state files, Lambda code blobs, S3 object data when
  `S3_PERSIST=1`, and a manifest. 409 on duplicate, 400 on invalid name (single path segment, traversal-safe)
  - `POST /_ministack/state/restore {"name": "..."}` — **hot restore into the running instance**: in-memory reset → file swap → per-service restore → pollers/schedulers restarted. Same
  semantics as a process restart (RUNNING Step Functions executions → `FAILED`/`States.ServiceRestart`, open API GW WebSocket connections closed). Existence is checked before anything is wiped,
  so a typo'd name 404s without touching live state
  - `GET /_ministack/state/checkpoints` / `DELETE /_ministack/state/checkpoints/<name>`

  **`PERSIST_INTERVAL`** (seconds, default `0` = off, requires `PERSIST_STATE=1`) — periodic autosave so crash/OOM/`SIGKILL`, which no shutdown hook can catch, loses at most one interval of
  state.

  ## Fixed

  - **SIGTERM/`docker stop` flush**: an `atexit` safety net saves state when `PERSIST_STATE=1` and the lifespan shutdown save didn't run. No change to the existing signal handler or lifespan
  path — the net only fires when they didn't.
  - **`/_ministack/reset` file wipe**: was gated on `PERSIST_STATE`, so files written by the explicit save endpoint with the gate off survived reset and could be resurrected into a later
  checkpoint. Now wipes `${STATE_DIR}/*.json` unconditionally, and also removes `lambda-blobs/` (previously orphaned blobs leaked after every reset). Named checkpoints survive reset by design —
  snapshot → reset → restore is the intended workflow.

  ## Design notes

  - Checkpoints **hardlink** Lambda code blobs (copy on cross-device): `lambda_svc.get_state()` prunes orphan blobs on every call, so a checkpoint must own its blob files or a later save
  corrupts it. Content-addressed sha256 names make hardlinks safe.
  - All mutating endpoints serialize behind the same reset lock as `/_ministack/reset`, which also gates request admission — snapshots are near-quiescent. A new `save_all_resilient` retries
  `get_state()` snapshots that race in-flight requests.
  - Fully additive to existing persistence: `save_state`/`load_state`/`save_all`, the shutdown save, and every service's `get_state`/`restore_state` contract are unchanged. New primitives
  (`write_state_file`/`read_state_file`) are ungated and path-parameterized; `core/checkpoints.py` is a new module.
  - Checkpoints capture state files of modules not loaded this run (prior-boot state) by copying their live `STATE_DIR` files, instead of force-importing all ~55 service modules.

  ## Tests

  `tests/test_checkpoints.py` (39 tests): checkpoint CRUD, name validation (traversal, length), blob-prune survival, unloaded-module capture, hot restore round-trips (incl. Lambda code bytes
  and SFN RUNNING→FAILED), gate independence, reset interaction (files wiped without gate, blobs cleaned, checkpoints survive), autosave loop/gating, atexit once-only semantics, and a serial
  SIGTERM integration test (`python -m ministack` + boto3 + `kill -TERM` → `sqs.json` present).

  Verified end-to-end against a live server: REST API + `AWS_PROXY` Lambda integration → checkpoint → delete both → hot restore → invoke returns the Lambda response again, with `PERSIST_STATE`
  unset.

  Checked:
  - ruff clean (one pre-existing `I001` in `services/s3.py`, untouched here)
  - `pytest tests/test_checkpoints.py tests/test_persistence.py` green (172)
  - live-server regressions green: `test_ministack`, `test_apigatewayv1`, `test_lambda`, `test_ses`, `test_account`, `test_tagging` (621 total)
  - README (env-var table + persistence section) and CHANGELOG updated