### PR TITLE
feat(cfn): support AWS::Lambda::Url

### DIFF
--- a/ministack/services/cloudformation/provisioners.py
+++ b/ministack/services/cloudformation/provisioners.py
@@ -702,6 +702,70 @@ def _lambda_delete(physical_id, props):
     _lambda_svc._functions.pop(physical_id, None)
 
 
+def _lambda_url_target(props):
+    func, func_name, _resource_arn, target_qualifier = _lambda_function_for_cfn_ref(
+        props.get("TargetFunctionArn", "")
+    )
+    qualifier = props.get("Qualifier") or target_qualifier
+    return func, func_name, qualifier
+
+
+def _lambda_url_config_data(props):
+    data = {
+        "AuthType": props.get("AuthType", "NONE"),
+        "InvokeMode": props.get("InvokeMode", "BUFFERED"),
+    }
+    if "Cors" in props:
+        data["Cors"] = props["Cors"]
+    return data
+
+
+def _lambda_url_attributes(config):
+    return {
+        "FunctionArn": config["FunctionArn"],
+        "FunctionUrl": config["FunctionUrl"],
+    }
+
+
+def _lambda_url_create(logical_id, props, stack_name):
+    func, func_name, qualifier = _lambda_url_target(props)
+    if not func:
+        raise ValueError(f"Lambda function not found: {props.get('TargetFunctionArn', '')}")
+    status, _headers, body = _lambda_svc._create_function_url_config(
+        func_name, _lambda_url_config_data(props), qualifier,
+    )
+    if status >= 400:
+        raise ValueError(f"AWS::Lambda::Url create failed: {body!r}")
+    config = json.loads(body)
+    resource_name = _lambda_svc._url_config_key(func_name, qualifier)
+    return resource_name, _lambda_url_attributes(config)
+
+
+def _lambda_url_update(physical_id, old_props, new_props, stack_name):
+    if any(
+        new_props.get(key) != old_props.get(key)
+        for key in ("TargetFunctionArn", "Qualifier")
+    ):
+        new_id, attrs = _lambda_url_create(physical_id, new_props, stack_name)
+        _lambda_url_delete(physical_id, old_props)
+        return new_id, attrs
+
+    _func, func_name, qualifier = _lambda_url_target(new_props)
+    data = _lambda_url_config_data(new_props)
+    if "Cors" not in new_props and "Cors" in old_props:
+        data["Cors"] = {}
+    status, _headers, body = _lambda_svc._update_function_url_config(
+        func_name, data, qualifier,
+    )
+    if status >= 400:
+        raise ValueError(f"AWS::Lambda::Url update failed: {body!r}")
+    return physical_id, _lambda_url_attributes(json.loads(body))
+
+
+def _lambda_url_delete(physical_id, props):
+    _lambda_svc._function_urls.pop(physical_id, None)
+
+
 # --- IAM Role ---
 
 def _iam_role_create(logical_id, props, stack_name):
@@ -4989,6 +5053,11 @@ _RESOURCE_HANDLERS = {
     # before delegating to the Table engine.
     "AWS::DynamoDB::GlobalTable": {"create": _ddb_global_table_create, "delete": _ddb_global_table_delete},
     "AWS::Lambda::Function": {"create": _lambda_create, "delete": _lambda_delete},
+    "AWS::Lambda::Url": {
+        "create": _lambda_url_create,
+        "update": _lambda_url_update,
+        "delete": _lambda_url_delete,
+    },
     "AWS::IAM::Role": {"create": _iam_role_create, "delete": _iam_role_delete},
     "AWS::IAM::Policy": {"create": _iam_policy_create, "delete": _iam_policy_delete},
     "AWS::IAM::InstanceProfile": {"create": _iam_ip_create, "delete": _iam_ip_delete},

--- a/ministack/services/lambda_svc.py
+++ b/ministack/services/lambda_svc.py
@@ -6070,6 +6070,8 @@ def _update_function_url_config(func_name: str, data: dict, qualifier: str | Non
         cfg["AuthType"] = data["AuthType"]
     if "Cors" in data:
         cfg["Cors"] = data["Cors"]
+    if "InvokeMode" in data:
+        cfg["InvokeMode"] = data["InvokeMode"]
     cfg["LastModifiedTime"] = _now_iso()
     return json_response(cfg)
 

--- a/tests/test_cfn.py
+++ b/tests/test_cfn.py
@@ -1102,6 +1102,82 @@ def test_cfn_lambda_permission(cfn, lam):
     lam.delete_function(FunctionName="cfn-perm-fn")
 
 
+def test_cfn_lambda_url_uses_function_url_state(cfn, lam):
+    """CloudFormation Lambda URLs share state with the Lambda Function URL API."""
+    suffix = _uuid_mod.uuid4().hex[:8]
+    stack_name = f"cfn-lambda-url-{suffix}"
+    function_name = f"cfn-url-{suffix}"
+
+    def template(auth_type, invoke_mode):
+        return {
+            "AWSTemplateFormatVersion": "2010-09-09",
+            "Resources": {
+                "Function": {
+                    "Type": "AWS::Lambda::Function",
+                    "Properties": {
+                        "FunctionName": function_name,
+                        "Runtime": "python3.12",
+                        "Handler": "index.handler",
+                        "Role": "arn:aws:iam::000000000000:role/lambda-role",
+                        "Code": {
+                            "ZipFile": "def handler(event, context):\n    return {'statusCode': 200}\n"
+                        },
+                    },
+                },
+                "FunctionUrl": {
+                    "Type": "AWS::Lambda::Url",
+                    "Properties": {
+                        "TargetFunctionArn": {"Ref": "Function"},
+                        "AuthType": auth_type,
+                        "InvokeMode": invoke_mode,
+                        "Cors": {"AllowOrigins": ["https://example.com"]},
+                    },
+                },
+            },
+            "Outputs": {
+                "UrlRef": {"Value": {"Ref": "FunctionUrl"}},
+                "FunctionArn": {
+                    "Value": {"Fn::GetAtt": ["FunctionUrl", "FunctionArn"]}
+                },
+                "FunctionUrl": {
+                    "Value": {"Fn::GetAtt": ["FunctionUrl", "FunctionUrl"]}
+                },
+            },
+        }
+
+    cfn.create_stack(
+        StackName=stack_name,
+        TemplateBody=json.dumps(template("NONE", "BUFFERED")),
+    )
+    stack = _wait_stack(cfn, stack_name)
+    assert stack["StackStatus"] == "CREATE_COMPLETE", stack.get("StackStatusReason")
+    outputs = {item["OutputKey"]: item["OutputValue"] for item in stack["Outputs"]}
+    assert outputs["UrlRef"] == function_name
+    config = lam.get_function_url_config(FunctionName=function_name)
+    assert config["FunctionUrl"] == outputs["FunctionUrl"]
+    assert config["FunctionArn"] == outputs["FunctionArn"]
+    assert config["AuthType"] == "NONE"
+    assert config["InvokeMode"] == "BUFFERED"
+    original_url = config["FunctionUrl"]
+
+    cfn.update_stack(
+        StackName=stack_name,
+        TemplateBody=json.dumps(template("AWS_IAM", "RESPONSE_STREAM")),
+    )
+    stack = _wait_stack(cfn, stack_name)
+    assert stack["StackStatus"] == "UPDATE_COMPLETE", stack.get("StackStatusReason")
+    config = lam.get_function_url_config(FunctionName=function_name)
+    assert config["FunctionUrl"] == original_url
+    assert config["AuthType"] == "AWS_IAM"
+    assert config["InvokeMode"] == "RESPONSE_STREAM"
+
+    cfn.delete_stack(StackName=stack_name)
+    _wait_stack(cfn, stack_name)
+    assert lam.list_function_url_configs(
+        FunctionName=function_name
+    )["FunctionUrlConfigs"] == []
+
+
 def test_cfn_lambda_permission_qualified_arn_uses_base_function_policy(cfn, lam):
     """Qualified FunctionName refs should add permission to the base function policy."""
     suffix = _uuid_mod.uuid4().hex[:8]


### PR DESCRIPTION
## Summary

- add a native CloudFormation provisioner for `AWS::Lambda::Url`
- share state with MiniStack's existing Lambda Function URL API
- expose the CloudFormation `Ref`, `FunctionArn`, and `FunctionUrl` values
- support mutable URL configuration updates and lifecycle deletion

## Validation

- `pytest tests/test_cfn.py::test_cfn_lambda_url_uses_function_url_state -q`
- `ruff check ministack/services/cloudformation/provisioners.py ministack/services/lambda_svc.py tests/test_cfn.py`
- `git diff --check`

Closes #1184
