### PR TITLE
fix(cognito): use resolved Username for Hosted UI auth code binding

### DIFF
--- a/ministack/services/cognito.py
+++ b/ministack/services/cognito.py
@@ -4649,7 +4649,7 @@ def handle_login_submit(method, path, headers, body, query_params):
         _pending_new_password[np_token] = {
             "pool_id": pool_id,
             "client_id": client_id,
-            "username": username,
+            "username": user["Username"],
             "redirect_uri": redirect_uri,
             "scope": scope,
             "state": state,
@@ -4663,7 +4663,7 @@ def handle_login_submit(method, path, headers, body, query_params):
         return 200, {"Content-Type": "text/html; charset=utf-8"}, html_body.encode("utf-8")
 
     return _issue_auth_code_redirect(
-        client_id, pool_id, redirect_uri, scope, username, nonce,
+        client_id, pool_id, redirect_uri, scope, user["Username"], nonce,
         code_challenge, code_challenge_method, state,
     )
 
@@ -4710,7 +4710,7 @@ def _handle_new_password_submit(np_token, form):
 
     return _issue_auth_code_redirect(
         session["client_id"], session["pool_id"], session["redirect_uri"], session["scope"],
-        session["username"], session["nonce"], session["code_challenge"],
+        user["Username"], session["nonce"], session["code_challenge"],
         session["code_challenge_method"], session["state"],
     )
 

--- a/tests/test_cognito.py
+++ b/tests/test_cognito.py
@@ -2961,6 +2961,83 @@ def test_oauth2_token_client_auth_basic():
     assert 'access_token' in resp
 
 
+def test_oauth2_login_username_attributes_email_alias_completes_token_exchange():
+    """With UsernameAttributes=["email"], logging in via the Hosted UI with
+    an email alias that differs from the real Username must still complete
+    the authorization code exchange. Logging in with the real Username must
+    also keep working."""
+    cognito_idp = make_client('cognito-idp')
+    pool = cognito_idp.create_user_pool(
+        PoolName='UsernameAttrsOAuthPool',
+        UsernameAttributes=['email'],
+    )
+    pool_id = pool['UserPool']['Id']
+
+    client_resp = cognito_idp.create_user_pool_client(
+        UserPoolId=pool_id,
+        ClientName='oauth2-test-client',
+        GenerateSecret=True,
+        AllowedOAuthFlows=['code'],
+        AllowedOAuthScopes=['openid', 'email', 'profile'],
+        AllowedOAuthFlowsUserPoolClient=True,
+        CallbackURLs=['http://localhost:3000/callback'],
+        LogoutURLs=['http://localhost:3000/logout'],
+        DefaultRedirectURI='http://localhost:3000/callback',
+        ExplicitAuthFlows=['ALLOW_USER_PASSWORD_AUTH', 'ALLOW_REFRESH_TOKEN_AUTH'],
+    )
+    client = client_resp['UserPoolClient']
+    client_id = client['ClientId']
+    client_secret = client['ClientSecret']
+
+    real_username = 'alice-sub-uuid'
+    cognito_idp.admin_create_user(
+        UserPoolId=pool_id,
+        Username=real_username,
+        UserAttributes=[
+            {'Name': 'email', 'Value': 'alice@example.com'},
+            {'Name': 'email_verified', 'Value': 'true'},
+        ],
+    )
+    cognito_idp.admin_set_user_password(
+        UserPoolId=pool_id, Username=real_username, Password='TestPass1!', Permanent=True,
+    )
+
+    def _login_and_exchange(username, state):
+        status, headers, body = _post_form(
+            f'{ENDPOINT}/login',
+            {
+                'username': username,
+                'password': 'TestPass1!',
+                'client_id': client_id,
+                'redirect_uri': 'http://localhost:3000/callback',
+                'scope': 'openid email',
+                'state': state,
+                'response_type': 'code',
+            },
+            follow_redirects=False,
+        )
+        assert status == 302
+        location = headers.get('location', '')
+        qs = urllib.parse.parse_qs(urllib.parse.urlparse(location).query)
+        code = qs['code'][0]
+
+        status, _, body = _post_form(f'{ENDPOINT}/oauth2/token', {
+            'grant_type': 'authorization_code',
+            'code': code,
+            'redirect_uri': 'http://localhost:3000/callback',
+            'client_id': client_id,
+            'client_secret': client_secret,
+        })
+        assert status == 200
+        resp = json.loads(body)
+        assert 'access_token' in resp
+
+    # Login via the email alias (differs from the real Username).
+    _login_and_exchange('alice@example.com', 'alias-state')
+    # Login via the real Username.
+    _login_and_exchange(real_username, 'real-state')
+
+
 # ---------------------------------------------------------------------------
 # Tests — /oauth2/userInfo
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- In user pools with alias attributes (e.g. `UsernameAttributes=["email"]`), the email alias entered on the Hosted UI login page was passed straight through to `_issue_auth_code_redirect()` and bound to the authorization code
- `/oauth2/token`'s `authorization_code` grant does a plain dict lookup on Username with no alias resolution, so signing in with an alias that differs from the real Username caused a `server_error` at token exchange
- Fixed `handle_login_submit()` and `_handle_new_password_submit()` to bind the authorization code to the real Username resolved by `_resolve_user()` (`user["Username"]`) instead of the raw form input
- Added a regression test verifying that both an email-alias login and a real-Username login complete the token exchange successfully

## Test plan
- [x] `pytest tests/test_cognito.py -k oauth2_login_username_attributes_email_alias` — 1 passed
- [x] `pytest tests/test_cognito.py` — 190 passed (no regressions)
