### PR TITLE
Scope MQ state by region

### DIFF
--- a/ministack/core/persistence.py
+++ b/ministack/core/persistence.py
@@ -31,6 +31,7 @@ SERVICE_STATE_FORMAT_VERSIONS = {
     "ecs": 3,
     "resource_groups": 3,
     "codebuild": 3,
+    "mq": 3,
     "ses": 3,
     "ses_v2": 3,
 }

--- a/ministack/services/mq.py
+++ b/ministack/services/mq.py
@@ -29,7 +29,13 @@ from urllib.parse import unquote
 
 from ministack.core.arn import ArnParseError, parse_arn
 from ministack.core.persistence import load_state
-from ministack.core.responses import AccountScopedDict, get_account_id, get_region, new_uuid
+from ministack.core.responses import (
+    AccountRegionScopedDict,
+    AccountScopedDict,
+    get_account_id,
+    get_region,
+    new_uuid,
+)
 
 logger = logging.getLogger("mq")
 
@@ -37,16 +43,17 @@ logger = logging.getLogger("mq")
 # ============================================================================
 # Module State
 # ============================================================================
-# These module-level dicts are scoped per AWS account/region via AccountScopedDict.
+# Broker-owned state is scoped per AWS account and region. ARN-keyed tags stay
+# account-scoped because the ARN itself includes the resource region.
 # Invariants to maintain:
 #   - _name_index[name] must exist iff _brokers[id].brokerName == name
 #   - _tags[arn] exists iff _brokers[id] with matching arn exists
 #   - _users[id] exists iff _brokers[id].engineType == "ACTIVEMQ"
 
-_brokers: AccountScopedDict = AccountScopedDict()
-_name_index: AccountScopedDict = AccountScopedDict()
+_brokers: AccountRegionScopedDict = AccountRegionScopedDict()
+_name_index: AccountRegionScopedDict = AccountRegionScopedDict()
 _tags: AccountScopedDict = AccountScopedDict()
-_users: AccountScopedDict = AccountScopedDict()
+_users: AccountRegionScopedDict = AccountRegionScopedDict()
 
 
 # ============================================================================
@@ -283,9 +290,40 @@ def restore_state(data: dict) -> None:
     if not data:
         return
     _brokers.update(data.get("brokers", {}))
-    _name_index.update(data.get("name_index", {}))
+
+    saved_name_index = data.get("name_index", {})
+    if isinstance(saved_name_index, AccountRegionScopedDict):
+        _name_index.update(saved_name_index)
+    else:
+        # Legacy name indexes carry neither an ARN nor a region. Rebuild the
+        # index from the broker records after their ARN-based migration.
+        for (account_id, region, broker_id), broker in _brokers.all_items():
+            broker_name = broker.get("brokerName")
+            if broker_name:
+                _name_index.set_scoped(account_id, region, broker_name, broker_id)
+
     _tags.update(data.get("tags", {}))
-    _users.update(data.get("users", {}))
+
+    saved_users = data.get("users", {})
+    if isinstance(saved_users, AccountRegionScopedDict):
+        _users.update(saved_users)
+    else:
+        if isinstance(saved_users, AccountScopedDict):
+            legacy_users = saved_users._data.items()
+        else:
+            account_id = get_account_id()
+            legacy_users = (((account_id, broker_id), users) for broker_id, users in saved_users.items())
+
+        # User maps are keyed only by broker ID, so place them beside their
+        # migrated parent broker rather than in the ambient startup region.
+        broker_regions = {
+            (account_id, broker_id): region
+            for (account_id, region, broker_id), _broker in _brokers.all_items()
+        }
+        for (account_id, broker_id), users in legacy_users:
+            region = broker_regions.get((account_id, broker_id))
+            if region:
+                _users.set_scoped(account_id, region, broker_id, users)
 
 
 try:

--- a/tests/test_mq.py
+++ b/tests/test_mq.py
@@ -7,6 +7,34 @@ import uuid
 import pytest
 from botocore.exceptions import ClientError
 
+
+@pytest.fixture
+def isolated_mq_module_state():
+    from ministack.core.responses import (
+        get_account_id,
+        get_region,
+        set_request_account_id,
+        set_request_region,
+    )
+    from ministack.services import mq as service
+
+    original_account = get_account_id()
+    original_region = get_region()
+    stores = (service._brokers, service._name_index, service._tags, service._users)
+    original_data = [dict(store._data) for store in stores]
+
+    service.reset()
+    set_request_account_id("111111111111")
+    set_request_region("us-east-1")
+    try:
+        yield service
+    finally:
+        service.reset()
+        for store, data in zip(stores, original_data):
+            store._data.update(data)
+        set_request_account_id(original_account)
+        set_request_region(original_region)
+
 # ###########################################################################
 # Helpers
 # ###########################################################################
@@ -955,9 +983,9 @@ def test_mq_update_user(mq):
 
     # Verify updates
     user = mq.describe_user(BrokerId=broker_id, Username="full_update_user")
-    assert user["ConsoleAccess"] == True
+    assert user["ConsoleAccess"]
     assert set(user["Groups"]) == {"admins", "ops"}
-    assert user["ReplicationUser"] == True
+    assert user["ReplicationUser"]
 
 def test_mq_update_user_with_non_existent_username(mq):
     broker_id = _create(mq, BrokerName=_name("user"), EngineType="ACTIVEMQ", EngineVersion="5.19")["BrokerId"]
@@ -1175,8 +1203,8 @@ def test_mq_multiple_brokers_isolated_users(mq):
 
     assert user1 is not None
     assert user2 is not None
-    assert user1["ConsoleAccess"] == True
-    assert user2["ConsoleAccess"] == False
+    assert user1["ConsoleAccess"]
+    assert not user2["ConsoleAccess"]
 
 
 def test_mq_recreate_broker_after_delete_has_fresh_tags_and_users(mq):
@@ -1228,3 +1256,118 @@ def test_mq_recreate_broker_after_delete_has_fresh_tags_and_users(mq):
 
     # Verify old ARN is different from new ARN
     assert broker_arn1 != broker_arn2
+
+
+def _regional_broker_body(name):
+    return {
+        "brokerName": name,
+        "engineType": "ACTIVEMQ",
+        "engineVersion": "5.19",
+        "hostInstanceType": "mq.m5.large",
+        "publiclyAccessible": False,
+        "deploymentMode": "SINGLE_INSTANCE",
+    }
+
+
+def test_mq_brokers_are_isolated_by_region(isolated_mq_module_state):
+    import json
+
+    from ministack.core.responses import set_request_region
+
+    service = isolated_mq_module_state
+    broker_name = "regional-shared-name"
+
+    east_status, _headers, east_body = service._create_broker(
+        _regional_broker_body(broker_name)
+    )
+    east_broker_id = json.loads(east_body)["brokerId"]
+
+    set_request_region("us-west-2")
+    west_status, _headers, west_body = service._create_broker(
+        _regional_broker_body(broker_name)
+    )
+    west_broker_id = json.loads(west_body)["brokerId"]
+
+    assert east_status == west_status == 200
+    assert east_broker_id != west_broker_id
+    _status, _headers, west_list_body = service._list_brokers({})
+    assert [b["brokerId"] for b in json.loads(west_list_body)["brokerSummaries"]] == [
+        west_broker_id
+    ]
+    assert service._describe_broker(east_broker_id)[0] == 404
+
+    set_request_region("us-east-1")
+    _status, _headers, east_list_body = service._list_brokers({})
+    assert [b["brokerId"] for b in json.loads(east_list_body)["brokerSummaries"]] == [
+        east_broker_id
+    ]
+    assert service._create_broker(_regional_broker_body(broker_name))[0] == 409
+
+
+def test_mq_legacy_state_follows_parent_broker_region(isolated_mq_module_state):
+    from ministack.core.responses import AccountScopedDict
+
+    service = isolated_mq_module_state
+    account_id = "111111111111"
+    broker_id = "legacy-broker-id"
+    broker_name = "legacy-broker"
+    broker_arn = f"arn:aws:mq:us-west-2:{account_id}:broker:{broker_id}"
+
+    brokers = AccountScopedDict()
+    brokers.set_scoped(account_id, "ignored", broker_id, {
+        "brokerId": broker_id,
+        "brokerName": broker_name,
+        "brokerArn": broker_arn,
+    })
+    name_index = AccountScopedDict()
+    name_index.set_scoped(account_id, "ignored", broker_name, broker_id)
+    tags = AccountScopedDict()
+    tags.set_scoped(account_id, "ignored", broker_arn, {"env": "legacy"})
+    users = AccountScopedDict()
+    users.set_scoped(account_id, "ignored", broker_id, {
+        "legacy-user": {"username": "legacy-user"}
+    })
+
+    service.restore_state({
+        "brokers": brokers,
+        "name_index": name_index,
+        "tags": tags,
+        "users": users,
+    })
+
+    assert service._brokers.get_scoped(account_id, "us-west-2", broker_id) is not None
+    assert service._brokers.get_scoped(account_id, "us-east-1", broker_id) is None
+    assert service._name_index.get_scoped(account_id, "us-west-2", broker_name) == broker_id
+    assert "legacy-user" in service._users.get_scoped(account_id, "us-west-2", broker_id)
+    assert service._tags.get_scoped(account_id, "ignored", broker_arn) == {"env": "legacy"}
+
+
+def test_mq_legacy_orphaned_users_are_dropped(isolated_mq_module_state):
+    from ministack.core.responses import AccountScopedDict
+
+    service = isolated_mq_module_state
+    account_id = "111111111111"
+    users = AccountScopedDict()
+    users.set_scoped(account_id, "ignored", "missing-broker-id", {
+        "orphaned-user": {"username": "orphaned-user"}
+    })
+
+    service.restore_state({"users": users})
+
+    assert not service._users.has_any()
+
+
+def test_mq_reset_clears_all_regions(isolated_mq_module_state):
+    from ministack.core.responses import set_request_region
+
+    service = isolated_mq_module_state
+    assert service._create_broker(_regional_broker_body("east-broker"))[0] == 200
+    set_request_region("us-west-2")
+    assert service._create_broker(_regional_broker_body("west-broker"))[0] == 200
+
+    service.reset()
+
+    assert not service._brokers.has_any()
+    assert not service._name_index.has_any()
+    assert not service._users.has_any()
+    assert service._tags._data == {}

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1909,6 +1909,40 @@ def test_codebuild_region_scoped_state_is_rejected_by_v2_reader(
     assert persistence.load_state("codebuild") is None
 
 
+def test_mq_region_scoped_state_is_rejected_by_v2_reader(monkeypatch, tmp_path):
+    """A rollback binary must reject MQ's regional schema instead of
+    accepting it as v2 and silently dropping every regional store."""
+    import json as _json
+
+    from ministack.core.responses import AccountRegionScopedDict
+
+    monkeypatch.setattr(persistence, "PERSIST_STATE", True)
+    monkeypatch.setattr(persistence, "STATE_DIR", str(tmp_path))
+
+    brokers = AccountRegionScopedDict()
+    brokers.set_scoped(
+        "000000000000",
+        "us-west-2",
+        "regional-broker",
+        {
+            "brokerArn": (
+                "arn:aws:mq:us-west-2:000000000000:broker:regional-broker"
+            )
+        },
+    )
+    persistence.save_state("mq", {"brokers": brokers})
+
+    raw = _json.loads((tmp_path / "mq.json").read_text())
+    assert raw["__ministack_format__"] == 3
+    loaded_brokers = persistence.load_state("mq")["brokers"]
+    assert loaded_brokers.get_scoped(
+        "000000000000", "us-west-2", "regional-broker"
+    )["brokerArn"].endswith("broker:regional-broker")
+
+    monkeypatch.setattr(persistence, "SERVICE_STATE_FORMAT_VERSIONS", {})
+    assert persistence.load_state("mq") is None
+
+
 def test_ses_region_scoped_state_is_rejected_by_v2_reader(monkeypatch, tmp_path):
     """A rollback binary must reject both SES persistence files after their
     stores become regional instead of accepting v2 and restoring them empty."""


### PR DESCRIPTION
## Why
AWS MQ brokers and users are regional, but MiniStack currently shares them across regions within an account, causing same-name collisions and cross-region list leakage.

## What
- Scope brokers, broker-name indexes, and broker users by account and region while keeping ARN-keyed tags account-scoped
- Rebuild region-less legacy name and user indexes beside each ARN-derived parent broker, dropping corrupt orphaned user maps without a parent
- Version MQ persistence so older binaries refuse incompatible regional snapshots
- Add regional collision/list isolation, legacy migration, orphan handling, reset, and rollback-safety coverage

## Risk Assessment
Low — the change is isolated to MQ state storage and retains legacy snapshot compatibility.

## Validation

* `uv run --extra dev ruff check ministack/core/persistence.py ministack/services/mq.py tests/test_mq.py`
* `uv run --extra dev pytest tests/test_mq.py -q` with local MiniStack server (`103 passed`)
* `uv run --extra dev pytest tests/test_persistence.py -q` (`170 passed`)
