### PR TITLE
fix(s3): preserve content type on versioned reads (#1083)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 ### Added
 - **IoT — MQTT publishes are routed through topic rules to Lambda** — an MQTT/`iot-data` publish is now matched against each account's topic rules by the rule's `FROM '<topic filter>'` clause (with `+`/`#` wildcards), and every matching enabled rule's `lambda` actions are invoked asynchronously with the message payload as the event (`SELECT *`). Basic Ingest is supported: a publish to `$aws/rules/<ruleName>` is delivered straight to that rule's actions and bypasses pub/sub. Disabled rules are skipped.
 
+### Fixed
+- **S3 — versioned object reads preserve `Content-Type`** — `GetObject` with a `VersionId` always returned `application/octet-stream`, even when that version was written with an explicit content type. PutObject version records now retain their own content type, and versioned reads return it while preserving the existing fallback for older records. Reported by @aaronsteed (#1083).
+
 ## [1.4.2] — 2026-07-13
 
 ### Added

--- a/ministack/services/s3.py
+++ b/ministack/services/s3.py
@@ -2231,6 +2231,7 @@ def _put_object(bucket_name: str, key: str, body: bytes, headers: dict):
             "size": obj["size"],
             "is_latest": True,
             "data": body,
+            "content_type": obj.get("content_type") or "application/octet-stream",
             "storage_class": obj.get("storage_class") or "STANDARD",
             "checksums": obj.get("checksums") or {},
         })
@@ -2534,7 +2535,7 @@ def _get_object(bucket_name: str, key: str, headers: dict, query_params: dict = 
         for v in versions:
             if v["version_id"] == version_id:
                 resp_headers = {
-                    "Content-Type": "application/octet-stream",
+                    "Content-Type": v.get("content_type") or "application/octet-stream",
                     "ETag": v["etag"],
                     "Content-Length": str(v["size"]),
                     "Last-Modified": iso_to_rfc7231(v["last_modified"]),

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -2197,6 +2197,68 @@ def test_s3_put_object_content_type_preserved(s3):
     resp = s3.get_object(Bucket="qa-s3-ct", Key="page.html")
     assert "text/html" in resp["ContentType"]
 
+
+def test_s3_versioned_get_object_preserves_content_type(s3):
+    """Content-Type set on PutObject is returned when reading by VersionId."""
+    bucket = "qa-s3-versioned-ct"
+    s3.create_bucket(Bucket=bucket)
+    s3.put_bucket_versioning(
+        Bucket=bucket,
+        VersioningConfiguration={"Status": "Enabled"},
+    )
+
+    put = s3.put_object(
+        Bucket=bucket,
+        Key="page.html",
+        Body=b"<html/>",
+        ContentType="text/html; charset=utf-8",
+    )
+
+    response = s3.get_object(
+        Bucket=bucket,
+        Key="page.html",
+        VersionId=put["VersionId"],
+    )
+    assert response["ContentType"] == "text/html; charset=utf-8"
+
+
+def test_s3_versioned_get_object_preserves_content_type_per_version(s3):
+    """Each object version returns the Content-Type supplied for that version."""
+    bucket = "qa-s3-versioned-ct-history"
+    s3.create_bucket(Bucket=bucket)
+    s3.put_bucket_versioning(
+        Bucket=bucket,
+        VersioningConfiguration={"Status": "Enabled"},
+    )
+
+    text_version = s3.put_object(
+        Bucket=bucket,
+        Key="document",
+        Body=b"plain text",
+        ContentType="text/plain",
+    )["VersionId"]
+    json_version = s3.put_object(
+        Bucket=bucket,
+        Key="document",
+        Body=b'{"value": 1}',
+        ContentType="application/json",
+    )["VersionId"]
+
+    text_response = s3.get_object(
+        Bucket=bucket,
+        Key="document",
+        VersionId=text_version,
+    )
+    json_response = s3.get_object(
+        Bucket=bucket,
+        Key="document",
+        VersionId=json_version,
+    )
+
+    assert text_response["ContentType"] == "text/plain"
+    assert json_response["ContentType"] == "application/json"
+
+
 def test_s3_put_object_storage_class_roundtrip(s3):
     """PutObject with StorageClass is returned by GetObject and HeadObject (#534)."""
     s3.create_bucket(Bucket="qa-s3-sc")


### PR DESCRIPTION
Fixes #1083.

## Summary

`GetObject` with a `VersionId` always returned `application/octet-stream`, even when that object version was written with an explicit `Content-Type`. The current-object path retained the header, but the per-version record did not.

## Fix

- Store the normalized `content_type` on version records created by `PutObject`.
- Return that per-version value from `GetObject`; records created before this change continue to fall back to `application/octet-stream`.

## Test plan

- [x] `test_s3_versioned_get_object_preserves_content_type` — a version written with an explicit content type returns it when fetched by `VersionId`.
- [x] `test_s3_versioned_get_object_preserves_content_type_per_version` — two versions of the same key retain and return their distinct content types.
