### PR TITLE
Fix Cognito ListUsers status filter matching wrong field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to MiniStack will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Versioning follows [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- **Cognito — `ListUsers` `status` filter matched against the wrong field** — `Filter='status = "Enabled"'`/`"Disabled"` was compared against `UserStatus` (the confirmation-state enum: `CONFIRMED`, `FORCE_CHANGE_PASSWORD`, `UNCONFIRMED`, etc.), which never equals the literal string `"Enabled"`/`"Disabled"`. As a result, filtering by `status` always returned an empty list, regardless of how many users existed or their actual enabled/disabled state. `status` now correctly reflects the account's `Enabled` boolean toggled by `AdminEnableUser`/`AdminDisableUser`, matching real AWS Cognito's `ListUsers` Filter semantics. Contributed by @jey-mfv.
+
 ## [1.4.2] — 2026-07-13
 
 ### Added

--- a/ministack/services/cognito.py
+++ b/ministack/services/cognito.py
@@ -4829,7 +4829,11 @@ def _apply_user_filter(users: list, filter_str: str) -> list:
         if attr_name == "username":
             field_val = user.get("Username", "")
         elif attr_name == "status":
-            field_val = user.get("UserStatus", "")
+            # "status" filters on the account's Enabled/Disabled state (toggled by
+            # AdminEnableUser/AdminDisableUser), not the UserStatus confirmation-state enum
+            # (CONFIRMED, FORCE_CHANGE_PASSWORD, etc.). Matches real AWS Cognito's ListUsers
+            # Filter semantics, where "status" = "Enabled" never matches UserStatus values.
+            field_val = "Enabled" if user.get("Enabled", True) else "Disabled"
         elif attr_name == "email_verified":
             field_val = attr_dict.get("email_verified", "")
         if op == "=" and field_val == value:

--- a/tests/test_cognito.py
+++ b/tests/test_cognito.py
@@ -146,6 +146,20 @@ def test_cognito_list_users_filter_quoted_attribute_name(cognito_idp):
     resp = cognito_idp.list_users(UserPoolId=pid, Filter='"email" = "nonexistent@example.com"')
     assert resp["Users"] == []
 
+def test_cognito_list_users_filter_status(cognito_idp):
+    pid = cognito_idp.create_user_pool(PoolName="StatusFilterUsersPool")["UserPool"]["Id"]
+    cognito_idp.admin_create_user(UserPoolId=pid, Username="active-user")
+    cognito_idp.admin_create_user(UserPoolId=pid, Username="disabled-user")
+    cognito_idp.admin_disable_user(UserPoolId=pid, Username="disabled-user")
+
+    resp = cognito_idp.list_users(UserPoolId=pid, Filter='status = "Enabled"')
+    usernames = [u["Username"] for u in resp["Users"]]
+    assert usernames == ["active-user"]
+
+    resp = cognito_idp.list_users(UserPoolId=pid, Filter='status = "Disabled"')
+    usernames = [u["Username"] for u in resp["Users"]]
+    assert usernames == ["disabled-user"]
+
 def test_cognito_admin_set_user_password(cognito_idp):
     pid = cognito_idp.create_user_pool(PoolName="PwdPool")["UserPool"]["Id"]
     cid = cognito_idp.create_user_pool_client(


### PR DESCRIPTION
## Summary

`ListUsers` with `Filter='status = "Enabled"'` (or `"Disabled"`) always returns an empty list, regardless of how many users exist or their actual enabled/disabled state.

`_apply_user_filter` compares the `status` filter value against `UserStatus` — the confirmation-state enum (`CONFIRMED`, `FORCE_CHANGE_PASSWORD`, `UNCONFIRMED`, etc.) — which never equals the literal string `"Enabled"`/`"Disabled"`:

```python
elif attr_name == "status":
    field_val = user.get("UserStatus", "")
```

On real AWS Cognito, the `status` filter attribute reflects the account's **Enabled/Disabled** state — the boolean toggled by `AdminEnableUser`/`AdminDisableUser` — not the confirmation-state enum. This fix reads the correct field:

```python
elif attr_name == "status":
    field_val = "Enabled" if user.get("Enabled", True) else "Disabled"
```

## Test plan

- Added `test_cognito_list_users_filter_status` in `tests/test_cognito.py`, covering both `status = "Enabled"` and `status = "Disabled"` after `AdminDisableUser`.
- Verified the new test fails against the unfixed code (`assert [] == ['active-user']`) and passes with the fix.
- Full `tests/test_cognito.py` suite passes (134/134).
- `ruff check` passes on all changed files (pre-existing unrelated errors in `scheduler.py` are untouched by this change).

Found while integrating MiniStack as a local Cognito emulator for our team's app, which relies on this filter to exclude soft-deleted (disabled) users from an admin user-listing endpoint.