### PR TITLE
ci: allow fork-PR checkout in publish-pr after checkout@v6 default change

### DIFF
--- a/.github/workflows/docker-publish-on-pr.yml
+++ b/.github/workflows/docker-publish-on-pr.yml
@@ -48,10 +48,19 @@ jobs:
             (`Dockerfile`, `.dockerignore`, or files under `.github/`). A maintainer
             will review and build the preview image manually before it is published.
 
+      # checkout@v6 now refuses fork-PR checkouts from pull_request_target
+      # unless explicitly allowed, which has failed this job for every fork PR
+      # since 2026-07-20. Checking out the PR head is intentional here: the
+      # guard above keeps PRs that touch the build/CI surface from reaching
+      # this step, and the build passes no secrets (only MINISTACK_VERSION as
+      # a build-arg). persist-credentials is disabled so the untrusted tree
+      # never holds the repo token — no later step needs git credentials.
       - uses: actions/checkout@v6
         if: steps.guard.outputs.skip != 'true'
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
+          persist-credentials: false
 
       - name: Get short SHA
         id: short_sha


### PR DESCRIPTION
## Why

`publish-pr` has failed for **every fork PR since 2026-07-20** (e.g. [this run](https://github.com/ministackorg/ministack/actions/runs/29849322726/job/88697865281), and the runs for #1104, #1105, #1122). Nothing changed in this repo — `actions/checkout` is referenced by the floating `@v6` tag, and a recent v6 release flipped its default to refuse checking out fork PR code from `pull_request_target` workflows:

```
##[error]Refusing to check out fork pull request code from a 'pull_request_target' workflow. This workflow runs with...
```

The last passing fork-PR run was 2026-07-20 15:19 UTC; every one after 16:52 UTC fails in ~13s at the checkout step.

## What

- `allow-unsafe-pr-checkout: true` on the checkout step — building the fork PR's head is this workflow's whole purpose, and the existing path-based guard already keeps PRs that touch the build/CI surface (`Dockerfile*`, `.dockerignore`, `.github/`) from ever reaching the checkout. No secrets are exposed to the build (only `MINISTACK_VERSION` is passed as a build-arg).
- `persist-credentials: false` — the hardening checkout v6 pairs with that flag: the untrusted tree never holds the repo token. No step after checkout uses git credentials (QEMU/buildx setup, Docker Hub login, build, PR comment all use their own inputs).

## Testing

Since the base branch's workflow definition is what runs for `pull_request_target`, this PR can't exercise its own change (and the guard will correctly skip the preview build for it, since it touches `.github/`). The first fork PR updated after merge will confirm it — #1122 is a candidate.
