### PR TITLE
Scope Batch state by region

### DIFF
--- a/ministack/app.py
+++ b/ministack/app.py
@@ -344,7 +344,7 @@ _state_map = {
     "stepfunctions": "stepfunctions", "alb": "alb",
     "glue": "glue", "mwaa": "mwaa", "efs": "efs", "waf": "waf",
     "athena": "athena", "emr": "emr", "cloudfront": "cloudfront",
-    "codebuild": "codebuild", "acm": "acm", "firehose": "firehose",
+    "codebuild": "codebuild", "batch": "batch", "acm": "acm", "firehose": "firehose",
     "ses": "ses", "ses_v2": "ses_v2",
     "servicediscovery": "servicediscovery", "s3files": "s3files",
     "appconfig": "appconfig", "transfer": "transfer",

--- a/ministack/core/persistence.py
+++ b/ministack/core/persistence.py
@@ -27,6 +27,7 @@ STATE_DIR = os.environ.get("STATE_DIR", "/tmp/ministack-state")
 # still load and migrate. (U4)
 STATE_FORMAT_VERSION = 2
 SERVICE_STATE_FORMAT_VERSIONS = {
+    "batch": 3,
     "ecs": 3,
     "resource_groups": 3,
     "codebuild": 3,

--- a/ministack/services/batch.py
+++ b/ministack/services/batch.py
@@ -58,7 +58,9 @@ def restore_state(data):
         (_jobs, "jobs"),
     ):
         store.clear()
-        store.update(data.get(key) or {})
+        restored = data.get(key)
+        if restored is not None:
+            store.update(restored)
 
 
 def _json(status, body):

--- a/ministack/services/batch.py
+++ b/ministack/services/batch.py
@@ -14,6 +14,7 @@ import re
 import time
 
 from ministack.core.arn import ArnParseError, parse_arn
+from ministack.core.persistence import load_state
 from ministack.core.responses import (
     AccountRegionScopedDict,
     error_response_json,
@@ -61,6 +62,14 @@ def restore_state(data):
         restored = data.get(key)
         if restored is not None:
             store.update(restored)
+
+
+try:
+    _restored = load_state("batch")
+    if _restored:
+        restore_state(_restored)
+except Exception:
+    logger.exception("Failed to restore persisted state; continuing with fresh store")
 
 
 def _json(status, body):

--- a/ministack/services/batch.py
+++ b/ministack/services/batch.py
@@ -2,7 +2,7 @@
 AWS Batch stub (rest-json).
 
 Endpoints under ``/v1/``. Stores compute environments, job queues, job
-definitions, and jobs in account-scoped state. Submitted jobs immediately
+definitions, and jobs in account-and-region-scoped state. Submitted jobs immediately
 transition to ``SUCCEEDED`` — Batch is a control-plane/scheduler emulator
 here, not a real container runner.
 """
@@ -15,7 +15,7 @@ import time
 
 from ministack.core.arn import ArnParseError, parse_arn
 from ministack.core.responses import (
-    AccountScopedDict,
+    AccountRegionScopedDict,
     error_response_json,
     get_account_id,
     get_region,
@@ -24,10 +24,10 @@ from ministack.core.responses import (
 
 logger = logging.getLogger("batch")
 
-_compute_envs = AccountScopedDict()   # name -> dict
-_job_queues = AccountScopedDict()     # name -> dict
-_job_definitions = AccountScopedDict()  # name -> [revisions]
-_jobs = AccountScopedDict()           # job_id -> dict
+_compute_envs = AccountRegionScopedDict()   # name -> dict
+_job_queues = AccountRegionScopedDict()     # name -> dict
+_job_definitions = AccountRegionScopedDict()  # name -> [revisions]
+_jobs = AccountRegionScopedDict()           # job_id -> dict
 
 _JOB_QUEUE_NAME_RE = re.compile(r"^[A-Za-z0-9_-]{1,128}$")
 
@@ -58,8 +58,7 @@ def restore_state(data):
         (_jobs, "jobs"),
     ):
         store.clear()
-        for k, v in (data.get(key) or {}).items():
-            store[k] = v
+        store.update(data.get(key) or {})
 
 
 def _json(status, body):

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -8,8 +8,8 @@ ENDPOINT = os.environ.get("MINISTACK_ENDPOINT", "http://localhost:4566")
 REGION = "us-east-1"
 
 
-def _client(service, account="test"):
-    return boto3.client(service, endpoint_url=ENDPOINT, region_name=REGION,
+def _client(service, account="test", region=REGION):
+    return boto3.client(service, endpoint_url=ENDPOINT, region_name=region,
                         aws_access_key_id=account, aws_secret_access_key="test")
 
 
@@ -331,3 +331,123 @@ def test_batch_update_compute_environment_merges_compute_resources(batch):
     assert ce["computeResources"]["instanceTypes"] == ["m5.large"]
     assert ce["computeResources"]["subnets"] == ["subnet-aaa"]
     assert ce["computeResources"]["securityGroupIds"] == ["sg-aaa"]
+
+def test_batch_resources_are_region_scoped():
+    east = _client("batch", region="us-east-1")
+    west = _client("batch", region="us-west-2")
+    suffix = _uid()
+    ce_name = f"ce-region-{suffix}"
+    jq_name = f"jq-region-{suffix}"
+    jd_name = f"jd-region-{suffix}"
+    job_name = f"job-region-{suffix}"
+
+    for client in (east, west):
+        ce = client.create_compute_environment(
+            computeEnvironmentName=ce_name,
+            type="MANAGED",
+            serviceRole="arn:aws:iam::000000000000:role/batch",
+        )
+        jq = client.create_job_queue(
+            jobQueueName=jq_name,
+            priority=1,
+            computeEnvironmentOrder=[{"order": 1, "computeEnvironment": ce["computeEnvironmentArn"]}],
+        )
+        jd = client.register_job_definition(
+            jobDefinitionName=jd_name,
+            type="container",
+            containerProperties={"image": "busybox", "memory": 128, "vcpus": 1},
+        )
+        client.submit_job(
+            jobName=job_name,
+            jobQueue=jq["jobQueueArn"],
+            jobDefinition=jd["jobDefinitionArn"],
+        )
+
+    for client, region in ((east, "us-east-1"), (west, "us-west-2")):
+        compute_envs = client.describe_compute_environments(
+            computeEnvironments=[ce_name]
+        )["computeEnvironments"]
+        queues = client.describe_job_queues(jobQueues=[jq_name])["jobQueues"]
+        definitions = client.describe_job_definitions(
+            jobDefinitionName=jd_name,
+        )["jobDefinitions"]
+        jobs = client.list_jobs(jobQueue=jq_name)["jobSummaryList"]
+
+        assert len(compute_envs) == 1
+        assert len(queues) == 1
+        assert len(definitions) == 1
+        assert len(jobs) == 1
+        assert f":{region}:" in compute_envs[0]["computeEnvironmentArn"]
+        assert f":{region}:" in queues[0]["jobQueueArn"]
+        assert f":{region}:" in definitions[0]["jobDefinitionArn"]
+        assert f":{region}:" in jobs[0]["jobArn"]
+
+
+def test_batch_restore_legacy_state_uses_resource_arn_region():
+    from ministack.core.responses import (
+        AccountScopedDict,
+        set_request_account_id,
+        set_request_region,
+    )
+    from ministack.services import batch as service
+
+    account_id = "111111111111"
+    resource_region = "us-west-2"
+    boot_region = "us-east-1"
+    stores = {
+        "compute_envs": (
+            "legacy-ce",
+            {
+                "computeEnvironmentArn": (
+                    f"arn:aws:batch:{resource_region}:{account_id}:"
+                    "compute-environment/legacy-ce"
+                )
+            },
+        ),
+        "job_queues": (
+            "legacy-queue",
+            {
+                "jobQueueArn": (
+                    f"arn:aws:batch:{resource_region}:{account_id}:"
+                    "job-queue/legacy-queue"
+                )
+            },
+        ),
+        "job_definitions": (
+            "legacy-definition",
+            [
+                {
+                    "jobDefinitionArn": (
+                        f"arn:aws:batch:{resource_region}:{account_id}:job-definition/legacy-definition:1"
+                    )
+                }
+            ],
+        ),
+        "jobs": (
+            "legacy-job-id",
+            {
+                "jobArn": (
+                    f"arn:aws:batch:{resource_region}:{account_id}:"
+                    "job/legacy-job-id"
+                )
+            },
+        ),
+    }
+
+    set_request_account_id(account_id)
+    set_request_region(boot_region)
+    legacy_state = {}
+    for state_key, (resource_key, value) in stores.items():
+        store = AccountScopedDict()
+        store[resource_key] = value
+        legacy_state[state_key] = store
+
+    service.reset()
+    try:
+        service.restore_state(legacy_state)
+        for state_key, (resource_key, value) in stores.items():
+            store = getattr(service, f"_{state_key}")
+            assert store.get_scoped(account_id, resource_region, resource_key) == value
+            assert store.get_scoped(account_id, boot_region, resource_key) is None
+    finally:
+        service.reset()

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -451,3 +451,41 @@ def test_batch_restore_legacy_state_uses_resource_arn_region():
             assert store.get_scoped(account_id, boot_region, resource_key) is None
     finally:
         service.reset()
+
+
+def test_batch_restore_current_state_preserves_non_boot_regions():
+    from ministack.core.responses import set_request_account_id, set_request_region
+    from ministack.services import batch as service
+
+    account_id = "111111111111"
+    boot_region = "us-east-1"
+    resource_region = "us-west-2"
+    resources = {
+        "compute_envs": ("regional-ce", {"state": "ENABLED"}),
+        "job_queues": ("regional-queue", {"state": "ENABLED"}),
+        "job_definitions": ("regional-definition", [{"revision": 1}]),
+        "jobs": ("regional-job", {"status": "SUCCEEDED"}),
+    }
+
+    set_request_account_id(account_id)
+    set_request_region(boot_region)
+    service.reset()
+    try:
+        for state_key, (resource_key, value) in resources.items():
+            getattr(service, f"_{state_key}").set_scoped(
+                account_id, resource_region, resource_key, value
+            )
+
+        snapshot = service.get_state()
+        assert not snapshot["compute_envs"]
+
+        service.reset()
+        service.restore_state(snapshot)
+
+        for state_key, (resource_key, value) in resources.items():
+            store = getattr(service, f"_{state_key}")
+            assert store.get_scoped(
+                account_id, resource_region, resource_key
+            ) == value
+    finally:
+        service.reset()

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1907,3 +1907,34 @@ def test_codebuild_region_scoped_state_is_rejected_by_v2_reader(
     # Simulate the previous binary, whose highest understood format is v2.
     monkeypatch.setattr(persistence, "SERVICE_STATE_FORMAT_VERSIONS", {})
     assert persistence.load_state("codebuild") is None
+
+
+def test_batch_region_scoped_state_is_rejected_by_v2_reader(monkeypatch, tmp_path):
+    """A rollback binary must reject Batch's regional schema instead of
+    accepting it as v2 and silently dropping every regional store."""
+    import json as _json
+
+    from ministack.core.responses import AccountRegionScopedDict
+
+    monkeypatch.setattr(persistence, "PERSIST_STATE", True)
+    monkeypatch.setattr(persistence, "STATE_DIR", str(tmp_path))
+
+    jobs = AccountRegionScopedDict()
+    jobs.set_scoped(
+        "000000000000",
+        "us-west-2",
+        "regional-job",
+        {"jobArn": "arn:aws:batch:us-west-2:000000000000:job/regional-job"},
+    )
+    persistence.save_state("batch", {"jobs": jobs})
+
+    raw = _json.loads((tmp_path / "batch.json").read_text())
+    assert raw["__ministack_format__"] == 3
+    loaded_jobs = persistence.load_state("batch")["jobs"]
+    assert loaded_jobs.get_scoped(
+        "000000000000", "us-west-2", "regional-job"
+    )["jobArn"].endswith("job/regional-job")
+
+    # Simulate the previous binary, whose highest understood format is v2.
+    monkeypatch.setattr(persistence, "SERVICE_STATE_FORMAT_VERSIONS", {})
+    assert persistence.load_state("batch") is None

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1938,3 +1938,45 @@ def test_batch_region_scoped_state_is_rejected_by_v2_reader(monkeypatch, tmp_pat
     # Simulate the previous binary, whose highest understood format is v2.
     monkeypatch.setattr(persistence, "SERVICE_STATE_FORMAT_VERSIONS", {})
     assert persistence.load_state("batch") is None
+
+
+def test_batch_persistence_lifecycle_restores_regional_state(monkeypatch, tmp_path):
+    """The gateway save map and Batch import-time restore must preserve state
+    outside the ambient boot region across a process-shaped reload."""
+    import importlib
+
+    from ministack.app import _build_persistence_save_dict, _state_map
+    from ministack.core.responses import set_request_account_id, set_request_region
+    from ministack.services import batch as service
+
+    account_id = "111111111111"
+    boot_region = "us-east-1"
+    resource_region = "us-west-2"
+    job_id = "regional-job"
+    job = {
+        "jobArn": f"arn:aws:batch:{resource_region}:{account_id}:job/{job_id}",
+        "status": "SUCCEEDED",
+    }
+
+    monkeypatch.setattr(persistence, "PERSIST_STATE", True)
+    monkeypatch.setattr(persistence, "STATE_DIR", str(tmp_path))
+    set_request_account_id(account_id)
+    set_request_region(boot_region)
+    service.reset()
+    try:
+        service._jobs.set_scoped(account_id, resource_region, job_id, job)
+
+        assert _state_map["batch"] == "batch"
+        save_dict = _build_persistence_save_dict()
+        assert "batch" in save_dict
+        persistence.save_all({"batch": save_dict["batch"]})
+
+        service.reset()
+        importlib.reload(service)
+
+        assert service._jobs.get_scoped(
+            account_id, resource_region, job_id
+        ) == job
+        assert service._jobs.get_scoped(account_id, boot_region, job_id) is None
+    finally:
+        service.reset()


### PR DESCRIPTION
## Why
AWS Batch resources are regional, but MiniStack currently shares compute environments, queues, definitions, and jobs across regions within an account.

## What
- Scope all four Batch stores by account and region
- Preserve every legacy account while deriving each resource's region from its nested ARN
- Preserve current snapshots whose resources exist only outside the boot region
- Version the regional persistence schema so older binaries refuse incompatible snapshots
- Add end-to-end regional isolation, legacy migration, current round-trip, and rollback-safety coverage

## Risk Assessment
Low — the change is isolated to Batch state storage and retains legacy snapshot compatibility.

## Validation

* `uv run --extra dev ruff check ministack/app.py ministack/core/persistence.py ministack/services/batch.py tests/test_batch.py`
* `uv run --extra dev pytest tests/test_batch.py -q` with local MiniStack server (`16 passed`)
* `uv run --extra dev pytest tests/test_persistence.py -q` (`168 passed`)
