### PR TITLE
fix(cfn): restore API Gateway provisioners

### DIFF
--- a/ministack/services/cloudformation/provisioners.py
+++ b/ministack/services/cloudformation/provisioners.py
@@ -2439,6 +2439,27 @@ def _apigw_request_validator_delete(physical_id, props):
     pass
 
 
+# --- API Gateway DocumentationVersion ---
+
+def _apigw_documentation_version_identity(props):
+    return f"{props.get('RestApiId', '')}/{props.get('DocumentationVersion', '')}"
+
+
+def _apigw_documentation_version_create(logical_id, props, stack_name):
+    # Documentation snapshots do not affect MiniStack's permissive local API
+    # request handling. A native CFN identity is sufficient for templates and
+    # dependent resources to complete their lifecycle.
+    return _apigw_documentation_version_identity(props), {}
+
+
+def _apigw_documentation_version_update(physical_id, old_props, new_props, stack_name):
+    return _apigw_documentation_version_identity(new_props), {}
+
+
+def _apigw_documentation_version_delete(physical_id, props):
+    pass
+
+
 # --- Lambda EventSourceMapping ---
 
 def _lambda_esm_create(logical_id, props, stack_name):
@@ -5317,6 +5338,7 @@ _RESOURCE_HANDLERS = {
         "create": _apigw_request_validator_create,
         "update": _apigw_request_validator_update,
         "delete": _apigw_request_validator_delete,
+    },
     "AWS::ApiGateway::DocumentationVersion": {
         "create": _apigw_documentation_version_create,
         "update": _apigw_documentation_version_update,

--- a/tests/test_cfn.py
+++ b/tests/test_cfn.py
@@ -5222,6 +5222,67 @@ def test_cfn_apigateway_request_validator_identity(cfn, apigw_v1):
         apigw_v1.delete_rest_api(restApiId=api_id)
 
 
+def test_cfn_apigateway_documentation_version_lifecycle(cfn, apigw_v1):
+    """DocumentationVersion has a stable CFN identity and supports replacement."""
+    suffix = _uuid_mod.uuid4().hex[:8]
+    stack_name = f"cfn-documentation-version-{suffix}"
+    api_id = apigw_v1.create_rest_api(name=f"documentation-version-{suffix}")["id"]
+
+    def template(version, description):
+        return {
+            "Resources": {
+                "DocumentationVersion": {
+                    "Type": "AWS::ApiGateway::DocumentationVersion",
+                    "Properties": {
+                        "RestApiId": api_id,
+                        "DocumentationVersion": version,
+                        "Description": description,
+                    },
+                },
+            },
+        }
+
+    def physical_id():
+        detail = cfn.describe_stack_resource(
+            StackName=stack_name,
+            LogicalResourceId="DocumentationVersion",
+        )["StackResourceDetail"]
+        return detail["PhysicalResourceId"]
+
+    try:
+        cfn.create_stack(
+            StackName=stack_name,
+            TemplateBody=json.dumps(template("v1", "Created")),
+        )
+        stack = _wait_stack(cfn, stack_name)
+        assert stack["StackStatus"] == "CREATE_COMPLETE", stack.get("StackStatusReason")
+        created_id = physical_id()
+        assert created_id == f"{api_id}/v1"
+
+        cfn.update_stack(
+            StackName=stack_name,
+            TemplateBody=json.dumps(template("v1", "Updated")),
+        )
+        stack = _wait_stack(cfn, stack_name)
+        assert stack["StackStatus"] == "UPDATE_COMPLETE", stack.get("StackStatusReason")
+        assert physical_id() == created_id
+
+        cfn.update_stack(
+            StackName=stack_name,
+            TemplateBody=json.dumps(template("v2", "Replacement")),
+        )
+        stack = _wait_stack(cfn, stack_name)
+        assert stack["StackStatus"] == "UPDATE_COMPLETE", stack.get("StackStatusReason")
+        assert physical_id() == f"{api_id}/v2"
+    finally:
+        try:
+            cfn.delete_stack(StackName=stack_name)
+            _wait_stack(cfn, stack_name)
+        except ClientError:
+            pass
+        apigw_v1.delete_rest_api(restApiId=api_id)
+
+
 # ---------------------------------------------------------------------------
 # ApiGatewayV1 Integration with OpenAPI spec parsing
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why
PR #1189 accidentally removed the existing API Gateway DocumentationVersion provisioners and left the new RequestValidator handler mapping unclosed, preventing CloudFormation provisioners from loading on `main`.

## What
- Restore the existing DocumentationVersion create, update, and delete helpers
- Close the RequestValidator handler entry before the DocumentationVersion registration
- Restore lifecycle coverage for both API Gateway resource types

## Risk Assessment
Low — this restores the pre-#1189 DocumentationVersion behavior and fixes the handler-table boundary without changing the new RequestValidator implementation.

## Validation
- `.venv/bin/python -m py_compile ministack/services/cloudformation/provisioners.py` — passed
- `.venv/bin/ruff check --no-cache ministack/services/cloudformation/provisioners.py tests/test_cfn.py && git diff --check` — passed
- `MINISTACK_ENDPOINT=http://127.0.0.1:4572 .venv/bin/pytest tests/test_cfn.py -v --tb=short` — both API Gateway lifecycle regressions passed; full module reached 132 passed with 2 unrelated local callback-listener failures
