### PR TITLE
fix(autoscaling): report mock in-service instances so capacity waiters converge

### DIFF
--- a/ministack/services/autoscaling.py
+++ b/ministack/services/autoscaling.py
@@ -5,7 +5,8 @@ All in-memory, no actual instance scaling.
 
 Supports:
   ASG:       CreateAutoScalingGroup, DescribeAutoScalingGroups, UpdateAutoScalingGroup,
-             DeleteAutoScalingGroup, DescribeAutoScalingInstances, DescribeScalingActivities
+             DeleteAutoScalingGroup, SetDesiredCapacity, DescribeAutoScalingInstances,
+             DescribeScalingActivities
   Refresh:   StartInstanceRefresh, DescribeInstanceRefreshes, CancelInstanceRefresh
   LC:        CreateLaunchConfiguration, DescribeLaunchConfigurations, DeleteLaunchConfiguration
   Policies:  PutScalingPolicy, DescribePolicies, DeletePolicy
@@ -111,7 +112,73 @@ def _asg_arn(name):
 
 # ---------------------------------------------------------------------------
 # AutoScalingGroup
+#
+# No real instances run, but terraform-provider-aws's aws_autoscaling_group
+# capacity waiter polls DescribeAutoScalingGroups until DesiredCapacity
+# instances report InService/Healthy. A group that reports zero forever blocks
+# every apply for the full wait_for_capacity_timeout (10m) and then fails, so we
+# materialize DesiredCapacity mock instances the same way a real ASG launches
+# them. They ride the group record, inheriting the existing persistence / reset
+# plumbing (like InstanceRefreshes).
 # ---------------------------------------------------------------------------
+
+def _reconcile_instances(asg):
+    """Resize the group's Instances list to exactly DesiredCapacity entries.
+
+    Scale-up appends InService/Healthy instances round-robined across the
+    group's AZs; scale-down removes from the end, matching a Default
+    termination policy.
+    """
+    desired = asg["DesiredCapacity"]
+    instances = asg["Instances"]
+    if len(instances) > desired:
+        del instances[desired:]
+        return
+    azs = asg["AvailabilityZones"] or [f"{get_region()}a"]
+    launch_template = asg.get("LaunchTemplate") or {}
+    launch_config = asg.get("LaunchConfigurationName", "")
+    while len(instances) < desired:
+        instances.append({
+            "InstanceId": "i-" + new_uuid().replace("-", "")[:17],
+            "LifecycleState": "InService",
+            "HealthStatus": "Healthy",
+            "AvailabilityZone": azs[len(instances) % len(azs)],
+            # Real ASGs stamp new instances with the group's scale-in setting.
+            "ProtectedFromScaleIn": asg["NewInstancesProtectedFromScaleIn"],
+            "LaunchTemplate": launch_template,
+            "LaunchConfigurationName": launch_config,
+        })
+
+
+def _instance_member_xml(inst, include_group_name=""):
+    """Render one instance. DescribeAutoScalingInstances also carries the
+    owning AutoScalingGroupName, so callers pass it when needed."""
+    launch_template = inst.get("LaunchTemplate") or {}
+    lt_xml = ""
+    if launch_template:
+        lt_xml = (f"<LaunchTemplate>"
+                  f"<LaunchTemplateId>{launch_template.get('LaunchTemplateId', '')}</LaunchTemplateId>"
+                  f"<LaunchTemplateName>{launch_template.get('LaunchTemplateName', '')}</LaunchTemplateName>"
+                  f"<Version>{launch_template.get('Version', '')}</Version></LaunchTemplate>")
+    launch_config = inst.get("LaunchConfigurationName", "")
+    lc_xml = f"<LaunchConfigurationName>{launch_config}</LaunchConfigurationName>" if launch_config else ""
+    group_xml = f"<AutoScalingGroupName>{include_group_name}</AutoScalingGroupName>" if include_group_name else ""
+    return (f"<member>"
+            f"<InstanceId>{inst['InstanceId']}</InstanceId>"
+            f"{group_xml}"
+            f"<AvailabilityZone>{inst['AvailabilityZone']}</AvailabilityZone>"
+            f"<LifecycleState>{inst['LifecycleState']}</LifecycleState>"
+            f"<HealthStatus>{inst['HealthStatus']}</HealthStatus>"
+            f"<ProtectedFromScaleIn>{'true' if inst['ProtectedFromScaleIn'] else 'false'}</ProtectedFromScaleIn>"
+            f"{lt_xml}{lc_xml}"
+            f"</member>")
+
+
+def _instances_xml(asg):
+    if not asg["Instances"]:
+        return "<Instances/>"
+    return "<Instances>" + "".join(_instance_member_xml(i) for i in asg["Instances"]) + "</Instances>"
+
 
 def _create_asg(p):
     name = _p(p, "AutoScalingGroupName")
@@ -168,6 +235,8 @@ def _create_asg(p):
     _asgs[name]["Tags"] = tags
     _tags[name] = tags
 
+    _reconcile_instances(_asgs[name])
+
     logger.info("CreateAutoScalingGroup: %s", name)
     return _xml(200, "CreateAutoScalingGroupResponse", "<CreateAutoScalingGroupResult/>")
 
@@ -208,7 +277,7 @@ def _describe_asgs(p):
                     f"<TerminationPolicies>{tp}</TerminationPolicies>"
                     f"<NewInstancesProtectedFromScaleIn>{'true' if asg['NewInstancesProtectedFromScaleIn'] else 'false'}</NewInstancesProtectedFromScaleIn>"
                     f"<Tags>{tags_xml}</Tags>"
-                    f"<Instances/>"
+                    f"{_instances_xml(asg)}"
                     f"{lt_xml}"
                     f"<LaunchConfigurationName>{asg.get('LaunchConfigurationName', '')}</LaunchConfigurationName>"
                     f"</member>")
@@ -230,7 +299,21 @@ def _update_asg(p):
         asg["HealthCheckType"] = _p(p, "HealthCheckType")
     if _p(p, "VPCZoneIdentifier"):
         asg["VPCZoneIdentifier"] = _p(p, "VPCZoneIdentifier")
+    _reconcile_instances(asg)
     return _xml(200, "UpdateAutoScalingGroupResponse", "<UpdateAutoScalingGroupResult/>")
+
+
+def _set_desired_capacity(p):
+    name = _p(p, "AutoScalingGroupName")
+    asg = _asgs.get(name)
+    if not asg:
+        return _error("ValidationError", f"AutoScalingGroup {name} not found")
+    desired = _p(p, "DesiredCapacity")
+    if desired == "":
+        return _error("ValidationError", "DesiredCapacity is required")
+    asg["DesiredCapacity"] = int(desired)
+    _reconcile_instances(asg)
+    return _xml(200, "SetDesiredCapacityResponse", "")
 
 
 def _delete_asg(p):
@@ -245,8 +328,15 @@ def _delete_asg(p):
 
 
 def _describe_asg_instances(p):
+    wanted = _parse_member_list(p, "InstanceIds")
+    members = ""
+    for name, asg in _asgs.items():
+        for inst in asg["Instances"]:
+            if wanted and inst["InstanceId"] not in wanted:
+                continue
+            members += _instance_member_xml(inst, include_group_name=name)
     return _xml(200, "DescribeAutoScalingInstancesResponse",
-                "<DescribeAutoScalingInstancesResult><AutoScalingInstances/></DescribeAutoScalingInstancesResult>")
+                f"<DescribeAutoScalingInstancesResult><AutoScalingInstances>{members}</AutoScalingInstances></DescribeAutoScalingInstancesResult>")
 
 
 def _describe_scaling_activities(p):
@@ -588,6 +678,7 @@ _ACTION_MAP = {
     "DescribeAutoScalingGroups": _describe_asgs,
     "UpdateAutoScalingGroup": _update_asg,
     "DeleteAutoScalingGroup": _delete_asg,
+    "SetDesiredCapacity": _set_desired_capacity,
     "DescribeAutoScalingInstances": _describe_asg_instances,
     "DescribeScalingActivities": _describe_scaling_activities,
     "StartInstanceRefresh": _start_instance_refresh,

--- a/tests/test_autoscaling.py
+++ b/tests/test_autoscaling.py
@@ -963,3 +963,108 @@ def test_cancel_instance_refresh_when_none_active(autoscaling):
         assert "ActiveInstanceRefreshNotFound" in str(exc.value)
     finally:
         autoscaling.delete_auto_scaling_group(AutoScalingGroupName=asg)
+
+
+# ---------------------------------------------------------------------------
+# Mock in-service instances (capacity waiters)
+# ---------------------------------------------------------------------------
+
+
+def test_asg_reports_desired_capacity_instances(autoscaling):
+    name = _uid("asg-cap")
+    autoscaling.create_auto_scaling_group(
+        AutoScalingGroupName=name,
+        MinSize=1,
+        MaxSize=5,
+        DesiredCapacity=3,
+        AvailabilityZones=["us-east-1a"],
+        LaunchConfigurationName="dummy-lc",
+    )
+    try:
+        g = autoscaling.describe_auto_scaling_groups(
+            AutoScalingGroupNames=[name]
+        )["AutoScalingGroups"][0]
+        instances = g["Instances"]
+        assert len(instances) == 3
+        for inst in instances:
+            assert inst["InstanceId"].startswith("i-")
+            assert inst["LifecycleState"] == "InService"
+            assert inst["HealthStatus"] == "Healthy"
+            assert inst["AvailabilityZone"] == "us-east-1a"
+
+        described = autoscaling.describe_auto_scaling_instances()["AutoScalingInstances"]
+        for_group = [i for i in described if i["AutoScalingGroupName"] == name]
+        assert len(for_group) == 3
+        assert {i["InstanceId"] for i in for_group} == {i["InstanceId"] for i in instances}
+    finally:
+        autoscaling.delete_auto_scaling_group(AutoScalingGroupName=name)
+
+
+def test_set_desired_capacity_reconciles_instances(autoscaling):
+    name = _uid("asg-set")
+    autoscaling.create_auto_scaling_group(
+        AutoScalingGroupName=name,
+        MinSize=0,
+        MaxSize=5,
+        DesiredCapacity=1,
+        AvailabilityZones=["us-east-1a"],
+        LaunchConfigurationName="dummy-lc",
+    )
+    try:
+        autoscaling.set_desired_capacity(AutoScalingGroupName=name, DesiredCapacity=4)
+        g = autoscaling.describe_auto_scaling_groups(
+            AutoScalingGroupNames=[name]
+        )["AutoScalingGroups"][0]
+        assert len(g["Instances"]) == 4
+        assert all(i["LifecycleState"] == "InService" for i in g["Instances"])
+
+        autoscaling.set_desired_capacity(AutoScalingGroupName=name, DesiredCapacity=2)
+        g = autoscaling.describe_auto_scaling_groups(
+            AutoScalingGroupNames=[name]
+        )["AutoScalingGroups"][0]
+        assert len(g["Instances"]) == 2
+    finally:
+        autoscaling.delete_auto_scaling_group(AutoScalingGroupName=name)
+
+
+def test_update_asg_reconciles_instances(autoscaling):
+    name = _uid("asg-upd-cap")
+    autoscaling.create_auto_scaling_group(
+        AutoScalingGroupName=name,
+        MinSize=0,
+        MaxSize=5,
+        DesiredCapacity=0,
+        AvailabilityZones=["us-east-1a"],
+        LaunchConfigurationName="dummy-lc",
+    )
+    try:
+        assert autoscaling.describe_auto_scaling_groups(
+            AutoScalingGroupNames=[name]
+        )["AutoScalingGroups"][0]["Instances"] == []
+        autoscaling.update_auto_scaling_group(AutoScalingGroupName=name, DesiredCapacity=2)
+        g = autoscaling.describe_auto_scaling_groups(
+            AutoScalingGroupNames=[name]
+        )["AutoScalingGroups"][0]
+        assert len(g["Instances"]) == 2
+    finally:
+        autoscaling.delete_auto_scaling_group(AutoScalingGroupName=name)
+
+
+def test_asg_instances_round_robin_azs(autoscaling):
+    name = _uid("asg-az")
+    autoscaling.create_auto_scaling_group(
+        AutoScalingGroupName=name,
+        MinSize=0,
+        MaxSize=5,
+        DesiredCapacity=4,
+        AvailabilityZones=["us-east-1a", "us-east-1b"],
+        LaunchConfigurationName="dummy-lc",
+    )
+    try:
+        instances = autoscaling.describe_auto_scaling_groups(
+            AutoScalingGroupNames=[name]
+        )["AutoScalingGroups"][0]["Instances"]
+        azs = [i["AvailabilityZone"] for i in instances]
+        assert azs == ["us-east-1a", "us-east-1b", "us-east-1a", "us-east-1b"]
+    finally:
+        autoscaling.delete_auto_scaling_group(AutoScalingGroupName=name)


### PR DESCRIPTION
`CreateAutoScalingGroup` recorded the group but never materialized any instances, so `DescribeAutoScalingGroups` always returned an empty `Instances` member. terraform-provider-aws's `aws_autoscaling_group` capacity waiter polls DescribeAutoScalingGroups until `DesiredCapacity` instances are `InService`/`Healthy`, so every apply with the default `wait_for_capacity_timeout` (10m) blocked the full timeout and then failed: `waiting for Auto Scaling Group (<name>) capacity satisfied: context canceled`. Real ASGs launch instances; an emulator reporting zero forever is the parity gap.

Changes in `autoscaling.py`:

- Add `_reconcile_instances`, which resizes the group's `Instances` list to exactly `DesiredCapacity` mock entries (`InstanceId` `i-<17 hex>`, `LifecycleState` `InService`, `HealthStatus` `Healthy`, round-robin `AvailabilityZone` across the group's AZs, `ProtectedFromScaleIn` inherited from the group's `NewInstancesProtectedFromScaleIn`, echoing the group's LaunchTemplate/LaunchConfigurationName). Scale-down removes from the end, matching a Default termination policy. It is called from `CreateAutoScalingGroup`, `UpdateAutoScalingGroup`, and a new `SetDesiredCapacity` handler (registered in `_ACTION_MAP`), so the count tracks every capacity change.
- `DescribeAutoScalingGroups` now emits the instances (via a shared `_instance_member_xml` renderer) instead of the hardcoded `<Instances/>`. `DescribeAutoScalingInstances` — previously a stub returning an empty set — now returns the same instances across all groups, carrying the owning `AutoScalingGroupName` and honoring the `InstanceIds` filter.
- Instances live on the group record, so they inherit the existing persistence / `reset` / `restore_state` plumbing (the same as the `InstanceRefreshes` list). Instance refreshes are unaffected — they still complete immediately as `Successful`, and now coexist with a non-empty instance set.

Added `test_asg_reports_desired_capacity_instances` (create -> describe reports N InService/Healthy instances, also visible via DescribeAutoScalingInstances), `test_set_desired_capacity_reconciles_instances` (SetDesiredCapacity up then down reconciles the count), `test_update_asg_reconciles_instances` (UpdateAutoScalingGroup DesiredCapacity 0 -> 2), and `test_asg_instances_round_robin_azs` (AZ round-robin across two zones). All existing AutoScaling tests still pass.

Ran into this using ministack as the AWS endpoint for a Terraform setup: `aws_autoscaling_group` with the default (non-zero) `desired_capacity` and no `wait_for_capacity_timeout = "0"` override waits on DescribeAutoScalingGroups for the group to report that many healthy in-service instances. Against an emulator that reported zero, every apply hung for the full 10-minute timeout and then failed instead of converging.
