### PR TITLE
feat(cfn): support CloudFront origin access identities

### DIFF
--- a/ministack/services/cloudformation/provisioners.py
+++ b/ministack/services/cloudformation/provisioners.py
@@ -4449,6 +4449,38 @@ def _waf_web_acl_delete(physical_id, props):
 
 
 # ---------------------------------------------------------------------------
+# CloudFront Origin Access Identity
+# ---------------------------------------------------------------------------
+
+def _cf_oai_attributes(oai_id):
+    canonical_user_id = hashlib.sha256(
+        f"{get_account_id()}:{oai_id}".encode()
+    ).hexdigest()
+    return {"Id": oai_id, "S3CanonicalUserId": canonical_user_id}
+
+
+def _cf_oai_create(logical_id, props, stack_name):
+    config = props.get("CloudFrontOriginAccessIdentityConfig")
+    if not isinstance(config, dict):
+        raise ValueError(
+            "AWS::CloudFront::CloudFrontOriginAccessIdentity requires "
+            "CloudFrontOriginAccessIdentityConfig"
+        )
+    oai_id = _cf._dist_id()
+    return oai_id, _cf_oai_attributes(oai_id)
+
+
+def _cf_oai_update(physical_id, old_props, new_props, stack_name):
+    # Comment is mutable but local CloudFront/S3 access remains permissive, so
+    # retaining the identity is the only state required for an in-place update.
+    return physical_id, _cf_oai_attributes(physical_id)
+
+
+def _cf_oai_delete(physical_id, props):
+    pass
+
+
+# ---------------------------------------------------------------------------
 # CloudFront Distribution
 # ---------------------------------------------------------------------------
 
@@ -5123,6 +5155,11 @@ _RESOURCE_HANDLERS = {
     "AWS::ApiGatewayV2::Authorizer": {"create": _apigw_v2_authorizer_create, "delete": _apigw_v2_authorizer_delete},
     "AWS::SES::EmailIdentity": {"create": _ses_email_identity_create, "delete": _ses_email_identity_delete},
     "AWS::WAFv2::WebACL": {"create": _waf_web_acl_create, "delete": _waf_web_acl_delete},
+    "AWS::CloudFront::CloudFrontOriginAccessIdentity": {
+        "create": _cf_oai_create,
+        "update": _cf_oai_update,
+        "delete": _cf_oai_delete,
+    },
     "AWS::CloudFront::Distribution": {"create": _cf_distribution_create, "delete": _cf_distribution_delete},
     "AWS::CloudFront::KeyValueStore": {"create": _cf_kvs_create, "update": _cf_kvs_update, "delete": _cf_kvs_delete},
     "AWS::CloudWatch::Alarm": {"create": _cw_metric_alarm_create, "delete": _cw_metric_alarm_delete},

--- a/tests/test_cfn.py
+++ b/tests/test_cfn.py
@@ -2,6 +2,7 @@ import base64
 import io
 import json
 import os
+import re
 import time
 import urllib.request
 import uuid as _uuid_mod
@@ -4122,6 +4123,66 @@ def test_cfn_cloudfront_keyvaluestore_create_update_delete(cfn, cloudfront):
     with pytest.raises(ClientError) as exc:
         cloudfront.describe_key_value_store(Name=kvs_name)
     assert exc.value.response["Error"]["Code"] == "EntityNotFound"
+
+
+def test_cfn_cloudfront_origin_access_identity_attributes(cfn):
+    """CloudFront OAIs expose stable CFN identities and canonical user IDs."""
+    suffix = _uuid_mod.uuid4().hex[:8]
+    stack_name = f"cfn-cloudfront-oai-{suffix}"
+
+    def template(comment):
+        return {
+            "AWSTemplateFormatVersion": "2010-09-09",
+            "Resources": {
+                "OriginAccessIdentity": {
+                    "Type": "AWS::CloudFront::CloudFrontOriginAccessIdentity",
+                    "Properties": {
+                        "CloudFrontOriginAccessIdentityConfig": {
+                            "Comment": comment,
+                        },
+                    },
+                },
+            },
+            "Outputs": {
+                "OaiRef": {"Value": {"Ref": "OriginAccessIdentity"}},
+                "OaiId": {
+                    "Value": {"Fn::GetAtt": ["OriginAccessIdentity", "Id"]},
+                },
+                "CanonicalUserId": {
+                    "Value": {
+                        "Fn::GetAtt": [
+                            "OriginAccessIdentity",
+                            "S3CanonicalUserId",
+                        ],
+                    },
+                },
+            },
+        }
+
+    cfn.create_stack(
+        StackName=stack_name,
+        TemplateBody=json.dumps(template("initial comment")),
+    )
+    stack = _wait_stack(cfn, stack_name)
+    assert stack["StackStatus"] == "CREATE_COMPLETE", stack.get("StackStatusReason")
+    outputs = {item["OutputKey"]: item["OutputValue"] for item in stack["Outputs"]}
+    assert outputs["OaiRef"] == outputs["OaiId"]
+    assert re.fullmatch(r"E[A-Z0-9]{13}", outputs["OaiId"])
+    assert re.fullmatch(r"[0-9a-f]{64}", outputs["CanonicalUserId"])
+
+    original_outputs = outputs
+    cfn.update_stack(
+        StackName=stack_name,
+        TemplateBody=json.dumps(template("updated comment")),
+    )
+    stack = _wait_stack(cfn, stack_name)
+    assert stack["StackStatus"] == "UPDATE_COMPLETE", stack.get("StackStatusReason")
+    outputs = {item["OutputKey"]: item["OutputValue"] for item in stack["Outputs"]}
+    assert outputs == original_outputs
+
+    cfn.delete_stack(StackName=stack_name)
+    stack = _wait_stack(cfn, stack_name)
+    assert stack["StackStatus"] == "DELETE_COMPLETE"
 
 
 def test_cfn_cloudfront_distribution_supports_invalidations(cfn, cloudfront):


### PR DESCRIPTION
## Summary

- add a native CloudFormation provisioner for `AWS::CloudFront::CloudFrontOriginAccessIdentity`
- expose the identity through `Ref`, `Id`, and `S3CanonicalUserId`
- retain identity and attributes across mutable comment updates
- keep local CloudFront and S3 access permissive

## Validation

- `pytest tests/test_cfn.py::test_cfn_cloudfront_origin_access_identity_attributes -q`
- `ruff check ministack/services/cloudformation/provisioners.py tests/test_cfn.py`
- `git diff --check`

Closes #1186
