### PR TITLE
Scope SES state by region

### DIFF
--- a/ministack/app.py
+++ b/ministack/app.py
@@ -689,8 +689,7 @@ async def _handle_ses_messages_request(method: str, path: str, headers: dict, qu
     """Handle SES messages inspection endpoint.
 
     Supports filtering by account via the 'account' query parameter. When provided,
-    sets the request context to that account so emails are retrieved from the correct
-    AccountScopedDict._sent_emails_list.
+    returns messages grouped by account across the service's regional stores.
     """
     if path != "/_ministack/ses/messages" or method != "GET":
         return None
@@ -716,9 +715,15 @@ async def _handle_ses_messages_request(method: str, path: str, headers: dict, qu
         sent_emails_dict = {}
         try:
             all_data = mod._sent_emails.to_dict()
-            for (acct, key), val in all_data.items():
+            for scoped_key, val in all_data.items():
+                if len(scoped_key) == 2:
+                    acct, key = scoped_key
+                elif len(scoped_key) == 3:
+                    acct, _region, key = scoped_key
+                else:
+                    continue
                 if key == "entries" and isinstance(val, list):
-                    sent_emails_dict[acct] = val
+                    sent_emails_dict.setdefault(acct, []).extend(val)
         except Exception:
             # Fallback: empty dict on any unexpected shape
             sent_emails_dict = {}

--- a/ministack/core/persistence.py
+++ b/ministack/core/persistence.py
@@ -30,6 +30,8 @@ SERVICE_STATE_FORMAT_VERSIONS = {
     "ecs": 3,
     "resource_groups": 3,
     "codebuild": 3,
+    "ses": 3,
+    "ses_v2": 3,
 }
 
 

--- a/ministack/services/ses.py
+++ b/ministack/services/ses.py
@@ -39,18 +39,24 @@ from email.policy import default as default_policy
 from urllib.parse import parse_qs, unquote
 
 from ministack.core.persistence import PERSIST_STATE, load_state
-from ministack.core.responses import AccountScopedDict, get_account_id, get_region, new_uuid
+from ministack.core.responses import (
+    AccountRegionScopedDict,
+    AccountScopedDict,
+    get_account_id,
+    get_region,
+    new_uuid,
+)
 
 logger = logging.getLogger("ses")
 
 REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 
-_identities = AccountScopedDict()
-# Per-account sent-mail record. AccountScopedDict under "entries" so the list
-# manipulation stays simple but GetSendStatistics / inspection is scoped.
-_sent_emails = AccountScopedDict()
-_templates = AccountScopedDict()
-_configuration_sets = AccountScopedDict()
+_identities = AccountRegionScopedDict()
+# Per-account-and-region sent-mail record. The scoped dict stays under
+# "entries" so list manipulation remains simple while statistics stay regional.
+_sent_emails = AccountRegionScopedDict()
+_templates = AccountRegionScopedDict()
+_configuration_sets = AccountRegionScopedDict()
 
 
 def _sent_emails_list() -> list:
@@ -74,9 +80,25 @@ def get_state() -> dict:
 
 
 def restore_state(data: dict):
-    _identities.update(data.get("_identities", {}))
-    _templates.update(data.get("_templates", {}))
-    _configuration_sets.update(data.get("_configuration_sets", {}))
+    _restore_regional_store(_identities, data.get("_identities", {}))
+    _restore_regional_store(_templates, data.get("_templates", {}))
+    _restore_regional_store(
+        _configuration_sets, data.get("_configuration_sets", {})
+    )
+
+
+def _restore_regional_store(store, restored):
+    """Map legacy SES state to the boot region without inspecting content ARNs."""
+    if isinstance(restored, AccountRegionScopedDict):
+        store.update(restored)
+        return
+    if isinstance(restored, AccountScopedDict):
+        region = get_region()
+        for (account_id, key), value in restored._data.items():
+            store.set_scoped(account_id, region, key, value)
+        return
+    for key, value in restored.items():
+        store[key] = value
 
 
 try:

--- a/ministack/services/ses_v2.py
+++ b/ministack/services/ses_v2.py
@@ -17,16 +17,29 @@ import time
 
 from ministack.core.arn import ArnParseError, parse_arn
 from ministack.core.persistence import PERSIST_STATE, load_state
-from ministack.core.responses import AccountScopedDict, get_account_id, get_region, json_response, new_uuid, now_iso
-from ministack.services.ses import _build_mime_message, _parse_raw_mime, _sent_emails_list, _smtp_relay
+from ministack.core.responses import (
+    AccountRegionScopedDict,
+    get_account_id,
+    get_region,
+    json_response,
+    new_uuid,
+    now_iso,
+)
+from ministack.services.ses import (
+    _build_mime_message,
+    _parse_raw_mime,
+    _restore_regional_store,
+    _sent_emails_list,
+    _smtp_relay,
+)
 
 logger = logging.getLogger("ses-v2")
 
 REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 
-_identities = AccountScopedDict()        # identity -> dict
-_config_sets = AccountScopedDict()       # name -> dict
-_ses_tags = AccountScopedDict()          # resource_arn -> [tags]
+_identities = AccountRegionScopedDict()  # identity -> dict
+_config_sets = AccountRegionScopedDict()  # name -> dict
+_ses_tags = AccountRegionScopedDict()  # resource_arn -> [tags]
 
 
 def get_state() -> dict:
@@ -38,9 +51,9 @@ def get_state() -> dict:
 
 
 def restore_state(data: dict):
-    _identities.update(data.get("_identities", {}))
-    _config_sets.update(data.get("_config_sets", {}))
-    _ses_tags.update(data.get("_ses_tags", {}))
+    _restore_regional_store(_identities, data.get("_identities", {}))
+    _restore_regional_store(_config_sets, data.get("_config_sets", {}))
+    _restore_regional_store(_ses_tags, data.get("_ses_tags", {}))
 
 
 try:

--- a/ministack/services/ses_v2.py
+++ b/ministack/services/ses_v2.py
@@ -19,6 +19,7 @@ from ministack.core.arn import ArnParseError, parse_arn
 from ministack.core.persistence import PERSIST_STATE, load_state
 from ministack.core.responses import (
     AccountRegionScopedDict,
+    AccountScopedDict,
     get_account_id,
     get_region,
     json_response,
@@ -53,7 +54,39 @@ def get_state() -> dict:
 def restore_state(data: dict):
     _restore_regional_store(_identities, data.get("_identities", {}))
     _restore_regional_store(_config_sets, data.get("_config_sets", {}))
-    _restore_regional_store(_ses_tags, data.get("_ses_tags", {}))
+    _restore_tag_store(data.get("_ses_tags", {}))
+
+
+def _restore_tag_store(restored):
+    """Move legacy ARN-keyed tags with their boot-region resource."""
+    if isinstance(restored, AccountRegionScopedDict):
+        _ses_tags.update(restored)
+        return
+    if isinstance(restored, AccountScopedDict):
+        region = get_region()
+        for (account_id, resource_arn), tags in restored._data.items():
+            normalized_arn = _legacy_resource_arn_for_region(
+                resource_arn, account_id, region
+            )
+            _ses_tags.set_scoped(account_id, region, normalized_arn, tags)
+        return
+    for resource_arn, tags in restored.items():
+        account_id = get_account_id()
+        region = get_region()
+        normalized_arn = _legacy_resource_arn_for_region(
+            resource_arn, account_id, region
+        )
+        _ses_tags[normalized_arn] = tags
+
+
+def _legacy_resource_arn_for_region(resource_arn, account_id, region):
+    try:
+        spec = parse_arn(resource_arn)
+    except (ArnParseError, TypeError):
+        return resource_arn
+    if spec.partition != "aws" or spec.service != "ses":
+        return resource_arn
+    return f"arn:aws:ses:{region}:{account_id}:{spec.resource}"
 
 
 try:

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1907,3 +1907,36 @@ def test_codebuild_region_scoped_state_is_rejected_by_v2_reader(
     # Simulate the previous binary, whose highest understood format is v2.
     monkeypatch.setattr(persistence, "SERVICE_STATE_FORMAT_VERSIONS", {})
     assert persistence.load_state("codebuild") is None
+
+
+def test_ses_region_scoped_state_is_rejected_by_v2_reader(monkeypatch, tmp_path):
+    """A rollback binary must reject both SES persistence files after their
+    stores become regional instead of accepting v2 and restoring them empty."""
+    import json as _json
+
+    from ministack.core.responses import AccountRegionScopedDict
+
+    monkeypatch.setattr(persistence, "PERSIST_STATE", True)
+    monkeypatch.setattr(persistence, "STATE_DIR", str(tmp_path))
+
+    for service in ("ses", "ses_v2"):
+        identities = AccountRegionScopedDict()
+        identities.set_scoped(
+            "000000000000",
+            "us-west-2",
+            "regional@example.com",
+            {"VerificationStatus": "Success"},
+        )
+        persistence.save_state(service, {"_identities": identities})
+
+        raw = _json.loads((tmp_path / f"{service}.json").read_text())
+        assert raw["__ministack_format__"] == 3
+        loaded_identities = persistence.load_state(service)["_identities"]
+        assert loaded_identities.get_scoped(
+            "000000000000", "us-west-2", "regional@example.com"
+        )["VerificationStatus"] == "Success"
+
+    # Simulate the previous binary, whose highest understood format is v2.
+    monkeypatch.setattr(persistence, "SERVICE_STATE_FORMAT_VERSIONS", {})
+    assert persistence.load_state("ses") is None
+    assert persistence.load_state("ses_v2") is None

--- a/tests/test_ses.py
+++ b/tests/test_ses.py
@@ -583,12 +583,11 @@ def test_ses_messages_endpoint_reset(ses):
 # Verifies that the ?account query parameter properly validates and filters emails.
 # Invalid non-12-digit accounts now return a 400 InvalidAccountID error.
 # ---------------------------------------------------------------------------
-def _client(service, access_key="test"):
+def _client(service, access_key="test", region="us-east-1"):
     """Create a boto3 client with a specific access key."""
     import boto3
     from botocore.config import Config
     endpoint = os.environ.get("MINISTACK_ENDPOINT", "http://localhost:4566")
-    region = "us-east-1"
     return boto3.client(
         service,
         endpoint_url=endpoint,
@@ -684,4 +683,118 @@ def test_ses_messages_endpoint_account_filter():
     # Should return empty list (no emails for this account)
     assert "messages" in data
     assert data["messages"].get("123456789012", []) == [], "Expected 0 messages for account with no emails"
-  
+
+
+def test_ses_resources_and_send_statistics_are_region_scoped():
+    import urllib.request
+
+    east = _client("ses", region="us-east-1")
+    west = _client("ses", region="us-west-2")
+    suffix = _uuid_mod.uuid4().hex[:8]
+    identity = f"same-region-{suffix}@example.com"
+    template = f"same-region-template-{suffix}"
+    configuration_set = f"same-region-config-{suffix}"
+
+    for client, label in ((east, "east"), (west, "west")):
+        client.verify_email_identity(EmailAddress=identity)
+        client.create_template(
+            Template={
+                "TemplateName": template,
+                "SubjectPart": label,
+                "TextPart": label,
+            }
+        )
+        client.create_configuration_set(
+            ConfigurationSet={"Name": configuration_set}
+        )
+
+    assert east.get_template(TemplateName=template)["Template"]["SubjectPart"] == "east"
+    assert west.get_template(TemplateName=template)["Template"]["SubjectPart"] == "west"
+
+    east.delete_identity(Identity=identity)
+    east.delete_configuration_set(ConfigurationSetName=configuration_set)
+    assert identity not in east.list_identities()["Identities"]
+    assert identity in west.list_identities()["Identities"]
+    assert not any(
+        item["Name"] == configuration_set
+        for item in east.list_configuration_sets()["ConfigurationSets"]
+    )
+    assert any(
+        item["Name"] == configuration_set
+        for item in west.list_configuration_sets()["ConfigurationSets"]
+    )
+
+    east_before = east.get_send_quota()["SentLast24Hours"]
+    west_before = west.get_send_quota()["SentLast24Hours"]
+    for client, label in ((east, "east"), (west, "west")):
+        client.send_email(
+            Source=f"{label}-{identity}",
+            Destination={"ToAddresses": ["recipient@example.com"]},
+            Message={
+                "Subject": {"Data": label},
+                "Body": {"Text": {"Data": label}},
+            },
+        )
+
+    assert east.get_send_quota()["SentLast24Hours"] == east_before + 1
+    assert west.get_send_quota()["SentLast24Hours"] == west_before + 1
+
+    endpoint = os.environ.get("MINISTACK_ENDPOINT", "http://localhost:4566")
+    with urllib.request.urlopen(f"{endpoint}/_ministack/ses/messages") as response:
+        messages = json.loads(response.read())["messages"]["000000000000"]
+    sources = {message["Source"] for message in messages}
+    assert f"east-{identity}" in sources
+    assert f"west-{identity}" in sources
+
+
+def test_ses_restore_legacy_state_maps_unregionalized_values_to_boot_region():
+    from ministack.core.responses import (
+        AccountScopedDict,
+        set_request_account_id,
+        set_request_region,
+    )
+    from ministack.services import ses as service
+
+    account_id = "111111111111"
+    boot_region = "us-east-1"
+    foreign_region = "us-west-2"
+    values = {
+        "_identities": (
+            "legacy@example.com",
+            {
+                "VerificationStatus": "Success",
+                "NotificationTopics": {
+                    "Bounce": "arn:aws:sns:us-west-2:111111111111:legacy"
+                },
+            },
+        ),
+        "_templates": (
+            "legacy-template",
+            {
+                "TemplateName": "legacy-template",
+                "TextPart": "arn:aws:sns:us-west-2:111111111111:content",
+            },
+        ),
+        "_configuration_sets": (
+            "legacy-config",
+            {"Name": "legacy-config"},
+        ),
+    }
+
+    set_request_account_id(account_id)
+    set_request_region(boot_region)
+    legacy_state = {}
+    for state_key, (resource_key, value) in values.items():
+        store = AccountScopedDict()
+        store[resource_key] = value
+        legacy_state[state_key] = store
+
+    service.reset()
+    try:
+        service.restore_state(legacy_state)
+        for state_key, (resource_key, value) in values.items():
+            store = getattr(service, state_key)
+            assert store.get_scoped(account_id, boot_region, resource_key) == value
+            assert store.get_scoped(account_id, foreign_region, resource_key) is None
+    finally:
+        service.reset()

--- a/tests/test_ses.py
+++ b/tests/test_ses.py
@@ -889,7 +889,13 @@ def test_ses_v2_restore_legacy_state_maps_unregionalized_values_to_boot_region()
         service.restore_state(legacy_state)
         for state_key, (resource_key, value) in values.items():
             store = getattr(service, state_key)
-            assert store.get_scoped(account_id, boot_region, resource_key) == value
+            expected_key = resource_key
+            if state_key == "_ses_tags":
+                expected_key = resource_key.replace(
+                    f":{foreign_region}:", f":{boot_region}:"
+                )
+                assert store.get_scoped(account_id, boot_region, resource_key) is None
+            assert store.get_scoped(account_id, boot_region, expected_key) == value
             assert store.get_scoped(account_id, foreign_region, resource_key) is None
     finally:
         service.reset()

--- a/tests/test_ses.py
+++ b/tests/test_ses.py
@@ -747,6 +747,56 @@ def test_ses_resources_and_send_statistics_are_region_scoped():
     assert f"west-{identity}" in sources
 
 
+def test_ses_v2_resources_and_tags_are_region_scoped():
+    east = _client("sesv2", region="us-east-1")
+    west = _client("sesv2", region="us-west-2")
+    suffix = _uuid_mod.uuid4().hex[:8]
+    identity = f"same-v2-region-{suffix}.example.com"
+    configuration_set = f"same-v2-region-config-{suffix}"
+
+    for client, label in ((east, "east"), (west, "west")):
+        tags = [{"Key": "region", "Value": label}]
+        client.create_email_identity(EmailIdentity=identity, Tags=tags)
+        client.create_configuration_set(
+            ConfigurationSetName=configuration_set,
+            Tags=tags,
+        )
+
+    assert east.get_email_identity(EmailIdentity=identity)["Tags"] == [
+        {"Key": "region", "Value": "east"}
+    ]
+    assert west.get_email_identity(EmailIdentity=identity)["Tags"] == [
+        {"Key": "region", "Value": "west"}
+    ]
+
+    for client, region, label in (
+        (east, "us-east-1", "east"),
+        (west, "us-west-2", "west"),
+    ):
+        arn = (
+            f"arn:aws:ses:{region}:000000000000:"
+            f"configuration-set/{configuration_set}"
+        )
+        assert client.list_tags_for_resource(ResourceArn=arn)["Tags"] == [
+            {"Key": "region", "Value": label}
+        ]
+
+    east.delete_email_identity(EmailIdentity=identity)
+    east.delete_configuration_set(ConfigurationSetName=configuration_set)
+    assert not any(
+        item["IdentityName"] == identity
+        for item in east.list_email_identities()["EmailIdentities"]
+    )
+    assert any(
+        item["IdentityName"] == identity
+        for item in west.list_email_identities()["EmailIdentities"]
+    )
+    assert configuration_set not in east.list_configuration_sets()[
+        "ConfigurationSets"
+    ]
+    assert configuration_set in west.list_configuration_sets()["ConfigurationSets"]
+
+
 def test_ses_restore_legacy_state_maps_unregionalized_values_to_boot_region():
     from ministack.core.responses import (
         AccountScopedDict,
@@ -778,6 +828,51 @@ def test_ses_restore_legacy_state_maps_unregionalized_values_to_boot_region():
         "_configuration_sets": (
             "legacy-config",
             {"Name": "legacy-config"},
+        ),
+    }
+
+    set_request_account_id(account_id)
+    set_request_region(boot_region)
+    legacy_state = {}
+    for state_key, (resource_key, value) in values.items():
+        store = AccountScopedDict()
+        store[resource_key] = value
+        legacy_state[state_key] = store
+
+    service.reset()
+    try:
+        service.restore_state(legacy_state)
+        for state_key, (resource_key, value) in values.items():
+            store = getattr(service, state_key)
+            assert store.get_scoped(account_id, boot_region, resource_key) == value
+            assert store.get_scoped(account_id, foreign_region, resource_key) is None
+    finally:
+        service.reset()
+
+
+def test_ses_v2_restore_legacy_state_maps_unregionalized_values_to_boot_region():
+    from ministack.core.responses import (
+        AccountScopedDict,
+        set_request_account_id,
+        set_request_region,
+    )
+    from ministack.services import ses_v2 as service
+
+    account_id = "111111111111"
+    boot_region = "us-east-1"
+    foreign_region = "us-west-2"
+    values = {
+        "_identities": (
+            "legacy.example.com",
+            {"EmailIdentity": "legacy.example.com"},
+        ),
+        "_config_sets": (
+            "legacy-config",
+            {"ConfigurationSetName": "legacy-config"},
+        ),
+        "_ses_tags": (
+            "arn:aws:ses:us-west-2:111111111111:identity/legacy.example.com",
+            [{"Key": "legacy", "Value": "true"}],
         ),
     }
 


### PR DESCRIPTION
## Why
SES v1 and v2 resources and send statistics are regional in AWS, but MiniStack currently shares them across regions within an account.

## What
- Scope SES v1 identities, templates, configuration sets, and sent-mail statistics by account and region
- Scope SES v2 identities, configuration sets, and tags by account and region
- Map region-less legacy resources to the boot region without following incidental foreign ARNs
- Rewrite legacy SES v2 tag ARN keys so restored tags remain attached to boot-region resources
- Version both SES persistence schemas so older binaries refuse incompatible snapshots
- Preserve the admin messages endpoint's account-grouped, all-region inspection contract
- Add v1/v2 regional isolation, per-region statistics, admin aggregation, legacy restore, and rollback-safety coverage

## Risk Assessment
Low — the change is isolated to SES state storage and its internal admin adapter. Legacy snapshots remain readable with a deterministic boot-region fallback.

## Validation

* `uv run --extra dev ruff check ministack/app.py ministack/core/persistence.py ministack/services/ses.py ministack/services/ses_v2.py tests/test_ses.py`
* `uv run --extra dev pytest tests/test_ses.py -q` with local MiniStack server (`40 passed`)
* `uv run --extra dev pytest tests/test_persistence.py -q` (`165 passed`)
