### PR TITLE
Scope Inspector2 state by region

### DIFF
--- a/ministack/core/persistence.py
+++ b/ministack/core/persistence.py
@@ -30,6 +30,7 @@ SERVICE_STATE_FORMAT_VERSIONS = {
     "appsync": 3,
     "autoscaling": 3,
     "athena": 3,
+    "inspector2": 3,
     "batch": 3,
     "ecs": 3,
     "resource_groups": 3,

--- a/ministack/services/inspector2.py
+++ b/ministack/services/inspector2.py
@@ -12,6 +12,7 @@ import uuid
 from ministack.core.arn import ArnParseError, parse_arn
 from ministack.core.persistence import load_state
 from ministack.core.responses import (
+    AccountRegionScopedDict,
     AccountScopedDict,
     error_response_json,
     get_account_id,
@@ -21,12 +22,12 @@ from ministack.core.responses import (
 
 logger = logging.getLogger("inspector2")
 
-_account_config = AccountScopedDict()
-_findings = AccountScopedDict()
-_coverage = AccountScopedDict()
-_scan_history = AccountScopedDict()
+_account_config = AccountRegionScopedDict()
+_findings = AccountRegionScopedDict()
+_coverage = AccountRegionScopedDict()
+_scan_history = AccountRegionScopedDict()
 _tags = AccountScopedDict()
-_filters = AccountScopedDict()
+_filters = AccountRegionScopedDict()
 
 
 def _now_iso():
@@ -1025,37 +1026,62 @@ async def handle_request(method, path, headers, body, query_params):
 
 
 def get_state():
-    return {
-        "account_config": copy.deepcopy(dict(_account_config._data)),
-        "findings": copy.deepcopy(dict(_findings._data)),
-        "coverage": copy.deepcopy(dict(_coverage._data)),
-        "scan_history": copy.deepcopy(dict(_scan_history._data)),
-        "tags": copy.deepcopy(dict(_tags._data)),
-        "filters": copy.deepcopy(dict(_filters._data)),
-    }
+    return copy.deepcopy(
+        {
+            "account_config": _account_config,
+            "findings": _findings,
+            "coverage": _coverage,
+            "scan_history": _scan_history,
+            "tags": _tags,
+            "filters": _filters,
+        }
+    )
 
 
 def restore_state(data):
     if not data:
         return
-    acc_config = data.get("account_config", {})
-    if acc_config:
-        _account_config._data.update(acc_config)
-    findings = data.get("findings", {})
-    if findings:
-        _findings._data.update(findings)
-    coverage = data.get("coverage", {})
-    if coverage:
-        _coverage._data.update(coverage)
-    scan_history = data.get("scan_history", {})
-    if scan_history:
-        _scan_history._data.update(scan_history)
-    tags = data.get("tags", {})
-    if tags:
-        _tags._data.update(tags)
-    filters_data = data.get("filters", {})
-    if filters_data:
-        _filters._data.update(filters_data)
+    reset()
+    for store, state_key in (
+        (_account_config, "account_config"),
+        (_findings, "findings"),
+        (_coverage, "coverage"),
+        (_scan_history, "scan_history"),
+        (_filters, "filters"),
+    ):
+        _restore_regional_bucket(store, data.get(state_key, {}))
+    _restore_account_bucket(_tags, data.get("tags", {}))
+
+
+def _restore_regional_bucket(store, restored):
+    """Restore each legacy account bucket intact into the boot region."""
+    if isinstance(restored, AccountRegionScopedDict):
+        store.update(restored)
+        return
+
+    if isinstance(restored, AccountScopedDict):
+        items = restored._data.items()
+    else:
+        items = restored.items()
+
+    boot_region = get_region()
+    for key, value in items:
+        if isinstance(key, tuple) and len(key) == 2:
+            account_id, bucket_key = key
+        else:
+            account_id, bucket_key = get_account_id(), key
+        store.set_scoped(account_id, boot_region, bucket_key, value)
+
+
+def _restore_account_bucket(store, restored):
+    if isinstance(restored, AccountScopedDict):
+        store.update(restored)
+        return
+    for key, value in restored.items():
+        if isinstance(key, tuple) and len(key) == 2:
+            store._data[key] = value
+        else:
+            store[key] = value
 
 
 def reset():

--- a/tests/test_inspector2.py
+++ b/tests/test_inspector2.py
@@ -4,9 +4,157 @@ Integration tests for the Inspector2 emulator.
 
 import json
 
+import boto3
 import pytest
+from botocore.config import Config
 from botocore.exceptions import ClientError
 from conftest import ENDPOINT
+
+
+def _client(region="us-east-1", access_key="test"):
+    return boto3.client(
+        "inspector2",
+        endpoint_url=ENDPOINT,
+        aws_access_key_id=access_key,
+        aws_secret_access_key="test",
+        region_name=region,
+        config=Config(region_name=region, retries={"max_attempts": 0}),
+    )
+
+
+def test_inspector2_state_is_region_scoped():
+    east = _client("us-east-1")
+    west = _client("us-west-2")
+    filter_name = "same-name-regional-filter"
+
+    east.disable(resourceTypes=[])
+    west.disable(resourceTypes=[])
+    east.enable(resourceTypes=["ECR"])
+    west.enable(resourceTypes=["EC2"])
+    east_filter = east.create_filter(
+        name=filter_name,
+        action="NONE",
+        filterCriteria={},
+    )
+    west_filter = west.create_filter(
+        name=filter_name,
+        action="NONE",
+        filterCriteria={},
+    )
+    east.tag_resource(resourceArn=east_filter["arn"], tags={"region": "east"})
+    west.tag_resource(resourceArn=west_filter["arn"], tags={"region": "west"})
+
+    try:
+        east_findings = east.list_findings()["findings"]
+        west_findings = west.list_findings()["findings"]
+        assert east_findings
+        assert west_findings
+        assert {resource["type"] for finding in east_findings for resource in finding["resources"]} == {
+            "AWS_ECR_CONTAINER_IMAGE"
+        }
+        assert {resource["type"] for finding in west_findings for resource in finding["resources"]} == {
+            "AWS_EC2_INSTANCE"
+        }
+        assert east.list_coverage()["coveredResources"]
+        assert west.list_coverage()["coveredResources"]
+        assert east.list_filters()["filters"][0]["arn"] == east_filter["arn"]
+        assert west.list_filters()["filters"][0]["arn"] == west_filter["arn"]
+        assert ":us-east-1:" in east_filter["arn"]
+        assert ":us-west-2:" in west_filter["arn"]
+        assert east.list_tags_for_resource(resourceArn=east_filter["arn"])["tags"] == {
+            "region": "east"
+        }
+        assert west.list_tags_for_resource(resourceArn=west_filter["arn"])["tags"] == {
+            "region": "west"
+        }
+    finally:
+        east.delete_filter(arn=east_filter["arn"])
+        west.delete_filter(arn=west_filter["arn"])
+        east.disable(resourceTypes=[])
+        west.disable(resourceTypes=[])
+
+
+def test_inspector2_legacy_buckets_restore_to_boot_region():
+    from ministack.core.responses import (
+        AccountScopedDict,
+        get_account_id,
+        get_region,
+        set_request_account_id,
+        set_request_region,
+    )
+    from ministack.services import inspector2 as service
+
+    original_account = get_account_id()
+    original_region = get_region()
+    account_id = "111111111111"
+    boot_region = "us-east-1"
+    embedded_region = "us-west-2"
+    finding_arn = f"arn:aws:inspector2:{embedded_region}:{account_id}:finding/legacy"
+
+    set_request_account_id(account_id)
+    set_request_region(boot_region)
+    payload = {}
+    for state_key, value in (
+        ("account_config", {"ecr": {"status": "ENABLED"}}),
+        ("findings", [{"findingArn": finding_arn}]),
+        ("coverage", [{"resourceId": "legacy-resource"}]),
+        ("scan_history", {"lastScanAt": "legacy"}),
+        ("filters", {"legacy": {"arn": f"arn:aws:inspector2:{embedded_region}:{account_id}:filter/legacy"}}),
+    ):
+        store = AccountScopedDict()
+        store[account_id] = value
+        payload[state_key] = store
+    tags = AccountScopedDict()
+    tags[account_id] = {finding_arn: {"legacy": "true"}}
+    payload["tags"] = tags
+
+    service.reset()
+    try:
+        service.restore_state(payload)
+        for state_key in (
+            "account_config",
+            "findings",
+            "coverage",
+            "scan_history",
+            "filters",
+        ):
+            store = getattr(service, f"_{state_key}")
+            assert store.get_scoped(account_id, boot_region, account_id) is not None
+            assert store.get_scoped(account_id, embedded_region, account_id) is None
+        assert service._tags.get_scoped(account_id, "", account_id) == {
+            finding_arn: {"legacy": "true"}
+        }
+    finally:
+        service.reset()
+        set_request_account_id(original_account)
+        set_request_region(original_region)
+
+
+def test_inspector2_reset_clears_state_across_regions():
+    from ministack.core.responses import get_region, set_request_region
+    from ministack.services import inspector2 as service
+
+    original_region = get_region()
+    regional_stores = (
+        service._account_config,
+        service._findings,
+        service._coverage,
+        service._scan_history,
+        service._filters,
+    )
+    service.reset()
+    try:
+        for region in ("us-east-1", "us-west-2"):
+            set_request_region(region)
+            for store in regional_stores:
+                store["000000000000"] = {"region": region}
+        service._tags["000000000000"] = {"arn": {"tag": "value"}}
+        service.reset()
+        assert all(not store.has_any() for store in regional_stores)
+        assert not service._tags.to_dict()
+    finally:
+        service.reset()
+        set_request_region(original_region)
 
 
 class TestEnableDisable:
@@ -419,17 +567,7 @@ class TestMultitenancy:
     """Verify Inspector2 state is isolated per account ID."""
 
     def _client(self, access_key):
-        import boto3
-        from botocore.config import Config
-
-        return boto3.client(
-            "inspector2",
-            endpoint_url=ENDPOINT,
-            aws_access_key_id=access_key,
-            aws_secret_access_key="test",
-            region_name="us-east-1",
-            config=Config(region_name="us-east-1", retries={"max_attempts": 0}),
-        )
+        return _client(access_key=access_key)
 
     def test_findings_isolated_by_account(self):
         from ministack.services import inspector2 as _inspector2

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1868,6 +1868,37 @@ def test_appsync_region_scoped_state_is_rejected_by_v2_reader(
     assert persistence.load_state("appsync") is None
 
 
+def test_inspector2_region_scoped_state_is_rejected_by_v2_reader(
+    monkeypatch, tmp_path
+):
+    """A rollback binary must reject Inspector2 regional account buckets."""
+    import json as _json
+
+    from ministack.core.responses import AccountRegionScopedDict
+
+    monkeypatch.setattr(persistence, "PERSIST_STATE", True)
+    monkeypatch.setattr(persistence, "STATE_DIR", str(tmp_path))
+
+    configs = AccountRegionScopedDict()
+    configs.set_scoped(
+        "000000000000",
+        "us-west-2",
+        "000000000000",
+        {"ecr": {"status": "ENABLED"}},
+    )
+    persistence.save_state("inspector2", {"account_config": configs})
+
+    raw = _json.loads((tmp_path / "inspector2.json").read_text())
+    assert raw["__ministack_format__"] == 3
+    loaded = persistence.load_state("inspector2")["account_config"]
+    assert loaded.get_scoped(
+        "000000000000", "us-west-2", "000000000000"
+    ) == {"ecr": {"status": "ENABLED"}}
+
+    monkeypatch.setattr(persistence, "SERVICE_STATE_FORMAT_VERSIONS", {})
+    assert persistence.load_state("inspector2") is None
+
+
 def test_resource_groups_region_scoped_state_is_rejected_by_v2_reader(
     monkeypatch, tmp_path
 ):


### PR DESCRIPTION
## Why
AWS Inspector2 enablement, findings, coverage, scan history, and filters are regional, but MiniStack currently shares account-keyed buckets across regions, causing one region to overwrite or expose another region's state.

## What
- Scope account configuration, findings, coverage, scan history, and filters by account and region while keeping ARN-keyed tags account-scoped
- Restore each region-less legacy account bucket intact into the boot region instead of splitting nested findings by ARN
- Version Inspector2 persistence so older binaries refuse incompatible regional snapshots
- Add regional configuration/finding/filter isolation, account-scoped regional ARN tags, legacy migration, reset, and rollback-safety coverage

## Risk Assessment
Low — the change is isolated to Inspector2 state storage and retains legacy snapshot compatibility.

## Validation

* `uv run --extra dev ruff check ministack/core/persistence.py ministack/services/inspector2.py tests/test_inspector2.py`
* `uv run --extra dev pytest tests/test_inspector2.py -q` with local MiniStack server (`56 passed`)
* `uv run --extra dev pytest tests/test_persistence.py -q` (`170 passed`)
