### PR TITLE
feat(cfn): support AWS::EC2::VPCEndpoint

### DIFF
--- a/ministack/services/cloudformation/provisioners.py
+++ b/ministack/services/cloudformation/provisioners.py
@@ -3133,6 +3133,73 @@ def _ec2_vpc_delete(physical_id, props):
     _ec2._vpcs.pop(physical_id, None)
 
 
+def _ec2_vpc_endpoint_attributes(endpoint):
+    return {
+        "CreationTimestamp": endpoint["CreationTimestamp"],
+        "DnsEntries": endpoint.get("DnsEntries", []),
+        "Id": endpoint["VpcEndpointId"],
+        "NetworkInterfaceIds": endpoint.get("NetworkInterfaceIds", []),
+    }
+
+
+def _ec2_vpc_endpoint_create(logical_id, props, stack_name):
+    endpoint_id = "vpce-" + "".join(random.choices(string.hexdigits[:16], k=17))
+    endpoint = {
+        "VpcEndpointId": endpoint_id,
+        "VpcEndpointType": props.get("VpcEndpointType", "Gateway"),
+        "VpcId": props.get("VpcId", _ec2._DEFAULT_VPC_ID),
+        "ServiceName": props.get("ServiceName", ""),
+        "State": "available",
+        "RouteTableIds": list(props.get("RouteTableIds", [])),
+        "SubnetIds": list(props.get("SubnetIds", [])),
+        "SecurityGroupIds": list(props.get("SecurityGroupIds", [])),
+        "NetworkInterfaceIds": [],
+        "DnsEntries": [],
+        "PrivateDnsEnabled": props.get("PrivateDnsEnabled", False),
+        "PolicyDocument": props.get("PolicyDocument"),
+        "OwnerId": get_account_id(),
+        "CreationTimestamp": now_iso(),
+    }
+    _ec2._vpc_endpoints[endpoint_id] = endpoint
+    tags = [
+        {"Key": tag.get("Key", ""), "Value": tag.get("Value", "")}
+        for tag in props.get("Tags", [])
+    ]
+    if tags:
+        _ec2._tags[endpoint_id] = tags
+    return endpoint_id, _ec2_vpc_endpoint_attributes(endpoint)
+
+
+def _ec2_vpc_endpoint_update(physical_id, old_props, new_props, stack_name):
+    endpoint = _ec2._vpc_endpoints.get(physical_id)
+    if not endpoint:
+        return _ec2_vpc_endpoint_create(physical_id, new_props, stack_name)
+    endpoint.update({
+        "VpcEndpointType": new_props.get("VpcEndpointType", "Gateway"),
+        "VpcId": new_props.get("VpcId", _ec2._DEFAULT_VPC_ID),
+        "ServiceName": new_props.get("ServiceName", ""),
+        "RouteTableIds": list(new_props.get("RouteTableIds", [])),
+        "SubnetIds": list(new_props.get("SubnetIds", [])),
+        "SecurityGroupIds": list(new_props.get("SecurityGroupIds", [])),
+        "PrivateDnsEnabled": new_props.get("PrivateDnsEnabled", False),
+        "PolicyDocument": new_props.get("PolicyDocument"),
+    })
+    tags = [
+        {"Key": tag.get("Key", ""), "Value": tag.get("Value", "")}
+        for tag in new_props.get("Tags", [])
+    ]
+    if tags:
+        _ec2._tags[physical_id] = tags
+    else:
+        _ec2._tags.pop(physical_id, None)
+    return physical_id, _ec2_vpc_endpoint_attributes(endpoint)
+
+
+def _ec2_vpc_endpoint_delete(physical_id, props):
+    _ec2._vpc_endpoints.pop(physical_id, None)
+    _ec2._tags.pop(physical_id, None)
+
+
 def _ec2_subnet_create(logical_id, props, stack_name):
     import random
     import string
@@ -5099,6 +5166,11 @@ _RESOURCE_HANDLERS = {
     "AWS::KMS::Key": {"create": _kms_key_create, "delete": _kms_key_delete},
     "AWS::KMS::Alias": {"create": _kms_alias_create, "delete": _kms_alias_delete},
     "AWS::EC2::VPC": {"create": _ec2_vpc_create, "delete": _ec2_vpc_delete},
+    "AWS::EC2::VPCEndpoint": {
+        "create": _ec2_vpc_endpoint_create,
+        "update": _ec2_vpc_endpoint_update,
+        "delete": _ec2_vpc_endpoint_delete,
+    },
     "AWS::EC2::Subnet": {"create": _ec2_subnet_create, "delete": _ec2_subnet_delete},
     "AWS::EC2::SecurityGroup": {"create": _ec2_sg_create, "delete": _ec2_sg_delete},
     "AWS::EC2::InternetGateway": {"create": _ec2_igw_create, "delete": _ec2_igw_delete},

--- a/tests/test_cfn.py
+++ b/tests/test_cfn.py
@@ -1838,6 +1838,55 @@ def test_cfn_ec2_launch_template(cfn, ec2):
     desc2 = ec2.describe_launch_templates(LaunchTemplateIds=[lt_id])
     assert len(desc2["LaunchTemplates"]) == 0
 
+
+def test_cfn_ec2_vpc_endpoint_uses_ec2_state(cfn, ec2):
+    """CloudFormation VPC endpoints share the EC2 API state and expose their ID."""
+    suffix = _uuid_mod.uuid4().hex[:8]
+    stack_name = f"cfn-vpce-{suffix}"
+    template = {
+        "AWSTemplateFormatVersion": "2010-09-09",
+        "Resources": {
+            "Vpc": {
+                "Type": "AWS::EC2::VPC",
+                "Properties": {"CidrBlock": "10.40.0.0/16"},
+            },
+            "Endpoint": {
+                "Type": "AWS::EC2::VPCEndpoint",
+                "Properties": {
+                    "VpcEndpointType": "Gateway",
+                    "VpcId": {"Ref": "Vpc"},
+                    "ServiceName": "com.amazonaws.us-east-1.s3",
+                    "Tags": [{"Key": "source", "Value": "cloudformation"}],
+                },
+            },
+        },
+        "Outputs": {
+            "RefId": {"Value": {"Ref": "Endpoint"}},
+            "GetAttId": {"Value": {"Fn::GetAtt": ["Endpoint", "Id"]}},
+        },
+    }
+
+    cfn.create_stack(StackName=stack_name, TemplateBody=json.dumps(template))
+    stack = _wait_stack(cfn, stack_name)
+    assert stack["StackStatus"] == "CREATE_COMPLETE"
+    outputs = {item["OutputKey"]: item["OutputValue"] for item in stack["Outputs"]}
+    assert outputs["RefId"] == outputs["GetAttId"]
+    assert outputs["RefId"].startswith("vpce-")
+
+    endpoints = ec2.describe_vpc_endpoints(
+        VpcEndpointIds=[outputs["RefId"]]
+    )["VpcEndpoints"]
+    assert len(endpoints) == 1
+    assert endpoints[0]["VpcEndpointId"] == outputs["RefId"]
+    assert endpoints[0]["ServiceName"] == "com.amazonaws.us-east-1.s3"
+    assert endpoints[0]["Tags"] == [{"Key": "source", "Value": "cloudformation"}]
+
+    cfn.delete_stack(StackName=stack_name)
+    _wait_stack(cfn, stack_name)
+    assert ec2.describe_vpc_endpoints(
+        VpcEndpointIds=[outputs["RefId"]]
+    )["VpcEndpoints"] == []
+
 def test_cfn_elbv2_load_balancer_and_listener(cfn, elbv2):
     """CloudFormation provisions ELBv2 LoadBalancer + Listener and cleans both on delete."""
     uid = _uuid_mod.uuid4().hex[:8]


### PR DESCRIPTION
## Summary

- add a native CloudFormation provisioner for `AWS::EC2::VPCEndpoint`
- share endpoint and tag state with the existing EC2 service API
- expose CloudFormation endpoint attributes and clean up state on deletion
- cover `Ref`, `Fn::GetAtt`, EC2 API visibility, tags, and deletion

## Impact

CloudFormation and CDK stacks can create VPC endpoints locally and observe them through `DescribeVpcEndpoints`.

## Validation

- `.venv/bin/pytest tests/test_cfn.py::test_cfn_ec2_vpc_endpoint_uses_ec2_state -q`
- `.venv/bin/ruff check ministack/services/cloudformation/provisioners.py tests/test_cfn.py`
- `git diff --check`

Closes #1180
