### PR TITLE
feat(cfn): support AWS::ApiGateway::RequestValidator

### DIFF
--- a/ministack/services/cloudformation/provisioners.py
+++ b/ministack/services/cloudformation/provisioners.py
@@ -2337,6 +2337,25 @@ def _apigw_documentation_part_delete(physical_id, props):
         _apigw_v1._delete_documentation_part(api_id, physical_id)
 
 
+# --- API Gateway RequestValidator ---
+
+def _apigw_request_validator_create(logical_id, props, stack_name):
+    validator_id = new_uuid().replace("-", "")[:8]
+    return validator_id, {"RequestValidatorId": validator_id}
+
+
+def _apigw_request_validator_update(physical_id, old_props, new_props, stack_name):
+    # RestApiId and Name require replacement. Validation flags update in place;
+    # request handling remains deliberately permissive in the local data plane.
+    if any(new_props.get(key) != old_props.get(key) for key in ("RestApiId", "Name")):
+        return _apigw_request_validator_create(physical_id, new_props, stack_name)
+    return physical_id, {"RequestValidatorId": physical_id}
+
+
+def _apigw_request_validator_delete(physical_id, props):
+    pass
+
+
 # --- Lambda EventSourceMapping ---
 
 def _lambda_esm_create(logical_id, props, stack_name):
@@ -5067,6 +5086,11 @@ _RESOURCE_HANDLERS = {
         "create": _apigw_documentation_part_create,
         "update": _apigw_documentation_part_update,
         "delete": _apigw_documentation_part_delete,
+    },
+    "AWS::ApiGateway::RequestValidator": {
+        "create": _apigw_request_validator_create,
+        "update": _apigw_request_validator_update,
+        "delete": _apigw_request_validator_delete,
     },
     "AWS::Lambda::EventSourceMapping": {"create": _lambda_esm_create, "update": _lambda_esm_update, "delete": _lambda_esm_delete},
     "AWS::Lambda::EventInvokeConfig": {

--- a/tests/test_cfn.py
+++ b/tests/test_cfn.py
@@ -4935,6 +4935,77 @@ def test_cfn_apigateway_documentation_part_lifecycle(cfn, apigw_v1):
         apigw_v1.delete_rest_api(restApiId=api_id)
 
 
+def test_cfn_apigateway_request_validator_identity(cfn, apigw_v1):
+    """RequestValidator exposes its ID while local requests remain permissive."""
+    suffix = _uuid_mod.uuid4().hex[:8]
+    stack_name = f"cfn-request-validator-{suffix}"
+    api_id = apigw_v1.create_rest_api(name=f"request-validator-{suffix}")["id"]
+
+    def template(name, validate_body):
+        return {
+            "Resources": {
+                "RequestValidator": {
+                    "Type": "AWS::ApiGateway::RequestValidator",
+                    "Properties": {
+                        "RestApiId": api_id,
+                        "Name": name,
+                        "ValidateRequestBody": validate_body,
+                        "ValidateRequestParameters": True,
+                    },
+                },
+            },
+            "Outputs": {
+                "RefId": {"Value": {"Ref": "RequestValidator"}},
+                "GetAttId": {
+                    "Value": {
+                        "Fn::GetAtt": ["RequestValidator", "RequestValidatorId"]
+                    }
+                },
+            },
+        }
+
+    def physical_id():
+        detail = cfn.describe_stack_resource(
+            StackName=stack_name,
+            LogicalResourceId="RequestValidator",
+        )["StackResourceDetail"]
+        return detail["PhysicalResourceId"]
+
+    try:
+        cfn.create_stack(
+            StackName=stack_name,
+            TemplateBody=json.dumps(template("body-and-parameters", True)),
+        )
+        stack = _wait_stack(cfn, stack_name)
+        assert stack["StackStatus"] == "CREATE_COMPLETE", stack.get("StackStatusReason")
+        created_id = physical_id()
+        outputs = {item["OutputKey"]: item["OutputValue"] for item in stack["Outputs"]}
+        assert outputs == {"RefId": created_id, "GetAttId": created_id}
+
+        cfn.update_stack(
+            StackName=stack_name,
+            TemplateBody=json.dumps(template("body-and-parameters", False)),
+        )
+        stack = _wait_stack(cfn, stack_name)
+        assert stack["StackStatus"] == "UPDATE_COMPLETE", stack.get("StackStatusReason")
+        assert physical_id() == created_id
+
+        cfn.update_stack(
+            StackName=stack_name,
+            TemplateBody=json.dumps(template("replacement", False)),
+        )
+        stack = _wait_stack(cfn, stack_name)
+        assert stack["StackStatus"] == "UPDATE_COMPLETE", stack.get("StackStatusReason")
+        assert physical_id() != created_id
+    finally:
+        try:
+            cfn.delete_stack(StackName=stack_name)
+            _wait_stack(cfn, stack_name)
+        except ClientError:
+            pass
+        apigw_v1.delete_rest_api(restApiId=api_id)
+
+
 # ---------------------------------------------------------------------------
 # ApiGatewayV1 Integration with OpenAPI spec parsing
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- add a native CloudFormation provisioner for `AWS::ApiGateway::RequestValidator`
- return the validator ID through both `Ref` and `Fn::GetAtt RequestValidatorId`
- preserve the ID for validation-flag updates and replace it for immutable property changes
- keep local API request handling permissive

## Impact

CloudFormation and CDK stacks can declare request validators and reference their IDs without changing MiniStack's permissive request behavior.

## Validation

- `.venv/bin/pytest tests/test_cfn.py::test_cfn_apigateway_request_validator_identity -q`
- `.venv/bin/ruff check ministack/services/cloudformation/provisioners.py tests/test_cfn.py`
- `git diff --check`

Closes #1182
