### PR TITLE
Reject cross-region EventBridge Pipes

### DIFF
--- a/ministack/services/pipes.py
+++ b/ministack/services/pipes.py
@@ -29,6 +29,7 @@ from ministack.core.responses import (
 logger = logging.getLogger("pipes")
 
 REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
+CROSS_REGION_PIPE_ERROR = "Creating cross-region pipe is not permitted."
 
 _pipes = AccountRegionScopedDict()       # pipe_name -> pipe record
 _positions = AccountRegionScopedDict()   # pipe_arn -> next stream record index
@@ -142,7 +143,17 @@ def register_pipe(
     starting_position: str = "LATEST",
     tags: dict | None = None,
 ):
-    arn = f"arn:aws:pipes:{get_region()}:{get_account_id()}:pipe/{name}"
+    pipe_region = get_region()
+    # AWS rejects cross-region source/target ARNs before role validation.
+    for component_arn in (source, target):
+        try:
+            component_region = parse_arn(component_arn).region
+        except ArnParseError:
+            continue
+        if component_region and component_region != pipe_region:
+            raise ValueError(CROSS_REGION_PIPE_ERROR)
+
+    arn = f"arn:aws:pipes:{pipe_region}:{get_account_id()}:pipe/{name}"
     state = "STOPPED" if str(desired_state).upper() == "STOPPED" else "RUNNING"
     start = str(starting_position or "LATEST").upper()
     if start not in ("LATEST", "TRIM_HORIZON"):

--- a/tests/test_cfn.py
+++ b/tests/test_cfn.py
@@ -10,6 +10,8 @@ import pytest
 import urllib.request
 from botocore.exceptions import ClientError
 
+from ministack.services import pipes as _pipes
+
 
 def _wait_stack(cfn, name, timeout=30):
     """Poll until stack reaches terminal status."""
@@ -2347,6 +2349,61 @@ def test_cfn_pipes_dynamodb_stream_to_sns(cfn, ddb, sqs):
 
     cfn.delete_stack(StackName=stack_name)
     _wait_stack(cfn, stack_name)
+
+
+def test_cfn_pipes_rejects_cross_region_target(cfn):
+    uid = _uuid_mod.uuid4().hex[:8]
+    stack_name = f"cfn-pipe-xreg-{uid}"
+
+    template = {
+        "AWSTemplateFormatVersion": "2010-09-09",
+        "Resources": {
+            "DdbToSnsPipe": {
+                "Type": "AWS::Pipes::Pipe",
+                "Properties": {
+                    "Name": f"{stack_name}-pipe",
+                    "RoleArn": "arn:aws:iam::000000000000:role/test-pipe-role",
+                    "Source": (
+                        "arn:aws:dynamodb:us-east-1:000000000000:"
+                        f"table/{stack_name}-table/stream/2026-05-22T00:00:00.000"
+                    ),
+                    "Target": f"arn:aws:sns:us-west-2:000000000000:{stack_name}-topic",
+                    "SourceParameters": {
+                        "DynamoDBStreamParameters": {"StartingPosition": "TRIM_HORIZON"}
+                    },
+                },
+            },
+        },
+    }
+
+    try:
+        cfn.create_stack(
+            StackName=stack_name,
+            TemplateBody=json.dumps(template),
+            DisableRollback=True,
+        )
+        stack = _wait_stack(cfn, stack_name)
+
+        assert stack["StackStatus"] == "CREATE_FAILED"
+        assert _pipes.CROSS_REGION_PIPE_ERROR in stack.get("StackStatusReason", "")
+
+        events = cfn.describe_stack_events(StackName=stack_name)["StackEvents"]
+        pipe_events = [
+            event
+            for event in events
+            if event["LogicalResourceId"] == "DdbToSnsPipe"
+        ]
+        assert any(
+            event["ResourceStatus"] == "CREATE_FAILED"
+            and _pipes.CROSS_REGION_PIPE_ERROR in event.get("ResourceStatusReason", "")
+            for event in pipe_events
+        )
+    finally:
+        try:
+            cfn.delete_stack(StackName=stack_name)
+            _wait_stack(cfn, stack_name)
+        except ClientError:
+            pass
 
 
 def test_cfn_sns_topic_subscription_filter_policy_scope(cfn, sns, sqs):

--- a/tests/test_cfn.py
+++ b/tests/test_cfn.py
@@ -2,12 +2,12 @@ import io
 import json
 import os
 import time
+import urllib.request
 import uuid as _uuid_mod
 import zipfile
 from urllib.parse import urlparse
 
 import pytest
-import urllib.request
 from botocore.exceptions import ClientError
 
 from ministack.services import pipes as _pipes
@@ -1702,7 +1702,9 @@ def test_cfn_cdk_bootstrap_resources(cfn, s3, ecr):
         },
     }
     cfn.create_stack(StackName="CDKToolkit-v44", TemplateBody=json.dumps(template))
-    import time as _t; _t.sleep(2)
+    import time as _t
+
+    _t.sleep(2)
     stack = cfn.describe_stacks(StackName="CDKToolkit-v44")["Stacks"][0]
     assert stack["StackStatus"] == "CREATE_COMPLETE"
 

--- a/tests/test_pipes.py
+++ b/tests/test_pipes.py
@@ -1,6 +1,99 @@
+import pytest
+
 from ministack.core.responses import _request_region
 from ministack.services import dynamodb as _ddb
 from ministack.services import pipes as _pipes
+
+
+def _stream_arn(region, table_name="PipeTable"):
+    return (
+        f"arn:aws:dynamodb:{region}:000000000000:"
+        f"table/{table_name}/stream/2026-05-22T00:00:00.000"
+    )
+
+
+def _topic_arn(region, topic_name="PipeTopic"):
+    return f"arn:aws:sns:{region}:000000000000:{topic_name}"
+
+
+def test_register_pipe_rejects_cross_region_target(monkeypatch):
+    _pipes.reset()
+    monkeypatch.setattr(_pipes, "_ensure_poller", lambda: None)
+    region_token = _request_region.set("us-east-1")
+    try:
+        with pytest.raises(ValueError) as exc:
+            _pipes.register_pipe(
+                name="CrossRegionTargetPipe",
+                source=_stream_arn("us-east-1"),
+                target=_topic_arn("us-west-2"),
+                role_arn="arn:aws:iam::000000000000:role/test-pipe-role",
+            )
+
+        assert str(exc.value) == _pipes.CROSS_REGION_PIPE_ERROR
+        assert _pipes._pipes.get("CrossRegionTargetPipe") is None
+        assert not _pipes._positions.has_any()
+    finally:
+        _request_region.reset(region_token)
+        _pipes.reset()
+
+
+def test_register_pipe_rejects_cross_region_source(monkeypatch):
+    _pipes.reset()
+    monkeypatch.setattr(_pipes, "_ensure_poller", lambda: None)
+    region_token = _request_region.set("us-east-1")
+    try:
+        with pytest.raises(ValueError) as exc:
+            _pipes.register_pipe(
+                name="CrossRegionSourcePipe",
+                source=_stream_arn("us-west-2"),
+                target=_topic_arn("us-east-1"),
+                role_arn="arn:aws:iam::000000000000:role/test-pipe-role",
+            )
+
+        assert str(exc.value) == _pipes.CROSS_REGION_PIPE_ERROR
+        assert _pipes._pipes.get("CrossRegionSourcePipe") is None
+        assert not _pipes._positions.has_any()
+    finally:
+        _request_region.reset(region_token)
+        _pipes.reset()
+
+
+def test_register_pipe_allows_same_region_components(monkeypatch):
+    _pipes.reset()
+    monkeypatch.setattr(_pipes, "_ensure_poller", lambda: None)
+    region_token = _request_region.set("us-east-1")
+    try:
+        pipe = _pipes.register_pipe(
+            name="SameRegionPipe",
+            source=_stream_arn("us-east-1"),
+            target=_topic_arn("us-east-1"),
+            role_arn="arn:aws:iam::000000000000:role/test-pipe-role",
+        )
+
+        assert pipe["Arn"] == "arn:aws:pipes:us-east-1:000000000000:pipe/SameRegionPipe"
+        assert _pipes._pipes.get("SameRegionPipe") == pipe
+        assert _pipes._positions.get(pipe["Arn"]) == 0
+    finally:
+        _request_region.reset(region_token)
+        _pipes.reset()
+
+
+def test_register_pipe_region_guard_ignores_malformed_or_global_arns(monkeypatch):
+    _pipes.reset()
+    monkeypatch.setattr(_pipes, "_ensure_poller", lambda: None)
+    region_token = _request_region.set("us-east-1")
+    try:
+        pipe = _pipes.register_pipe(
+            name="GlobalOrMalformedPipe",
+            source="arn:aws:s3:::pipe-source-bucket/key",
+            target="not-an-arn",
+            role_arn="arn:aws:iam::000000000000:role/test-pipe-role",
+        )
+
+        assert _pipes._pipes.get("GlobalOrMalformedPipe") == pipe
+    finally:
+        _request_region.reset(region_token)
+        _pipes.reset()
 
 
 def test_pipes_stream_table_name_parser_requires_dynamodb_stream_arn():


### PR DESCRIPTION
## Why
MiniStack's current EventBridge Pipes implementation models same-region DynamoDB Streams to SNS flows. Cross-region source and target ARNs should be rejected before invalid pipe state is persisted.

## What
- Validate source and target ARN regions before registering a pipe
- Reject cross-region source/target pairs before state writes
- Surface cross-region rejection through CloudFormation `CREATE_FAILED`
- Add regression coverage for direct Pipes calls and CloudFormation creation

## Risk Assessment
Low: this narrows unsupported cross-region behavior while preserving same-region, global ARN, and malformed ARN handling covered by tests.

## Validation

* `uv run --extra dev ruff check ministack/services/pipes.py tests/test_pipes.py tests/test_cfn.py`
* `uv run --extra dev pytest tests/test_pipes.py -q` with local MiniStack server (`9 passed`)
* `uv run --extra dev pytest tests/test_cfn.py -q` with local MiniStack server (`106 passed`)