### PR TITLE
fix(cognito): distinguish PreTokenGeneration triggerSource by call path

### DIFF
--- a/ministack/services/cognito.py
+++ b/ministack/services/cognito.py
@@ -2270,16 +2270,19 @@ def _mfa_challenge_for_user(pool: dict, user: dict, pid: str, username: str) -> 
     }
 
 
-def _build_auth_result(pool_id: str, client_id: str, user: dict, nonce: str = "") -> dict:
+def _build_auth_result(pool_id: str, client_id: str, user: dict, nonce: str = "",
+                        trigger_source: str = "TokenGeneration_Authentication") -> dict:
     attrs = _attr_list_to_dict(user.get("Attributes", []))
     sub = attrs.get("sub", user["Username"])
     username = user.get("Username", "")
     groups = user.get("_groups", [])
     return {
         "AccessToken": _fake_token(sub, pool_id, client_id, "access", username=username,
-                                    user_attrs=attrs, groups=groups),
+                                    user_attrs=attrs, groups=groups,
+                                    trigger_source=trigger_source),
         "IdToken": _fake_token(sub, pool_id, client_id, "id", username=username,
-                               user_attrs=attrs, groups=groups, nonce=nonce),
+                               user_attrs=attrs, groups=groups, nonce=nonce,
+                               trigger_source=trigger_source),
         "RefreshToken": _fake_token(sub, pool_id, client_id, "refresh"),
         "TokenType": "Bearer",
         "ExpiresIn": 3600,
@@ -2339,7 +2342,8 @@ def _admin_initiate_auth(data):
         if _refresh_token_revoked(refresh_token, user):
             return error_response_json("NotAuthorizedException",
                                        "Refresh Token has been revoked", 400)
-        result = _build_auth_result(pid, cid, user)
+        result = _build_auth_result(pid, cid, user,
+                                     trigger_source="TokenGeneration_RefreshTokens")
         result.pop("RefreshToken", None)  # AWS doesn't return a new refresh token here
         return json_response({"AuthenticationResult": result})
 
@@ -2670,7 +2674,8 @@ def _initiate_auth(data):
         if _refresh_token_revoked(refresh_token, user):
             return error_response_json("NotAuthorizedException",
                                        "Refresh Token has been revoked", 400)
-        result = _build_auth_result(pid, cid, user)
+        result = _build_auth_result(pid, cid, user,
+                                     trigger_source="TokenGeneration_RefreshTokens")
         result.pop("RefreshToken", None)  # AWS doesn't return a new refresh token here
         return json_response({"AuthenticationResult": result})
 
@@ -4346,7 +4351,8 @@ def _oauth2_token(data, query_params, raw_body: bytes = b"", headers: dict | Non
             if not user:
                 return _oauth2_error("server_error", "User not found.")
 
-            result = _build_auth_result(pool_id, cid, user, nonce=entry.get("nonce", ""))
+            result = _build_auth_result(pool_id, cid, user, nonce=entry.get("nonce", ""),
+                                         trigger_source="TokenGeneration_HostedAuth")
             refresh_val = result["RefreshToken"]
             _refresh_tokens[refresh_val] = {
                 "pool_id": pool_id,
@@ -4385,8 +4391,10 @@ def _oauth2_token(data, query_params, raw_body: bytes = b"", headers: dict | Non
                 if user:
                     user_attrs = _attr_list_to_dict(user.get("Attributes", []))
 
-            access_token = _fake_token(sub, pool_id, effective_client_id, "access", username)
-            id_token = _fake_token(sub, pool_id, effective_client_id, "id", username, user_attrs=user_attrs)
+            access_token = _fake_token(sub, pool_id, effective_client_id, "access", username,
+                                        trigger_source="TokenGeneration_HostedAuth")
+            id_token = _fake_token(sub, pool_id, effective_client_id, "id", username, user_attrs=user_attrs,
+                                    trigger_source="TokenGeneration_HostedAuth")
             refresh_token = secrets.token_urlsafe(48)
 
             return json_response({
@@ -4424,8 +4432,10 @@ def _oauth2_token(data, query_params, raw_body: bytes = b"", headers: dict | Non
         sub = attrs.get("sub", user["Username"])
         username = user.get("Username", "")
         resp = {
-            "access_token": _fake_token(sub, pool_id, client_id, "access", username=username),
-            "id_token": _fake_token(sub, pool_id, client_id, "id", username=username, user_attrs=attrs),
+            "access_token": _fake_token(sub, pool_id, client_id, "access", username=username,
+                                         trigger_source="TokenGeneration_RefreshTokens"),
+            "id_token": _fake_token(sub, pool_id, client_id, "id", username=username, user_attrs=attrs,
+                                     trigger_source="TokenGeneration_RefreshTokens"),
             "token_type": "Bearer",
             "expires_in": 3600,
         }

--- a/tests/test_cognito.py
+++ b/tests/test_cognito.py
@@ -2873,6 +2873,79 @@ def test_cognito_pretoken_lambda_failure_fail_open(cognito_idp, lam):
     assert access["client_id"] == cid  # token still issued
 
 
+def test_cognito_pretoken_trigger_source_by_auth_flow(cognito_idp, lam):
+    """PreTokenGeneration's triggerSource should differ by call path, matching
+    real AWS: InitiateAuth(USER_PASSWORD_AUTH) -> TokenGeneration_Authentication,
+    REFRESH_TOKEN_AUTH/refresh_token grant -> TokenGeneration_RefreshTokens,
+    Hosted UI authorization_code grant -> TokenGeneration_HostedAuth. Before the
+    fix, every path fell through to _fake_token()'s default
+    TokenGeneration_Authentication (#003)."""
+    handler = (
+        "def handler(event, ctx):\n"
+        "    src = event['triggerSource']\n"
+        "    event['response']['claimsAndScopeOverrideDetails'] = {\n"
+        "        'accessTokenGeneration': {'claimsToAddOrOverride': {'seen_trigger_source': src}},\n"
+        "    }\n"
+        "    return event\n"
+    )
+    fn_name = "ministack-pretoken-trigger-source"
+    lam.create_function(
+        FunctionName=fn_name, Runtime="python3.12",
+        Role="arn:aws:iam::000000000000:role/test-role",
+        Handler="index.handler",
+        Code={"ZipFile": _make_pretoken_lambda_zip(handler)},
+    )
+    fn_arn = lam.get_function(FunctionName=fn_name)["Configuration"]["FunctionArn"]
+
+    pool_id, client = _setup_pool_with_user(cognito_idp)
+    cognito_idp.update_user_pool(
+        UserPoolId=pool_id,
+        LambdaConfig={"PreTokenGenerationConfig": {
+            "LambdaArn": fn_arn, "LambdaVersion": "V2_0",
+        }},
+    )
+    client_id = client["ClientId"]
+    client_secret = client.get("ClientSecret", "")
+
+    # InitiateAuth (USER_PASSWORD_AUTH) -> TokenGeneration_Authentication
+    auth = cognito_idp.initiate_auth(
+        ClientId=client_id, AuthFlow="USER_PASSWORD_AUTH",
+        AuthParameters={"USERNAME": "testuser", "PASSWORD": "TestPass1!"},
+    )["AuthenticationResult"]
+    assert _decode_jwt_claims(auth["AccessToken"])["seen_trigger_source"] == "TokenGeneration_Authentication"
+
+    # REFRESH_TOKEN_AUTH (InitiateAuth) -> TokenGeneration_RefreshTokens
+    refreshed = cognito_idp.initiate_auth(
+        ClientId=client_id, AuthFlow="REFRESH_TOKEN_AUTH",
+        AuthParameters={"REFRESH_TOKEN": auth["RefreshToken"]},
+    )["AuthenticationResult"]
+    assert _decode_jwt_claims(refreshed["AccessToken"])["seen_trigger_source"] == "TokenGeneration_RefreshTokens"
+
+    # Hosted UI (/login -> /oauth2/token authorization_code grant) -> TokenGeneration_HostedAuth
+    code = _do_login_and_get_code(cognito_idp, client_id)
+    status, _, body = _post_form(f"{ENDPOINT}/oauth2/token", {
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": "http://localhost:3000/callback",
+        "client_id": client_id,
+        "client_secret": client_secret,
+    })
+    assert status == 200, body
+    tokens = json.loads(body)
+    assert _decode_jwt_claims(tokens["access_token"])["seen_trigger_source"] == "TokenGeneration_HostedAuth"
+
+    # /oauth2/token refresh_token grant -> TokenGeneration_RefreshTokens
+    status2, _, body2 = _post_form(f"{ENDPOINT}/oauth2/token", {
+        "grant_type": "refresh_token",
+        "refresh_token": tokens["refresh_token"],
+        "client_id": client_id,
+        "client_secret": client_secret,
+    })
+    assert status2 == 200, body2
+    resp2 = json.loads(body2)
+    assert _decode_jwt_claims(resp2["access_token"])["seen_trigger_source"] == "TokenGeneration_RefreshTokens"
+
+
 @pytest.fixture
 def _enable_persistence(monkeypatch, tmp_path):
     """Force PERSIST_STATE on and point STATE_DIR at a tmp dir so


### PR DESCRIPTION
## Summary
- Fixed a bug where the `triggerSource` passed to the PreTokenGeneration Lambda always fell through to the default `TokenGeneration_Authentication`, regardless of the call path (InitiateAuth/AdminInitiateAuth's REFRESH_TOKEN_AUTH, the Hosted UI authorization_code grant, and the /oauth2/token refresh_token grant)
- Added a `trigger_source` parameter to `_build_auth_result` and threaded it through from each call site so it now returns `TokenGeneration_RefreshTokens` / `TokenGeneration_HostedAuth` depending on the path, matching real AWS behavior
- Left the `_fake_token` calls for the client_credentials grant, the fallback path, and Cognito Identity out of scope, since they have no user context and real AWS never invokes the PreTokenGeneration trigger for those paths either

## Test plan
- [x] Added `test_cognito_pretoken_trigger_source_by_auth_flow`, asserting the `triggerSource` the Lambda receives for each path:
  - InitiateAuth(USER_PASSWORD_AUTH) → `TokenGeneration_Authentication`
  - REFRESH_TOKEN_AUTH (InitiateAuth) → `TokenGeneration_RefreshTokens`
  - Hosted UI (`/login` → `/oauth2/token` authorization_code grant) →
`TokenGeneration_HostedAuth`
  - `/oauth2/token` refresh_token grant → `TokenGeneration_RefreshTokens`
- [x] Confirmed `pytest tests/test_cognito.py` passes
