### PR TITLE
fix: run apt-get upgrade in Dockerfile.full to patch base packages

### DIFF
--- a/Dockerfile.full
+++ b/Dockerfile.full
@@ -37,6 +37,7 @@ LABEL maintainer="MiniStack" \
 # Lambda Node.js + init scripts), then strip pip and locale/doc payload
 # we never use at runtime.
 RUN apt-get update \
+    && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends nodejs bash \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
     && rm -rf /var/lib/apt/lists/* /var/cache/apt/* /tmp/* \


### PR DESCRIPTION
## Summary

Adds `apt-get upgrade -y` to the final-stage `RUN` in `Dockerfile.full`. The block's comment says *"Upgrade base packages, install runtime essentials …"*, but the command only installs `nodejs`/`bash` — it never upgrades. So the Debian (debian 13 / trixie) base layer stays frozen at whatever `python:3.12-slim` shipped with.

The Alpine base `Dockerfile` already does the equivalent (`apk upgrade --no-cache`, *"pick up latest security patches"*). This makes `Dockerfile.full` do what it says and what its sibling does.

Fixes the base-package half of #1055.

## The change

```diff
 RUN apt-get update \
+    && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends nodejs bash \
```

One line. No other changes.

## Why

A Grype scan of the current `:full` image (`@sha256:dd2cf4d…`) reports 206 findings against Debian base packages (42 distinct packages). Many have no fixed Debian version *yet*, so this won't zero the count on day one — but it restores the documented behavior, aligns the two Dockerfiles, and means every rebuild automatically pulls Debian point-release security fixes as they land. Full breakdown in #1055.

The `--no-install-recommends`, `purge --auto-remove`, and `rm -rf /var/lib/apt/lists/*` steps that follow are unchanged, so the image-size discipline is preserved (the apt lists fetched by `update` are still cleaned in the same layer).

## Testing / caveats

- I could not run `docker build -f Dockerfile.full .` in my environment, so I have **not** built the resulting image locally. The change is a single, well-understood apt step that mirrors the already-working Alpine `Dockerfile`, but a maintainer CI build is the real confirmation.
- The RFC in #1055 (bumping the base `python:3.12-slim` → `python:3.13-slim` to clear the 26 Python-interpreter CVEs) is **out of scope** here — happy to send that as a separate PR if you want it.

---

*I maintain [e2e-ministack](https://github.com/scottschreckengaust/e2e-ministack), which pins and vuln-scans your `:full` image in CI — that's how this surfaced. Thanks for MiniStack!*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
