### PR TITLE
fix(eks): configurable OIDC issuer scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -696,6 +696,7 @@ end-to-end without any client config.
 | `OPENSEARCH_DASHBOARDS_BASE_PORT` | `15601` | Starting host port for per-domain Dashboards containers |
 | `OPENSEARCH_DASHBOARDS_IMAGE` | `opensearchproject/opensearch-dashboards:2.15.0` | Image used when spawning per-domain Dashboards containers |
 | `MINISTACK_OPENSEARCH_ENDPOINT` | _(unset)_ | If set (e.g. `localhost:9200`), every domain returns this endpoint instead of spawning a per-domain container — useful when you bring your own cluster |
+| `EKS_ISSUER_SCHEME` | `http` | URL scheme for the EKS cluster OIDC issuer advertised by `DescribeCluster` and the OIDC discovery document. Set `https` for IRSA terraform: `aws_iam_openid_connect_provider` client-side-validates that `url` is https (real EKS issuers always are). Discovery/JWKS are still served over the plain-http gateway |
 | `PERSIST_STATE` | `0` | Set `1` to persist service state across restarts |
 | `STATE_DIR` | `/tmp/ministack-state` | Directory for persisted state files |
 | `LAMBDA_EXECUTOR` | `local` | Lambda execution mode: `local` (subprocess) or `docker` (container). `provided` runtimes and `PackageType: Image` always use Docker |

--- a/ministack/services/eks.py
+++ b/ministack/services/eks.py
@@ -67,8 +67,23 @@ _oidc_keypair = None                  # (private_key, jwk_dict, kid)
 
 
 def _ministack_issuer_base():
+    """Base URL ministack advertises as the cluster's OIDC issuer.
+
+    Real EKS issuers are always https. terraform-provider-aws's
+    ``aws_iam_openid_connect_provider`` client-side-validates that ``url`` is
+    https, so an http-advertised issuer makes IRSA terraform fail before it
+    ever reaches the API. Setting ``EKS_ISSUER_SCHEME=https`` makes
+    DescribeCluster (and the discovery document, which echoes the same URL)
+    advertise an https issuer so those resources apply cleanly.
+
+    The discovery/JWKS endpoints themselves are still served over the plain
+    http gateway — clients that only register the issuer URL (e.g. terraform,
+    which supplies explicit thumbprints rather than fetching the document) work
+    regardless. The default stays http for backward compatibility.
+    """
     port = os.environ.get("GATEWAY_PORT", "4566")
-    return f"http://{_MINISTACK_HOST}:{port}/oidc"
+    scheme = os.environ.get("EKS_ISSUER_SCHEME", "http")
+    return f"{scheme}://{_MINISTACK_HOST}:{port}/oidc"
 
 
 def _new_oidc_id():

--- a/tests/test_eks.py
+++ b/tests/test_eks.py
@@ -487,6 +487,38 @@ def test_eks_oidc_discovery_document(eks):
             pass
 
 
+def test_eks_issuer_scheme_https_is_self_consistent(monkeypatch):
+    """EKS_ISSUER_SCHEME=https makes the advertised issuer https so terraform's
+    aws_iam_openid_connect_provider (which rejects non-https urls) applies.
+
+    Called in-process — the live gateway under test starts with the default
+    http scheme, so this exercises the override directly and confirms the
+    DescribeCluster issuer and the discovery document echo the same https URL
+    (a mismatch would make oidc clients that DO fetch the document reject it).
+    """
+    from ministack.services import eks as eks_svc
+
+    monkeypatch.setenv("EKS_ISSUER_SCHEME", "https")
+    oidc_id = eks_svc._new_oidc_id()
+    issuer = eks_svc._issuer_url(oidc_id)
+    assert issuer.startswith("https://"), issuer
+    assert "/oidc/id/" in issuer, issuer
+
+    status, _headers, body = eks_svc._oidc_discovery(oidc_id)
+    assert status == 200
+    doc = json.loads(body)
+    assert doc["issuer"] == issuer
+    assert doc["jwks_uri"] == f"{issuer}/keys"
+
+
+def test_eks_issuer_scheme_defaults_to_http(monkeypatch):
+    """Default (no override) keeps http for backward compatibility."""
+    from ministack.services import eks as eks_svc
+
+    monkeypatch.delenv("EKS_ISSUER_SCHEME", raising=False)
+    assert eks_svc._ministack_issuer_base().startswith("http://")
+
+
 # ---------------------------------------------------------------------------
 # Access Entries — modern EKS IAM bindings (replace aws-auth ConfigMap).
 # Crossplane / Terraform `aws_eks_access_entry` + `aws_eks_access_policy_association`


### PR DESCRIPTION
`_ministack_issuer_base()` hard-coded `http://`, so `DescribeCluster` advertised an `http` OIDC issuer. terraform-provider-aws's `aws_iam_openid_connect_provider` client-side-validates that `url` is https and rejects the plan before any request reaches the API: `expected "url" to have a url with schema of: "https"`. Real EKS issuers are always https, so IRSA terraform against ministack could never apply.

Changes in `eks.py`:

- Add an `EKS_ISSUER_SCHEME` env override to `_ministack_issuer_base()` (default `http` for backward compatibility). Setting `EKS_ISSUER_SCHEME=https` makes `DescribeCluster` advertise an https issuer.
- The issuer is computed in one place: both `DescribeCluster`'s `identity.oidc.issuer` (set from `_issuer_url` at create time) and the OIDC discovery document (`_oidc_discovery`, which re-derives `_issuer_url`) flow through `_ministack_issuer_base`, so they stay self-consistent — the discovery document's `issuer` echoes the same https URL, which oidc clients that fetch it require. The discovery/JWKS endpoints are still served over the plain-http gateway, so clients that only register the issuer URL (e.g. terraform with explicit thumbprints) work regardless.
- Document `EKS_ISSUER_SCHEME` in the README Configuration table alongside the other emulator env vars.

Added `test_eks_issuer_scheme_https_is_self_consistent` (with `EKS_ISSUER_SCHEME=https`, `_issuer_url` and the `_oidc_discovery` document both advertise the same https issuer) and `test_eks_issuer_scheme_defaults_to_http`. All existing EKS tests still pass.

Ran into this using ministack as the AWS endpoint for a Terraform setup: `aws_iam_openid_connect_provider` validates the `url` argument is https before it makes any call, so pointing it at a cluster's `identity.oidc.issuer` failed at plan time until the advertised issuer could be https.
