### PR TITLE
feat(transfer): scope state by region

### DIFF
--- a/ministack/core/persistence.py
+++ b/ministack/core/persistence.py
@@ -42,6 +42,7 @@ SERVICE_STATE_FORMAT_VERSIONS = {
     "servicediscovery": 3,
     "ses": 3,
     "ses_v2": 3,
+    "transfer": 3,
 }
 
 

--- a/ministack/services/transfer.py
+++ b/ministack/services/transfer.py
@@ -44,7 +44,7 @@ from typing import AsyncIterator, Optional
 
 from ministack.core.persistence import load_state
 from ministack.core.responses import (
-    AccountScopedDict,
+    AccountRegionScopedDict,
     error_response_json,
     get_account_id,
     get_region,
@@ -75,8 +75,8 @@ REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 # ---------------------------------------------------------------------------
 # In-memory state
 # ---------------------------------------------------------------------------
-_servers = AccountScopedDict()  # server_id -> server record
-_users = AccountScopedDict()    # "{server_id}/{user_name}" -> user record
+_servers = AccountRegionScopedDict()  # server_id -> server record
+_users = AccountRegionScopedDict()    # "{server_id}/{user_name}" -> user record
 
 
 def reset():
@@ -610,29 +610,29 @@ def _sftp_normalize_key(key_body: str) -> str:
 
 def _sftp_resolve_user_by_key(username: str, presented_key_body: str):
     """Scan every Transfer user across every account for a matching
-    (UserName, SshPublicKey) pair. Returns ``(account_id, server_id, user)``
-    or ``None``.
+    (UserName, SshPublicKey) pair. Returns
+    ``(account_id, region, server_id, user)`` or ``None``.
 
-    AccountScopedDict stores entries under tuple keys ``(account_id, key)``,
-    so we iterate ``_data.items()`` directly to scan across accounts —
-    `__iter__` would only yield the current request's account, which isn't
-    set during SFTP auth.
+    AccountRegionScopedDict stores entries under tuple keys
+    ``(account_id, region, key)``, so we iterate ``_data.items()`` directly
+    to scan across accounts and regions — `__iter__` would only yield the
+    current request's scope, which isn't set during SFTP auth.
     """
     presented = _sftp_normalize_key(presented_key_body)
     for scoped_key, user in _users._data.items():
-        account_id, _ = scoped_key
+        account_id, region, _ = scoped_key
         if user.get("UserName") != username:
             continue
         for key_record in user.get("SshPublicKeys", []):
             if _sftp_normalize_key(key_record.get("SshPublicKeyBody", "")) == presented:
-                return account_id, user["ServerId"], user
+                return account_id, region, user["ServerId"], user
     return None
 
 
-def _sftp_server_state(account_id: str, server_id: str):
+def _sftp_server_state(account_id: str, region: str, server_id: str):
     """Return the State of a Transfer server (ONLINE / OFFLINE) or None
-    if the server doesn't exist for the given account."""
-    server = _servers._data.get((account_id, server_id))
+    if the server doesn't exist for the given account and region."""
+    server = _servers.get_scoped(account_id, region, server_id)
     return server["State"] if server else None
 
 
@@ -785,9 +785,9 @@ def _sftp_build_server_factory(restrict_to_server_id: Optional[str] = None):
 
 
 class _MiniStackSSHServer(asyncssh.SSHServer if _ASYNCSSH_AVAILABLE else object):
-    """SSH-side auth callback. Resolves the (account, server, user) tuple
-    from the presented public key and stashes it on the connection so the
-    SFTP layer can read it back.
+    """SSH-side auth callback. Resolves the (account, region, server, user)
+    tuple from the presented public key and stashes it on the connection so
+    the SFTP layer can read it back.
 
     Subclassing :class:`asyncssh.SSHServer` (rather than just duck-typing
     the relevant methods) is required because asyncssh probes a wide set
@@ -839,17 +839,18 @@ class _MiniStackSSHServer(asyncssh.SSHServer if _ASYNCSSH_AVAILABLE else object)
         if not match:
             return False
 
-        account_id, server_id, user = match
+        account_id, region, server_id, user = match
         if self._restrict_to_server_id and server_id != self._restrict_to_server_id:
             return False
-        if _sftp_server_state(account_id, server_id) != "ONLINE":
+        if _sftp_server_state(account_id, region, server_id) != "ONLINE":
             return False
 
-        self._resolved = (account_id, server_id, user)
+        self._resolved = (account_id, region, server_id, user)
         if self._conn is not None:
             self._conn.set_extra_info(ministack_user=user)
             self._conn.set_extra_info(ministack_server_id=server_id)
             self._conn.set_extra_info(ministack_account_id=account_id)
+            self._conn.set_extra_info(ministack_region=region)
         return True
 
 
@@ -879,6 +880,7 @@ class _MiniStackSFTPServer(asyncssh.SFTPServer if _ASYNCSSH_AVAILABLE else objec
             conn = chan._conn
         self._user = conn.get_extra_info("ministack_user") if conn else None
         self._account_id = conn.get_extra_info("ministack_account_id") if conn else None
+        self._region = conn.get_extra_info("ministack_region") if conn else None
         self._server_id = conn.get_extra_info("ministack_server_id") if conn else None
         # Open-file map. Reads use BytesIO over the existing object body;
         # writes accumulate into a BytesIO that we PUT on close.
@@ -888,10 +890,12 @@ class _MiniStackSFTPServer(asyncssh.SFTPServer if _ASYNCSSH_AVAILABLE else objec
     def _resolve(self, path):
         """bytes path → (bucket, key) for the currently authenticated user,
         within their account context."""
-        from ministack.core.responses import set_request_account_id
+        from ministack.core.responses import set_request_account_id, set_request_region
 
         if self._account_id:
             set_request_account_id(self._account_id)
+        if self._region:
+            set_request_region(self._region)
         virtual = path.decode("utf-8", errors="replace") if isinstance(path, bytes) else path
         return _sftp_resolve_s3_target(self._user or {}, virtual)
 

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1903,6 +1903,64 @@ def test_emr_region_scoped_state_is_rejected_by_v2_reader(monkeypatch, tmp_path)
     assert persistence.load_state("emr") is None
 
 
+def test_transfer_region_scoped_state_is_rejected_by_v2_reader(
+    monkeypatch, tmp_path
+):
+    """A rollback binary must reject Transfer's regional schema instead of
+    accepting it as v2 and silently dropping regional servers and users."""
+    import json as _json
+
+    from ministack.core.responses import AccountRegionScopedDict
+
+    monkeypatch.setattr(persistence, "PERSIST_STATE", True)
+    monkeypatch.setattr(persistence, "STATE_DIR", str(tmp_path))
+
+    servers = AccountRegionScopedDict()
+    servers.set_scoped(
+        "000000000000",
+        "us-west-2",
+        "s-regionalserver01",
+        {
+            "ServerId": "s-regionalserver01",
+            "Arn": (
+                "arn:aws:transfer:us-west-2:000000000000:"
+                "server/s-regionalserver01"
+            ),
+        },
+    )
+    users = AccountRegionScopedDict()
+    users.set_scoped(
+        "000000000000",
+        "us-west-2",
+        "s-regionalserver01/regional-user",
+        {
+            "ServerId": "s-regionalserver01",
+            "UserName": "regional-user",
+            "Arn": (
+                "arn:aws:transfer:us-west-2:000000000000:"
+                "user/s-regionalserver01/regional-user"
+            ),
+        },
+    )
+    persistence.save_state("transfer", {"servers": servers, "users": users})
+
+    raw = _json.loads((tmp_path / "transfer.json").read_text())
+    assert raw["__ministack_format__"] == 3
+    loaded_servers = persistence.load_state("transfer")["servers"]
+    assert loaded_servers.get_scoped(
+        "000000000000", "us-west-2", "s-regionalserver01"
+    )["ServerId"] == "s-regionalserver01"
+    loaded_users = persistence.load_state("transfer")["users"]
+    assert loaded_users.get_scoped(
+        "000000000000",
+        "us-west-2",
+        "s-regionalserver01/regional-user",
+    )["UserName"] == "regional-user"
+
+    monkeypatch.setattr(persistence, "SERVICE_STATE_FORMAT_VERSIONS", {})
+    assert persistence.load_state("transfer") is None
+
+
 def test_resource_groups_region_scoped_state_is_rejected_by_v2_reader(
     monkeypatch, tmp_path
 ):

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -432,6 +432,20 @@ def _provision(transfer, s3, *, bucket=None, home_prefix="", logical_mappings=No
     }
 
 
+def _regional_transfer_client(region):
+    import boto3
+    from botocore.config import Config
+
+    return boto3.client(
+        "transfer",
+        endpoint_url=os.environ.get("MINISTACK_ENDPOINT", "http://localhost:4566"),
+        aws_access_key_id="test",
+        aws_secret_access_key="test",
+        region_name=region,
+        config=Config(region_name=region, retries={"mode": "standard"}),
+    )
+
+
 # ---------------------------------------------------------------------------
 # Happy path
 # ---------------------------------------------------------------------------
@@ -680,11 +694,9 @@ def test_sftp_concurrent_uploads_two_users(transfer, s3):
     transfer.delete_server(ServerId=b["server_id"])
 
 
-def test_sftp_key_disambiguates_overlapping_usernames(transfer, s3):
-    """Two servers, same UserName, different keys: each user's key routes
-    to the correct server's bucket. This is the AWS-faithful single-port
-    behavior — username alone isn't enough, the SSH key is the
-    disambiguator."""
+def test_sftp_key_disambiguates_overlapping_usernames(s3):
+    """Same UserName in two regions with distinct keys routes each login to
+    the matching regional user, server, and home-directory bucket."""
     suffix = uuid.uuid4().hex[:8]
     user_name = f"shared-{suffix}"
     bucket_a = f"sftp-share-a-{suffix}"
@@ -692,17 +704,19 @@ def test_sftp_key_disambiguates_overlapping_usernames(transfer, s3):
     s3.create_bucket(Bucket=bucket_a)
     s3.create_bucket(Bucket=bucket_b)
 
-    sid_a = transfer.create_server()["ServerId"]
-    sid_b = transfer.create_server()["ServerId"]
+    east = _regional_transfer_client("us-east-1")
+    west = _regional_transfer_client("us-west-2")
+    sid_a = east.create_server()["ServerId"]
+    sid_b = west.create_server()["ServerId"]
     priv_a, pub_a = _gen_keypair()
     priv_b, pub_b = _gen_keypair()
-    transfer.create_user(
+    east.create_user(
         ServerId=sid_a, UserName=user_name,
         Role="arn:aws:iam::000000000000:role/r",
         HomeDirectoryType="PATH", HomeDirectory=f"/{bucket_a}",
         SshPublicKeyBody=pub_a,
     )
-    transfer.create_user(
+    west.create_user(
         ServerId=sid_b, UserName=user_name,
         Role="arn:aws:iam::000000000000:role/r",
         HomeDirectoryType="PATH", HomeDirectory=f"/{bucket_b}",
@@ -720,8 +734,85 @@ def test_sftp_key_disambiguates_overlapping_usernames(transfer, s3):
 
     assert s3.get_object(Bucket=bucket_a, Key="marker")["Body"].read() == b"from-a"
     assert s3.get_object(Bucket=bucket_b, Key="marker")["Body"].read() == b"from-b"
-    transfer.delete_server(ServerId=sid_a)
-    transfer.delete_server(ServerId=sid_b)
+    east.delete_server(ServerId=sid_a)
+    west.delete_server(ServerId=sid_b)
+
+
+def test_sftp_auth_uses_server_region_and_stashes_connection_metadata():
+    from ministack.core.responses import (
+        get_account_id,
+        get_region,
+        set_request_account_id,
+        set_request_region,
+    )
+    from ministack.services import transfer as service
+
+    class _FakeConnection:
+        def __init__(self):
+            self.extra_info = {}
+
+        def set_extra_info(self, **kwargs):
+            self.extra_info.update(kwargs)
+
+    account_id = "111111111111"
+    east_region = "us-east-1"
+    west_region = "us-west-2"
+    server_id = "s-sharedregional01"
+    user_name = "shared-regional-user"
+    user_key = f"{server_id}/{user_name}"
+    original_account = get_account_id()
+    original_region = get_region()
+    _priv_east, pub_east = _gen_keypair()
+    _priv_west, pub_west = _gen_keypair()
+    east_user = {
+        "ServerId": server_id,
+        "UserName": user_name,
+        "SshPublicKeys": [{"SshPublicKeyBody": pub_east}],
+    }
+    west_user = {
+        "ServerId": server_id,
+        "UserName": user_name,
+        "SshPublicKeys": [{"SshPublicKeyBody": pub_west}],
+    }
+
+    service.reset()
+    try:
+        set_request_account_id(account_id)
+        service._servers.set_scoped(
+            account_id, east_region, server_id, {"State": "ONLINE"}
+        )
+        service._servers.set_scoped(
+            account_id, west_region, server_id, {"State": "OFFLINE"}
+        )
+        service._users.set_scoped(account_id, east_region, user_key, east_user)
+        service._users.set_scoped(account_id, west_region, user_key, west_user)
+
+        assert service._sftp_server_state(account_id, east_region, server_id) == "ONLINE"
+        assert service._sftp_server_state(account_id, west_region, server_id) == "OFFLINE"
+
+        connection = _FakeConnection()
+        auth_server = service._MiniStackSSHServer()
+        auth_server.connection_made(connection)
+        assert auth_server.validate_public_key(
+            user_name, asyncssh.import_public_key(pub_east)
+        )
+        assert auth_server._resolved == (
+            account_id, east_region, server_id, east_user
+        )
+        assert connection.extra_info["ministack_account_id"] == account_id
+        assert connection.extra_info["ministack_region"] == east_region
+        assert connection.extra_info["ministack_server_id"] == server_id
+        assert connection.extra_info["ministack_user"] == east_user
+
+        denied_server = service._MiniStackSSHServer()
+        denied_server.connection_made(_FakeConnection())
+        assert not denied_server.validate_public_key(
+            user_name, asyncssh.import_public_key(pub_west)
+        )
+    finally:
+        service.reset()
+        set_request_account_id(original_account)
+        set_request_region(original_region)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_transfer_region_state.py
+++ b/tests/test_transfer_region_state.py
@@ -1,0 +1,125 @@
+import pytest
+from botocore.exceptions import ClientError
+
+
+def test_transfer_servers_and_users_are_region_scoped():
+    import os
+
+    import boto3
+    from botocore.config import Config
+
+    def _client(region):
+        return boto3.client(
+            "transfer",
+            endpoint_url=os.environ.get("MINISTACK_ENDPOINT", "http://localhost:4566"),
+            aws_access_key_id="test",
+            aws_secret_access_key="test",
+            region_name=region,
+            config=Config(region_name=region, retries={"mode": "standard"}),
+        )
+
+    east = _client("us-east-1")
+    west = _client("us-west-2")
+    east_server = east.create_server()["ServerId"]
+    west_server = west.create_server()["ServerId"]
+    user_name = "same-name-regional-user"
+
+    try:
+        east.create_user(
+            ServerId=east_server,
+            UserName=user_name,
+            Role="arn:aws:iam::000000000000:role/transfer-role",
+        )
+        west.create_user(
+            ServerId=west_server,
+            UserName=user_name,
+            Role="arn:aws:iam::000000000000:role/transfer-role",
+        )
+
+        east_ids = {server["ServerId"] for server in east.list_servers()["Servers"]}
+        west_ids = {server["ServerId"] for server in west.list_servers()["Servers"]}
+        assert east_server in east_ids
+        assert east_server not in west_ids
+        assert west_server in west_ids
+        assert west_server not in east_ids
+        assert east.list_users(ServerId=east_server)["Users"][0]["UserName"] == user_name
+        assert west.list_users(ServerId=west_server)["Users"][0]["UserName"] == user_name
+        with pytest.raises(ClientError) as exc:
+            west.describe_server(ServerId=east_server)
+        assert exc.value.response["Error"]["Code"] == "ResourceNotFoundException"
+    finally:
+        east.delete_server(ServerId=east_server)
+        west.delete_server(ServerId=west_server)
+
+
+def test_transfer_legacy_state_restores_resources_to_arn_region():
+    from ministack.core.responses import (
+        AccountScopedDict,
+        get_account_id,
+        get_region,
+        set_request_account_id,
+        set_request_region,
+    )
+    from ministack.services import transfer as service
+
+    account_id = "111111111111"
+    boot_region = "us-east-1"
+    resource_region = "us-west-2"
+    server_id = "s-legacyregional01"
+    user_name = "legacy-user"
+    user_key = f"{server_id}/{user_name}"
+    original_account = get_account_id()
+    original_region = get_region()
+    servers = AccountScopedDict()
+    users = AccountScopedDict()
+
+    set_request_account_id(account_id)
+    set_request_region(boot_region)
+    servers[server_id] = {
+        "ServerId": server_id,
+        "Arn": f"arn:aws:transfer:{resource_region}:{account_id}:server/{server_id}",
+        "State": "ONLINE",
+    }
+    users[user_key] = {
+        "ServerId": server_id,
+        "UserName": user_name,
+        "Arn": (
+            f"arn:aws:transfer:{resource_region}:{account_id}:"
+            f"user/{server_id}/{user_name}"
+        ),
+    }
+
+    service.reset()
+    try:
+        service.restore_state({"servers": servers, "users": users})
+        assert service._servers.get_scoped(
+            account_id, resource_region, server_id
+        )["ServerId"] == server_id
+        assert service._users.get_scoped(
+            account_id, resource_region, user_key
+        )["UserName"] == user_name
+        assert service._servers.get_scoped(account_id, boot_region, server_id) is None
+        assert service._users.get_scoped(account_id, boot_region, user_key) is None
+    finally:
+        service.reset()
+        set_request_account_id(original_account)
+        set_request_region(original_region)
+
+
+def test_transfer_reset_clears_state_across_regions():
+    from ministack.core.responses import get_region, set_request_region
+    from ministack.services import transfer as service
+
+    original_region = get_region()
+    service.reset()
+    try:
+        for region in ("us-east-1", "us-west-2"):
+            set_request_region(region)
+            service._servers[f"server-{region}"] = {"State": "ONLINE"}
+            service._users[f"server-{region}/user"] = {"UserName": "user"}
+        service.reset()
+        assert not service._servers.has_any()
+        assert not service._users.has_any()
+    finally:
+        service.reset()
+        set_request_region(original_region)


### PR DESCRIPTION
## Why
Transfer servers and users are currently account-scoped, so resources created in one AWS region can appear in another. Regionalizing those stores also requires carrying the matched region through SFTP authentication, which runs outside request context.

## What
- Scope Transfer servers and users by account and region, including ARN-based legacy-state migration
- Resolve and stash the matched region during SFTP authentication, then use it for server-state and session context
- Advance Transfer persistence to format v3 and keep non-SFTP regional regressions collectable without `asyncssh`

## Risk Assessment
Moderate — this changes Transfer control-plane state, SFTP authentication routing, and persisted state. The shared SFTP listener still cannot distinguish identical username/key pairs across regions, a pre-existing mock limitation; distinct keys and per-server-port mode remain unambiguous.

## Validation
* `uv run --extra dev ruff check ministack/core/persistence.py ministack/services/transfer.py tests/test_transfer.py tests/test_transfer_region_state.py`
* `uv run --extra dev pytest tests/test_transfer.py tests/test_transfer_region_state.py -q` with local MiniStack server (`34 passed, 1 skipped`)
* `uv run --extra dev pytest tests/test_persistence.py -q` (`179 passed`)
