### PR TITLE
feat(cfn): support AWS::AppSync::FunctionConfiguration

### DIFF
--- a/ministack/services/cloudformation/provisioners.py
+++ b/ministack/services/cloudformation/provisioners.py
@@ -2656,6 +2656,40 @@ def _appsync_ds_delete(physical_id, props):
         _appsync._data_sources.get(parts[0], {}).pop(parts[1], None)
 
 
+def _appsync_function_attributes(api_id, function_id, props):
+    function_arn = (
+        f"arn:aws:appsync:{get_region()}:{get_account_id()}:"
+        f"apis/{api_id}/functions/{function_id}"
+    )
+    return {
+        "DataSourceName": props.get("DataSourceName", ""),
+        "FunctionArn": function_arn,
+        "FunctionId": function_id,
+        "Name": props.get("Name", ""),
+    }
+
+
+def _appsync_function_create(logical_id, props, stack_name):
+    api_id = props.get("ApiId", "")
+    function_id = new_uuid().replace("-", "")[:26]
+    attrs = _appsync_function_attributes(api_id, function_id, props)
+    # Pipeline execution remains permissive; the CFN identity and documented
+    # attributes are enough for resolvers to reference the local function.
+    return attrs["FunctionArn"], attrs
+
+
+def _appsync_function_update(physical_id, old_props, new_props, stack_name):
+    if new_props.get("ApiId") != old_props.get("ApiId"):
+        return _appsync_function_create(physical_id, new_props, stack_name)
+    function_id = physical_id.rsplit("/", 1)[-1]
+    attrs = _appsync_function_attributes(new_props.get("ApiId", ""), function_id, new_props)
+    return physical_id, attrs
+
+
+def _appsync_function_delete(physical_id, props):
+    pass
+
+
 def _appsync_resolver_create(logical_id, props, stack_name):
     api_id = props.get("ApiId", "")
     type_name = props.get("TypeName", "Query")
@@ -5080,6 +5114,11 @@ _RESOURCE_HANDLERS = {
     "AWS::SNS::TopicPolicy": {"create": _sns_topic_policy_create, "delete": _sns_topic_policy_delete},
     "AWS::AppSync::GraphQLApi": {"create": _appsync_api_create, "delete": _appsync_api_delete},
     "AWS::AppSync::DataSource": {"create": _appsync_ds_create, "delete": _appsync_ds_delete},
+    "AWS::AppSync::FunctionConfiguration": {
+        "create": _appsync_function_create,
+        "update": _appsync_function_update,
+        "delete": _appsync_function_delete,
+    },
     "AWS::AppSync::Resolver": {"create": _appsync_resolver_create, "delete": _appsync_resolver_delete},
     "AWS::AppSync::GraphQLSchema": {"create": _appsync_schema_create},
     "AWS::AppSync::ApiKey": {"create": _appsync_apikey_create, "delete": _appsync_apikey_delete},

--- a/tests/test_cfn.py
+++ b/tests/test_cfn.py
@@ -1838,6 +1838,85 @@ def test_cfn_ec2_launch_template(cfn, ec2):
     desc2 = ec2.describe_launch_templates(LaunchTemplateIds=[lt_id])
     assert len(desc2["LaunchTemplates"]) == 0
 
+
+def test_cfn_appsync_function_configuration_attributes(cfn, appsync):
+    """AppSync pipeline functions expose the identities consumed by resolvers."""
+    suffix = _uuid_mod.uuid4().hex[:8]
+    stack_name = f"cfn-appsync-function-{suffix}"
+    api_id = appsync.create_graphql_api(
+        name=f"pipeline-api-{suffix}",
+        authenticationType="API_KEY",
+    )["graphqlApi"]["apiId"]
+    appsync.create_data_source(
+        apiId=api_id,
+        name="NoneSource",
+        type="NONE",
+    )
+
+    def template(function_name):
+        return {
+            "AWSTemplateFormatVersion": "2010-09-09",
+            "Resources": {
+                "PipelineFunction": {
+                    "Type": "AWS::AppSync::FunctionConfiguration",
+                    "Properties": {
+                        "ApiId": api_id,
+                        "DataSourceName": "NoneSource",
+                        "Name": function_name,
+                        "FunctionVersion": "2018-05-29",
+                        "RequestMappingTemplate": "{}",
+                        "ResponseMappingTemplate": "$util.toJson($ctx.result)",
+                    },
+                },
+            },
+            "Outputs": {
+                "RefArn": {"Value": {"Ref": "PipelineFunction"}},
+                "FunctionArn": {
+                    "Value": {"Fn::GetAtt": ["PipelineFunction", "FunctionArn"]}
+                },
+                "FunctionId": {
+                    "Value": {"Fn::GetAtt": ["PipelineFunction", "FunctionId"]}
+                },
+                "FunctionName": {
+                    "Value": {"Fn::GetAtt": ["PipelineFunction", "Name"]}
+                },
+                "DataSourceName": {
+                    "Value": {"Fn::GetAtt": ["PipelineFunction", "DataSourceName"]}
+                },
+            },
+        }
+
+    try:
+        cfn.create_stack(
+            StackName=stack_name,
+            TemplateBody=json.dumps(template("ExampleFunction")),
+        )
+        stack = _wait_stack(cfn, stack_name)
+        assert stack["StackStatus"] == "CREATE_COMPLETE", stack.get("StackStatusReason")
+        outputs = {item["OutputKey"]: item["OutputValue"] for item in stack["Outputs"]}
+        assert outputs["RefArn"] == outputs["FunctionArn"]
+        assert outputs["RefArn"].endswith(f"/functions/{outputs['FunctionId']}")
+        assert outputs["FunctionName"] == "ExampleFunction"
+        assert outputs["DataSourceName"] == "NoneSource"
+        original_arn = outputs["FunctionArn"]
+
+        cfn.update_stack(
+            StackName=stack_name,
+            TemplateBody=json.dumps(template("UpdatedFunction")),
+        )
+        stack = _wait_stack(cfn, stack_name)
+        assert stack["StackStatus"] == "UPDATE_COMPLETE", stack.get("StackStatusReason")
+        outputs = {item["OutputKey"]: item["OutputValue"] for item in stack["Outputs"]}
+        assert outputs["FunctionArn"] == original_arn
+        assert outputs["FunctionName"] == "UpdatedFunction"
+    finally:
+        try:
+            cfn.delete_stack(StackName=stack_name)
+            _wait_stack(cfn, stack_name)
+        except ClientError:
+            pass
+        appsync.delete_graphql_api(apiId=api_id)
+
 def test_cfn_elbv2_load_balancer_and_listener(cfn, elbv2):
     """CloudFormation provisions ELBv2 LoadBalancer + Listener and cleans both on delete."""
     uid = _uuid_mod.uuid4().hex[:8]


### PR DESCRIPTION
## Summary

- add a native CloudFormation provisioner for `AWS::AppSync::FunctionConfiguration`
- use the function ARN as the CloudFormation physical ID and `Ref` value
- expose `FunctionArn`, `FunctionId`, `Name`, and `DataSourceName`
- preserve identity across mutable updates while keeping pipeline execution permissive

## Impact

CloudFormation and CDK pipeline resolvers can declare AppSync functions and consume their documented identities locally.

## Validation

- `.venv/bin/pytest tests/test_cfn.py::test_cfn_appsync_function_configuration_attributes -q`
- `.venv/bin/ruff check ministack/services/cloudformation/provisioners.py tests/test_cfn.py`
- `git diff --check`

Closes #1183
