### PR TITLE
Preserve EventBridge region scope

### DIFF
--- a/ministack/services/eventbridge.py
+++ b/ministack/services/eventbridge.py
@@ -34,6 +34,7 @@ from datetime import datetime, timedelta, timezone
 
 from ministack.core.arn import ArnParseError, parse_arn
 from ministack.core.responses import (
+    AccountRegionScopedDict,
     AccountScopedDict,
     error_response_json,
     get_account_id,
@@ -93,26 +94,26 @@ def _coerce_timestamp(value):
 
 from ministack.core.persistence import PERSIST_STATE, load_state
 
-# Per-account bus registry. The "default" bus is lazily created per account
-# on first access so every tenant has its own default bus with an ARN whose
-# account-id segment matches the caller.
-_event_buses = AccountScopedDict()
-_rules = AccountScopedDict()
-_targets = AccountScopedDict()
-# Per-account event log — AccountScopedDict under "entries" keeps the list
-# semantics while scoping reads to the caller's account.
-_events_log = AccountScopedDict()
-_tags = AccountScopedDict()
-_archives = AccountScopedDict()
-_event_bus_policies = AccountScopedDict()  # bus_name -> {Statement: [...]}
-_connections = AccountScopedDict()         # connection_name -> {...}
-_api_destinations = AccountScopedDict()    # destination_name -> {...}
-_replays = AccountScopedDict()              # replay_name -> replay record
-_endpoints = AccountScopedDict()            # endpoint name -> endpoint record
-# Partner event sources, per-account (key: "account|name" pattern inside each tenant).
-_partner_event_sources = AccountScopedDict()
+# Per-account and per-region registries. The "default" bus is lazily created
+# per account/region on first access so every tenant has its own default bus
+# with ARN account-id and region segments matching the caller.
+_event_buses = AccountRegionScopedDict()
+_rules = AccountRegionScopedDict()
+_targets = AccountRegionScopedDict()
+# AccountRegionScopedDict under "entries" keeps list semantics while scoping
+# reads to the caller's account and region.
+_events_log = AccountRegionScopedDict()
+_tags = AccountRegionScopedDict()
+_archives = AccountRegionScopedDict()
+_event_bus_policies = AccountRegionScopedDict()  # bus_name -> {Statement: [...]}
+_connections = AccountRegionScopedDict()         # connection_name -> {...}
+_api_destinations = AccountRegionScopedDict()    # destination_name -> {...}
+_replays = AccountRegionScopedDict()             # replay_name -> replay record
+_endpoints = AccountRegionScopedDict()           # endpoint name -> endpoint record
+# Partner event sources, per-account/region (key: "account|name" pattern inside each tenant).
+_partner_event_sources = AccountRegionScopedDict()
 
-# Tracks when each scheduled rule last fired: {(account_id, rule_key): timestamp}.
+# Tracks when each scheduled rule last fired: {(account_id, region, rule_key): timestamp}.
 # Plain dict (not AccountScopedDict) because the scheduler thread owns it globally.
 _rule_last_fired: dict = {}
 
@@ -159,7 +160,7 @@ def restore_state(data):
     if data:
         _event_buses.update(data.get("buses", {}))
         _rules.update(data.get("rules", {}))
-        _targets.update(data.get("targets", {}))
+        _restore_targets_store(data.get("targets", {}))
         _tags.update(data.get("tags", {}))
         _archives.update(data.get("archives", {}))
         _replays.update(data.get("replays", {}))
@@ -172,17 +173,17 @@ def restore_state(data):
             _partner_event_sources.clear()
             _partner_event_sources.update(pe)
 
-        for bus in _event_buses.values():
+        for bus in _event_buses.all_values():
             if "CreationTime" in bus:
                 bus["CreationTime"] = _coerce_timestamp(bus["CreationTime"])
             if "LastModifiedTime" in bus:
                 bus["LastModifiedTime"] = _coerce_timestamp(bus["LastModifiedTime"])
 
-        for rule in _rules.values():
+        for rule in _rules.all_values():
             if "CreationTime" in rule:
                 rule["CreationTime"] = _coerce_timestamp(rule["CreationTime"])
 
-        for rep in _replays.values():
+        for rep in _replays.all_values():
             for tk in ("ReplayStartTime", "ReplayEndTime", "EventStartTime", "EventEndTime"):
                 if tk in rep and rep[tk] is not None:
                     rep[tk] = _coerce_timestamp(rep[tk])
@@ -193,6 +194,61 @@ def restore_state(data):
             if rep.get("State") in ("STARTING", "RUNNING"):
                 rep["State"] = "FAILED"
                 rep["ReplayEndTime"] = _now_ts()
+
+
+def _events_record_scope(record: dict | None, default_account_id: str | None = None) -> tuple[str, str]:
+    if isinstance(record, dict):
+        for key in (
+            "Arn",
+            "ArchiveArn",
+            "ReplayArn",
+            "ConnectionArn",
+            "ApiDestinationArn",
+            "EventSourceArn",
+        ):
+            arn = record.get(key)
+            if not isinstance(arn, str) or not arn.startswith("arn:"):
+                continue
+            try:
+                spec = parse_arn(arn)
+            except ArnParseError:
+                continue
+            if spec.service == "events":
+                return spec.account_id or default_account_id or get_account_id(), spec.region or get_region()
+    return default_account_id or get_account_id(), get_region()
+
+
+def _rule_scope(rule_key: str, default_account_id: str | None = None) -> tuple[str, str]:
+    for (account_id, region, key), rule in _rules.all_items():
+        if key != rule_key:
+            continue
+        if default_account_id is not None and account_id != default_account_id:
+            continue
+        scoped_account_id, scoped_region = _events_record_scope(rule, account_id)
+        return scoped_account_id, scoped_region
+    return default_account_id or get_account_id(), get_region()
+
+
+def _restore_targets_store(data) -> None:
+    if isinstance(data, AccountRegionScopedDict):
+        _targets.update(data)
+        return
+    if isinstance(data, AccountScopedDict):
+        for (account_id, rule_key), targets in data._data.items():
+            scoped_account_id, region = _rule_scope(rule_key, account_id)
+            _targets.set_scoped(scoped_account_id, region, rule_key, copy.deepcopy(targets))
+        return
+    if isinstance(data, dict):
+        for key, targets in data.items():
+            if isinstance(key, tuple) and len(key) == 3:
+                account_id, region, rule_key = key
+            elif isinstance(key, tuple) and len(key) == 2:
+                account_id, rule_key = key
+                account_id, region = _rule_scope(rule_key, account_id)
+            else:
+                rule_key = key
+                account_id, region = _rule_scope(rule_key)
+            _targets.set_scoped(account_id, region, rule_key, copy.deepcopy(targets))
 
 
 try:
@@ -2382,13 +2438,13 @@ def _tick_scheduled_rules():
     """Fire any enabled scheduled rule whose interval has elapsed."""
     now = _now_ts()
     now_dt = datetime.fromtimestamp(now, tz=timezone.utc)
-    # Iterate _rules._data directly so we see every account, not just the
-    # ContextVar default.  Keys are (account_id, rule_key) tuples.
-    for (account_id, rule_key), rule in list(_rules._data.items()):
+    # Iterate _rules._data directly so we see every account/region, not just
+    # the ContextVar default. Keys are (account_id, region, rule_key) tuples.
+    for (account_id, region, rule_key), rule in list(_rules._data.items()):
         if rule.get("State") != "ENABLED":
             continue
         schedule = rule.get("ScheduleExpression", "")
-        state_key = (account_id, rule_key)
+        state_key = (account_id, region, rule_key)
 
         interval = _parse_rate_seconds(schedule)
         if interval is not None:
@@ -2416,7 +2472,7 @@ def _tick_scheduled_rules():
                 continue
 
         _rule_last_fired[state_key] = now
-        targets = _targets._data.get((account_id, rule_key), [])
+        targets = _targets._data.get((account_id, region, rule_key), [])
         if not targets:
             continue
         try:
@@ -2432,6 +2488,7 @@ def _tick_scheduled_rules():
             rule_arn.service != "events"
             or not rule_arn.region
             or rule_arn.account_id != account_id
+            or rule_arn.region != region
             or not rule_arn.resource.startswith("rule/")
         ):
             logger.warning(
@@ -2443,7 +2500,7 @@ def _tick_scheduled_rules():
         previous_account = get_account_id()
         previous_region = get_region()
         set_request_account_id(account_id)
-        set_request_region(rule_arn.region)
+        set_request_region(region)
         try:
             event = {
                 "EventId": new_uuid(),

--- a/ministack/services/eventbridge.py
+++ b/ministack/services/eventbridge.py
@@ -1195,7 +1195,16 @@ def _invoke_target(target, event, rule):
         elif spec.service == "states":
             _dispatch_to_stepfunctions(arn, event_payload)
         elif not _target_matches_request_scope(spec):
-            logger.warning("EventBridge: target %s is outside the current account/region scope", arn)
+            # AWS parity: EventBridge accepts cross-region SNS/SQS targets at PutTargets, then records a
+            # FailedInvocations delivery failure without cross-region delivery. MiniStack does not model
+            # that metric or DLQs, so the faithful observable outcome is to accept the target and drop
+            # the invocation here. Confirmed against AWS on 2026-07-13; see
+            # RESEARCH/MINISTACK_CROSSREGION_SNS_TARGET_POLICY.md.
+            logger.warning(
+                "EventBridge: target %s not delivered: cross-region invocation failed "
+                "(FailedInvocation-equivalent)",
+                arn,
+            )
         elif spec.service == "lambda":
             _dispatch_to_lambda(arn, event_payload)
         elif spec.service == "sqs":
@@ -1209,6 +1218,7 @@ def _invoke_target(target, event, rule):
 
 
 def _target_matches_request_scope(spec) -> bool:
+    # Cross-region targets are accepted at PutTargets but fail delivery here for AWS parity.
     return spec.account_id == get_account_id() and spec.region == get_region()
 
 

--- a/ministack/services/eventbridge.py
+++ b/ministack/services/eventbridge.py
@@ -1609,18 +1609,28 @@ def _start_replay(data):
         "ReplayStartTime": now,
     }
     _replays[name] = replay
+    replay_account_id = get_account_id()
+    replay_region = get_region()
 
     def _run():
-        replay["State"] = "RUNNING"
-        for event in list(archive.get("Events", [])):
-            ts = event.get("Time", 0)
-            if not (event_start <= ts <= event_end):
-                continue
-            replayed = dict(event)
-            replayed["EventBusName"] = dest_bus_name
-            _dispatch_event(replayed)
-        replay["State"] = "COMPLETED"
-        replay["ReplayEndTime"] = _now_ts()
+        previous_account = get_account_id()
+        previous_region = get_region()
+        set_request_account_id(replay_account_id)
+        set_request_region(replay_region)
+        try:
+            replay["State"] = "RUNNING"
+            for event in list(archive.get("Events", [])):
+                ts = event.get("Time", 0)
+                if not (event_start <= ts <= event_end):
+                    continue
+                replayed = dict(event)
+                replayed["EventBusName"] = dest_bus_name
+                _dispatch_event(replayed)
+            replay["State"] = "COMPLETED"
+            replay["ReplayEndTime"] = _now_ts()
+        finally:
+            set_request_account_id(previous_account)
+            set_request_region(previous_region)
 
     t = threading.Thread(target=_run, daemon=True)
     t.start()

--- a/ministack/services/s3.py
+++ b/ministack/services/s3.py
@@ -50,10 +50,12 @@ from ministack.core.persistence import PERSIST_STATE, load_state
 from ministack.core.responses import (
     AccountScopedDict,
     get_account_id,
+    get_region,
     iso_to_rfc7231,
     md5_hash,
     new_uuid,
     now_iso,
+    set_request_region,
     sha256_hash,
 )
 
@@ -1917,7 +1919,7 @@ def _fire_s3_event(
                 {
                     "eventVersion": "2.1",
                     "eventSource": "aws:s3",
-                    "awsRegion": os.environ.get("MINISTACK_REGION", "us-east-1"),
+                    "awsRegion": bucket_region,
                     "eventTime": event_time,
                     "eventName": short_event,
                     "userIdentity": {"principalId": "EXAMPLE"},
@@ -1998,9 +2000,14 @@ def _fire_s3_event(
                     "Time": event_time,
                     "Resources": [f"arn:aws:s3:::{bucket_name}"],
                     "Account": get_account_id(),
-                    "Region": os.environ.get("MINISTACK_REGION", "us-east-1"),
+                    "Region": bucket_region,
                 }
-                _eb._dispatch_event(eb_event)
+                previous_region = get_region()
+                set_request_region(bucket_region)
+                try:
+                    _eb._dispatch_event(eb_event)
+                finally:
+                    set_request_region(previous_region)
                 logger.debug("S3→EventBridge: %s (%s) for %s/%s", detail_type, event_name, bucket_name, key)
         except Exception:
             logger.exception("S3→EventBridge delivery failed for %s/%s", bucket_name, key)

--- a/tests/test_eventbridge.py
+++ b/tests/test_eventbridge.py
@@ -21,6 +21,16 @@ def _events_client(region_name):
     )
 
 
+def _sqs_client(region_name):
+    return boto3.client(
+        "sqs",
+        endpoint_url=os.environ.get("MINISTACK_ENDPOINT", "http://localhost:4566"),
+        aws_access_key_id="test",
+        aws_secret_access_key="test",
+        region_name=region_name,
+    )
+
+
 def test_eventbridge_bus_rule(eb):
     eb.create_event_bus(Name="test-bus")
     eb.put_rule(
@@ -1990,6 +2000,84 @@ def test_eventbridge_replay_destination_receives_events(eb, sqs):
         "Replayed events should be dispatched to the destination bus and arrive in SQS"
     )
     eb.delete_archive(ArchiveName=arch_name)
+
+
+def test_eventbridge_replay_dispatch_uses_replay_region(eb, sqs):
+    """Replay worker dispatches under the Region where StartReplay was called."""
+    west = _events_client("us-west-2")
+    west_sqs = _sqs_client("us-west-2")
+    suffix = _uuid_mod.uuid4().hex[:8]
+    bus_name = f"rp-region-bus-{suffix}"
+    rule_name = f"rp-region-rule-{suffix}"
+    source = f"region.replay.{suffix}"
+
+    east_bus_arn = eb.create_event_bus(Name=bus_name)["EventBusArn"]
+    west_bus_arn = west.create_event_bus(Name=bus_name)["EventBusArn"]
+    assert east_bus_arn.endswith(f":event-bus/{bus_name}")
+    assert west_bus_arn == f"arn:aws:events:us-west-2:000000000000:event-bus/{bus_name}"
+
+    east_q_url = sqs.create_queue(QueueName=f"rp-region-east-{suffix}")["QueueUrl"]
+    east_q_arn = sqs.get_queue_attributes(
+        QueueUrl=east_q_url,
+        AttributeNames=["QueueArn"],
+    )["Attributes"]["QueueArn"]
+    west_q_url = west_sqs.create_queue(QueueName=f"rp-region-west-{suffix}")["QueueUrl"]
+    west_q_arn = west_sqs.get_queue_attributes(
+        QueueUrl=west_q_url,
+        AttributeNames=["QueueArn"],
+    )["Attributes"]["QueueArn"]
+
+    for client, target_arn in ((eb, east_q_arn), (west, west_q_arn)):
+        client.put_rule(
+            Name=rule_name,
+            EventBusName=bus_name,
+            EventPattern=json.dumps({"source": [source]}),
+            State="ENABLED",
+        )
+        client.put_targets(
+            Rule=rule_name,
+            EventBusName=bus_name,
+            Targets=[{"Id": "target", "Arn": target_arn}],
+        )
+
+    arch_name = f"rp-region-arch-{suffix}"
+    west.create_archive(ArchiveName=arch_name, EventSourceArn=west_bus_arn)
+    west.put_events(
+        Entries=[
+            {
+                "Source": source,
+                "DetailType": "ReplayRegion",
+                "Detail": json.dumps({"region": "us-west-2"}),
+                "EventBusName": bus_name,
+            }
+        ]
+    )
+    archive_arn = west.describe_archive(ArchiveName=arch_name)["ArchiveArn"]
+    # Drain live delivery from the seed PutEvents call; the final assertion
+    # should only observe the replay delivery.
+    west_sqs.receive_message(QueueUrl=west_q_url, MaxNumberOfMessages=10, WaitTimeSeconds=1)
+
+    west.start_replay(
+        ReplayName=f"rp-region-{suffix}",
+        EventSourceArn=archive_arn,
+        EventStartTime=0,
+        EventEndTime=time.time() + 3600,
+        Destination={"Arn": west_bus_arn},
+    )
+    time.sleep(0.5)
+
+    west_msgs = west_sqs.receive_message(
+        QueueUrl=west_q_url,
+        MaxNumberOfMessages=10,
+        WaitTimeSeconds=2,
+    )
+    east_msgs = sqs.receive_message(
+        QueueUrl=east_q_url,
+        MaxNumberOfMessages=10,
+        WaitTimeSeconds=1,
+    )
+    assert len(west_msgs.get("Messages", [])) >= 1
+    assert east_msgs.get("Messages", []) == []
 
 
 def test_eventbridge_archive_event_count_unchanged_after_replay(eb):

--- a/tests/test_eventbridge.py
+++ b/tests/test_eventbridge.py
@@ -11,6 +11,16 @@ import pytest
 from botocore.exceptions import ClientError
 
 
+def _events_client(region_name):
+    return boto3.client(
+        "events",
+        endpoint_url=os.environ.get("MINISTACK_ENDPOINT", "http://localhost:4566"),
+        aws_access_key_id="test",
+        aws_secret_access_key="test",
+        region_name=region_name,
+    )
+
+
 def test_eventbridge_bus_rule(eb):
     eb.create_event_bus(Name="test-bus")
     eb.put_rule(
@@ -55,6 +65,98 @@ def test_eventbridge_targets(eb):
     )
     resp = eb.list_targets_by_rule(Rule="target-rule")
     assert len(resp["Targets"]) == 1
+
+
+def test_eventbridge_buses_rules_and_targets_are_region_scoped(eb):
+    west = _events_client("us-west-2")
+    bus_name = f"region-bus-{_uuid_mod.uuid4().hex[:8]}"
+    rule_name = f"region-rule-{_uuid_mod.uuid4().hex[:8]}"
+
+    east_bus_arn = eb.create_event_bus(Name=bus_name)["EventBusArn"]
+    west_bus_arn = west.create_event_bus(Name=bus_name)["EventBusArn"]
+    assert east_bus_arn == f"arn:aws:events:us-east-1:000000000000:event-bus/{bus_name}"
+    assert west_bus_arn == f"arn:aws:events:us-west-2:000000000000:event-bus/{bus_name}"
+
+    eb.put_rule(
+        Name=rule_name,
+        EventBusName=bus_name,
+        ScheduleExpression="rate(5 minutes)",
+        State="ENABLED",
+    )
+    west.put_rule(
+        Name=rule_name,
+        EventBusName=bus_name,
+        ScheduleExpression="rate(10 minutes)",
+        State="ENABLED",
+    )
+    eb.put_targets(
+        Rule=rule_name,
+        EventBusName=bus_name,
+        Targets=[
+            {
+                "Id": "east",
+                "Arn": "arn:aws:lambda:us-east-1:000000000000:function:east-fn",
+            }
+        ],
+    )
+    west.put_targets(
+        Rule=rule_name,
+        EventBusName=bus_name,
+        Targets=[
+            {
+                "Id": "west",
+                "Arn": "arn:aws:lambda:us-west-2:000000000000:function:west-fn",
+            }
+        ],
+    )
+
+    assert eb.describe_event_bus(Name=bus_name)["Arn"] == east_bus_arn
+    assert west.describe_event_bus(Name=bus_name)["Arn"] == west_bus_arn
+    assert eb.describe_rule(Name=rule_name, EventBusName=bus_name)["Arn"] == (
+        f"arn:aws:events:us-east-1:000000000000:rule/{bus_name}/{rule_name}"
+    )
+    assert west.describe_rule(Name=rule_name, EventBusName=bus_name)["Arn"] == (
+        f"arn:aws:events:us-west-2:000000000000:rule/{bus_name}/{rule_name}"
+    )
+    assert [t["Id"] for t in eb.list_targets_by_rule(Rule=rule_name, EventBusName=bus_name)["Targets"]] == ["east"]
+    assert [t["Id"] for t in west.list_targets_by_rule(Rule=rule_name, EventBusName=bus_name)["Targets"]] == ["west"]
+
+    eb.delete_rule(Name=rule_name, EventBusName=bus_name)
+    eb.delete_event_bus(Name=bus_name)
+
+    assert west.describe_event_bus(Name=bus_name)["Arn"] == west_bus_arn
+    assert [t["Id"] for t in west.list_targets_by_rule(Rule=rule_name, EventBusName=bus_name)["Targets"]] == ["west"]
+
+
+def test_eventbridge_rule_names_by_target_and_remove_targets_are_region_scoped(eb):
+    west = _events_client("us-west-2")
+    rule_name = f"region-target-index-{_uuid_mod.uuid4().hex[:8]}"
+    east_target_arn = "arn:aws:lambda:us-east-1:000000000000:function:index-east"
+    west_target_arn = "arn:aws:lambda:us-west-2:000000000000:function:index-west"
+
+    eb.put_rule(
+        Name=rule_name,
+        ScheduleExpression="rate(5 minutes)",
+        State="ENABLED",
+    )
+    west.put_rule(
+        Name=rule_name,
+        ScheduleExpression="rate(5 minutes)",
+        State="ENABLED",
+    )
+    eb.put_targets(Rule=rule_name, Targets=[{"Id": "east", "Arn": east_target_arn}])
+    west.put_targets(Rule=rule_name, Targets=[{"Id": "west", "Arn": west_target_arn}])
+
+    assert eb.list_rule_names_by_target(TargetArn=east_target_arn)["RuleNames"] == [rule_name]
+    assert eb.list_rule_names_by_target(TargetArn=west_target_arn)["RuleNames"] == []
+    assert west.list_rule_names_by_target(TargetArn=west_target_arn)["RuleNames"] == [rule_name]
+    assert west.list_rule_names_by_target(TargetArn=east_target_arn)["RuleNames"] == []
+
+    eb.remove_targets(Rule=rule_name, Ids=["east"])
+
+    assert eb.list_targets_by_rule(Rule=rule_name)["Targets"] == []
+    assert [t["Id"] for t in west.list_targets_by_rule(Rule=rule_name)["Targets"]] == ["west"]
+    assert west.list_rule_names_by_target(TargetArn=west_target_arn)["RuleNames"] == [rule_name]
 
 
 def test_eventbridge_put_targets_rejects_malformed_target_arn(eb):
@@ -215,6 +317,85 @@ def test_eventbridge_foreign_region_sqs_target_does_not_deliver_to_same_name_que
         ]
     )
 
+    msgs = sqs.receive_message(QueueUrl=q_url, MaxNumberOfMessages=1, WaitTimeSeconds=1)
+    assert msgs.get("Messages", []) == []
+
+
+def test_eventbridge_same_region_sns_target_dispatches_to_topic(eb, sns, sqs):
+    topic_name = f"target-sns-{_uuid_mod.uuid4().hex[:8]}"
+    queue_name = f"target-sns-{_uuid_mod.uuid4().hex[:8]}"
+    rule_name = f"target-sns-{_uuid_mod.uuid4().hex[:8]}"
+    topic_arn = sns.create_topic(Name=topic_name)["TopicArn"]
+    q_url = sqs.create_queue(QueueName=queue_name)["QueueUrl"]
+    q_arn = sqs.get_queue_attributes(
+        QueueUrl=q_url,
+        AttributeNames=["QueueArn"],
+    )["Attributes"]["QueueArn"]
+    sns.subscribe(TopicArn=topic_arn, Protocol="sqs", Endpoint=q_arn)
+    eb.put_rule(
+        Name=rule_name,
+        EventPattern=json.dumps({"source": ["same.region.sns"]}),
+        State="ENABLED",
+    )
+    eb.put_targets(
+        Rule=rule_name,
+        Targets=[{"Id": "local-sns", "Arn": topic_arn}],
+    )
+
+    resp = eb.put_events(
+        Entries=[
+            {
+                "Source": "same.region.sns",
+                "DetailType": "SameRegionSns",
+                "Detail": json.dumps({"delivered": True}),
+                "EventBusName": "default",
+            }
+        ]
+    )
+
+    assert resp["FailedEntryCount"] == 0
+    msgs = sqs.receive_message(QueueUrl=q_url, MaxNumberOfMessages=1, WaitTimeSeconds=1)
+    assert len(msgs.get("Messages", [])) == 1
+    body = json.loads(msgs["Messages"][0]["Body"])
+    payload = json.loads(body["Message"])
+    assert payload["source"] == "same.region.sns"
+    assert payload["detail"] == {"delivered": True}
+
+
+def test_eventbridge_foreign_region_sns_target_does_not_deliver_to_same_name_topic(eb, sns, sqs):
+    topic_name = f"target-foreign-sns-{_uuid_mod.uuid4().hex[:8]}"
+    queue_name = f"target-foreign-sns-{_uuid_mod.uuid4().hex[:8]}"
+    rule_name = f"target-foreign-sns-{_uuid_mod.uuid4().hex[:8]}"
+    topic_arn = sns.create_topic(Name=topic_name)["TopicArn"]
+    q_url = sqs.create_queue(QueueName=queue_name)["QueueUrl"]
+    q_arn = sqs.get_queue_attributes(
+        QueueUrl=q_url,
+        AttributeNames=["QueueArn"],
+    )["Attributes"]["QueueArn"]
+    sns.subscribe(TopicArn=topic_arn, Protocol="sqs", Endpoint=q_arn)
+    west_arn = f"arn:aws:sns:us-west-2:000000000000:{topic_name}"
+    eb.put_rule(
+        Name=rule_name,
+        EventPattern=json.dumps({"source": ["foreign.sns"]}),
+        State="ENABLED",
+    )
+    eb.put_targets(
+        Rule=rule_name,
+        Targets=[{"Id": "foreign-sns", "Arn": west_arn}],
+    )
+
+    resp = eb.put_events(
+        Entries=[
+            {
+                "Source": "foreign.sns",
+                "DetailType": "ForeignRegionSns",
+                "Detail": json.dumps({"should": "not-deliver"}),
+                "EventBusName": "default",
+            }
+        ]
+    )
+
+    assert resp["FailedEntryCount"] == 0
     msgs = sqs.receive_message(QueueUrl=q_url, MaxNumberOfMessages=1, WaitTimeSeconds=1)
     assert msgs.get("Messages", []) == []
 
@@ -1966,19 +2147,22 @@ def isolated_scheduler():
 
 
 _ACCOUNT = "000000000000"
+_REGION = "us-east-1"
 _RULE_KEY = "default|unit-test-rule"
-_STATE_KEY = (_ACCOUNT, _RULE_KEY)
+_STATE_KEY = (_ACCOUNT, _REGION, _RULE_KEY)
 _DUMMY_TARGET = [{"Id": "t1", "Arn": "arn:aws:lambda:us-east-1:000000000000:function:dummy"}]
 
-def _seed_rule(schedule="rate(1 minute)", state="ENABLED"):
-    _eb._rules._data[_STATE_KEY] = {
+def _seed_rule(schedule="rate(1 minute)", state="ENABLED", region=_REGION):
+    state_key = (_ACCOUNT, region, _RULE_KEY)
+    _eb._rules._data[state_key] = {
         "Name": "unit-test-rule",
         "ScheduleExpression": schedule,
         "State": state,
         "EventBusName": "default",
-        "Arn": "arn:aws:events:us-east-1:000000000000:rule/unit-test-rule",
+        "Arn": f"arn:aws:events:{region}:000000000000:rule/unit-test-rule",
     }
-    _eb._targets._data[_STATE_KEY] = list(_DUMMY_TARGET)
+    _eb._targets._data[state_key] = list(_DUMMY_TARGET)
+    return state_key
 
 
 from unittest.mock import patch as _patch
@@ -2009,17 +2193,14 @@ def test_scheduler_restores_rule_region_while_dispatching(isolated_scheduler):
     observed = []
     try:
         set_request_region("us-east-1")
-        _seed_rule()
-        _eb._rules._data[_STATE_KEY]["Arn"] = (
-            "arn:aws:events:us-west-2:000000000000:rule/unit-test-rule"
-        )
-        _eb._targets._data[_STATE_KEY] = [
+        west_state_key = _seed_rule(region="us-west-2")
+        _eb._targets._data[west_state_key] = [
             {
                 "Id": "sfn",
                 "Arn": "arn:aws:states:us-west-2:000000000000:stateMachine:scheduled",
             }
         ]
-        _eb._rule_last_fired[_STATE_KEY] = _eb._now_ts() - 65
+        _eb._rule_last_fired[west_state_key] = _eb._now_ts() - 65
         isolated_scheduler.side_effect = (
             lambda _target, event, _rule: observed.append((_eb.get_region(), event["Region"]))
         )

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -955,6 +955,208 @@ def test_sns_region_scoped_stores_survive_warm_boot_in_original_scope():
         set_request_region(original_region)
 
 
+def test_eventbridge_region_scoped_stores_survive_warm_boot_in_original_scope():
+    """EventBridge regional stores remain in their original account/region
+    after the real JSON persistence path."""
+    from ministack.core.responses import (
+        get_account_id,
+        get_region,
+        set_request_account_id,
+        set_request_region,
+    )
+
+    mod = _get_module("eventbridge")
+    mod.reset()
+    original_account = get_account_id()
+    original_region = get_region()
+    try:
+        set_request_account_id("111111111111")
+        set_request_region("us-west-2")
+
+        now = mod._now_ts()
+        bus_name = "persisted-bus"
+        rule_name = "persisted-rule"
+        archive_name = "persisted-archive"
+        replay_name = "persisted-replay"
+        endpoint_name = "persisted-endpoint"
+        connection_name = "persisted-connection"
+        api_destination_name = "persisted-api"
+        partner_name = "persisted-partner"
+        bus_arn = f"arn:aws:events:us-west-2:111111111111:event-bus/{bus_name}"
+        rule_key = mod._rule_key(rule_name, bus_name)
+        rule_arn = f"arn:aws:events:us-west-2:111111111111:rule/{bus_name}/{rule_name}"
+        archive_arn = f"arn:aws:events:us-west-2:111111111111:archive/{archive_name}"
+        replay_arn = f"arn:aws:events:us-west-2:111111111111:replay/{replay_name}"
+        endpoint_arn = f"arn:aws:events:us-west-2:111111111111:endpoint/{endpoint_name}"
+        connection_arn = f"arn:aws:events:us-west-2:111111111111:connection/{connection_name}"
+        api_destination_arn = (
+            f"arn:aws:events:us-west-2:111111111111:api-destination/{api_destination_name}"
+        )
+        partner_arn = f"arn:aws:events:us-west-2:222222222222:event-source/{partner_name}"
+
+        mod._event_buses[bus_name] = {
+            "Name": bus_name,
+            "Arn": bus_arn,
+            "CreationTime": now,
+            "LastModifiedTime": now,
+        }
+        mod._rules[rule_key] = {
+            "Name": rule_name,
+            "Arn": rule_arn,
+            "EventBusName": bus_name,
+            "ScheduleExpression": "rate(5 minutes)",
+            "State": "ENABLED",
+            "CreationTime": now,
+        }
+        mod._targets[rule_key] = [
+            {
+                "Id": "persisted-target",
+                "Arn": "arn:aws:sqs:us-west-2:111111111111:persisted-queue",
+            }
+        ]
+        mod._tags[rule_arn] = {"env": "test"}
+        mod._archives[archive_name] = {
+            "ArchiveName": archive_name,
+            "ArchiveArn": archive_arn,
+            "EventSourceArn": bus_arn,
+            "State": "ENABLED",
+            "CreationTime": now,
+            "EventCount": 0,
+            "Events": [],
+        }
+        mod._replays[replay_name] = {
+            "ReplayName": replay_name,
+            "ReplayArn": replay_arn,
+            "EventSourceArn": archive_arn,
+            "Destination": {"Arn": bus_arn},
+            "State": "COMPLETED",
+            "ReplayStartTime": now,
+            "ReplayEndTime": now,
+        }
+        mod._endpoints[endpoint_name] = {
+            "Name": endpoint_name,
+            "Arn": endpoint_arn,
+            "EndpointUrl": f"https://{endpoint_name}.global-events.us-west-2.amazonaws.com",
+            "State": "ACTIVE",
+            "CreationTime": now,
+            "LastModifiedTime": now,
+        }
+        mod._event_bus_policies[bus_name] = {
+            "Version": "2012-10-17",
+            "Statement": [{"Sid": "Allow", "Resource": bus_arn}],
+        }
+        mod._connections[connection_name] = {
+            "Name": connection_name,
+            "ConnectionArn": connection_arn,
+            "ConnectionState": "AUTHORIZED",
+            "AuthorizationType": "API_KEY",
+            "CreationTime": now,
+            "LastModifiedTime": now,
+        }
+        mod._api_destinations[api_destination_name] = {
+            "Name": api_destination_name,
+            "ApiDestinationArn": api_destination_arn,
+            "ApiDestinationState": "ACTIVE",
+            "ConnectionArn": connection_arn,
+            "InvocationEndpoint": "https://example.com",
+            "HttpMethod": "POST",
+            "CreationTime": now,
+            "LastModifiedTime": now,
+        }
+        mod._partner_event_sources[mod._partner_key("222222222222", partner_name)] = {
+            "Name": partner_name,
+            "Account": "222222222222",
+            "EventSourceArn": partner_arn,
+        }
+
+        _round_trip_dict(mod, "eventbridge")
+
+        assert mod._event_buses[bus_name]["Arn"] == bus_arn
+        assert mod._rules[rule_key]["Arn"] == rule_arn
+        assert mod._targets[rule_key][0]["Id"] == "persisted-target"
+        assert mod._tags[rule_arn]["env"] == "test"
+        assert mod._archives[archive_name]["ArchiveArn"] == archive_arn
+        assert mod._replays[replay_name]["ReplayArn"] == replay_arn
+        assert mod._endpoints[endpoint_name]["Arn"] == endpoint_arn
+        assert mod._event_bus_policies[bus_name]["Statement"][0]["Resource"] == bus_arn
+        assert mod._connections[connection_name]["ConnectionArn"] == connection_arn
+        assert mod._api_destinations[api_destination_name]["ApiDestinationArn"] == api_destination_arn
+        partner_key = mod._partner_key("222222222222", partner_name)
+        assert mod._partner_event_sources[partner_key]["EventSourceArn"] == partner_arn
+
+        set_request_region("us-east-1")
+        assert mod._event_buses.get(bus_name) is None
+        assert mod._rules.get(rule_key) is None
+        assert mod._targets.get(rule_key) is None
+        assert mod._tags.get(rule_arn) is None
+        assert mod._archives.get(archive_name) is None
+        assert mod._replays.get(replay_name) is None
+        assert mod._endpoints.get(endpoint_name) is None
+        assert mod._event_bus_policies.get(bus_name) is None
+        assert mod._connections.get(connection_name) is None
+        assert mod._api_destinations.get(api_destination_name) is None
+        assert mod._partner_event_sources.get(partner_key) is None
+
+        set_request_account_id("222222222222")
+        set_request_region("us-west-2")
+        assert mod._event_buses.get(bus_name) is None
+        assert mod._rules.get(rule_key) is None
+        assert mod._targets.get(rule_key) is None
+    finally:
+        mod.reset()
+        set_request_account_id(original_account)
+        set_request_region(original_region)
+
+
+def test_eventbridge_legacy_account_scoped_targets_restore_to_rule_region():
+    """Legacy target stores are scoped to the EventBridge rule region, not the
+    target ARN region, when migrating from account-only persistence."""
+    from ministack.core.responses import (
+        AccountScopedDict,
+        get_account_id,
+        get_region,
+        set_request_account_id,
+        set_request_region,
+    )
+
+    mod = _get_module("eventbridge")
+    mod.reset()
+    original_account = get_account_id()
+    original_region = get_region()
+    try:
+        set_request_account_id("111111111111")
+        set_request_region("us-east-1")
+        rule_key = mod._rule_key("legacy-rule", "default")
+        legacy_rules = AccountScopedDict()
+        legacy_targets = AccountScopedDict()
+        legacy_rules[rule_key] = {
+            "Name": "legacy-rule",
+            "Arn": "arn:aws:events:us-west-2:111111111111:rule/legacy-rule",
+            "EventBusName": "default",
+            "ScheduleExpression": "rate(5 minutes)",
+            "State": "ENABLED",
+        }
+        legacy_targets[rule_key] = [
+            {
+                "Id": "foreign-sns",
+                "Arn": "arn:aws:sns:eu-central-1:111111111111:legacy-topic",
+            }
+        ]
+
+        mod.restore_state({"rules": legacy_rules, "targets": legacy_targets})
+
+        set_request_region("us-west-2")
+        assert mod._rules[rule_key]["Name"] == "legacy-rule"
+        assert mod._targets[rule_key][0]["Id"] == "foreign-sns"
+
+        set_request_region("eu-central-1")
+        assert mod._targets.get(rule_key) is None
+    finally:
+        mod.reset()
+        set_request_account_id(original_account)
+        set_request_region(original_region)
+
+
 # ── Import-order regression for the ECS NameError trap ───────────────
 
 def test_ecs_module_reload_with_persisted_attributes_does_not_namerror():

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -1806,6 +1806,51 @@ def test_s3_eventbridge_notification(s3, sqs, eb):
     assert body["detail"]["reason"] == "PutObject"
 
 
+def test_s3_eventbridge_notification_dispatches_in_bucket_region(s3):
+    """S3 EventBridge delivery should use the bucket region, not the request region."""
+    uid = _uuid_mod.uuid4().hex[:8]
+    bucket_name = f"s3-eb-west-bkt-{uid}"
+    queue_name = f"s3-eb-west-q-{uid}"
+    rule_name = f"s3-eb-west-rule-{uid}"
+    west_eb = _regional_client("events", "us-west-2")
+    west_sqs = _regional_client("sqs", "us-west-2")
+
+    s3.create_bucket(
+        Bucket=bucket_name,
+        CreateBucketConfiguration={"LocationConstraint": "us-west-2"},
+    )
+    queue_url = west_sqs.create_queue(QueueName=queue_name)["QueueUrl"]
+    queue_arn = west_sqs.get_queue_attributes(
+        QueueUrl=queue_url, AttributeNames=["QueueArn"],
+    )["Attributes"]["QueueArn"]
+    assert ":us-west-2:" in queue_arn
+
+    s3.put_bucket_notification_configuration(
+        Bucket=bucket_name,
+        NotificationConfiguration={"EventBridgeConfiguration": {}},
+    )
+    west_eb.put_rule(
+        Name=rule_name,
+        EventPattern=json.dumps({"source": ["aws.s3"], "detail-type": ["Object Created"]}),
+        State="ENABLED",
+    )
+    west_eb.put_targets(
+        Rule=rule_name,
+        Targets=[{"Id": "west-sqs-target", "Arn": queue_arn}],
+    )
+
+    # The S3 client fixture is signed for us-east-1; the bucket itself is us-west-2.
+    s3.put_object(Bucket=bucket_name, Key="west-region.txt", Body=b"world")
+    time.sleep(0.5)
+
+    msgs = west_sqs.receive_message(QueueUrl=queue_url, MaxNumberOfMessages=10, WaitTimeSeconds=2)
+    assert "Messages" in msgs and len(msgs["Messages"]) > 0
+    body = json.loads(msgs["Messages"][0]["Body"])
+    assert body["region"] == "us-west-2"
+    assert body["detail"]["bucket"]["name"] == bucket_name
+    assert body["detail"]["object"]["key"] == "west-region.txt"
+
+
 def test_s3_eventbridge_notification_copy_reason(s3, sqs, eb):
     """A CopyObject create carries reason ``CopyObject`` (not a hardcoded ``PutObject``)."""
     s3.create_bucket(Bucket="s3-eb-copy-bkt")

--- a/tests/test_sns.py
+++ b/tests/test_sns.py
@@ -166,6 +166,13 @@ def test_sns_subscription_attributes_are_region_scoped(sns):
         SubscriptionArn=west_sub,
     )["Attributes"]["TopicArn"] == west_arn
 
+    east_subs = [sub["SubscriptionArn"] for sub in sns.list_subscriptions()["Subscriptions"]]
+    west_subs = [sub["SubscriptionArn"] for sub in west.list_subscriptions()["Subscriptions"]]
+    assert east_sub in east_subs
+    assert west_sub not in east_subs
+    assert west_sub in west_subs
+    assert east_sub not in west_subs
+
     with pytest.raises(ClientError) as exc:
         sns.get_subscription_attributes(SubscriptionArn=west_sub)
     assert exc.value.response["Error"]["Code"] == "NotFound"
@@ -1560,6 +1567,12 @@ def test_sns_platform_applications_and_endpoints_are_region_scoped(sns):
     with pytest.raises(ClientError) as exc:
         sns.get_endpoint_attributes(EndpointArn=west_endpoint)
     assert exc.value.response["Error"]["Code"] == "NotFound"
+
+    sns.delete_platform_application(PlatformApplicationArn=east_app)
+    with pytest.raises(ClientError) as exc:
+        sns.get_endpoint_attributes(EndpointArn=east_endpoint)
+    assert exc.value.response["Error"]["Code"] == "NotFound"
+    assert west.get_endpoint_attributes(EndpointArn=west_endpoint)["Attributes"]["Token"] == token
 
 
 def test_sns_create_platform_endpoint_stores_token_and_enabled(sns):


### PR DESCRIPTION
## Why
MiniStack's multi-region support needs EventBridge state and S3 EventBridge notifications to respect the request or resource region instead of leaking through a global default.

## What
- Scope EventBridge rules, targets, archives, replays, schedules, and persisted state by region
- Preserve replay and scheduler behavior within the client region
- Dispatch S3 EventBridge notifications through the bucket region
- Add regression coverage for EventBridge region isolation, S3 bucket-region dispatch, persistence, and SNS targets

## Risk Assessment
Medium-low: this changes emulator state routing for EventBridge and S3 notifications, but the affected behavior is covered by focused service tests and keeps existing same-region behavior intact.

## Validation

* `uv run --extra dev ruff check ministack/services/eventbridge.py ministack/services/s3.py tests/test_eventbridge.py tests/test_s3.py tests/test_sns.py`
* `uv run --extra dev pytest tests/test_eventbridge.py -q` with local MiniStack server (`137 passed`)
* `uv run --extra dev pytest tests/test_s3.py -q` with local MiniStack server (`173 passed, 1 skipped`)
* `uv run --extra dev pytest tests/test_sns.py -q` with local MiniStack server (`83 passed`)
* `uv run --extra dev pytest tests/test_persistence.py -q` (`156 passed`)
