### PR TITLE
Scope Cloud Map state by region

### DIFF
--- a/ministack/core/persistence.py
+++ b/ministack/core/persistence.py
@@ -31,6 +31,7 @@ SERVICE_STATE_FORMAT_VERSIONS = {
     "ecs": 3,
     "resource_groups": 3,
     "codebuild": 3,
+    "servicediscovery": 3,
     "ses": 3,
     "ses_v2": 3,
 }

--- a/ministack/services/servicediscovery.py
+++ b/ministack/services/servicediscovery.py
@@ -12,6 +12,7 @@ import xml.etree.ElementTree as ET
 
 from ministack.core.arn import ArnParseError, parse_arn
 from ministack.core.responses import (
+    AccountRegionScopedDict,
     AccountScopedDict,
     error_response_json,
     get_account_id,
@@ -25,15 +26,16 @@ logger = logging.getLogger("servicediscovery")
 
 REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 
-# In-memory state
-_namespaces = AccountScopedDict()     # ns_id -> namespace dict
-_services = AccountScopedDict()       # svc_id -> service dict
-_instances = AccountScopedDict()      # svc_id -> {instance_id -> instance dict}
-_operations = AccountScopedDict()     # op_id -> operation dict
-_resource_tags = AccountScopedDict()  # resource_arn -> [{"Key": ..., "Value": ...}]
-_service_attributes = AccountScopedDict()      # svc_id -> {key: value}
-_instance_health_status = AccountScopedDict()  # svc_id -> {instance_id: status}
-_instances_revision = AccountScopedDict()      # svc_id -> int
+# In-memory state. Resource and child stores are regional. ARN-keyed tags stay
+# account-scoped because the resource ARN already includes its region.
+_namespaces = AccountRegionScopedDict()     # ns_id -> namespace dict
+_services = AccountRegionScopedDict()       # svc_id -> service dict
+_instances = AccountRegionScopedDict()      # svc_id -> {instance_id -> instance dict}
+_operations = AccountRegionScopedDict()     # op_id -> operation dict
+_resource_tags = AccountScopedDict()        # resource_arn -> [{"Key": ..., "Value": ...}]
+_service_attributes = AccountRegionScopedDict()      # svc_id -> {key: value}
+_instance_health_status = AccountRegionScopedDict()  # svc_id -> {instance_id: status}
+_instances_revision = AccountRegionScopedDict()      # svc_id -> int
 
 
 def get_state():
@@ -49,17 +51,65 @@ def get_state():
     }
 
 
+def _restore_regional_store(target, saved, region_for_value=None):
+    if isinstance(saved, AccountRegionScopedDict):
+        target.update(saved)
+        return
+
+    if isinstance(saved, AccountScopedDict):
+        saved_items = saved._data.items()
+    else:
+        account_id = get_account_id()
+        saved_items = (((account_id, key), value) for key, value in saved.items())
+
+    for (account_id, key), value in saved_items:
+        region = region_for_value(account_id, key, value) if region_for_value else None
+        region = region or target._region_for_legacy_value(key, value)
+        target.set_scoped(account_id, region, key, value)
+
+
 def load_persisted_state(data):
     if not data:
         return
     _namespaces.update(data.get("namespaces", {}))
     _services.update(data.get("services", {}))
-    _instances.update(data.get("instances", {}))
-    _operations.update(data.get("operations", {}))
+
+    namespace_regions = {
+        (account_id, namespace_id): region
+        for (account_id, region, namespace_id), _namespace in _namespaces.all_items()
+    }
+    service_regions = {
+        (account_id, service_id): region
+        for (account_id, region, service_id), _service in _services.all_items()
+    }
+
+    def service_region(account_id, service_id, _value):
+        return service_regions.get((account_id, service_id))
+
+    def operation_region(account_id, _operation_id, operation):
+        targets = operation.get("Targets", {})
+        service_id = targets.get("SERVICE")
+        namespace_id = targets.get("NAMESPACE")
+        return service_regions.get((account_id, service_id)) or namespace_regions.get(
+            (account_id, namespace_id)
+        )
+
+    # Legacy child records have no ARN of their own. Keep them beside their
+    # migrated parent service instead of assigning them to the boot region.
+    _restore_regional_store(_instances, data.get("instances", {}), service_region)
+    _restore_regional_store(_operations, data.get("operations", {}), operation_region)
     _resource_tags.update(data.get("resource_tags", {}))
-    _service_attributes.update(data.get("service_attributes", {}))
-    _instance_health_status.update(data.get("instance_health_status", {}))
-    _instances_revision.update(data.get("instances_revision", {}))
+    _restore_regional_store(
+        _service_attributes, data.get("service_attributes", {}), service_region
+    )
+    _restore_regional_store(
+        _instance_health_status,
+        data.get("instance_health_status", {}),
+        service_region,
+    )
+    _restore_regional_store(
+        _instances_revision, data.get("instances_revision", {}), service_region
+    )
 
 
 def reset():

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1909,6 +1909,43 @@ def test_codebuild_region_scoped_state_is_rejected_by_v2_reader(
     assert persistence.load_state("codebuild") is None
 
 
+def test_servicediscovery_region_scoped_state_is_rejected_by_v2_reader(
+    monkeypatch, tmp_path
+):
+    """A rollback binary must reject Cloud Map's regional schema instead of
+    accepting it as v2 and silently dropping every regional store."""
+    import json as _json
+
+    from ministack.core.responses import AccountRegionScopedDict
+
+    monkeypatch.setattr(persistence, "PERSIST_STATE", True)
+    monkeypatch.setattr(persistence, "STATE_DIR", str(tmp_path))
+
+    namespaces = AccountRegionScopedDict()
+    namespaces.set_scoped(
+        "000000000000",
+        "us-west-2",
+        "ns-regional",
+        {
+            "Arn": (
+                "arn:aws:servicediscovery:us-west-2:000000000000:"
+                "namespace/ns-regional"
+            )
+        },
+    )
+    persistence.save_state("servicediscovery", {"namespaces": namespaces})
+
+    raw = _json.loads((tmp_path / "servicediscovery.json").read_text())
+    assert raw["__ministack_format__"] == 3
+    loaded_namespaces = persistence.load_state("servicediscovery")["namespaces"]
+    assert loaded_namespaces.get_scoped(
+        "000000000000", "us-west-2", "ns-regional"
+    )["Arn"].endswith("namespace/ns-regional")
+
+    monkeypatch.setattr(persistence, "SERVICE_STATE_FORMAT_VERSIONS", {})
+    assert persistence.load_state("servicediscovery") is None
+
+
 def test_ses_region_scoped_state_is_rejected_by_v2_reader(monkeypatch, tmp_path):
     """A rollback binary must reject both SES persistence files after their
     stores become regional instead of accepting v2 and restoring them empty."""

--- a/tests/test_servicediscovery.py
+++ b/tests/test_servicediscovery.py
@@ -1,3 +1,4 @@
+import asyncio
 import io
 import json
 import os
@@ -480,3 +481,195 @@ def test_servicediscovery_tag_apis_reject_missing_local_resources(resource_arn, 
         assert body["__type"] == expected_error
 
     assert sd_svc._resource_tags.get(resource_arn) is None
+
+
+def _create_http_namespace_direct(name, tags=None):
+    status, _, body = _json_result(
+        asyncio.run(
+            sd_svc._create_namespace(
+                {
+                    "Name": name,
+                    "Tags": tags or [],
+                    "_action": "CreateHttpNamespace",
+                }
+            )
+        )
+    )
+    assert status == 200
+    operation = _json_result(
+        sd_svc._get_operation({"OperationId": body["OperationId"]})
+    )[2]["Operation"]
+    return operation["Targets"]["NAMESPACE"]
+
+
+def _create_service_direct(namespace_id, name):
+    status, _, body = _json_result(
+        sd_svc._create_service({"NamespaceId": namespace_id, "Name": name})
+    )
+    assert status == 200
+    return body["Service"]["Id"]
+
+
+def test_servicediscovery_state_is_isolated_by_region():
+    from ministack.core.responses import set_request_region
+
+    namespace_name = "shared-http-namespace"
+    service_name = "shared-service"
+
+    east_namespace_id = _create_http_namespace_direct(
+        namespace_name, [{"Key": "region", "Value": "east"}]
+    )
+    east_service_id = _create_service_direct(east_namespace_id, service_name)
+    assert _json_result(
+        sd_svc._register_instance(
+            {
+                "ServiceId": east_service_id,
+                "InstanceId": "shared-instance",
+                "Attributes": {"AWS_INSTANCE_IPV4": "10.0.0.1"},
+            }
+        )
+    )[0] == 200
+    east_operation_ids = set(sd_svc._operations.keys())
+
+    set_request_region("us-west-2")
+    west_namespace_id = _create_http_namespace_direct(
+        namespace_name, [{"Key": "region", "Value": "west"}]
+    )
+    west_service_id = _create_service_direct(west_namespace_id, service_name)
+    assert _json_result(
+        sd_svc._register_instance(
+            {
+                "ServiceId": west_service_id,
+                "InstanceId": "shared-instance",
+                "Attributes": {"AWS_INSTANCE_IPV4": "10.0.0.2"},
+            }
+        )
+    )[0] == 200
+    west_operation_ids = set(sd_svc._operations.keys())
+
+    assert _json_result(sd_svc._list_namespaces({}))[2]["Namespaces"] == [
+        sd_svc._namespaces[west_namespace_id]
+    ]
+    assert _json_result(sd_svc._list_services({}))[2]["Services"] == [
+        sd_svc._services[west_service_id]
+    ]
+    listed_west_operation_ids = {
+        operation["Id"]
+        for operation in _json_result(sd_svc._list_operations({}))[2]["Operations"]
+    }
+    assert listed_west_operation_ids == west_operation_ids
+    assert listed_west_operation_ids.isdisjoint(east_operation_ids)
+    assert _json_result(sd_svc._get_namespace({"Id": east_namespace_id}))[0] == 404
+    assert _json_result(sd_svc._get_service({"Id": east_service_id}))[0] == 404
+    assert _json_result(
+        sd_svc._get_instance(
+            {"ServiceId": east_service_id, "InstanceId": "shared-instance"}
+        )
+    )[0] == 404
+
+    set_request_region("us-east-1")
+    assert _json_result(sd_svc._list_namespaces({}))[2]["Namespaces"] == [
+        sd_svc._namespaces[east_namespace_id]
+    ]
+    assert _json_result(
+        asyncio.run(sd_svc._create_namespace({"Name": namespace_name}))
+    )[0] == 409
+
+
+def test_servicediscovery_legacy_children_follow_parent_service_region():
+    from ministack.core.responses import AccountScopedDict
+
+    account_id = "000000000000"
+    region = "us-west-2"
+    namespace_id = "ns-legacy"
+    service_id = "srv-legacy"
+    operation_id = "op-legacy"
+    namespace_arn = (
+        f"arn:aws:servicediscovery:{region}:{account_id}:namespace/{namespace_id}"
+    )
+    service_arn = (
+        f"arn:aws:servicediscovery:{region}:{account_id}:service/{service_id}"
+    )
+
+    def legacy_store(key, value):
+        store = AccountScopedDict()
+        store.set_scoped(account_id, "ignored", key, value)
+        return store
+
+    sd_svc.load_persisted_state(
+        {
+            "namespaces": legacy_store(
+                namespace_id,
+                {"Id": namespace_id, "Arn": namespace_arn, "Name": "legacy.local"},
+            ),
+            "services": legacy_store(
+                service_id,
+                {
+                    "Id": service_id,
+                    "Arn": service_arn,
+                    "Name": "legacy-service",
+                    "NamespaceId": namespace_id,
+                },
+            ),
+            "instances": legacy_store(
+                service_id, {"instance-1": {"Id": "instance-1"}}
+            ),
+            "operations": legacy_store(
+                operation_id,
+                {
+                    "Id": operation_id,
+                    "Targets": {"SERVICE": service_id},
+                    "Status": "SUCCESS",
+                },
+            ),
+            "resource_tags": legacy_store(
+                service_arn, [{"Key": "legacy", "Value": "true"}]
+            ),
+            "service_attributes": legacy_store(service_id, {"team": "legacy"}),
+            "instance_health_status": legacy_store(
+                service_id, {"instance-1": "HEALTHY"}
+            ),
+            "instances_revision": legacy_store(service_id, 7),
+        }
+    )
+
+    for store in (
+        sd_svc._services,
+        sd_svc._instances,
+        sd_svc._service_attributes,
+        sd_svc._instance_health_status,
+        sd_svc._instances_revision,
+    ):
+        assert store.get_scoped(account_id, region, service_id) is not None
+        assert store.get_scoped(account_id, "us-east-1", service_id) is None
+    assert sd_svc._namespaces.get_scoped(account_id, region, namespace_id) is not None
+    assert sd_svc._operations.get_scoped(account_id, region, operation_id) is not None
+    assert sd_svc._resource_tags.get_scoped(account_id, "ignored", service_arn) == [
+        {"Key": "legacy", "Value": "true"}
+    ]
+
+
+def test_servicediscovery_reset_clears_all_regions():
+    from ministack.core.responses import set_request_region
+
+    regional_stores = (
+        sd_svc._namespaces,
+        sd_svc._services,
+        sd_svc._instances,
+        sd_svc._operations,
+        sd_svc._service_attributes,
+        sd_svc._instance_health_status,
+        sd_svc._instances_revision,
+    )
+    for region in ("us-east-1", "us-west-2"):
+        set_request_region(region)
+        for store in regional_stores:
+            store[f"key-{region}"] = {}
+        sd_svc._resource_tags[
+            f"arn:aws:servicediscovery:{region}:000000000000:service/key-{region}"
+        ] = []
+
+    sd_svc.reset()
+
+    assert all(not store.has_any() for store in regional_stores)
+    assert sd_svc._resource_tags._data == {}


### PR DESCRIPTION
## Why
AWS Cloud Map namespaces, services, and instances are regional, but MiniStack currently shares them across regions within an account, causing same-name collisions and cross-region list leakage.

## What
- Scope Cloud Map resources, child state, operations, attributes, health, and revision state by account and region while keeping ARN-keyed tags account-scoped
- Restore region-less legacy child records beside their ARN-derived parent namespace or service
- Version Cloud Map persistence so older binaries refuse incompatible regional snapshots
- Add regional collision/list isolation, legacy migration, reset, and rollback-safety coverage

## Risk Assessment
Low — the change is isolated to Cloud Map state storage and retains legacy snapshot compatibility.

## Validation

* `uv run --extra dev ruff check ministack/core/persistence.py ministack/services/servicediscovery.py tests/test_servicediscovery.py`
* `uv run --extra dev pytest tests/test_servicediscovery.py -q` with local MiniStack server (`23 passed`)
* `uv run --extra dev pytest tests/test_persistence.py -q` (`170 passed`)
