### PR TITLE
feat(cfn): support AWS::ApiGateway::DocumentationVersion

### DIFF
--- a/ministack/services/cloudformation/provisioners.py
+++ b/ministack/services/cloudformation/provisioners.py
@@ -2337,6 +2337,27 @@ def _apigw_documentation_part_delete(physical_id, props):
         _apigw_v1._delete_documentation_part(api_id, physical_id)
 
 
+# --- API Gateway DocumentationVersion ---
+
+def _apigw_documentation_version_identity(props):
+    return f"{props.get('RestApiId', '')}/{props.get('DocumentationVersion', '')}"
+
+
+def _apigw_documentation_version_create(logical_id, props, stack_name):
+    # Documentation snapshots do not affect MiniStack's permissive local API
+    # request handling. A native CFN identity is sufficient for templates and
+    # dependent resources to complete their lifecycle.
+    return _apigw_documentation_version_identity(props), {}
+
+
+def _apigw_documentation_version_update(physical_id, old_props, new_props, stack_name):
+    return _apigw_documentation_version_identity(new_props), {}
+
+
+def _apigw_documentation_version_delete(physical_id, props):
+    pass
+
+
 # --- Lambda EventSourceMapping ---
 
 def _lambda_esm_create(logical_id, props, stack_name):
@@ -5067,6 +5088,11 @@ _RESOURCE_HANDLERS = {
         "create": _apigw_documentation_part_create,
         "update": _apigw_documentation_part_update,
         "delete": _apigw_documentation_part_delete,
+    },
+    "AWS::ApiGateway::DocumentationVersion": {
+        "create": _apigw_documentation_version_create,
+        "update": _apigw_documentation_version_update,
+        "delete": _apigw_documentation_version_delete,
     },
     "AWS::Lambda::EventSourceMapping": {"create": _lambda_esm_create, "update": _lambda_esm_update, "delete": _lambda_esm_delete},
     "AWS::Lambda::EventInvokeConfig": {

--- a/tests/test_cfn.py
+++ b/tests/test_cfn.py
@@ -4935,6 +4935,67 @@ def test_cfn_apigateway_documentation_part_lifecycle(cfn, apigw_v1):
         apigw_v1.delete_rest_api(restApiId=api_id)
 
 
+def test_cfn_apigateway_documentation_version_lifecycle(cfn, apigw_v1):
+    """DocumentationVersion has a stable CFN identity and supports replacement."""
+    suffix = _uuid_mod.uuid4().hex[:8]
+    stack_name = f"cfn-documentation-version-{suffix}"
+    api_id = apigw_v1.create_rest_api(name=f"documentation-version-{suffix}")["id"]
+
+    def template(version, description):
+        return {
+            "Resources": {
+                "DocumentationVersion": {
+                    "Type": "AWS::ApiGateway::DocumentationVersion",
+                    "Properties": {
+                        "RestApiId": api_id,
+                        "DocumentationVersion": version,
+                        "Description": description,
+                    },
+                },
+            },
+        }
+
+    def physical_id():
+        detail = cfn.describe_stack_resource(
+            StackName=stack_name,
+            LogicalResourceId="DocumentationVersion",
+        )["StackResourceDetail"]
+        return detail["PhysicalResourceId"]
+
+    try:
+        cfn.create_stack(
+            StackName=stack_name,
+            TemplateBody=json.dumps(template("v1", "Created")),
+        )
+        stack = _wait_stack(cfn, stack_name)
+        assert stack["StackStatus"] == "CREATE_COMPLETE", stack.get("StackStatusReason")
+        created_id = physical_id()
+        assert created_id == f"{api_id}/v1"
+
+        cfn.update_stack(
+            StackName=stack_name,
+            TemplateBody=json.dumps(template("v1", "Updated")),
+        )
+        stack = _wait_stack(cfn, stack_name)
+        assert stack["StackStatus"] == "UPDATE_COMPLETE", stack.get("StackStatusReason")
+        assert physical_id() == created_id
+
+        cfn.update_stack(
+            StackName=stack_name,
+            TemplateBody=json.dumps(template("v2", "Replacement")),
+        )
+        stack = _wait_stack(cfn, stack_name)
+        assert stack["StackStatus"] == "UPDATE_COMPLETE", stack.get("StackStatusReason")
+        assert physical_id() == f"{api_id}/v2"
+    finally:
+        try:
+            cfn.delete_stack(StackName=stack_name)
+            _wait_stack(cfn, stack_name)
+        except ClientError:
+            pass
+        apigw_v1.delete_rest_api(restApiId=api_id)
+
+
 # ---------------------------------------------------------------------------
 # ApiGatewayV1 Integration with OpenAPI spec parsing
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- add a native CloudFormation provisioner for `AWS::ApiGateway::DocumentationVersion`
- provide a stable physical identity scoped to the REST API and documentation version
- preserve that identity for description-only updates and replace it when the version changes
- keep the local API Gateway data plane permissive

## Impact

CloudFormation and CDK stacks containing documentation-version resources can complete without requiring local documentation snapshot enforcement.

## Validation

- `.venv/bin/pytest tests/test_cfn.py::test_cfn_apigateway_documentation_version_lifecycle -q`
- `.venv/bin/ruff check ministack/services/cloudformation/provisioners.py tests/test_cfn.py`
- `git diff --check`

Closes #1181
