### PR TITLE
Scope AppSync state by region

### DIFF
--- a/ministack/core/persistence.py
+++ b/ministack/core/persistence.py
@@ -27,6 +27,7 @@ STATE_DIR = os.environ.get("STATE_DIR", "/tmp/ministack-state")
 # still load and migrate. (U4)
 STATE_FORMAT_VERSION = 2
 SERVICE_STATE_FORMAT_VERSIONS = {
+    "appsync": 3,
     "batch": 3,
     "ecs": 3,
     "resource_groups": 3,

--- a/ministack/services/appsync.py
+++ b/ministack/services/appsync.py
@@ -27,12 +27,14 @@ import time
 from ministack.core.arn import ArnParseError, parse_arn
 from ministack.core.persistence import PERSIST_STATE, load_state
 from ministack.core.responses import (
+    AccountRegionScopedDict,
     AccountScopedDict,
     error_response_json,
     get_account_id,
     get_region,
     json_response,
     new_uuid,
+    set_request_region,
 )
 
 logger = logging.getLogger("appsync")
@@ -43,11 +45,11 @@ REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 # In-memory state
 # ---------------------------------------------------------------------------
 
-_apis = AccountScopedDict()            # apiId -> api record
-_api_keys = AccountScopedDict()        # apiId -> {keyId -> key record}
-_data_sources = AccountScopedDict()    # apiId -> {name -> data source record}
-_resolvers = AccountScopedDict()       # apiId -> {typeName -> {fieldName -> resolver record}}
-_types = AccountScopedDict()           # apiId -> {typeName -> type record}
+_apis = AccountRegionScopedDict()            # apiId -> api record
+_api_keys = AccountRegionScopedDict()        # apiId -> {keyId -> key record}
+_data_sources = AccountRegionScopedDict()    # apiId -> {name -> data source record}
+_resolvers = AccountRegionScopedDict()       # apiId -> {typeName -> {fieldName -> resolver record}}
+_types = AccountRegionScopedDict()           # apiId -> {typeName -> type record}
 _tags = AccountScopedDict()            # resource_arn -> {key: value}
 
 # ---------------------------------------------------------------------------
@@ -96,6 +98,39 @@ def _validate_tag_resource_arn(arn):
     if not api or api.get("arn") != arn:
         return error_response_json("NotFoundException", f"GraphQL API {api_id or arn} not found", 404)
     return None
+
+
+def _select_api_region(api_id):
+    """Select the unique stored region for an unsigned GraphQL data request."""
+    if api_id in _apis:
+        return True
+
+    account_id = get_account_id()
+    matches = [
+        region
+        for (stored_account, region, stored_api_id), _api in _apis.all_items()
+        if stored_account == account_id and stored_api_id == api_id
+    ]
+    if len(matches) != 1:
+        return False
+    set_request_region(matches[0])
+    return True
+
+
+def _has_sigv4_credentials(headers, query_params):
+    """Return whether the data request carries an explicit SigV4 region."""
+    query_params = query_params or {}
+    auth = headers.get("authorization") or headers.get("Authorization") or ""
+    if auth.startswith("AWS4-HMAC-SHA256") and "Credential=" in auth:
+        return True
+
+    credential = (
+        query_params.get("X-Amz-Credential")
+        or query_params.get("x-amz-credential")
+    )
+    if isinstance(credential, (list, tuple)):
+        credential = credential[0] if credential else ""
+    return bool(credential)
 
 
 def _json(status, body):
@@ -537,7 +572,10 @@ async def handle_request(method, path, headers, body, query_params):
     # GraphQL data plane: POST /graphql or POST /v1/apis/{apiId}/graphql
     if path == "/graphql" and method == "POST":
         api_key = headers.get("x-api-key", "")
-        api_id = _resolve_api_by_key(api_key)
+        api_id = _resolve_api_by_key(
+            api_key,
+            allow_cross_region=not _has_sigv4_credentials(headers, query_params),
+        )
         if not api_id:
             return error_response_json("UnauthorizedException", "Valid API key required", 401)
         data = json.loads(body) if body else {}
@@ -547,6 +585,8 @@ async def handle_request(method, path, headers, body, query_params):
         parts = path.split("/")
         if len(parts) >= 5:
             api_id = parts[3]
+            if not _has_sigv4_credentials(headers, query_params):
+                _select_api_region(api_id)
             data = json.loads(body) if body else {}
             return _execute_graphql(api_id, data, request_headers=headers)
 
@@ -676,12 +716,40 @@ def get_state():
 
 def restore_state(data):
     """Restore state from persisted data."""
+    reset()
     _apis.update(data.get("apis", {}))
-    _api_keys.update(data.get("api_keys", {}))
-    _data_sources.update(data.get("data_sources", {}))
-    _resolvers.update(data.get("resolvers", {}))
-    _types.update(data.get("types", {}))
+    api_regions = {
+        (account_id, api_id): region
+        for (account_id, region, api_id), _api in _apis.all_items()
+    }
+    for store, key in (
+        (_api_keys, "api_keys"),
+        (_data_sources, "data_sources"),
+        (_resolvers, "resolvers"),
+        (_types, "types"),
+    ):
+        _restore_api_child_store(store, data.get(key, {}), api_regions)
     _tags.update(data.get("tags", {}))
+
+
+def _restore_api_child_store(store, restored, api_regions):
+    """Adopt legacy API children into their parent GraphQL API's region."""
+    if isinstance(restored, AccountRegionScopedDict):
+        store.update(restored)
+        return
+
+    if isinstance(restored, AccountScopedDict):
+        items = restored._data.items()
+    else:
+        account_id = get_account_id()
+        items = (((account_id, api_id), value) for api_id, value in restored.items())
+
+    for (account_id, api_id), value in items:
+        region = api_regions.get(
+            (account_id, api_id),
+            store._region_for_legacy_value(api_id, value),
+        )
+        store.set_scoped(account_id, region, api_id, value)
 
 
 # ---------------------------------------------------------------------------
@@ -698,15 +766,39 @@ _GQL_OP_RE = _re.compile(
 _GQL_FIELD_RE = _re.compile(r'(\w+)\s*(?:\(([^)]*)\))?\s*(?:\{([^}]*)\})?')
 
 
-def _resolve_api_by_key(api_key_value):
+def _resolve_api_by_key(api_key_value, allow_cross_region=True):
     """Find the API ID that owns this API key."""
     for api_id, keys in _api_keys.items():
         for kid, key in keys.items():
             if kid == api_key_value or key.get("id") == api_key_value:
                 return api_id
-    # Fallback: if only one API exists, use it
-    if len(_apis) == 1:
-        return next(iter(_apis))
+
+    if not allow_cross_region:
+        # Signed requests may use the sole API in their credential region,
+        # but must not discover an API stored in another region.
+        if len(_apis) == 1:
+            return next(iter(_apis))
+        return None
+
+    account_id = get_account_id()
+    for (stored_account, region, api_id), keys in _api_keys.all_items():
+        if stored_account != account_id:
+            continue
+        for kid, key in keys.items():
+            if kid == api_key_value or key.get("id") == api_key_value:
+                set_request_region(region)
+                return api_id
+
+    # Fallback: if only one API exists in this account, use its region.
+    matches = [
+        (region, api_id)
+        for (stored_account, region, api_id), _api in _apis.all_items()
+        if stored_account == account_id
+    ]
+    if len(matches) == 1:
+        region, api_id = matches[0]
+        set_request_region(region)
+        return api_id
     return None
 
 
@@ -966,6 +1058,18 @@ def _resolve_field(api_id, resolver, args, sub_fields, variables,
 
 
 def _resolve_dynamodb(data_source, resolver, args, sub_fields):
+    """Execute a DynamoDB resolver in the data source's configured region."""
+    config = data_source.get("dynamodbConfig", {})
+    request_region = get_region()
+    data_source_region = config.get("awsRegion") or request_region
+    set_request_region(data_source_region)
+    try:
+        return _resolve_dynamodb_in_region(data_source, resolver, args, sub_fields)
+    finally:
+        set_request_region(request_region)
+
+
+def _resolve_dynamodb_in_region(data_source, resolver, args, sub_fields):
     """Execute a DynamoDB resolver — auto-detect operation from field name and args."""
     import ministack.services.dynamodb as _ddb
 

--- a/ministack/services/tagging.py
+++ b/ministack/services/tagging.py
@@ -166,6 +166,12 @@ def _collect_cognito():
 def _collect_appsync():
     import ministack.services.appsync as svc
     for arn, tags in svc._tags.items():
+        try:
+            spec = parse_arn(arn)
+        except ArnParseError:
+            continue
+        if spec.region != get_region():
+            continue
         yield arn, _normalise_flat(tags)
 
 

--- a/tests/test_appsync.py
+++ b/tests/test_appsync.py
@@ -5,12 +5,23 @@ import time
 import urllib.request
 import uuid as _uuid_mod
 import zipfile
-from urllib.parse import urlparse
+from urllib.parse import quote, urlparse
 
+import boto3
 import pytest
 from botocore.exceptions import ClientError
 
 _ENDPOINT = "http://localhost:4566"
+
+
+def _client(region):
+    return boto3.client(
+        "appsync",
+        endpoint_url=_ENDPOINT,
+        region_name=region,
+        aws_access_key_id="test",
+        aws_secret_access_key="test",
+    )
 
 
 def test_appsync_create_and_list_api():
@@ -25,6 +36,245 @@ def test_appsync_create_and_list_api():
 
     apis = appsync.list_graphql_apis()["graphqlApis"]
     assert any(a["apiId"] == api["apiId"] for a in apis)
+
+
+def test_appsync_graphql_apis_are_region_scoped():
+    east = _client("us-east-1")
+    west = _client("us-west-2")
+    east_api = east.create_graphql_api(
+        name="regional-api-east", authenticationType="API_KEY"
+    )["graphqlApi"]
+    west_api = west.create_graphql_api(
+        name="regional-api-west", authenticationType="API_KEY"
+    )["graphqlApi"]
+
+    try:
+        east_ids = {api["apiId"] for api in east.list_graphql_apis()["graphqlApis"]}
+        west_ids = {api["apiId"] for api in west.list_graphql_apis()["graphqlApis"]}
+        assert east_api["apiId"] in east_ids
+        assert east_api["apiId"] not in west_ids
+        assert west_api["apiId"] in west_ids
+        assert west_api["apiId"] not in east_ids
+        assert ":us-east-1:" in east_api["arn"]
+        assert ":us-west-2:" in west_api["arn"]
+
+        # Local data-plane URLs do not encode or sign a region. The API ID
+        # must select its stored region before resolver execution.
+        west_graphql = _appsync_graphql_post(
+            f"{_ENDPOINT}/v1/apis/{west_api['apiId']}/graphql",
+            "{ __typename }",
+        )
+        assert "errors" not in west_graphql
+    finally:
+        east.delete_graphql_api(apiId=east_api["apiId"])
+        west.delete_graphql_api(apiId=west_api["apiId"])
+
+
+@pytest.mark.parametrize("credential_location", ["header", "query"])
+def test_appsync_signed_graphql_request_preserves_region(credential_location):
+    east = _client("us-east-1")
+    api = east.create_graphql_api(
+        name=f"signed-region-{credential_location}", authenticationType="API_KEY"
+    )["graphqlApi"]
+    url = f"{_ENDPOINT}/v1/apis/{api['apiId']}/graphql"
+    headers = {}
+    credential = "test/20260722/us-west-2/appsync/aws4_request"
+    if credential_location == "header":
+        headers["Authorization"] = (
+            f"AWS4-HMAC-SHA256 Credential={credential}, "
+            "SignedHeaders=host;x-amz-date, Signature=fake"
+        )
+    else:
+        url = f"{url}?X-Amz-Credential={quote(credential, safe='')}"
+
+    try:
+        with pytest.raises(urllib.error.HTTPError) as exc:
+            _appsync_graphql_post(url, "{ __typename }", headers=headers)
+        assert exc.value.code == 404
+    finally:
+        east.delete_graphql_api(apiId=api["apiId"])
+
+
+@pytest.mark.parametrize("api_selector", ["api_key", "single_api_fallback"])
+def test_appsync_signed_root_graphql_request_preserves_region(api_selector):
+    east = _client("us-east-1")
+    api = east.create_graphql_api(
+        name=f"signed-root-region-{api_selector}",
+        authenticationType="API_KEY" if api_selector == "api_key" else "AWS_IAM",
+    )["graphqlApi"]
+    url = f"{_ENDPOINT}/graphql"
+    headers = {
+        "Host": f"{api['apiId']}.appsync-api.us-east-1.localhost:4566",
+        "Authorization": (
+            "AWS4-HMAC-SHA256 "
+            "Credential=test/20260722/us-west-2/appsync/aws4_request, "
+            "SignedHeaders=host;x-amz-date, Signature=fake"
+        ),
+    }
+    if api_selector == "api_key":
+        headers["x-api-key"] = east.create_api_key(apiId=api["apiId"])["apiKey"]["id"]
+
+    try:
+        with pytest.raises(urllib.error.HTTPError) as exc:
+            _appsync_graphql_post(url, "{ __typename }", headers=headers)
+        assert exc.value.code == 401
+    finally:
+        east.delete_graphql_api(apiId=api["apiId"])
+
+
+def test_appsync_signed_root_graphql_request_uses_current_region_fallback():
+    west = _client("us-west-2")
+    api = west.create_graphql_api(
+        name="signed-root-current-region-fallback",
+        authenticationType="AWS_IAM",
+    )["graphqlApi"]
+    headers = {
+        "Host": f"{api['apiId']}.appsync-api.us-west-2.localhost:4566",
+        "Authorization": (
+            "AWS4-HMAC-SHA256 "
+            "Credential=test/20260722/us-west-2/appsync/aws4_request, "
+            "SignedHeaders=host;x-amz-date, Signature=fake"
+        ),
+    }
+
+    try:
+        response = _appsync_graphql_post(
+            f"{_ENDPOINT}/graphql",
+            "{ __typename }",
+            headers=headers,
+        )
+        assert "errors" not in response
+    finally:
+        west.delete_graphql_api(apiId=api["apiId"])
+
+
+def test_appsync_graphql_honors_dynamodb_data_source_region():
+    east_ddb = boto3.client(
+        "dynamodb",
+        endpoint_url=_ENDPOINT,
+        region_name="us-east-1",
+        aws_access_key_id="test",
+        aws_secret_access_key="test",
+    )
+    west_appsync = _client("us-west-2")
+    table_name = f"appsync-cross-region-{_uuid_mod.uuid4().hex[:12]}"
+    east_ddb.create_table(
+        TableName=table_name,
+        KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
+        AttributeDefinitions=[{"AttributeName": "id", "AttributeType": "S"}],
+        BillingMode="PAY_PER_REQUEST",
+    )
+    east_ddb.put_item(
+        TableName=table_name,
+        Item={"id": {"S": "item-1"}, "name": {"S": "East item"}},
+    )
+    api = west_appsync.create_graphql_api(
+        name="cross-region-ddb", authenticationType="API_KEY"
+    )["graphqlApi"]
+    west_appsync.create_data_source(
+        apiId=api["apiId"],
+        name="east-table",
+        type="AMAZON_DYNAMODB",
+        dynamodbConfig={"tableName": table_name, "awsRegion": "us-east-1"},
+    )
+    west_appsync.create_resolver(
+        apiId=api["apiId"],
+        typeName="Query",
+        fieldName="getItem",
+        dataSourceName="east-table",
+    )
+
+    try:
+        response = _appsync_graphql_post(
+            f"{_ENDPOINT}/v1/apis/{api['apiId']}/graphql",
+            'query { getItem(id: "item-1") { id name } }',
+        )
+        assert response["data"]["getItem"] == {
+            "id": "item-1",
+            "name": "East item",
+        }
+    finally:
+        west_appsync.delete_graphql_api(apiId=api["apiId"])
+        east_ddb.delete_table(TableName=table_name)
+
+
+def test_appsync_legacy_children_restore_beside_parent_api():
+    from ministack.core.responses import (
+        AccountScopedDict,
+        get_account_id,
+        get_region,
+        set_request_account_id,
+        set_request_region,
+    )
+    from ministack.services import appsync as service
+
+    original_account = get_account_id()
+    original_region = get_region()
+    account_id = "111111111111"
+    boot_region = "us-east-1"
+    api_region = "us-west-2"
+    api_id = "legacy-api"
+    apis = AccountScopedDict()
+    tags = AccountScopedDict()
+
+    set_request_account_id(account_id)
+    set_request_region(boot_region)
+    api_arn = f"arn:aws:appsync:{api_region}:{account_id}:apis/{api_id}"
+    apis[api_id] = {"apiId": api_id, "arn": api_arn}
+    tags[api_arn] = {"legacy": "true"}
+    payload = {"apis": apis, "tags": tags}
+    for key in ("api_keys", "data_sources", "resolvers", "types"):
+        children = AccountScopedDict()
+        children[api_id] = {"legacy": key}
+        payload[key] = children
+
+    service.reset()
+    try:
+        service.restore_state(payload)
+        assert service._apis.get_scoped(account_id, api_region, api_id)["arn"] == api_arn
+        for store in (
+            service._api_keys,
+            service._data_sources,
+            service._resolvers,
+            service._types,
+        ):
+            assert store.get_scoped(account_id, api_region, api_id) is not None
+            assert store.get_scoped(account_id, boot_region, api_id) is None
+        assert service._tags.get(api_arn) == {"legacy": "true"}
+    finally:
+        service.reset()
+        set_request_account_id(original_account)
+        set_request_region(original_region)
+
+
+def test_appsync_reset_clears_all_regions():
+    from ministack.core.responses import get_region, set_request_region
+    from ministack.services import appsync as service
+
+    original_region = get_region()
+    regional_stores = (
+        service._apis,
+        service._api_keys,
+        service._data_sources,
+        service._resolvers,
+        service._types,
+    )
+    service.reset()
+    try:
+        for region in ("us-east-1", "us-west-2"):
+            set_request_region(region)
+            for store in regional_stores:
+                store[f"resource-{region}"] = {"region": region}
+        service._tags["arn:aws:appsync:us-east-1:000000000000:apis/tagged"] = {
+            "tag": "value"
+        }
+
+        service.reset()
+        assert all(not store.has_any() for store in regional_stores)
+        assert not service._tags._data
+    finally:
+        service.reset()
+        set_request_region(original_region)
 
 def test_appsync_get_and_delete_api():
     from conftest import make_client

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1832,6 +1832,42 @@ def test_ecs_region_scoped_state_is_rejected_by_v2_reader(monkeypatch, tmp_path)
     assert persistence.load_state("ecs") is None
 
 
+def test_appsync_region_scoped_state_is_rejected_by_v2_reader(
+    monkeypatch, tmp_path
+):
+    """A rollback binary must reject AppSync's regional schema instead of
+    accepting it as v2 and silently dropping every regional store."""
+    import json as _json
+
+    from ministack.core.responses import AccountRegionScopedDict
+
+    monkeypatch.setattr(persistence, "PERSIST_STATE", True)
+    monkeypatch.setattr(persistence, "STATE_DIR", str(tmp_path))
+
+    apis = AccountRegionScopedDict()
+    apis.set_scoped(
+        "000000000000",
+        "us-west-2",
+        "regional-api",
+        {
+            "apiId": "regional-api",
+            "arn": "arn:aws:appsync:us-west-2:000000000000:apis/regional-api",
+        },
+    )
+    persistence.save_state("appsync", {"apis": apis})
+
+    raw = _json.loads((tmp_path / "appsync.json").read_text())
+    assert raw["__ministack_format__"] == 3
+    loaded_apis = persistence.load_state("appsync")["apis"]
+    assert loaded_apis.get_scoped(
+        "000000000000", "us-west-2", "regional-api"
+    )["apiId"] == "regional-api"
+
+    # Simulate the previous binary, whose highest understood format is v2.
+    monkeypatch.setattr(persistence, "SERVICE_STATE_FORMAT_VERSIONS", {})
+    assert persistence.load_state("appsync") is None
+
+
 def test_resource_groups_region_scoped_state_is_rejected_by_v2_reader(
     monkeypatch, tmp_path
 ):

--- a/tests/test_tagging.py
+++ b/tests/test_tagging.py
@@ -374,6 +374,25 @@ def test_tagging_get_resources_appsync(tagging, appsync):
     assert api_arn in arns
 
 
+def test_tagging_get_resources_appsync_is_region_scoped():
+    east_appsync = _regional_client("appsync", "us-east-1")
+    west_tagging = _regional_client("resourcegroupstaggingapi", "us-west-2")
+    api = east_appsync.create_graphql_api(
+        name="tg-appsync-regional",
+        authenticationType="API_KEY",
+        tags={_TAG_KEY: "appsync-east"},
+    )["graphqlApi"]
+
+    try:
+        resp = west_tagging.get_resources(
+            TagFilters=[{"Key": _TAG_KEY, "Values": ["appsync-east"]}]
+        )
+        arns = [r["ResourceARN"] for r in resp["ResourceTagMappingList"]]
+        assert api["arn"] not in arns
+    finally:
+        east_appsync.delete_graphql_api(apiId=api["apiId"])
+
+
 def test_tagging_get_resources_scheduler(tagging, scheduler):
     scheduler.create_schedule(
         Name="tg-scheduler-sched",


### PR DESCRIPTION
## Why
AWS AppSync APIs and their child resources are regional, but MiniStack currently shares them across regions within an account, causing cross-region list leakage and lookups.

## What
- Scope GraphQL APIs, API keys, data sources, resolvers, and types by account and region while keeping ARN-keyed tags account-scoped
- Restore legacy child stores beside their ARN-derived parent API
- Resolve unsigned local GraphQL data-plane requests to the unique stored API region before executing resolvers
- Version AppSync persistence and add regional list/data-plane, migration, reset, and rollback-safety coverage

## Risk Assessment
Low — the change is isolated to AppSync state storage and preserves local GraphQL data-plane routing plus legacy snapshot compatibility.

## Validation

* `uv run --extra dev ruff check ministack/core/persistence.py ministack/services/appsync.py tests/test_appsync.py`
* `uv run --extra dev pytest tests/test_appsync.py -q` with local MiniStack server (`30 passed`)
* `uv run --extra dev pytest tests/test_persistence.py -q` (`170 passed`)
