### PR TITLE
fix(s3tables): Iceberg REST compat fixes for DuckDB and Spark

### DIFF
--- a/ministack/core/responses.py
+++ b/ministack/core/responses.py
@@ -421,6 +421,20 @@ def error_response_json(code: str, message: str, status: int = 400) -> tuple:
     }, body
 
 
+def error_response_iceberg(error_type: str, message: str, status: int = 400) -> tuple:
+    """Iceberg REST catalog error response, per the spec's ErrorModel.
+
+    This is a different wire shape from AWS's own JSON-1.0 errors (`error_response_json`)
+    -- clients speaking the Iceberg REST protocol (e.g. duckdb-iceberg) require a top-level
+    `error` object with `message`/`type`/`code`, or they can't tell "not found" apart from
+    any other failure and raise an opaque error instead of proceeding (e.g. treating a
+    missing table as create-worthy).
+    """
+    data = {"error": {"message": message, "type": error_type, "code": status}}
+    body = json.dumps(data, ensure_ascii=False).encode("utf-8")
+    return status, {"Content-Type": "application/json"}, body
+
+
 def now_iso() -> str:
     """Current time in AWS ISO format."""
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"

--- a/ministack/core/responses.py
+++ b/ministack/core/responses.py
@@ -421,20 +421,6 @@ def error_response_json(code: str, message: str, status: int = 400) -> tuple:
     }, body
 
 
-def error_response_iceberg(error_type: str, message: str, status: int = 400) -> tuple:
-    """Iceberg REST catalog error response, per the spec's ErrorModel.
-
-    This is a different wire shape from AWS's own JSON-1.0 errors (`error_response_json`)
-    -- clients speaking the Iceberg REST protocol (e.g. duckdb-iceberg) require a top-level
-    `error` object with `message`/`type`/`code`, or they can't tell "not found" apart from
-    any other failure and raise an opaque error instead of proceeding (e.g. treating a
-    missing table as create-worthy).
-    """
-    data = {"error": {"message": message, "type": error_type, "code": status}}
-    body = json.dumps(data, ensure_ascii=False).encode("utf-8")
-    return status, {"Content-Type": "application/json"}, body
-
-
 def now_iso() -> str:
     """Current time in AWS ISO format."""
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"

--- a/ministack/services/s3tables.py
+++ b/ministack/services/s3tables.py
@@ -509,7 +509,17 @@ def _iceberg_commit_table(namespace, table_name, data, allow_cross_region):
                     "snapshot-id": update.get("snapshot-id", -1),
                     "type": update.get("type", "branch")}
             elif action == "add-schema":
-                metadata.setdefault("schemas", []).append(update.get("schema", {}))
+                new_schema = update.get("schema", {})
+                metadata.setdefault("schemas", []).append(new_schema)
+                # Real Iceberg REST catalogs track the high-water mark of assigned
+                # field IDs so clients can allocate the next one; this was static from
+                # table creation, so every add-schema after the first computed its next
+                # field ID from the same stale value, colliding IDs across ALTER TABLE
+                # ADD COLUMN calls (each landed on the same "next" ID instead of a fresh
+                # one).
+                field_ids = [f["id"] for f in new_schema.get("fields", []) if "id" in f]
+                if field_ids:
+                    metadata["last-column-id"] = max(metadata.get("last-column-id", 0), max(field_ids))
             elif action == "set-current-schema":
                 metadata["current-schema-id"] = update.get("schema-id", 0)
             elif action == "add-partition-spec":

--- a/ministack/services/s3tables.py
+++ b/ministack/services/s3tables.py
@@ -597,6 +597,19 @@ def _iceberg_create_table(namespace, data, allow_cross_region):
     if not bucket_arn:
         return _error_response_iceberg("NoSuchNamespaceException", f"Namespace {namespace} not found", 404)
 
+    key = _table_key(bucket_arn, namespace, table_name)
+    if key in _tables:
+        # Not idempotent by design, per the Iceberg REST spec -- a resent CreateTable
+        # (e.g. a client retry after a lost response to a create that already landed)
+        # must be rejected, the same conflict the S3 Tables control-plane path
+        # (_create_table, above) already enforces. Without this check, a retry
+        # silently wipes the existing table's schemas/snapshots/data and replaces
+        # it with an empty fresh one -- worse than a crash, since it loses data
+        # with no error raised at all.
+        return _error_response_iceberg(
+            "AlreadyExistsException", f"Table already exists: {namespace}.{table_name}", 409
+        )
+
     schema_fields = [{"name": f.get("name", ""), "type": f.get("type", "string") if isinstance(f.get("type"), str) else "string",
                        "required": f.get("required", False)} for f in schema.get("fields", [])]
 
@@ -613,7 +626,6 @@ def _iceberg_create_table(namespace, data, allow_cross_region):
         iceberg_metadata["default-spec-id"] = partition_spec.get("spec-id", 0)
     metadata_location = f"s3://{bucket_name}/{namespace}/{table_name}/metadata/v0.metadata.json"
     arn = _table_arn(bucket_arn, namespace, table_name)
-    key = _table_key(bucket_arn, namespace, table_name)
 
     table = {
         "name": table_name, "tableARN": arn, "namespace": [namespace],

--- a/ministack/services/s3tables.py
+++ b/ministack/services/s3tables.py
@@ -204,6 +204,7 @@ def _initial_iceberg_metadata(table_name, schema_fields, location):
         "sort-orders": [{"order-id": 0, "fields": []}],
         "properties": {}, "current-snapshot-id": -1, "refs": {},
         "snapshots": [], "statistics": [], "snapshot-log": [], "metadata-log": [],
+        "next-row-id": 0,
     }
 
 
@@ -511,13 +512,27 @@ def _iceberg_commit_table(namespace, table_name, data, allow_cross_region):
                 metadata["current-snapshot-id"] = snapshot.get("snapshot-id", -1)
                 metadata["last-updated-ms"] = int(time.time() * 1000)
                 metadata["last-sequence-number"] = metadata.get("last-sequence-number", 0) + 1
+                # V3 row lineage: advance the table's next-row-id past whatever
+                # row-ids this snapshot claims to have assigned (added-rows),
+                # so later commits/reads see a consistent, always-present value.
+                metadata["next-row-id"] = metadata.get("next-row-id", 0) + snapshot.get("added-rows", 0)
             elif action == "set-snapshot-ref":
                 metadata.setdefault("refs", {})[update.get("ref-name", "main")] = {
                     "snapshot-id": update.get("snapshot-id", -1),
                     "type": update.get("type", "branch")}
             elif action == "add-schema":
                 new_schema = update.get("schema", {})
-                metadata.setdefault("schemas", []).append(new_schema)
+                # Idempotent per the Iceberg REST spec: clients (e.g. Spark and
+                # DuckDB) re-send add-schema on every commit even when nothing
+                # changed, and don't always serialize the same schema identically
+                # (e.g. an empty identifier-field-ids present or absent) -- so
+                # comparing schemas isn't reliable. What actually breaks readers
+                # (Spark's schemasById()) is two entries sharing a schema-id, so
+                # enforce that invariant directly rather than deduping by content.
+                existing = metadata.setdefault("schemas", [])
+                new_id = new_schema.get("schema-id")
+                if not any(s.get("schema-id") == new_id for s in existing):
+                    existing.append(new_schema)
                 # Advance last-column-id to the highest field ID seen, so the next
                 # add-schema allocates fresh IDs instead of colliding with these.
                 field_ids = [f["id"] for f in new_schema.get("fields", []) if "id" in f]
@@ -527,12 +542,22 @@ def _iceberg_commit_table(namespace, table_name, data, allow_cross_region):
                 metadata["current-schema-id"] = update.get("schema-id", 0)
             elif action in ("add-spec", "add-partition-spec"):
                 # Accepts both "add-spec" (the spec's wire name) and the
-                # non-standard "add-partition-spec".
-                metadata.setdefault("partition-specs", []).append(update.get("spec", {}))
+                # non-standard "add-partition-spec". Idempotent by spec-id, same
+                # reasoning as add-schema above -- clients re-declare unchanged
+                # specs on every commit.
+                new_spec = update.get("spec", {})
+                specs = metadata.setdefault("partition-specs", [])
+                new_spec_id = new_spec.get("spec-id")
+                if not any(s.get("spec-id") == new_spec_id for s in specs):
+                    specs.append(new_spec)
             elif action == "set-default-spec":
                 metadata["default-spec-id"] = update.get("spec-id", 0)
             elif action == "add-sort-order":
-                metadata.setdefault("sort-orders", []).append(update.get("sort-order", {}))
+                new_order = update.get("sort-order", {})
+                orders = metadata.setdefault("sort-orders", [])
+                new_order_id = new_order.get("order-id")
+                if not any(o.get("order-id") == new_order_id for o in orders):
+                    orders.append(new_order)
             elif action == "set-default-sort-order":
                 metadata["default-sort-order-id"] = update.get("sort-order-id", 0)
             elif action == "set-properties":

--- a/ministack/services/s3tables.py
+++ b/ministack/services/s3tables.py
@@ -507,15 +507,23 @@ def _iceberg_commit_table(namespace, table_name, data, allow_cross_region):
         for update in data.get("updates", []):
             action = update.get("action", "")
             if action == "add-snapshot":
+                # Idempotent per the Iceberg REST spec, same reasoning as add-schema
+                # below -- a client can resend a commit whose response it never saw
+                # (e.g. a timeout) after it already landed. Guard by snapshot-id like
+                # the other add-* actions do, instead of appending unconditionally,
+                # or a resent commit duplicates the snapshot and later readers
+                # (Iceberg's snapshotsById()) crash with "Multiple entries with same key".
                 snapshot = update.get("snapshot", {})
-                metadata.setdefault("snapshots", []).append(snapshot)
+                existing = metadata.setdefault("snapshots", [])
+                if not any(s.get("snapshot-id") == snapshot.get("snapshot-id") for s in existing):
+                    existing.append(snapshot)
+                    # V3 row lineage: advance the table's next-row-id past whatever
+                    # row-ids this snapshot claims to have assigned (added-rows), so
+                    # later commits/reads see a consistent, always-present value.
+                    metadata["next-row-id"] = metadata.get("next-row-id", 0) + snapshot.get("added-rows", 0)
+                    metadata["last-sequence-number"] = metadata.get("last-sequence-number", 0) + 1
                 metadata["current-snapshot-id"] = snapshot.get("snapshot-id", -1)
                 metadata["last-updated-ms"] = int(time.time() * 1000)
-                metadata["last-sequence-number"] = metadata.get("last-sequence-number", 0) + 1
-                # V3 row lineage: advance the table's next-row-id past whatever
-                # row-ids this snapshot claims to have assigned (added-rows),
-                # so later commits/reads see a consistent, always-present value.
-                metadata["next-row-id"] = metadata.get("next-row-id", 0) + snapshot.get("added-rows", 0)
             elif action == "set-snapshot-ref":
                 metadata.setdefault("refs", {})[update.get("ref-name", "main")] = {
                     "snapshot-id": update.get("snapshot-id", -1),

--- a/ministack/services/s3tables.py
+++ b/ministack/services/s3tables.py
@@ -507,12 +507,7 @@ def _iceberg_commit_table(namespace, table_name, data, allow_cross_region):
         for update in data.get("updates", []):
             action = update.get("action", "")
             if action == "add-snapshot":
-                # Idempotent per the Iceberg REST spec, same reasoning as add-schema
-                # below -- a client can resend a commit whose response it never saw
-                # (e.g. a timeout) after it already landed. Guard by snapshot-id like
-                # the other add-* actions do, instead of appending unconditionally,
-                # or a resent commit duplicates the snapshot and later readers
-                # (Iceberg's snapshotsById()) crash with "Multiple entries with same key".
+                # Idempotent per the Iceberg REST spec
                 snapshot = update.get("snapshot", {})
                 existing = metadata.setdefault("snapshots", [])
                 if not any(s.get("snapshot-id") == snapshot.get("snapshot-id") for s in existing):
@@ -530,15 +525,9 @@ def _iceberg_commit_table(namespace, table_name, data, allow_cross_region):
                     "type": update.get("type", "branch")}
             elif action == "add-schema":
                 new_schema = update.get("schema", {})
-                # Idempotent per the Iceberg REST spec: clients (e.g. Spark and
-                # DuckDB) re-send add-schema on every commit even when nothing
-                # changed, and don't always serialize the same schema identically
-                # (e.g. an empty identifier-field-ids present or absent) -- so
-                # comparing schemas isn't reliable. What actually breaks readers
-                # (Spark's schemasById()) is two entries sharing a schema-id, so
-                # enforce that invariant directly rather than deduping by content.
                 existing = metadata.setdefault("schemas", [])
                 new_id = new_schema.get("schema-id")
+                # Idempotent per the Iceberg REST spec
                 if not any(s.get("schema-id") == new_id for s in existing):
                     existing.append(new_schema)
                 # Advance last-column-id to the highest field ID seen, so the next
@@ -550,12 +539,11 @@ def _iceberg_commit_table(namespace, table_name, data, allow_cross_region):
                 metadata["current-schema-id"] = update.get("schema-id", 0)
             elif action in ("add-spec", "add-partition-spec"):
                 # Accepts both "add-spec" (the spec's wire name) and the
-                # non-standard "add-partition-spec". Idempotent by spec-id, same
-                # reasoning as add-schema above -- clients re-declare unchanged
-                # specs on every commit.
+                # non-standard "add-partition-spec"
                 new_spec = update.get("spec", {})
                 specs = metadata.setdefault("partition-specs", [])
                 new_spec_id = new_spec.get("spec-id")
+                # Idempotent per the Iceberg REST spec
                 if not any(s.get("spec-id") == new_spec_id for s in specs):
                     specs.append(new_spec)
             elif action == "set-default-spec":
@@ -599,13 +587,6 @@ def _iceberg_create_table(namespace, data, allow_cross_region):
 
     key = _table_key(bucket_arn, namespace, table_name)
     if key in _tables:
-        # Not idempotent by design, per the Iceberg REST spec -- a resent CreateTable
-        # (e.g. a client retry after a lost response to a create that already landed)
-        # must be rejected, the same conflict the S3 Tables control-plane path
-        # (_create_table, above) already enforces. Without this check, a retry
-        # silently wipes the existing table's schemas/snapshots/data and replaces
-        # it with an empty fresh one -- worse than a crash, since it loses data
-        # with no error raised at all.
         return _error_response_iceberg(
             "AlreadyExistsException", f"Table already exists: {namespace}.{table_name}", 409
         )

--- a/ministack/services/s3tables.py
+++ b/ministack/services/s3tables.py
@@ -522,7 +522,10 @@ def _iceberg_commit_table(namespace, table_name, data, allow_cross_region):
                     metadata["last-column-id"] = max(metadata.get("last-column-id", 0), max(field_ids))
             elif action == "set-current-schema":
                 metadata["current-schema-id"] = update.get("schema-id", 0)
-            elif action == "add-partition-spec":
+            elif action in ("add-spec", "add-partition-spec"):
+                # The Iceberg REST spec's real wire name is "add-spec" (what
+                # spec-compliant clients like duckdb-iceberg send); "add-partition-spec"
+                # is accepted too for callers still using the non-standard name.
                 metadata.setdefault("partition-specs", []).append(update.get("spec", {}))
             elif action == "set-default-spec":
                 metadata["default-spec-id"] = update.get("spec-id", 0)

--- a/ministack/services/s3tables.py
+++ b/ministack/services/s3tables.py
@@ -39,7 +39,6 @@ from ministack.core.arn import ArnParseError, parse_arn
 from ministack.core.persistence import PERSIST_STATE, load_state
 from ministack.core.responses import (
     AccountRegionScopedDict,
-    error_response_iceberg,
     error_response_json,
     get_account_id,
     get_region,
@@ -434,6 +433,13 @@ def _update_table_metadata_location(bucket_arn, namespace, table_name, data):
 
 # ── Iceberg REST catalog (data plane for Spark) ───────────
 
+def _error_response_iceberg(error_type: str, message: str, status: int = 400) -> tuple:
+    """Iceberg REST catalog error response, per the spec's ErrorModel."""
+    data = {"error": {"message": message, "type": error_type, "code": status}}
+    body = json.dumps(data, ensure_ascii=False).encode("utf-8")
+    return status, {"Content-Type": "application/json"}, body
+
+
 def _iceberg_config():
     return json_response({"defaults": {
         "client.region": get_region(),
@@ -458,7 +464,7 @@ def _iceberg_list_namespaces(allow_cross_region):
 def _iceberg_get_namespace(namespace, allow_cross_region):
     if _iceberg_values(_namespaces, lambda ns: _namespace_name(ns) == namespace, allow_cross_region):
         return json_response({"namespace": [namespace], "properties": {}})
-    return error_response_iceberg("NoSuchNamespaceException", f"Namespace {namespace} not found", 404)
+    return _error_response_iceberg("NoSuchNamespaceException", f"Namespace {namespace} not found", 404)
 
 
 def _iceberg_list_tables(namespace, allow_cross_region):
@@ -485,7 +491,7 @@ def _iceberg_load_table(namespace, table_name, allow_cross_region):
                 "s3.region": get_region(), "client.region": get_region(),
             },
         })
-    return error_response_iceberg("NoSuchTableException", f"Table {namespace}.{table_name} not found", 404)
+    return _error_response_iceberg("NoSuchTableException", f"Table {namespace}.{table_name} not found", 404)
 
 
 def _iceberg_commit_table(namespace, table_name, data, allow_cross_region):
@@ -512,21 +518,16 @@ def _iceberg_commit_table(namespace, table_name, data, allow_cross_region):
             elif action == "add-schema":
                 new_schema = update.get("schema", {})
                 metadata.setdefault("schemas", []).append(new_schema)
-                # Real Iceberg REST catalogs track the high-water mark of assigned
-                # field IDs so clients can allocate the next one; this was static from
-                # table creation, so every add-schema after the first computed its next
-                # field ID from the same stale value, colliding IDs across ALTER TABLE
-                # ADD COLUMN calls (each landed on the same "next" ID instead of a fresh
-                # one).
+                # Advance last-column-id to the highest field ID seen, so the next
+                # add-schema allocates fresh IDs instead of colliding with these.
                 field_ids = [f["id"] for f in new_schema.get("fields", []) if "id" in f]
                 if field_ids:
                     metadata["last-column-id"] = max(metadata.get("last-column-id", 0), max(field_ids))
             elif action == "set-current-schema":
                 metadata["current-schema-id"] = update.get("schema-id", 0)
             elif action in ("add-spec", "add-partition-spec"):
-                # The Iceberg REST spec's real wire name is "add-spec" (what
-                # spec-compliant clients like duckdb-iceberg send); "add-partition-spec"
-                # is accepted too for callers still using the non-standard name.
+                # Accepts both "add-spec" (the spec's wire name) and the
+                # non-standard "add-partition-spec".
                 metadata.setdefault("partition-specs", []).append(update.get("spec", {}))
             elif action == "set-default-spec":
                 metadata["default-spec-id"] = update.get("spec-id", 0)
@@ -550,7 +551,7 @@ def _iceberg_commit_table(namespace, table_name, data, allow_cross_region):
         table["modifiedAt"] = now_iso()
         return json_response({"metadata-location": new_loc, "metadata": metadata})
 
-    return error_response_iceberg("NoSuchTableException", f"Table {namespace}.{table_name} not found", 404)
+    return _error_response_iceberg("NoSuchTableException", f"Table {namespace}.{table_name} not found", 404)
 
 
 def _iceberg_create_table(namespace, data, allow_cross_region):
@@ -561,7 +562,7 @@ def _iceberg_create_table(namespace, data, allow_cross_region):
     if matches:
         bucket_arn = matches[0].get("tableBucketARN")
     if not bucket_arn:
-        return error_response_iceberg("NoSuchNamespaceException", f"Namespace {namespace} not found", 404)
+        return _error_response_iceberg("NoSuchNamespaceException", f"Namespace {namespace} not found", 404)
 
     schema_fields = [{"name": f.get("name", ""), "type": f.get("type", "string") if isinstance(f.get("type"), str) else "string",
                        "required": f.get("required", False)} for f in schema.get("fields", [])]
@@ -573,11 +574,8 @@ def _iceberg_create_table(namespace, data, allow_cross_region):
         iceberg_metadata["schemas"] = [schema]
     partition_spec = data.get("partition-spec")
     if partition_spec:
-        # _initial_iceberg_metadata hardcodes an empty spec-id-0 spec; honor whatever
-        # partition spec the client actually asked for at creation time instead (e.g.
-        # duckdb-iceberg's CREATE TABLE ... PARTITIONED BY), or the client's own later
-        # add-spec/set-default-spec commit -- which reads this response back into its
-        # local table state -- ends up asserting the empty one right back at us.
+        # Use the client's requested partition spec as the table's default spec,
+        # so a later add-spec/set-default-spec commit matches it and doesn't fail.
         iceberg_metadata["partition-specs"] = [partition_spec]
         iceberg_metadata["default-spec-id"] = partition_spec.get("spec-id", 0)
     metadata_location = f"s3://{bucket_name}/{namespace}/{table_name}/metadata/v0.metadata.json"

--- a/ministack/services/s3tables.py
+++ b/ministack/services/s3tables.py
@@ -39,6 +39,7 @@ from ministack.core.arn import ArnParseError, parse_arn
 from ministack.core.persistence import PERSIST_STATE, load_state
 from ministack.core.responses import (
     AccountRegionScopedDict,
+    error_response_iceberg,
     error_response_json,
     get_account_id,
     get_region,
@@ -457,7 +458,7 @@ def _iceberg_list_namespaces(allow_cross_region):
 def _iceberg_get_namespace(namespace, allow_cross_region):
     if _iceberg_values(_namespaces, lambda ns: _namespace_name(ns) == namespace, allow_cross_region):
         return json_response({"namespace": [namespace], "properties": {}})
-    return error_response_json("NotFoundException", f"Namespace {namespace} not found", 404)
+    return error_response_iceberg("NoSuchNamespaceException", f"Namespace {namespace} not found", 404)
 
 
 def _iceberg_list_tables(namespace, allow_cross_region):
@@ -484,7 +485,7 @@ def _iceberg_load_table(namespace, table_name, allow_cross_region):
                 "s3.region": get_region(), "client.region": get_region(),
             },
         })
-    return error_response_json("NotFoundException", f"Table {namespace}.{table_name} not found", 404)
+    return error_response_iceberg("NoSuchTableException", f"Table {namespace}.{table_name} not found", 404)
 
 
 def _iceberg_commit_table(namespace, table_name, data, allow_cross_region):
@@ -549,7 +550,7 @@ def _iceberg_commit_table(namespace, table_name, data, allow_cross_region):
         table["modifiedAt"] = now_iso()
         return json_response({"metadata-location": new_loc, "metadata": metadata})
 
-    return error_response_json("NotFoundException", f"Table {namespace}.{table_name} not found", 404)
+    return error_response_iceberg("NoSuchTableException", f"Table {namespace}.{table_name} not found", 404)
 
 
 def _iceberg_create_table(namespace, data, allow_cross_region):
@@ -560,7 +561,7 @@ def _iceberg_create_table(namespace, data, allow_cross_region):
     if matches:
         bucket_arn = matches[0].get("tableBucketARN")
     if not bucket_arn:
-        return error_response_json("NotFoundException", f"Namespace {namespace} not found", 404)
+        return error_response_iceberg("NoSuchNamespaceException", f"Namespace {namespace} not found", 404)
 
     schema_fields = [{"name": f.get("name", ""), "type": f.get("type", "string") if isinstance(f.get("type"), str) else "string",
                        "required": f.get("required", False)} for f in schema.get("fields", [])]

--- a/ministack/services/s3tables.py
+++ b/ministack/services/s3tables.py
@@ -571,6 +571,15 @@ def _iceberg_create_table(namespace, data, allow_cross_region):
     iceberg_metadata = _initial_iceberg_metadata(table_name, schema_fields, location)
     if schema:
         iceberg_metadata["schemas"] = [schema]
+    partition_spec = data.get("partition-spec")
+    if partition_spec:
+        # _initial_iceberg_metadata hardcodes an empty spec-id-0 spec; honor whatever
+        # partition spec the client actually asked for at creation time instead (e.g.
+        # duckdb-iceberg's CREATE TABLE ... PARTITIONED BY), or the client's own later
+        # add-spec/set-default-spec commit -- which reads this response back into its
+        # local table state -- ends up asserting the empty one right back at us.
+        iceberg_metadata["partition-specs"] = [partition_spec]
+        iceberg_metadata["default-spec-id"] = partition_spec.get("spec-id", 0)
     metadata_location = f"s3://{bucket_name}/{namespace}/{table_name}/metadata/v0.metadata.json"
     arn = _table_arn(bucket_arn, namespace, table_name)
     key = _table_key(bucket_arn, namespace, table_name)

--- a/tests/test_s3tables.py
+++ b/tests/test_s3tables.py
@@ -627,6 +627,77 @@ def test_s3tables_iceberg_transactions_commit(s3tables):
         s3tables.delete_table_bucket(tableBucketARN=bucket_arn)
 
 
+def test_s3tables_iceberg_create_table_rejects_resend_instead_of_wiping_data(s3tables):
+    """CreateTable is not idempotent per the Iceberg REST spec -- a resent create
+    (e.g. a client retry after a lost response to a create that already landed)
+    must be rejected with a conflict, matching the S3 Tables control-plane path's
+    existing 409 behaviour. Before this guard, a resend silently replaced the
+    table's metadata with a fresh empty one, discarding any snapshots/schema
+    already committed -- worse than a crash, since nothing signals data was lost."""
+    bucket_name = f"tb-createretry-{_uuid_mod.uuid4().hex[:6]}"
+    bucket_arn = s3tables.create_table_bucket(name=bucket_name)["arn"]
+    ns = f"ns_{_uuid_mod.uuid4().hex[:6]}"
+    table = f"t_{_uuid_mod.uuid4().hex[:6]}"
+    try:
+        s3tables.create_namespace(tableBucketARN=bucket_arn, namespace=[ns])
+
+        _iceberg_json(
+            f"/iceberg/v1/namespaces/{ns}/tables",
+            method="POST",
+            payload={"name": table, "schema": {"type": "struct", "schema-id": 0, "fields": []}},
+        )
+        # Commit a snapshot so there's real state a resent create could destroy.
+        snapshot_id = 42
+        _iceberg_json(
+            f"/iceberg/v1/namespaces/{ns}/tables/{table}",
+            method="POST",
+            payload={
+                "requirements": [],
+                "updates": [
+                    {
+                        "action": "add-snapshot",
+                        "snapshot": {
+                            "snapshot-id": snapshot_id,
+                            "sequence-number": 1,
+                            "timestamp-ms": 1700000000000,
+                            "manifest-list": f"s3://{bucket_name}/{ns}/{table}/metadata/snap.avro",
+                            "summary": {"operation": "append"},
+                        },
+                    },
+                ],
+            },
+        )
+
+        # Resend the identical create, simulating a retry of a create whose first
+        # response was lost.
+        try:
+            _iceberg_json(
+                f"/iceberg/v1/namespaces/{ns}/tables",
+                method="POST",
+                payload={"name": table, "schema": {"type": "struct", "schema-id": 0, "fields": []}},
+            )
+            assert False, "expected a 409 conflict on resent CreateTable"
+        except urllib.error.HTTPError as e:
+            assert e.code == 409
+            body = json.loads(e.read().decode("utf-8"))
+            assert body["error"]["type"] == "AlreadyExistsException"
+
+        # The original snapshot must still be there -- not wiped by the resend.
+        loaded = _iceberg_json(f"/iceberg/v1/namespaces/{ns}/tables/{table}")
+        snap_ids = [s.get("snapshot-id") for s in loaded["metadata"]["snapshots"]]
+        assert snapshot_id in snap_ids, "resent create-table must not wipe existing table state"
+    finally:
+        try:
+            s3tables.delete_table(tableBucketARN=bucket_arn, namespace=ns, name=table)
+        except Exception:
+            pass
+        try:
+            s3tables.delete_namespace(tableBucketARN=bucket_arn, namespace=ns)
+        except Exception:
+            pass
+        s3tables.delete_table_bucket(tableBucketARN=bucket_arn)
+
+
 def test_s3tables_iceberg_add_snapshot_is_idempotent_by_snapshot_id(s3tables):
     """A resent add-snapshot commit (e.g. a client retry after a timed-out response
     that actually landed) must not duplicate the snapshot -- Iceberg's own

--- a/tests/test_s3tables.py
+++ b/tests/test_s3tables.py
@@ -744,36 +744,24 @@ def test_s3tables_iceberg_add_spec_uses_real_wire_action_name(s3tables):
         s3tables.delete_table_bucket(tableBucketARN=bucket_arn)
 
 
-def test_s3tables_iceberg_404_uses_spec_error_shape(s3tables):
+def test_s3tables_iceberg_404_uses_spec_error_shape():
     """The Iceberg REST spec's ErrorModel is a top-level `error` object with
     `message`/`type`/`code` -- not AWS's own `__type`-keyed JSON-1.0 shape used
     elsewhere in this file's S3-control-plane responses. duckdb-iceberg's client
     parses specifically for `error.{message,type,code}` (see GetErrorMessage in
     its source) and throws an opaque error if that shape isn't present, rather
     than recognizing "not found" and proceeding (e.g. to CREATE TABLE)."""
-    bucket_name = f"tb-errshape-{_uuid_mod.uuid4().hex[:6]}"
-    bucket_arn = s3tables.create_table_bucket(name=bucket_name)["arn"]
-    ns = f"ns_{_uuid_mod.uuid4().hex[:6]}"
     try:
-        s3tables.create_namespace(tableBucketARN=bucket_arn, namespace=[ns])
-
-        try:
-            _iceberg_json(f"/iceberg/v1/namespaces/{ns}/tables/does-not-exist")
-            assert False, "expected a 404"
-        except urllib.error.HTTPError as e:
-            assert e.code == 404
-            body = json.loads(e.read().decode("utf-8"))
-            assert "error" in body, f"missing spec-required 'error' key: {body}"
-            error = body["error"]
-            assert error["type"] == "NoSuchTableException"
-            assert error["code"] == 404
-            assert "message" in error
-    finally:
-        try:
-            s3tables.delete_namespace(tableBucketARN=bucket_arn, namespace=ns)
-        except Exception:
-            pass
-        s3tables.delete_table_bucket(tableBucketARN=bucket_arn)
+        _iceberg_json("/iceberg/v1/namespaces/does-not-exist/tables/does-not-exist")
+        assert False, "expected a 404"
+    except urllib.error.HTTPError as e:
+        assert e.code == 404
+        body = json.loads(e.read().decode("utf-8"))
+        assert "error" in body, f"missing spec-required 'error' key: {body}"
+        error = body["error"]
+        assert error["type"] in ("NoSuchNamespaceException", "NoSuchTableException")
+        assert error["code"] == 404
+        assert "message" in error
 
 
 def test_s3tables_iceberg_create_table_honors_requested_partition_spec(s3tables):

--- a/tests/test_s3tables.py
+++ b/tests/test_s3tables.py
@@ -627,6 +627,59 @@ def test_s3tables_iceberg_transactions_commit(s3tables):
         s3tables.delete_table_bucket(tableBucketARN=bucket_arn)
 
 
+def test_s3tables_iceberg_add_snapshot_is_idempotent_by_snapshot_id(s3tables):
+    """A resent add-snapshot commit (e.g. a client retry after a timed-out response
+    that actually landed) must not duplicate the snapshot -- Iceberg's own
+    snapshotsById() crashes with "Multiple entries with same key" if it does, since
+    it maps the snapshots list by snapshot-id."""
+    bucket_name = f"tb-snap-{_uuid_mod.uuid4().hex[:6]}"
+    bucket_arn = s3tables.create_table_bucket(name=bucket_name)["arn"]
+    ns = f"ns_{_uuid_mod.uuid4().hex[:6]}"
+    table = f"t_{_uuid_mod.uuid4().hex[:6]}"
+    try:
+        s3tables.create_namespace(tableBucketARN=bucket_arn, namespace=[ns])
+        s3tables.create_table(tableBucketARN=bucket_arn, namespace=ns, name=table, format="ICEBERG")
+
+        snapshot_id = 4546744772296523781
+        payload = {
+            "requirements": [],
+            "updates": [
+                {
+                    "action": "add-snapshot",
+                    "snapshot": {
+                        "snapshot-id": snapshot_id,
+                        "sequence-number": 1,
+                        "timestamp-ms": 1700000000000,
+                        "manifest-list": f"s3://{bucket_name}/{ns}/{table}/metadata/snap.avro",
+                        "summary": {"operation": "append", "added-rows": 4},
+                    },
+                },
+            ],
+        }
+
+        # Send the identical commit twice, simulating a client retry of a commit
+        # whose first response was lost (e.g. a slow/overloaded server).
+        for _ in range(2):
+            _iceberg_json(f"/iceberg/v1/namespaces/{ns}/tables/{table}", method="POST", payload=payload)
+
+        loaded = _iceberg_json(f"/iceberg/v1/namespaces/{ns}/tables/{table}")
+        metadata = loaded["metadata"]
+        snap_ids = [s.get("snapshot-id") for s in metadata["snapshots"]]
+        assert snap_ids.count(snapshot_id) == 1, "resent add-snapshot must not duplicate the snapshot"
+        assert metadata["current-snapshot-id"] == snapshot_id
+        assert metadata["last-sequence-number"] == 1, "a no-op retry must not advance last-sequence-number again"
+    finally:
+        try:
+            s3tables.delete_table(tableBucketARN=bucket_arn, namespace=ns, name=table)
+        except Exception:
+            pass
+        try:
+            s3tables.delete_namespace(tableBucketARN=bucket_arn, namespace=ns)
+        except Exception:
+            pass
+        s3tables.delete_table_bucket(tableBucketARN=bucket_arn)
+
+
 def test_s3tables_iceberg_add_schema_advances_last_column_id(s3tables):
     """Each add-schema commit must bump last-column-id to the new schema's highest
     field ID, so a client allocating the *next* column's ID (e.g. DuckDB's

--- a/tests/test_s3tables.py
+++ b/tests/test_s3tables.py
@@ -625,3 +625,74 @@ def test_s3tables_iceberg_transactions_commit(s3tables):
         except Exception:
             pass
         s3tables.delete_table_bucket(tableBucketARN=bucket_arn)
+
+
+def test_s3tables_iceberg_add_schema_advances_last_column_id(s3tables):
+    """Each add-schema commit must bump last-column-id to the new schema's highest
+    field ID, so a client allocating the *next* column's ID (e.g. DuckDB's
+    ALTER TABLE ... ADD COLUMN) doesn't collide with a previous add-schema's fields."""
+    bucket_name = f"tb-lcid-{_uuid_mod.uuid4().hex[:6]}"
+    bucket_arn = s3tables.create_table_bucket(name=bucket_name)["arn"]
+    ns = f"ns_{_uuid_mod.uuid4().hex[:6]}"
+    table = f"t_{_uuid_mod.uuid4().hex[:6]}"
+    try:
+        s3tables.create_namespace(tableBucketARN=bucket_arn, namespace=[ns])
+        s3tables.create_table(tableBucketARN=bucket_arn, namespace=ns, name=table, format="ICEBERG")
+
+        _iceberg_json(
+            f"/iceberg/v1/namespaces/{ns}/tables/{table}",
+            method="POST",
+            payload={
+                "requirements": [],
+                "updates": [
+                    {
+                        "action": "add-schema",
+                        "schema": {
+                            "type": "struct", "schema-id": 1,
+                            "fields": [{"id": 1, "name": "colA", "required": False, "type": "string"}],
+                        },
+                    },
+                    {"action": "set-current-schema", "schema-id": 1},
+                ],
+            },
+        )
+        first = _iceberg_json(f"/iceberg/v1/namespaces/{ns}/tables/{table}")
+        assert first["metadata"]["last-column-id"] == 1
+
+        _iceberg_json(
+            f"/iceberg/v1/namespaces/{ns}/tables/{table}",
+            method="POST",
+            payload={
+                "requirements": [],
+                "updates": [
+                    {
+                        "action": "add-schema",
+                        "schema": {
+                            "type": "struct", "schema-id": 2,
+                            "fields": [
+                                {"id": 1, "name": "colA", "required": False, "type": "string"},
+                                {"id": 2, "name": "colB", "required": False, "type": "long"},
+                            ],
+                        },
+                    },
+                    {"action": "set-current-schema", "schema-id": 2},
+                ],
+            },
+        )
+        second = _iceberg_json(f"/iceberg/v1/namespaces/{ns}/tables/{table}")
+        metadata = second["metadata"]
+        assert metadata["last-column-id"] == 2
+
+        current_schema = next(s for s in metadata["schemas"] if s["schema-id"] == metadata["current-schema-id"])
+        field_ids = [f["id"] for f in current_schema["fields"]]
+        assert field_ids == [1, 2], "field IDs must not collide across separate add-schema commits"
+    finally:
+        try:
+            s3tables.delete_table(tableBucketARN=bucket_arn, namespace=ns, name=table)
+        except Exception:
+            pass
+        try:
+            s3tables.delete_namespace(tableBucketARN=bucket_arn, namespace=ns)
+        except Exception:
+            pass
+        s3tables.delete_table_bucket(tableBucketARN=bucket_arn)

--- a/tests/test_s3tables.py
+++ b/tests/test_s3tables.py
@@ -742,3 +742,35 @@ def test_s3tables_iceberg_add_spec_uses_real_wire_action_name(s3tables):
         except Exception:
             pass
         s3tables.delete_table_bucket(tableBucketARN=bucket_arn)
+
+
+def test_s3tables_iceberg_404_uses_spec_error_shape(s3tables):
+    """The Iceberg REST spec's ErrorModel is a top-level `error` object with
+    `message`/`type`/`code` -- not AWS's own `__type`-keyed JSON-1.0 shape used
+    elsewhere in this file's S3-control-plane responses. duckdb-iceberg's client
+    parses specifically for `error.{message,type,code}` (see GetErrorMessage in
+    its source) and throws an opaque error if that shape isn't present, rather
+    than recognizing "not found" and proceeding (e.g. to CREATE TABLE)."""
+    bucket_name = f"tb-errshape-{_uuid_mod.uuid4().hex[:6]}"
+    bucket_arn = s3tables.create_table_bucket(name=bucket_name)["arn"]
+    ns = f"ns_{_uuid_mod.uuid4().hex[:6]}"
+    try:
+        s3tables.create_namespace(tableBucketARN=bucket_arn, namespace=[ns])
+
+        try:
+            _iceberg_json(f"/iceberg/v1/namespaces/{ns}/tables/does-not-exist")
+            assert False, "expected a 404"
+        except urllib.error.HTTPError as e:
+            assert e.code == 404
+            body = json.loads(e.read().decode("utf-8"))
+            assert "error" in body, f"missing spec-required 'error' key: {body}"
+            error = body["error"]
+            assert error["type"] == "NoSuchTableException"
+            assert error["code"] == 404
+            assert "message" in error
+    finally:
+        try:
+            s3tables.delete_namespace(tableBucketARN=bucket_arn, namespace=ns)
+        except Exception:
+            pass
+        s3tables.delete_table_bucket(tableBucketARN=bucket_arn)

--- a/tests/test_s3tables.py
+++ b/tests/test_s3tables.py
@@ -774,3 +774,47 @@ def test_s3tables_iceberg_404_uses_spec_error_shape(s3tables):
         except Exception:
             pass
         s3tables.delete_table_bucket(tableBucketARN=bucket_arn)
+
+
+def test_s3tables_iceberg_create_table_honors_requested_partition_spec(s3tables):
+    """The create-table endpoint's response must echo back the partition spec the
+    client actually asked for, not a hardcoded empty one -- clients (e.g.
+    duckdb-iceberg) initialize their own local table state from this response, so an
+    empty echo here gets asserted right back at the server on the very next commit,
+    permanently losing the partition spec even though it was in the original request."""
+    bucket_name = f"tb-createspec-{_uuid_mod.uuid4().hex[:6]}"
+    bucket_arn = s3tables.create_table_bucket(name=bucket_name)["arn"]
+    ns = f"ns_{_uuid_mod.uuid4().hex[:6]}"
+    table = f"t_{_uuid_mod.uuid4().hex[:6]}"
+    try:
+        s3tables.create_namespace(tableBucketARN=bucket_arn, namespace=[ns])
+
+        created = _iceberg_json(
+            f"/iceberg/v1/namespaces/{ns}/tables",
+            method="POST",
+            payload={
+                "name": table,
+                "schema": {
+                    "type": "struct", "schema-id": 0,
+                    "fields": [{"id": 1, "name": "ts", "required": False, "type": "timestamp"}],
+                },
+                "partition-spec": {
+                    "spec-id": 0,
+                    "fields": [{"source-id": 1, "field-id": 1000, "name": "day_ts", "transform": "day"}],
+                },
+            },
+        )
+        metadata = created["metadata"]
+        spec = next(s for s in metadata["partition-specs"] if s["spec-id"] == metadata["default-spec-id"])
+        assert spec["fields"], "create-table response must echo back the requested partition spec, not an empty one"
+        assert spec["fields"][0]["transform"] == "day"
+    finally:
+        try:
+            s3tables.delete_table(tableBucketARN=bucket_arn, namespace=ns, name=table)
+        except Exception:
+            pass
+        try:
+            s3tables.delete_namespace(tableBucketARN=bucket_arn, namespace=ns)
+        except Exception:
+            pass
+        s3tables.delete_table_bucket(tableBucketARN=bucket_arn)

--- a/tests/test_s3tables.py
+++ b/tests/test_s3tables.py
@@ -696,3 +696,49 @@ def test_s3tables_iceberg_add_schema_advances_last_column_id(s3tables):
         except Exception:
             pass
         s3tables.delete_table_bucket(tableBucketARN=bucket_arn)
+
+
+def test_s3tables_iceberg_add_spec_uses_real_wire_action_name(s3tables):
+    """The Iceberg REST spec's real action name for adding a partition spec is
+    "add-spec" (what duckdb-iceberg actually sends) — not "add-partition-spec",
+    a non-standard name only some hand-rolled callers use. Both must work."""
+    bucket_name = f"tb-spec-{_uuid_mod.uuid4().hex[:6]}"
+    bucket_arn = s3tables.create_table_bucket(name=bucket_name)["arn"]
+    ns = f"ns_{_uuid_mod.uuid4().hex[:6]}"
+    table = f"t_{_uuid_mod.uuid4().hex[:6]}"
+    try:
+        s3tables.create_namespace(tableBucketARN=bucket_arn, namespace=[ns])
+        s3tables.create_table(tableBucketARN=bucket_arn, namespace=ns, name=table, format="ICEBERG")
+
+        _iceberg_json(
+            f"/iceberg/v1/namespaces/{ns}/tables/{table}",
+            method="POST",
+            payload={
+                "requirements": [],
+                "updates": [
+                    {
+                        "action": "add-spec",
+                        "spec": {
+                            "spec-id": 1,
+                            "fields": [{"source-id": 1, "field-id": 1000, "name": "day_col", "transform": "day"}],
+                        },
+                    },
+                    {"action": "set-default-spec", "spec-id": 1},
+                ],
+            },
+        )
+        loaded = _iceberg_json(f"/iceberg/v1/namespaces/{ns}/tables/{table}")
+        metadata = loaded["metadata"]
+        spec_ids = [s["spec-id"] for s in metadata["partition-specs"]]
+        assert 1 in spec_ids, "add-spec must append the new partition spec"
+        assert metadata["default-spec-id"] == 1
+    finally:
+        try:
+            s3tables.delete_table(tableBucketARN=bucket_arn, namespace=ns, name=table)
+        except Exception:
+            pass
+        try:
+            s3tables.delete_namespace(tableBucketARN=bucket_arn, namespace=ns)
+        except Exception:
+            pass
+        s3tables.delete_table_bucket(tableBucketARN=bucket_arn)


### PR DESCRIPTION
#### DuckDB fixes (ALTER TABLE / CREATE TABLE):
- Advance last-column-id on add-schema commits; it never moved, so field
  IDs collided across ALTER TABLE ADD COLUMN calls
- Recognize add-spec, the Iceberg REST spec's actual wire action name for
  adding a partition spec, alongside the old non-standard add-partition-spec
- Honor the partition spec supplied at create-table time instead of
  hardcoding an empty one
- Switch Iceberg REST 404s to the spec's IcebergErrorResponse shape
  ({"error": {"message", "type", "code"}}) instead of AWS JSON-1.0

#### Spark and retry-safety fixes:
- Populate next-row-id on V3 table metadata (it was never set at all,
  so Spark failed to parse metadata: "Cannot parse missing long:
  next-row-id"); advance it by each snapshot's added-rows on commit
- Make add-schema/add-spec/add-sort-order idempotent by id, so
  re-declaring an unchanged one (Spark does this on every write) no
  longer piles up duplicate entries that crash id-keyed lookups
  ("Multiple entries with same key")
- Make add-snapshot idempotent by snapshot-id for the same reason, on a
  resent commit after a client retry
- Reject a resent CreateTable with 409 instead of silently wiping an
  existing table's metadata, matching the control-plane CreateTable's
  existing conflict check