### PR TITLE
Aurora MySQL version-to-image mapping + 8.0/8.4 parameter-group differentiation

### DIFF
--- a/ministack/services/rds.py
+++ b/ministack/services/rds.py
@@ -85,6 +85,20 @@ _port_counter = [BASE_PORT]
 _docker = None
 _ministack_network = None
 
+AURORA_MYSQL_ENGINE_VERSIONS = [
+    ("5.7.mysql_aurora.2.12.6", "aurora-mysql5.7"),
+    ("8.0.mysql_aurora.3.12.0", "aurora-mysql8.0"),
+    ("8.4.mysql_aurora.8.4.7", "aurora-mysql8.4"),
+]
+
+AURORA_MYSQL_IMAGE_MAP = {
+    "5.6": "mysql:5.6",
+    "5.7": "mysql:5.7",
+    "8.0": "mysql:8.0",
+    "8.4": "mysql:8.4",
+}
+DEFAULT_AURORA_MYSQL_IMAGE = "mysql:8.4"
+
 
 # ── Persistence ────────────────────────────────────────────
 
@@ -2148,57 +2162,7 @@ def _describe_db_parameters(p):
         return _error("DBParameterGroupNotFound", f"Parameter group {name} not found.", 404)
 
     source_filter = _p(p, "Source")  # "user", "engine-default", or None (all)
-
-    family = pg.get("DBParameterGroupFamily", "")
-    default_params = _default_parameters_for_family(family)
-
-    custom = pg.get("Parameters", {})
-    default_names = {p["name"] for p in default_params}
-    params_xml = ""
-    for param in default_params:
-        pname = param["name"]
-        cval = custom.get(pname)
-        if isinstance(cval, dict):
-            value = cval.get("ParameterValue", param.get("default", ""))
-            apply_method = cval.get("ApplyMethod", "pending-reboot")
-        else:
-            value = cval if cval is not None else param.get("default", "")
-            apply_method = "pending-reboot"
-        source = "user" if pname in custom else "engine-default"
-        if source_filter and source != source_filter:
-            continue
-        params_xml += f"""<Parameter>
-            <ParameterName>{pname}</ParameterName>
-            <ParameterValue>{value}</ParameterValue>
-            <Description>{_esc(param.get('description', ''))}</Description>
-            <Source>{source}</Source>
-            <ApplyType>{param.get('apply_type', 'dynamic')}</ApplyType>
-            <DataType>{param.get('data_type', 'string')}</DataType>
-            <IsModifiable>{str(param.get('modifiable', True)).lower()}</IsModifiable>
-            <ApplyMethod>{apply_method}</ApplyMethod>
-        </Parameter>"""
-    # Include custom parameters not in the defaults
-    for pname, cval in custom.items():
-        if pname in default_names:
-            continue
-        if source_filter and source_filter != "user":
-            continue
-        if isinstance(cval, dict):
-            value = cval.get("ParameterValue", "")
-            apply_method = cval.get("ApplyMethod", "immediate")
-        else:
-            value = cval if cval is not None else ""
-            apply_method = "immediate"
-        params_xml += f"""<Parameter>
-            <ParameterName>{pname}</ParameterName>
-            <ParameterValue>{value}</ParameterValue>
-            <Description></Description>
-            <Source>user</Source>
-            <ApplyType>dynamic</ApplyType>
-            <DataType>string</DataType>
-            <IsModifiable>true</IsModifiable>
-            <ApplyMethod>{apply_method}</ApplyMethod>
-        </Parameter>"""
+    params_xml = _parameter_group_parameters_xml(pg, source_filter)
 
     return _xml(200, "DescribeDBParametersResponse",
         f"<DescribeDBParametersResult><Parameters>{params_xml}</Parameters></DescribeDBParametersResult>")
@@ -2328,30 +2292,9 @@ def _describe_db_cluster_parameters(p):
     if not pg:
         return _error("DBParameterGroupNotFound",
             f"DB cluster parameter group {name} not found.", 404)
-    params = pg.get("Parameters", {})
-    # When filtering by source, treat all stored params as "user" source.
-    # If filter is "engine-default" and we have no defaults list, return empty.
-    if source_filter and source_filter != "user":
-        params = {}
-    if not params:
-        return _xml(200, "DescribeDBClusterParametersResponse",
-            "<DescribeDBClusterParametersResult><Parameters/></DescribeDBClusterParametersResult>")
-    members = []
-    for pname, pinfo in params.items():
-        pvalue = pinfo.get("ParameterValue", "")
-        apply_method = pinfo.get("ApplyMethod", "immediate")
-        members.append(
-            f"<Parameter>"
-            f"<ParameterName>{pname}</ParameterName>"
-            f"<ParameterValue>{pvalue}</ParameterValue>"
-            f"<Source>user</Source>"
-            f"<ApplyMethod>{apply_method}</ApplyMethod>"
-            f"<IsModifiable>true</IsModifiable>"
-            f"<ApplyType>dynamic</ApplyType>"
-            f"</Parameter>"
-        )
+    members = _parameter_group_parameters_xml(pg, source_filter)
     return _xml(200, "DescribeDBClusterParametersResponse",
-        f"<DescribeDBClusterParametersResult><Parameters>{''.join(members)}</Parameters></DescribeDBClusterParametersResult>")
+        f"<DescribeDBClusterParametersResult><Parameters>{members}</Parameters></DescribeDBClusterParametersResult>")
 
 
 def _modify_db_cluster_param_group(p):
@@ -3095,11 +3038,12 @@ def _describe_engine_versions(p):
             ("16.4", "aurora-postgresql16"),
             ("15.3", "aurora-postgresql15"), ("14.8", "aurora-postgresql14"),
         ],
-        "aurora-mysql": [
-            ("8.0.mysql_aurora.3.03.0", "aurora-mysql8.0"),
-        ],
+        "aurora-mysql": AURORA_MYSQL_ENGINE_VERSIONS,
     }
     versions = versions_map.get(engine, [("15.3", "15")])
+    if engine == "aurora-mysql" and version_filter and not any(ver == version_filter for ver, _ in versions):
+        family = _aurora_mysql_parameter_group_family(version_filter)
+        versions = [(version_filter, family)] if family else []
     members = ""
     supports_global = engine in ("aurora-mysql", "aurora-postgresql")
     for ver, family in versions:
@@ -3567,6 +3511,74 @@ def _parameter_member_prefix(params, prefix="Parameters"):
     return f"{prefix}.Parameter"
 
 
+def _parameter_xml(
+    name,
+    value,
+    source,
+    apply_method,
+    description="",
+    apply_type="dynamic",
+    data_type="string",
+    modifiable=True,
+):
+    return f"""<Parameter>
+            <ParameterName>{name}</ParameterName>
+            <ParameterValue>{value}</ParameterValue>
+            <Description>{_esc(description)}</Description>
+            <Source>{source}</Source>
+            <ApplyType>{apply_type}</ApplyType>
+            <DataType>{data_type}</DataType>
+            <IsModifiable>{str(modifiable).lower()}</IsModifiable>
+            <ApplyMethod>{apply_method}</ApplyMethod>
+        </Parameter>"""
+
+
+def _parameter_group_parameters_xml(pg, source_filter):
+    family = pg.get("DBParameterGroupFamily", "")
+    default_params = _default_parameters_for_family(family)
+    custom = pg.get("Parameters", {})
+    default_names = {p["name"] for p in default_params}
+    params_xml = ""
+
+    for param in default_params:
+        pname = param["name"]
+        cval = custom.get(pname)
+        if isinstance(cval, dict):
+            value = cval.get("ParameterValue", param.get("default", ""))
+            apply_method = cval.get("ApplyMethod", "pending-reboot")
+        else:
+            value = cval if cval is not None else param.get("default", "")
+            apply_method = "pending-reboot"
+        source = "user" if pname in custom else "engine-default"
+        if source_filter and source != source_filter:
+            continue
+        params_xml += _parameter_xml(
+            pname,
+            value,
+            source,
+            apply_method,
+            param.get("description", ""),
+            param.get("apply_type", "dynamic"),
+            param.get("data_type", "string"),
+            param.get("modifiable", True),
+        )
+
+    for pname, cval in custom.items():
+        if pname in default_names:
+            continue
+        if source_filter and source_filter != "user":
+            continue
+        if isinstance(cval, dict):
+            value = cval.get("ParameterValue", "")
+            apply_method = cval.get("ApplyMethod", "immediate")
+        else:
+            value = cval if cval is not None else ""
+            apply_method = "immediate"
+        params_xml += _parameter_xml(pname, value, "user", apply_method)
+
+    return params_xml
+
+
 def _parse_filters(params):
     """Parse Filters.member.N.Name / Filters.member.N.Values.member.M."""
     filters = {}
@@ -3636,6 +3648,30 @@ def _default_engine_version(engine):
     return defaults.get(engine, "15.3")
 
 
+def _mysql_community_major_minor(engine_version):
+    version = engine_version or ""
+    head = version.split(".mysql_aurora.")[0] if ".mysql_aurora." in version else version
+    parts = head.split(".")
+    return ".".join(parts[:2]) if len(parts) >= 2 else head
+
+
+def _is_mysql_major_minor(value):
+    parts = value.split(".")
+    return len(parts) == 2 and all(part.isdigit() for part in parts)
+
+
+def _aurora_mysql_parameter_group_family(engine_version):
+    major_minor = _mysql_community_major_minor(engine_version)
+    if not _is_mysql_major_minor(major_minor):
+        return ""
+    return f"aurora-mysql{major_minor}"
+
+
+def _mysql_image_for_version(engine_version):
+    major_minor = _mysql_community_major_minor(engine_version)
+    return AURORA_MYSQL_IMAGE_MAP.get(major_minor, DEFAULT_AURORA_MYSQL_IMAGE)
+
+
 def _default_port(engine):
     if "mysql" in engine or "mariadb" in engine or "aurora-mysql" in engine:
         return "3306"
@@ -3675,7 +3711,7 @@ def _docker_image_for_engine(engine, engine_version, user, password, db_name):
         )
     if "mysql" in engine or "aurora-mysql" in engine:
         return (
-            apply_image_prefix("mysql:8"),
+            apply_image_prefix(_mysql_image_for_version(engine_version)),
             {"MYSQL_ROOT_PASSWORD": password, "MYSQL_ROOT_HOST": "%",
              "MYSQL_DATABASE": db_name,
              "MYSQL_USER": user, "MYSQL_PASSWORD": password},
@@ -3725,6 +3761,12 @@ def _default_parameters_for_family(family):
             {"name": "long_query_time", "default": "10", "description": "Slow query threshold",
              "apply_type": "dynamic", "data_type": "float", "modifiable": True},
         ]
+        if not family.lower().endswith("8.4"):
+            base.append(
+                {"name": "skip-character-set-client-handshake", "default": "1",
+                 "description": "Skip character set client handshake",
+                 "apply_type": "static", "data_type": "boolean", "modifiable": True}
+            )
     return base
 
 

--- a/ministack/services/rds.py
+++ b/ministack/services/rds.py
@@ -85,11 +85,48 @@ _port_counter = [BASE_PORT]
 _docker = None
 _ministack_network = None
 
+# Aurora MySQL versions are the creatable set returned by AWS RDS as of
+# 2026-07-09. Refresh with:
+#   aws rds describe-db-engine-versions --engine aurora-mysql \
+#     --query 'DBEngineVersions[].[EngineVersion,DBParameterGroupFamily]' \
+#     --output text | sort -V
+# Keep the Docker image mapping below aligned to the community MySQL major.minor:
+# 5.7 -> mysql:5.7, 8.0 -> mysql:8.0, 8.4 -> mysql:8.4. AWS's default can trail
+# the latest advertised version, so update _default_engine_version deliberately.
 AURORA_MYSQL_ENGINE_VERSIONS = [
+    ("5.7.mysql_aurora.2.11.1", "aurora-mysql5.7"),
+    ("5.7.mysql_aurora.2.11.2", "aurora-mysql5.7"),
+    ("5.7.mysql_aurora.2.11.3", "aurora-mysql5.7"),
+    ("5.7.mysql_aurora.2.11.4", "aurora-mysql5.7"),
+    ("5.7.mysql_aurora.2.11.5", "aurora-mysql5.7"),
+    ("5.7.mysql_aurora.2.11.6", "aurora-mysql5.7"),
+    ("5.7.mysql_aurora.2.12.0", "aurora-mysql5.7"),
+    ("5.7.mysql_aurora.2.12.1", "aurora-mysql5.7"),
+    ("5.7.mysql_aurora.2.12.2", "aurora-mysql5.7"),
+    ("5.7.mysql_aurora.2.12.3", "aurora-mysql5.7"),
+    ("5.7.mysql_aurora.2.12.4", "aurora-mysql5.7"),
+    ("5.7.mysql_aurora.2.12.5", "aurora-mysql5.7"),
     ("5.7.mysql_aurora.2.12.6", "aurora-mysql5.7"),
+    ("8.0.mysql_aurora.3.04.0", "aurora-mysql8.0"),
+    ("8.0.mysql_aurora.3.04.1", "aurora-mysql8.0"),
+    ("8.0.mysql_aurora.3.04.2", "aurora-mysql8.0"),
+    ("8.0.mysql_aurora.3.04.3", "aurora-mysql8.0"),
+    ("8.0.mysql_aurora.3.04.4", "aurora-mysql8.0"),
+    ("8.0.mysql_aurora.3.04.6", "aurora-mysql8.0"),
+    ("8.0.mysql_aurora.3.08.0", "aurora-mysql8.0"),
+    ("8.0.mysql_aurora.3.08.1", "aurora-mysql8.0"),
+    ("8.0.mysql_aurora.3.08.2", "aurora-mysql8.0"),
+    ("8.0.mysql_aurora.3.09.0", "aurora-mysql8.0"),
+    ("8.0.mysql_aurora.3.10.0", "aurora-mysql8.0"),
+    ("8.0.mysql_aurora.3.10.1", "aurora-mysql8.0"),
+    ("8.0.mysql_aurora.3.10.2", "aurora-mysql8.0"),
+    ("8.0.mysql_aurora.3.10.3", "aurora-mysql8.0"),
+    ("8.0.mysql_aurora.3.10.4", "aurora-mysql8.0"),
+    ("8.0.mysql_aurora.3.11.1", "aurora-mysql8.0"),
     ("8.0.mysql_aurora.3.12.0", "aurora-mysql8.0"),
     ("8.4.mysql_aurora.8.4.7", "aurora-mysql8.4"),
 ]
+AURORA_MYSQL_ENGINE_VERSION_SET = {version for version, _ in AURORA_MYSQL_ENGINE_VERSIONS}
 
 AURORA_MYSQL_IMAGE_MAP = {
     "5.6": "mysql:5.6",
@@ -986,7 +1023,11 @@ def _create_db_instance(p):
         return _error("DBInstanceAlreadyExistsFault", f"DB instance {db_id} already exists", 400)
 
     engine = _p(p, "Engine") or "postgres"
-    engine_version = _p(p, "EngineVersion") or _default_engine_version(engine)
+    explicit_engine_version = _p(p, "EngineVersion")
+    engine_version_error = _unsupported_aurora_mysql_engine_version_error(engine, explicit_engine_version)
+    if engine_version_error:
+        return engine_version_error
+    engine_version = explicit_engine_version or _default_engine_version(engine)
     db_class = _p(p, "DBInstanceClass") or "db.t3.micro"
     master_user = _p(p, "MasterUsername") or "admin"
     master_pass = _p(p, "MasterUserPassword") or "password"
@@ -1688,11 +1729,15 @@ def _create_db_cluster(p):
                 400,
             )
         engine = expected_engine or engine
-    engine_version = _p(p, "EngineVersion") or _default_engine_version(engine)
+    explicit_engine_version = _p(p, "EngineVersion")
+    engine_version_error = _unsupported_aurora_mysql_engine_version_error(engine, explicit_engine_version)
+    if engine_version_error:
+        return engine_version_error
+    engine_version = explicit_engine_version or _default_engine_version(engine)
     if global_cluster:
         expected_engine_version = global_cluster.get("EngineVersion")
         if (
-            _p(p, "EngineVersion")
+            explicit_engine_version
             and expected_engine_version
             and engine_version != expected_engine_version
         ):
@@ -3041,9 +3086,6 @@ def _describe_engine_versions(p):
         "aurora-mysql": AURORA_MYSQL_ENGINE_VERSIONS,
     }
     versions = versions_map.get(engine, [("15.3", "15")])
-    if engine == "aurora-mysql" and version_filter and not any(ver == version_filter for ver, _ in versions):
-        family = _aurora_mysql_parameter_group_family(version_filter)
-        versions = [(version_filter, family)] if family else []
     members = ""
     supports_global = engine in ("aurora-mysql", "aurora-postgresql")
     for ver, family in versions:
@@ -3074,6 +3116,9 @@ def _describe_orderable_options(p):
     engine = _p(p, "Engine") or "postgres"
     engine_version = _p(p, "EngineVersion")
     db_class = _p(p, "DBInstanceClass")
+    engine_version_error = _unsupported_aurora_mysql_engine_version_error(engine, engine_version)
+    if engine_version_error:
+        return engine_version_error
 
     instance_classes = [
         "db.t3.micro", "db.t3.small", "db.t3.medium", "db.t3.large",
@@ -3643,9 +3688,23 @@ def _format_time(ts):
 def _default_engine_version(engine):
     defaults = {
         "postgres": "15.3", "mysql": "8.0.33", "mariadb": "10.6.14",
-        "aurora-postgresql": "15.3", "aurora-mysql": "8.0.mysql_aurora.3.03.0",
+        "aurora-postgresql": "15.3", "aurora-mysql": "8.0.mysql_aurora.3.10.3",
     }
     return defaults.get(engine, "15.3")
+
+
+def _unsupported_aurora_mysql_engine_version_error(engine, engine_version):
+    if (
+        engine == "aurora-mysql"
+        and engine_version
+        and engine_version not in AURORA_MYSQL_ENGINE_VERSION_SET
+    ):
+        return _error(
+            "InvalidParameterCombination",
+            f"Cannot find version {engine_version} for aurora-mysql",
+            400,
+        )
+    return None
 
 
 def _mysql_community_major_minor(engine_version):
@@ -3653,18 +3712,6 @@ def _mysql_community_major_minor(engine_version):
     head = version.split(".mysql_aurora.")[0] if ".mysql_aurora." in version else version
     parts = head.split(".")
     return ".".join(parts[:2]) if len(parts) >= 2 else head
-
-
-def _is_mysql_major_minor(value):
-    parts = value.split(".")
-    return len(parts) == 2 and all(part.isdigit() for part in parts)
-
-
-def _aurora_mysql_parameter_group_family(engine_version):
-    major_minor = _mysql_community_major_minor(engine_version)
-    if not _is_mysql_major_minor(major_minor):
-        return ""
-    return f"aurora-mysql{major_minor}"
 
 
 def _mysql_image_for_version(engine_version):

--- a/tests/test_rds.py
+++ b/tests/test_rds.py
@@ -10,6 +10,42 @@ from urllib.parse import urlparse
 import pytest
 from botocore.exceptions import ClientError
 
+DEFAULT_AURORA_MYSQL_ENGINE_VERSION = "8.0.mysql_aurora.3.10.3"
+UNSUPPORTED_AURORA_MYSQL_ENGINE_VERSION = "9.0.mysql_aurora.9.0.1"
+EXPECTED_AURORA_MYSQL_ENGINE_VERSIONS = {
+    "5.7.mysql_aurora.2.11.1": "aurora-mysql5.7",
+    "5.7.mysql_aurora.2.11.2": "aurora-mysql5.7",
+    "5.7.mysql_aurora.2.11.3": "aurora-mysql5.7",
+    "5.7.mysql_aurora.2.11.4": "aurora-mysql5.7",
+    "5.7.mysql_aurora.2.11.5": "aurora-mysql5.7",
+    "5.7.mysql_aurora.2.11.6": "aurora-mysql5.7",
+    "5.7.mysql_aurora.2.12.0": "aurora-mysql5.7",
+    "5.7.mysql_aurora.2.12.1": "aurora-mysql5.7",
+    "5.7.mysql_aurora.2.12.2": "aurora-mysql5.7",
+    "5.7.mysql_aurora.2.12.3": "aurora-mysql5.7",
+    "5.7.mysql_aurora.2.12.4": "aurora-mysql5.7",
+    "5.7.mysql_aurora.2.12.5": "aurora-mysql5.7",
+    "5.7.mysql_aurora.2.12.6": "aurora-mysql5.7",
+    "8.0.mysql_aurora.3.04.0": "aurora-mysql8.0",
+    "8.0.mysql_aurora.3.04.1": "aurora-mysql8.0",
+    "8.0.mysql_aurora.3.04.2": "aurora-mysql8.0",
+    "8.0.mysql_aurora.3.04.3": "aurora-mysql8.0",
+    "8.0.mysql_aurora.3.04.4": "aurora-mysql8.0",
+    "8.0.mysql_aurora.3.04.6": "aurora-mysql8.0",
+    "8.0.mysql_aurora.3.08.0": "aurora-mysql8.0",
+    "8.0.mysql_aurora.3.08.1": "aurora-mysql8.0",
+    "8.0.mysql_aurora.3.08.2": "aurora-mysql8.0",
+    "8.0.mysql_aurora.3.09.0": "aurora-mysql8.0",
+    "8.0.mysql_aurora.3.10.0": "aurora-mysql8.0",
+    "8.0.mysql_aurora.3.10.1": "aurora-mysql8.0",
+    "8.0.mysql_aurora.3.10.2": "aurora-mysql8.0",
+    "8.0.mysql_aurora.3.10.3": "aurora-mysql8.0",
+    "8.0.mysql_aurora.3.10.4": "aurora-mysql8.0",
+    "8.0.mysql_aurora.3.11.1": "aurora-mysql8.0",
+    "8.0.mysql_aurora.3.12.0": "aurora-mysql8.0",
+    "8.4.mysql_aurora.8.4.7": "aurora-mysql8.4",
+}
+
 
 def test_rds_create(rds):
     rds.create_db_instance(
@@ -82,6 +118,7 @@ def test_rds_cluster_default_field_serialization(rds):
     assert cluster.get("DatabaseName") is None
     assert cluster.get("NetworkType") == "IPV4"
     assert cluster.get("EngineLifecycleSupport") == "open-source-rds-extended-support"
+    assert cluster["EngineVersion"] == DEFAULT_AURORA_MYSQL_ENGINE_VERSION
 
 def test_rds_cluster_explicit_field_round_trip(rds):
     """Explicit DatabaseName / NetworkType / EngineLifecycleSupport round-trip
@@ -792,17 +829,66 @@ def test_rds_describe_aurora_mysql_engine_versions_by_family(rds):
         v["EngineVersion"]: v["DBParameterGroupFamily"]
         for v in resp["DBEngineVersions"]
     }
-    assert families["5.7.mysql_aurora.2.12.6"] == "aurora-mysql5.7"
-    assert families["8.0.mysql_aurora.3.12.0"] == "aurora-mysql8.0"
-    assert families["8.4.mysql_aurora.8.4.7"] == "aurora-mysql8.4"
+    assert families == EXPECTED_AURORA_MYSQL_ENGINE_VERSIONS
+    assert DEFAULT_AURORA_MYSQL_ENGINE_VERSION in families
 
     filtered = rds.describe_db_engine_versions(
         Engine="aurora-mysql",
-        EngineVersion="8.4.mysql_aurora.8.4.9",
+        EngineVersion=UNSUPPORTED_AURORA_MYSQL_ENGINE_VERSION,
     )["DBEngineVersions"]
-    assert len(filtered) == 1
-    assert filtered[0]["EngineVersion"] == "8.4.mysql_aurora.8.4.9"
-    assert filtered[0]["DBParameterGroupFamily"] == "aurora-mysql8.4"
+    assert filtered == []
+
+
+def test_rds_aurora_mysql_create_rejects_unsupported_explicit_engine_version(rds):
+    with pytest.raises(ClientError) as cluster_exc:
+        rds.create_db_cluster(
+            DBClusterIdentifier="unsupported-aurora-version-cluster",
+            Engine="aurora-mysql",
+            EngineVersion=UNSUPPORTED_AURORA_MYSQL_ENGINE_VERSION,
+            MasterUsername="admin",
+            MasterUserPassword="password123",
+        )
+    assert cluster_exc.value.response["Error"]["Code"] == "InvalidParameterCombination"
+    assert (
+        cluster_exc.value.response["Error"]["Message"]
+        == f"Cannot find version {UNSUPPORTED_AURORA_MYSQL_ENGINE_VERSION} for aurora-mysql"
+    )
+
+    with pytest.raises(ClientError) as instance_exc:
+        rds.create_db_instance(
+            DBInstanceIdentifier="unsupported-aurora-version-instance",
+            DBInstanceClass="db.t3.micro",
+            Engine="aurora-mysql",
+            EngineVersion=UNSUPPORTED_AURORA_MYSQL_ENGINE_VERSION,
+            MasterUsername="admin",
+            MasterUserPassword="password123",
+            AllocatedStorage=20,
+        )
+    assert instance_exc.value.response["Error"]["Code"] == "InvalidParameterCombination"
+    assert (
+        instance_exc.value.response["Error"]["Message"]
+        == f"Cannot find version {UNSUPPORTED_AURORA_MYSQL_ENGINE_VERSION} for aurora-mysql"
+    )
+
+
+def test_rds_aurora_mysql_create_accepts_cataloged_84_engine_version(rds):
+    rds.create_db_cluster(
+        DBClusterIdentifier="supported-aurora-84-cluster",
+        Engine="aurora-mysql",
+        EngineVersion="8.4.mysql_aurora.8.4.7",
+        MasterUsername="admin",
+        MasterUserPassword="password123",
+    )
+    try:
+        cluster = rds.describe_db_clusters(
+            DBClusterIdentifier="supported-aurora-84-cluster"
+        )["DBClusters"][0]
+        assert cluster["EngineVersion"] == "8.4.mysql_aurora.8.4.7"
+    finally:
+        rds.delete_db_cluster(
+            DBClusterIdentifier="supported-aurora-84-cluster",
+            SkipFinalSnapshot=True,
+        )
 
 
 def test_rds_aurora_mysql_parameter_defaults_are_family_aware(rds):
@@ -1410,6 +1496,36 @@ def test_rds_describe_orderable_db_instance_options(rds):
     assert len(options2) == 1
     assert options2[0]["DBInstanceClass"] == "db.t3.micro"
     assert options2[0]["Engine"] == "mysql"
+
+    aurora_default = rds.describe_orderable_db_instance_options(
+        Engine="aurora-mysql",
+        DBInstanceClass="db.t3.micro",
+    )["OrderableDBInstanceOptions"]
+    assert len(aurora_default) == 1
+    assert aurora_default[0]["DBInstanceClass"] == "db.t3.micro"
+    assert aurora_default[0]["Engine"] == "aurora-mysql"
+    assert aurora_default[0]["EngineVersion"] == DEFAULT_AURORA_MYSQL_ENGINE_VERSION
+
+    aurora_supported = rds.describe_orderable_db_instance_options(
+        Engine="aurora-mysql",
+        EngineVersion="8.4.mysql_aurora.8.4.7",
+        DBInstanceClass="db.t3.micro",
+    )["OrderableDBInstanceOptions"]
+    assert len(aurora_supported) == 1
+    assert aurora_supported[0]["DBInstanceClass"] == "db.t3.micro"
+    assert aurora_supported[0]["Engine"] == "aurora-mysql"
+    assert aurora_supported[0]["EngineVersion"] == "8.4.mysql_aurora.8.4.7"
+
+    with pytest.raises(ClientError) as exc:
+        rds.describe_orderable_db_instance_options(
+            Engine="aurora-mysql",
+            EngineVersion=UNSUPPORTED_AURORA_MYSQL_ENGINE_VERSION,
+        )
+    assert exc.value.response["Error"]["Code"] == "InvalidParameterCombination"
+    assert (
+        exc.value.response["Error"]["Message"]
+        == f"Cannot find version {UNSUPPORTED_AURORA_MYSQL_ENGINE_VERSION} for aurora-mysql"
+    )
 
 
 def test_rds_enable_http_endpoint(rds):

--- a/tests/test_rds.py
+++ b/tests/test_rds.py
@@ -688,11 +688,12 @@ def test_rds_modify_and_describe_cluster_parameters(rds):
     p = next(p for p in params if p["ParameterName"] == "innodb_lock_wait_timeout")
     assert p["ParameterValue"] == "60"
     assert p["ApplyMethod"] == "immediate"
-    # engine-default filter should return empty when no defaults are tracked
     resp2 = rds.describe_db_cluster_parameters(
         DBClusterParameterGroupName="test-cparam-persist", Source="engine-default"
     )
-    assert len(resp2["Parameters"]) == 0
+    default_names = [p["ParameterName"] for p in resp2["Parameters"]]
+    assert "max_connections" in default_names
+    assert "innodb_lock_wait_timeout" not in default_names
 
 
 def test_rds_describe_cluster_parameters_emits_source(rds):
@@ -783,6 +784,81 @@ def test_rds_describe_engine_versions_family(rds):
         family = v["DBParameterGroupFamily"]
         # Should be e.g. "aurora-mysql8.0", not "aurora-mysqlaurora-mysql8.0"
         assert not family.startswith("aurora-mysqlaurora-"), f"Double-prefixed family: {family}"
+
+
+def test_rds_describe_aurora_mysql_engine_versions_by_family(rds):
+    resp = rds.describe_db_engine_versions(Engine="aurora-mysql")
+    families = {
+        v["EngineVersion"]: v["DBParameterGroupFamily"]
+        for v in resp["DBEngineVersions"]
+    }
+    assert families["5.7.mysql_aurora.2.12.6"] == "aurora-mysql5.7"
+    assert families["8.0.mysql_aurora.3.12.0"] == "aurora-mysql8.0"
+    assert families["8.4.mysql_aurora.8.4.7"] == "aurora-mysql8.4"
+
+    filtered = rds.describe_db_engine_versions(
+        Engine="aurora-mysql",
+        EngineVersion="8.4.mysql_aurora.8.4.9",
+    )["DBEngineVersions"]
+    assert len(filtered) == 1
+    assert filtered[0]["EngineVersion"] == "8.4.mysql_aurora.8.4.9"
+    assert filtered[0]["DBParameterGroupFamily"] == "aurora-mysql8.4"
+
+
+def test_rds_aurora_mysql_parameter_defaults_are_family_aware(rds):
+    rds.create_db_parameter_group(
+        DBParameterGroupName="test-mysql80-defaults",
+        DBParameterGroupFamily="aurora-mysql8.0",
+        Description="aurora mysql 8.0 defaults",
+    )
+    rds.create_db_parameter_group(
+        DBParameterGroupName="test-mysql84-defaults",
+        DBParameterGroupFamily="aurora-mysql8.4",
+        Description="aurora mysql 8.4 defaults",
+    )
+    mysql80 = rds.describe_db_parameters(
+        DBParameterGroupName="test-mysql80-defaults",
+        Source="engine-default",
+    )["Parameters"]
+    mysql84 = rds.describe_db_parameters(
+        DBParameterGroupName="test-mysql84-defaults",
+        Source="engine-default",
+    )["Parameters"]
+
+    mysql80_names = {p["ParameterName"] for p in mysql80}
+    mysql84_names = {p["ParameterName"] for p in mysql84}
+    assert "max_connections" in mysql80_names
+    assert "max_connections" in mysql84_names
+    assert "skip-character-set-client-handshake" in mysql80_names
+    assert "skip-character-set-client-handshake" not in mysql84_names
+
+
+def test_rds_cluster_parameter_defaults_are_family_aware(rds):
+    rds.create_db_cluster_parameter_group(
+        DBClusterParameterGroupName="test-cmysql80-defaults",
+        DBParameterGroupFamily="aurora-mysql8.0",
+        Description="aurora mysql 8.0 cluster defaults",
+    )
+    rds.create_db_cluster_parameter_group(
+        DBClusterParameterGroupName="test-cmysql84-defaults",
+        DBParameterGroupFamily="aurora-mysql8.4",
+        Description="aurora mysql 8.4 cluster defaults",
+    )
+    mysql80 = rds.describe_db_cluster_parameters(
+        DBClusterParameterGroupName="test-cmysql80-defaults",
+        Source="engine-default",
+    )["Parameters"]
+    mysql84 = rds.describe_db_cluster_parameters(
+        DBClusterParameterGroupName="test-cmysql84-defaults",
+        Source="engine-default",
+    )["Parameters"]
+
+    mysql80_names = {p["ParameterName"] for p in mysql80}
+    mysql84_names = {p["ParameterName"] for p in mysql84}
+    assert "max_connections" in mysql80_names
+    assert "max_connections" in mysql84_names
+    assert "skip-character-set-client-handshake" in mysql80_names
+    assert "skip-character-set-client-handshake" not in mysql84_names
 
 
 def test_rds_parse_member_list_both_formats():
@@ -1425,19 +1501,35 @@ def test_docker_image_for_engine_aurora_postgres_18_uses_new_layout():
     assert data_path_18 == "/var/lib/postgresql"
 
 
-def test_docker_image_for_engine_mysql_unchanged():
-    """MySQL / MariaDB / Aurora MySQL keep /var/lib/mysql — the Postgres 18
-    layout change does not touch them."""
+def test_mysql_image_for_version_maps_aurora_tracks():
+    from ministack.services.rds import _mysql_image_for_version
+
+    assert _mysql_image_for_version("8.4.mysql_aurora.8.4.7") == "mysql:8.4"
+    assert _mysql_image_for_version("8.0.mysql_aurora.3.12.0") == "mysql:8.0"
+    assert _mysql_image_for_version("5.7.mysql_aurora.2.12.6") == "mysql:5.7"
+    assert _mysql_image_for_version("5.6.mysql_aurora.1.23.4") == "mysql:5.6"
+    assert _mysql_image_for_version("8.4.7") == "mysql:8.4"
+    assert _mysql_image_for_version("9.0.mysql_aurora.9.0.1") == "mysql:8.4"
+    assert _mysql_image_for_version("not-a-version") == "mysql:8.4"
+
+
+def test_docker_image_for_engine_mysql_uses_versioned_images():
+    """MySQL / MariaDB / Aurora MySQL keep /var/lib/mysql, but MySQL-compatible
+    engines use explicit versioned MySQL images instead of the floating mysql:8 tag."""
     from ministack.services.rds import _docker_image_for_engine
 
-    for engine, version in [
-        ("mysql", "8.0.33"),
-        ("aurora-mysql", "8.0.mysql_aurora.3.03.0"),
-        ("mariadb", "10.6.14"),
+    for engine, version, expected_image in [
+        ("mysql", "8.0.33", "mysql:8.0"),
+        ("mysql", "5.7.43", "mysql:5.7"),
+        ("aurora-mysql", "5.7.mysql_aurora.2.12.6", "mysql:5.7"),
+        ("aurora-mysql", "8.0.mysql_aurora.3.12.0", "mysql:8.0"),
+        ("aurora-mysql", "8.4.mysql_aurora.8.4.7", "mysql:8.4"),
+        ("mariadb", "10.6.14", "mariadb:latest"),
     ]:
-        _, _, port, data_path = _docker_image_for_engine(
+        image, _, port, data_path = _docker_image_for_engine(
             engine, version, "admin", "pw", "mydb"
         )
+        assert image == expected_image
         assert port == 3306
         assert data_path == "/var/lib/mysql"
 


### PR DESCRIPTION
## Why
MiniStack currently runs Aurora MySQL with the floating `mysql:8` Docker image, which can silently boot a MySQL 8.4 container for Aurora MySQL 8.0 test cases. Provider work for Aurora MySQL 8.4 also needs MiniStack to report the correct DB parameter group family and family-specific defaults.

## What
- Map Aurora MySQL engine versions to explicit MySQL image tracks: 5.7, 8.0, and 8.4.
- Return family-aware Aurora MySQL engine versions, including synthesized families for future patch versions.
- Share default/user parameter rendering for DB and DB cluster parameter groups.
- Omit `skip-character-set-client-handshake` from `aurora-mysql8.4` defaults while keeping it for older Aurora MySQL families.
- Keep the defensive 5.6 image-map row for older Aurora MySQL version strings.

## Risk Assessment
Low-to-medium for RDS emulation only. The change narrows MySQL container selection by engine version and expands existing RDS parameter metadata; existing default fallback remains `mysql:8.4` for unknown tracks.

## References
- Source-backed live smoke passed for Aurora MySQL 8.0: `8.0.mysql_aurora.3.12.0` booted and `SELECT VERSION()` returned `8.0.46`.
- Source-backed live smoke passed for Aurora MySQL 8.4: `8.4.mysql_aurora.8.4.7` booted and `SELECT VERSION()` returned `8.4.10`.
- Focused source-backed pytest on port 4567: `7 passed, 73 deselected`.
- Lint: `ruff check ministack/services/rds.py tests/test_rds.py` passed.

