### PR TITLE
feat(cfn): support AWS::Logs::ResourcePolicy

### DIFF
--- a/ministack/services/cloudformation/provisioners.py
+++ b/ministack/services/cloudformation/provisioners.py
@@ -1136,6 +1136,25 @@ def _cwlogs_delete(physical_id, props):
     _cw_logs._log_groups.pop(physical_id, None)
 
 
+# --- CloudWatch Logs ResourcePolicy ---
+
+def _cwlogs_resource_policy_create(logical_id, props, stack_name):
+    policy_name = props.get("PolicyName")
+    if not policy_name:
+        raise ValueError("AWS::Logs::ResourcePolicy requires PolicyName")
+    # Local log delivery is intentionally permissive, so the policy only needs
+    # its CloudFormation identity rather than a data-plane enforcement store.
+    return policy_name, {}
+
+
+def _cwlogs_resource_policy_update(physical_id, old_props, new_props, stack_name):
+    return _cwlogs_resource_policy_create(physical_id, new_props, stack_name)
+
+
+def _cwlogs_resource_policy_delete(physical_id, props):
+    pass
+
+
 # --- CloudWatch Logs SubscriptionFilter (#896) ---
 
 def _cwlogs_subfilter_create(logical_id, props, stack_name):
@@ -5018,6 +5037,11 @@ _RESOURCE_HANDLERS = {
         "delete": _appconfig_deployment_delete,
     },
     "AWS::Logs::LogGroup": {"create": _cwlogs_create, "delete": _cwlogs_delete},
+    "AWS::Logs::ResourcePolicy": {
+        "create": _cwlogs_resource_policy_create,
+        "update": _cwlogs_resource_policy_update,
+        "delete": _cwlogs_resource_policy_delete,
+    },
     "AWS::Logs::SubscriptionFilter": {"create": _cwlogs_subfilter_create, "delete": _cwlogs_subfilter_delete},
     "AWS::Events::Rule": {"create": _eb_rule_create, "delete": _eb_rule_delete},
     "AWS::Events::EventBus": {"create": _eb_event_bus_create, "delete": _eb_event_bus_delete},

--- a/tests/test_cfn.py
+++ b/tests/test_cfn.py
@@ -5140,6 +5140,68 @@ def test_cfn_logs_subscription_filter_provisions(cfn, logs):
         logs.describe_subscription_filters(logGroupName="/cfn/subfilter-test")
 
 
+def test_cfn_logs_resource_policy_identity_and_lifecycle(cfn):
+    """Logs resource policies expose their policy name without enforcing it."""
+    suffix = _uuid_mod.uuid4().hex[:8]
+    stack_name = f"cfn-logs-policy-{suffix}"
+    policy_name = f"logs-policy-{suffix}"
+
+    def template(statement_sid, name=policy_name):
+        return {
+            "AWSTemplateFormatVersion": "2010-09-09",
+            "Resources": {
+                "LogsPolicy": {
+                    "Type": "AWS::Logs::ResourcePolicy",
+                    "Properties": {
+                        "PolicyName": name,
+                        "PolicyDocument": json.dumps({
+                            "Version": "2012-10-17",
+                            "Statement": [{
+                                "Sid": statement_sid,
+                                "Effect": "Allow",
+                                "Principal": {"Service": "route53.amazonaws.com"},
+                                "Action": "logs:PutLogEvents",
+                                "Resource": "*",
+                            }],
+                        }),
+                    },
+                },
+            },
+            "Outputs": {
+                "PolicyName": {"Value": {"Ref": "LogsPolicy"}},
+            },
+        }
+
+    cfn.create_stack(
+        StackName=stack_name,
+        TemplateBody=json.dumps(template("InitialPolicy")),
+    )
+    stack = _wait_stack(cfn, stack_name)
+    assert stack["StackStatus"] == "CREATE_COMPLETE", stack.get("StackStatusReason")
+    assert stack["Outputs"][0]["OutputValue"] == policy_name
+
+    cfn.update_stack(
+        StackName=stack_name,
+        TemplateBody=json.dumps(template("UpdatedPolicy")),
+    )
+    stack = _wait_stack(cfn, stack_name)
+    assert stack["StackStatus"] == "UPDATE_COMPLETE", stack.get("StackStatusReason")
+    assert stack["Outputs"][0]["OutputValue"] == policy_name
+
+    updated_name = f"{policy_name}-updated"
+    cfn.update_stack(
+        StackName=stack_name,
+        TemplateBody=json.dumps(template("UpdatedPolicy", updated_name)),
+    )
+    stack = _wait_stack(cfn, stack_name)
+    assert stack["StackStatus"] == "UPDATE_COMPLETE", stack.get("StackStatusReason")
+    assert stack["Outputs"][0]["OutputValue"] == updated_name
+
+    cfn.delete_stack(StackName=stack_name)
+    stack = _wait_stack(cfn, stack_name)
+    assert stack["StackStatus"] == "DELETE_COMPLETE"
+
+
 def test_cfn_change_set_detects_parameter_driven_change(cfn, s3):
     """A change set must detect a parameter-driven property change (e.g. a Lambda
     Code S3Key behind a Ref) so `aws cloudformation deploy` doesn't silently


### PR DESCRIPTION
## Summary

- add a native CloudFormation provisioner for `AWS::Logs::ResourcePolicy`
- expose the policy name through `Ref`
- support policy document and policy name updates across the stack lifecycle
- retain MiniStack's permissive local Logs data-plane behavior

## Validation

- `pytest tests/test_cfn.py::test_cfn_logs_resource_policy_identity_and_lifecycle -q`
- `ruff check ministack/services/cloudformation/provisioners.py tests/test_cfn.py`
- `git diff --check`

Closes #1185
