### PR TITLE
Scope AppSync Events state by region

### DIFF
--- a/ministack/core/persistence.py
+++ b/ministack/core/persistence.py
@@ -28,6 +28,7 @@ STATE_DIR = os.environ.get("STATE_DIR", "/tmp/ministack-state")
 STATE_FORMAT_VERSION = 2
 SERVICE_STATE_FORMAT_VERSIONS = {
     "appsync": 3,
+    "appsync_events": 3,
     "autoscaling": 3,
     "bedrock_agentcore": 3,
     "athena": 3,

--- a/ministack/services/appsync_events.py
+++ b/ministack/services/appsync_events.py
@@ -28,6 +28,7 @@ import time
 
 from ministack.core.persistence import load_state
 from ministack.core.responses import (
+    AccountRegionScopedDict,
     AccountScopedDict,
     error_response_json,
     get_account_id,
@@ -45,15 +46,15 @@ _MINISTACK_HOST = os.environ.get("MINISTACK_HOST", "localhost")
 # ---------------------------------------------------------------------------
 
 # apiId -> api record
-_apis = AccountScopedDict()
+_apis = AccountRegionScopedDict()
 # apiId -> {name -> channel namespace record}
-_channel_namespaces = AccountScopedDict()
+_channel_namespaces = AccountRegionScopedDict()
 # apiId -> {keyId -> api key record}
-_api_keys = AccountScopedDict()
+_api_keys = AccountRegionScopedDict()
 
 # Active realtime connections, keyed by opaque connection id assigned on accept.
-# {connection_id -> {"api_id": str, "account_id": str, "outbox": asyncio.Queue,
-#                     "subscriptions": {sub_id -> pattern}}}
+# {connection_id -> {"api_id": str, "account_id": str, "region": str,
+#                     "outbox": asyncio.Queue, "subscriptions": {sub_id -> pattern}}}
 _connections: dict[str, dict] = {}
 _connections_lock: asyncio.Lock | None = None
 
@@ -63,6 +64,14 @@ def _get_connections_lock() -> asyncio.Lock:
     if _connections_lock is None:
         _connections_lock = asyncio.Lock()
     return _connections_lock
+
+
+def _discover_api_scope(api_id: str, account_id: str) -> tuple[str, str] | None:
+    """Return the API's account/region scope without crossing tenants."""
+    for (scoped_account_id, region, scoped_api_id), _api in _apis.all_items():
+        if scoped_account_id == account_id and scoped_api_id == api_id:
+            return scoped_account_id, region
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -79,12 +88,37 @@ def get_state():
     }
 
 
+def _restore_api_child_store(
+    store: AccountRegionScopedDict,
+    restored: AccountRegionScopedDict | AccountScopedDict | dict,
+) -> None:
+    """Adopt legacy namespace/key records into their parent API's region."""
+    if isinstance(restored, AccountRegionScopedDict):
+        store.update(restored)
+        return
+    if not restored:
+        return
+
+    if isinstance(restored, AccountScopedDict):
+        items = restored._data.items()
+    else:
+        account_id = get_account_id()
+        items = (((account_id, api_id), value) for api_id, value in restored.items())
+
+    for (account_id, api_id), value in items:
+        api_scope = _discover_api_scope(api_id, account_id)
+        region = api_scope[1] if api_scope else get_region()
+        store.set_scoped(account_id, region, api_id, value)
+
+
 def restore_state(data):
     if not data:
         return
     _apis.update(data.get("apis", {}))
-    _channel_namespaces.update(data.get("channel_namespaces", {}))
-    _api_keys.update(data.get("api_keys", {}))
+    _restore_api_child_store(
+        _channel_namespaces, data.get("channel_namespaces", {})
+    )
+    _restore_api_child_store(_api_keys, data.get("api_keys", {}))
 
 
 # Same contract as apigateway.py (used by app.py persistence loader)
@@ -110,7 +144,15 @@ def reset():
 # Helpers
 # ---------------------------------------------------------------------------
 
-_APPSYNC_API_HOST_RE = re.compile(r"^([a-z0-9]+)\.appsync-api\.")
+_AWS_REGION_HOST_SEGMENT = r"[a-z0-9]+(?:-[a-z0-9]+)+-\d+"
+_APPSYNC_API_HOST_RE = re.compile(
+    rf"^([a-z0-9]+)\.appsync-api"
+    rf"(?:\.({_AWS_REGION_HOST_SEGMENT}))?(?:[.:]|$)"
+)
+_APPSYNC_REALTIME_HOST_RE = re.compile(
+    rf"^([a-z0-9]+)\.appsync-realtime-api"
+    rf"(?:\.({_AWS_REGION_HOST_SEGMENT}))?(?:[.:]|$)"
+)
 
 
 def _now() -> int:
@@ -153,6 +195,18 @@ def _default_dns_for_api(api_id: str) -> dict[str, str]:
             f"{api_id}.appsync-realtime-api.{region}.{mini_host}:{port}"
         ),
     }
+
+
+def _is_advertised_dns_host(
+    api_id: str, host: str, dns_kind: str
+) -> bool:
+    """Return whether ``host`` is the stored endpoint for the scoped API."""
+    api = _apis.get(api_id)
+    advertised_host = api.get("dns", {}).get(dns_kind) if api else None
+    return (
+        isinstance(advertised_host, str)
+        and host.lower() == advertised_host.lower()
+    )
 
 
 def _default_event_config(requested: dict | None) -> dict:
@@ -531,7 +585,14 @@ async def handle_request(method, path, headers, body, query_params):
     host = headers.get("host", "")
     host_match = _APPSYNC_API_HOST_RE.match(host)
     if host_match and path == "/event" and method == "POST":
-        return await _publish(host_match.group(1), headers, body)
+        return await _publish_from_host(
+            host_match.group(1),
+            host_match.group(2),
+            host,
+            headers,
+            body,
+            query_params,
+        )
 
     if path.startswith("/v2/apis"):
         return await _handle_mgmt(method, path, headers, body, query_params)
@@ -811,6 +872,53 @@ def _delete_api_key(api_id, key_id):
 # Data plane — HTTP publish
 # ---------------------------------------------------------------------------
 
+def _has_sigv4_credentials(headers: dict, query_params: dict | None) -> bool:
+    """Return whether the publish request carries an explicit SigV4 region."""
+    query_params = query_params or {}
+    auth = headers.get("authorization") or headers.get("Authorization") or ""
+    if auth.startswith("AWS4-HMAC-SHA256") and "Credential=" in auth:
+        return True
+
+    credential = (
+        query_params.get("X-Amz-Credential")
+        or query_params.get("x-amz-credential")
+    )
+    if isinstance(credential, (list, tuple)):
+        credential = credential[0] if credential else ""
+    return bool(credential)
+
+
+async def _publish_from_host(
+    api_id: str,
+    host_region: str | None,
+    host: str,
+    headers: dict,
+    body: bytes,
+    query_params: dict | None,
+):
+    """Publish in the host API's region when API-key auth supplies no SigV4 scope."""
+    if _has_sigv4_credentials(headers, query_params):
+        return await _publish(api_id, headers, body)
+
+    api_scope = _discover_api_scope(api_id, get_account_id())
+    if api_scope is None:
+        return _not_found(f"Api {api_id} not found")
+
+    from ministack.core.responses import _request_region
+
+    region_token = _request_region.set(api_scope[1])
+    try:
+        if (
+            not _is_advertised_dns_host(api_id, host, "HTTP")
+            and host_region is not None
+            and api_scope[1] != host_region
+        ):
+            return _not_found(f"Api {api_id} not found")
+        return await _publish(api_id, headers, body)
+    finally:
+        _request_region.reset(region_token)
+
+
 async def _publish(api_id: str, headers: dict, body: bytes):
     if api_id not in _apis:
         return _not_found(f"Api {api_id} not found")
@@ -935,6 +1043,48 @@ async def handle_websocket(scope, receive, send, api_id: str):
     if msg.get("type") != "websocket.connect":
         return
 
+    host = ""
+    for name, value in scope.get("headers", []):
+        if name.decode("latin-1").lower() == "host":
+            host = value.decode("latin-1")
+            break
+    host_match = _APPSYNC_REALTIME_HOST_RE.match(host)
+    host_region = host_match.group(2) if host_match else None
+
+    account_id = get_account_id()
+    api_scope = _discover_api_scope(api_id, account_id)
+    if api_scope is None:
+        await send({"type": "websocket.close", "code": 1008})
+        return
+
+    from ministack.core.responses import _request_account_id, _request_region
+    account_id, region = api_scope
+    account_token = _request_account_id.set(account_id)
+    region_token = _request_region.set(region)
+    try:
+        if (
+            not _is_advertised_dns_host(api_id, host, "REALTIME")
+            and host_region is not None
+            and region != host_region
+        ):
+            await send({"type": "websocket.close", "code": 1008})
+            return
+        await _handle_websocket_in_api_scope(
+            scope, receive, send, api_id, account_id, region
+        )
+    finally:
+        _request_region.reset(region_token)
+        _request_account_id.reset(account_token)
+
+
+async def _handle_websocket_in_api_scope(
+    scope,
+    receive,
+    send,
+    api_id: str,
+    account_id: str,
+    region: str,
+):
     if api_id not in _apis:
         await send({"type": "websocket.close", "code": 1008})
         return
@@ -1015,16 +1165,13 @@ async def handle_websocket(scope, receive, send, api_id: str):
         ):
             return
 
-    from ministack.core.responses import _request_account_id
-    account_id = get_account_id()
-    token = _request_account_id.set(account_id)
-
     connection_id = new_uuid()
     outbox: asyncio.Queue = asyncio.Queue()
     async with _get_connections_lock():
         _connections[connection_id] = {
             "api_id": api_id,
             "account_id": account_id,
+            "region": region,
             "outbox": outbox,
             "subscriptions": {},
             "auth": conn_auth,
@@ -1089,7 +1236,6 @@ async def handle_websocket(scope, receive, send, api_id: str):
         ka_task.cancel()
         async with _get_connections_lock():
             _connections.pop(connection_id, None)
-        _request_account_id.reset(token)
         try:
             await send({"type": "websocket.close", "code": 1000})
         except Exception:

--- a/tests/test_appsync_events.py
+++ b/tests/test_appsync_events.py
@@ -26,6 +26,7 @@ import struct
 import time
 from urllib.parse import urlparse
 
+import boto3
 import pytest
 from botocore.exceptions import ClientError
 
@@ -164,6 +165,16 @@ def _create_api(appsync, name):
     return appsync.create_api(name=name, eventConfig=_DEFAULT_EVENT_CONFIG)["api"]
 
 
+def _appsync_client(region: str, account: str = "test"):
+    return boto3.client(
+        "appsync",
+        endpoint_url=_ENDPOINT,
+        region_name=region,
+        aws_access_key_id=account,
+        aws_secret_access_key="test",
+    )
+
+
 async def _invoke_asgi_http(
     method: str,
     path: str,
@@ -228,7 +239,7 @@ def _create_namespace(appsync, api_id, name):
     return appsync.create_channel_namespace(apiId=api_id, name=name)["channelNamespace"]
 
 
-def _minimal_sigv4_appsync_authorization() -> str:
+def _minimal_sigv4_appsync_authorization(region: str = "us-east-1") -> str:
     """SigV4-shaped header with credential scope ``.../appsync/aws4_request`` (unsigned).
 
     MiniStack's router only inspects the ``Credential=`` segment — real Lambdas
@@ -236,7 +247,7 @@ def _minimal_sigv4_appsync_authorization() -> str:
     """
     return (
         "AWS4-HMAC-SHA256 "
-        "Credential=testkey/20260127/us-east-1/appsync/aws4_request, "
+        f"Credential=testkey/20260127/{region}/appsync/aws4_request, "
         "SignedHeaders=host;x-amz-date, "
         "Signature=" + "0" * 64
     )
@@ -404,6 +415,65 @@ def test_get_list_update_delete_api(appsync):
     assert exc.value.response["Error"]["Code"] == "NotFoundException"
 
 
+def test_event_apis_and_children_are_region_scoped():
+    east = _appsync_client("us-east-1")
+    west = _appsync_client("us-west-2")
+    east_api = _create_api(east, "same-regional-events-api")
+    west_api = _create_api(west, "same-regional-events-api")
+
+    try:
+        east.create_channel_namespace(apiId=east_api["apiId"], name="east-only")
+        west.create_channel_namespace(apiId=west_api["apiId"], name="west-only")
+        east_key = east.create_api_key(
+            apiId=east_api["apiId"], description="east-only"
+        )["apiKey"]
+        west_key = west.create_api_key(
+            apiId=west_api["apiId"], description="west-only"
+        )["apiKey"]
+
+        assert east.get_api(apiId=east_api["apiId"])["api"]["apiId"] == east_api[
+            "apiId"
+        ]
+        assert west.get_api(apiId=west_api["apiId"])["api"]["apiId"] == west_api[
+            "apiId"
+        ]
+        with pytest.raises(ClientError):
+            west.get_api(apiId=east_api["apiId"])
+        with pytest.raises(ClientError):
+            east.get_api(apiId=west_api["apiId"])
+
+        east_ids = {api["apiId"] for api in east.list_apis()["apis"]}
+        west_ids = {api["apiId"] for api in west.list_apis()["apis"]}
+        assert east_api["apiId"] in east_ids
+        assert west_api["apiId"] not in east_ids
+        assert west_api["apiId"] in west_ids
+        assert east_api["apiId"] not in west_ids
+
+        assert {
+            ns["name"]
+            for ns in east.list_channel_namespaces(apiId=east_api["apiId"])[
+                "channelNamespaces"
+            ]
+        } == {"east-only"}
+        assert {
+            ns["name"]
+            for ns in west.list_channel_namespaces(apiId=west_api["apiId"])[
+                "channelNamespaces"
+            ]
+        } == {"west-only"}
+        assert {
+            key["id"]
+            for key in east.list_api_keys(apiId=east_api["apiId"])["apiKeys"]
+        } == {east_key["id"]}
+        assert {
+            key["id"]
+            for key in west.list_api_keys(apiId=west_api["apiId"])["apiKeys"]
+        } == {west_key["id"]}
+    finally:
+        east.delete_api(apiId=east_api["apiId"])
+        west.delete_api(apiId=west_api["apiId"])
+
+
 def test_api_key_crud_via_v1_path(appsync, api):
     """boto3's ``create_api_key`` / ``list_api_keys`` / ``delete_api_key`` all
     target the v1 GraphQL endpoint. The Terraform AWS provider's
@@ -548,6 +618,113 @@ def test_publish_with_appsync_sigv4_scope_on_events_vhost():
     asyncio.run(_run())
 
 
+def test_unsigned_api_key_publish_discovers_event_api_host_region(monkeypatch):
+    """API-key publish uses the Event API host region when SigV4 supplies none."""
+    from ministack.core.responses import get_region
+    from ministack.services import appsync_events as ae
+
+    monkeypatch.setenv("APPSYNC_EVENTS_ENFORCE_AUTH", "1")
+    monkeypatch.setenv(
+        "APPSYNC_EVENTS_HTTP_HOST_TEMPLATE",
+        "{api_id}.appsync-api.internal-edge-1:{port}",
+    )
+    monkeypatch.setenv(
+        "APPSYNC_EVENTS_REALTIME_HOST_TEMPLATE",
+        "{api_id}.appsync-realtime-api.internal-edge-1:{port}",
+    )
+    ae.reset()
+    west_auth = _minimal_sigv4_appsync_authorization("us-west-2")
+    east_auth = _minimal_sigv4_appsync_authorization()
+    mgmt_host = "example.appsync-api.us-west-2.localhost:4566"
+
+    async def _run():
+        create_body = json.dumps(
+            {"name": "api-key-pub-west", "eventConfig": _DEFAULT_EVENT_CONFIG}
+        ).encode()
+        post_msgs = await _invoke_asgi_http(
+            "POST",
+            "/v2/apis",
+            mgmt_host,
+            create_body,
+            extra_headers={"authorization": west_auth},
+        )
+        post_status, _, post_body = _asgi_response(post_msgs)
+        assert post_status == 200
+        created = json.loads(post_body.decode())["api"]
+        api_id = created["apiId"]
+        custom_pub_host = created["dns"]["HTTP"]
+        assert custom_pub_host == (
+            f"{api_id}.appsync-api.internal-edge-1:4566"
+        )
+
+        ns_msgs = await _invoke_asgi_http(
+            "POST",
+            f"/v2/apis/{api_id}/channelNamespaces",
+            mgmt_host,
+            json.dumps({"name": "default"}).encode(),
+            extra_headers={"authorization": west_auth},
+        )
+        ns_status, _, ns_raw = _asgi_response(ns_msgs)
+        assert ns_status == 200, ns_raw
+
+        key_msgs = await _invoke_asgi_http(
+            "POST",
+            f"/v1/apis/{api_id}/apikeys",
+            mgmt_host,
+            json.dumps({"description": "regional-publisher"}).encode(),
+            extra_headers={"authorization": west_auth},
+        )
+        key_status, _, key_raw = _asgi_response(key_msgs)
+        assert key_status == 200, key_raw
+        api_key = json.loads(key_raw.decode())["apiKey"]["id"]
+
+        pub_host = f"{api_id}.appsync-api.us-west-2.amazonaws.com"
+        pub_body = json.dumps(
+            {"channel": "/default/room1", "events": [json.dumps("west")]}
+        ).encode()
+        pub_msgs = await _invoke_asgi_http(
+            "POST",
+            "/event",
+            pub_host,
+            pub_body,
+            extra_headers={"x-api-key": api_key},
+        )
+        pub_status, _, pub_raw = _asgi_response(pub_msgs)
+        assert pub_status == 200, pub_raw
+        assert len(json.loads(pub_raw.decode())["successful"]) == 1
+        assert get_region() == "us-east-1"
+
+        custom_pub_msgs = await _invoke_asgi_http(
+            "POST",
+            "/event",
+            custom_pub_host,
+            pub_body,
+            extra_headers={"x-api-key": api_key},
+        )
+        custom_status, _, custom_raw = _asgi_response(custom_pub_msgs)
+        assert custom_status == 200, custom_raw
+        assert len(json.loads(custom_raw.decode())["successful"]) == 1
+        assert get_region() == "us-east-1"
+
+        wrong_region_msgs = await _invoke_asgi_http(
+            "POST",
+            "/event",
+            pub_host,
+            pub_body,
+            extra_headers={
+                "authorization": east_auth,
+                "x-api-key": api_key,
+            },
+        )
+        wrong_status, _, wrong_raw = _asgi_response(wrong_region_msgs)
+        assert wrong_status == 404, wrong_raw
+
+    try:
+        asyncio.run(_run())
+    finally:
+        ae.reset()
+
+
 def test_publish_with_appsync_sigv4_on_management_host_still_404():
     """``POST /event`` on the AppSync *management* vhost is not an Events publish URL."""
     auth = _minimal_sigv4_appsync_authorization()
@@ -640,6 +817,390 @@ def test_websocket_unsubscribe_stops_delivery(api):
         assert after is None
     finally:
         ws.close()
+
+
+def test_websocket_discovers_resource_region_and_pins_frame_context(monkeypatch):
+    from ministack.core.responses import (
+        get_account_id,
+        get_region,
+        set_request_account_id,
+        set_request_region,
+    )
+    from ministack.services import appsync_events as ae
+
+    original_account = get_account_id()
+    original_region = get_region()
+    account_id = "111111111111"
+    wrong_account_id = "222222222222"
+    resource_region = "us-west-2"
+    credential_region = "us-east-1"
+    authorizer_arn = (
+        f"arn:aws:lambda:{resource_region}:{account_id}:function:events-authorizer"
+    )
+    ae.reset()
+    try:
+        set_request_account_id(account_id)
+        set_request_region(resource_region)
+        status, _, body = ae._create_api(
+            json.dumps(
+                {
+                    "name": "regional-websocket-api",
+                    "eventConfig": {
+                        "authProviders": [
+                            {
+                                "authType": "AWS_LAMBDA",
+                                "lambdaAuthorizerConfig": {
+                                    "authorizerUri": authorizer_arn,
+                                },
+                            }
+                        ],
+                    },
+                }
+            ).encode()
+        )
+        assert status == 200
+        api_id = json.loads(body)["api"]["apiId"]
+        assert ae._create_channel_namespace(
+            api_id, b'{"name":"default"}'
+        )[0] == 200
+
+        set_request_region(credential_region)
+        assert api_id not in ae._apis
+        assert ae._discover_api_scope(api_id, account_id) == (
+            account_id,
+            resource_region,
+        )
+        assert ae._discover_api_scope(api_id, wrong_account_id) is None
+
+        authorizer_calls = []
+
+        def _fake_authorizer(
+            arn,
+            api_id_arg,
+            operation,
+            channel,
+            namespace,
+            authorization_token,
+            request_headers,
+        ):
+            authorizer_calls.append(
+                {
+                    "arn": arn,
+                    "api_id": api_id_arg,
+                    "operation": operation,
+                    "account_id": get_account_id(),
+                    "region": get_region(),
+                }
+            )
+            return authorization_token == "allow", {"region": get_region()}
+
+        monkeypatch.setattr(ae, "_events_authorizer_invoke", _fake_authorizer)
+
+        async def _run():
+            incoming: asyncio.Queue = asyncio.Queue()
+            sent = []
+
+            async def receive():
+                return await incoming.get()
+
+            async def send(message):
+                sent.append(message)
+
+            async def wait_for_frame(frame_type):
+                for _ in range(200):
+                    for message in sent:
+                        if message.get("type") != "websocket.send":
+                            continue
+                        frame = json.loads(message["text"])
+                        if frame.get("type") == frame_type:
+                            return frame
+                    await asyncio.sleep(0.005)
+                raise AssertionError(f"timed out waiting for {frame_type}")
+
+            protocols = (
+                f"{_encode_auth_header({'Authorization': 'allow'})}, "
+                "aws-appsync-event-ws"
+            )
+            scope = {
+                "headers": [
+                    (
+                        b"host",
+                        (
+                            f"{api_id}.appsync-realtime-api."
+                            f"{resource_region}.amazonaws.com"
+                        ).encode("ascii"),
+                    ),
+                    (b"sec-websocket-protocol", protocols.encode("utf-8")),
+                ],
+            }
+            task = asyncio.create_task(
+                ae.handle_websocket(scope, receive, send, api_id)
+            )
+            await incoming.put({"type": "websocket.connect"})
+            for _ in range(200):
+                if any(msg.get("type") == "websocket.accept" for msg in sent):
+                    break
+                await asyncio.sleep(0.005)
+            else:
+                raise AssertionError("websocket was not accepted")
+
+            await incoming.put(
+                {
+                    "type": "websocket.receive",
+                    "text": json.dumps({"type": "connection_init"}),
+                }
+            )
+            await wait_for_frame("connection_ack")
+            connection = next(iter(ae._connections.values()))
+            assert connection["region"] == resource_region
+
+            await incoming.put(
+                {
+                    "type": "websocket.receive",
+                    "text": json.dumps(
+                        {
+                            "type": "subscribe",
+                            "id": "sub-regional",
+                            "channel": "/default/room",
+                        }
+                    ),
+                }
+            )
+            await wait_for_frame("subscribe_success")
+
+            event = json.dumps({"message": "regional"})
+            await incoming.put(
+                {
+                    "type": "websocket.receive",
+                    "text": json.dumps(
+                        {
+                            "type": "publish",
+                            "id": "pub-regional",
+                            "channel": "/default/room",
+                            "events": [event],
+                        }
+                    ),
+                }
+            )
+            publish = await wait_for_frame("publish_success")
+            data = await wait_for_frame("data")
+            assert publish["id"] == "pub-regional"
+            assert data == {
+                "type": "data",
+                "id": "sub-regional",
+                "event": [event],
+            }
+
+            await incoming.put({"type": "websocket.disconnect"})
+            await task
+
+        asyncio.run(_run())
+
+        assert {
+            call["operation"] for call in authorizer_calls
+        } == {
+            ae.EVENT_CONNECT,
+            ae.EVENT_SUBSCRIBE,
+            ae.EVENT_PUBLISH,
+        }
+        assert all(call["arn"] == authorizer_arn for call in authorizer_calls)
+        assert all(call["account_id"] == account_id for call in authorizer_calls)
+        assert all(call["region"] == resource_region for call in authorizer_calls)
+        assert get_account_id() == account_id
+        assert get_region() == credential_region
+        assert ae._connections == {}
+    finally:
+        ae.reset()
+        set_request_account_id(original_account)
+        set_request_region(original_region)
+
+
+def test_websocket_rejects_host_region_that_differs_from_api_scope():
+    from ministack.core.responses import (
+        get_account_id,
+        get_region,
+        set_request_account_id,
+        set_request_region,
+    )
+    from ministack.services import appsync_events as ae
+
+    original_account = get_account_id()
+    original_region = get_region()
+    account_id = "111111111111"
+    resource_region = "us-west-2"
+    credential_region = "us-east-1"
+    ae.reset()
+    try:
+        set_request_account_id(account_id)
+        set_request_region(resource_region)
+        status, _, body = ae._create_api(
+            json.dumps(
+                {
+                    "name": "regional-websocket-host-check",
+                    "eventConfig": _DEFAULT_EVENT_CONFIG,
+                }
+            ).encode()
+        )
+        assert status == 200
+        api_id = json.loads(body)["api"]["apiId"]
+
+        set_request_region(credential_region)
+
+        async def _run():
+            sent = []
+
+            async def receive():
+                return {"type": "websocket.connect"}
+
+            async def send(message):
+                sent.append(message)
+
+            protocols = (
+                f"{_encode_auth_header({'x-api-key': 'da2-local-test-key'})}, "
+                "aws-appsync-event-ws"
+            )
+            scope = {
+                "headers": [
+                    (
+                        b"host",
+                        (
+                            f"{api_id}.appsync-realtime-api."
+                            f"{credential_region}.amazonaws.com"
+                        ).encode("ascii"),
+                    ),
+                    (b"sec-websocket-protocol", protocols.encode("utf-8")),
+                ],
+            }
+            await ae.handle_websocket(scope, receive, send, api_id)
+            assert sent == [{"type": "websocket.close", "code": 1008}]
+
+        asyncio.run(_run())
+        assert get_account_id() == account_id
+        assert get_region() == credential_region
+    finally:
+        ae.reset()
+        set_request_account_id(original_account)
+        set_request_region(original_region)
+
+
+def test_websocket_accepts_region_shaped_configured_custom_host(monkeypatch):
+    from ministack.core.responses import (
+        get_region,
+        set_request_region,
+    )
+    from ministack.services import appsync_events as ae
+
+    original_region = get_region()
+    resource_region = "us-west-2"
+    monkeypatch.setenv(
+        "APPSYNC_EVENTS_HTTP_HOST_TEMPLATE",
+        "{api_id}.appsync-api.internal-edge-1:{port}",
+    )
+    monkeypatch.setenv(
+        "APPSYNC_EVENTS_REALTIME_HOST_TEMPLATE",
+        "{api_id}.appsync-realtime-api.internal-edge-1:{port}",
+    )
+    ae.reset()
+    try:
+        set_request_region(resource_region)
+        status, _, body = ae._create_api(
+            json.dumps(
+                {
+                    "name": "custom-websocket-host",
+                    "eventConfig": _DEFAULT_EVENT_CONFIG,
+                }
+            ).encode()
+        )
+        assert status == 200
+        created = json.loads(body)["api"]
+        api_id = created["apiId"]
+        custom_host = created["dns"]["REALTIME"]
+        assert custom_host == (
+            f"{api_id}.appsync-realtime-api.internal-edge-1:4566"
+        )
+
+        set_request_region("us-east-1")
+
+        async def _run():
+            incoming = iter(
+                [
+                    {"type": "websocket.connect"},
+                    {"type": "websocket.disconnect"},
+                ]
+            )
+            sent = []
+
+            async def receive():
+                return next(incoming)
+
+            async def send(message):
+                sent.append(message)
+
+            scope = {
+                "headers": [
+                    (b"host", custom_host.encode("ascii")),
+                    (
+                        b"sec-websocket-protocol",
+                        b"aws-appsync-event-ws",
+                    ),
+                ],
+            }
+            await ae.handle_websocket(scope, receive, send, api_id)
+            assert any(
+                message.get("type") == "websocket.accept"
+                for message in sent
+            )
+            assert not any(
+                message == {"type": "websocket.close", "code": 1008}
+                for message in sent
+            )
+
+        asyncio.run(_run())
+        assert get_region() == "us-east-1"
+    finally:
+        ae.reset()
+        set_request_region(original_region)
+
+
+def test_fanout_publish_isolates_connections_by_api_id():
+    from ministack.services import appsync_events as ae
+
+    async def _run():
+        first_outbox = asyncio.Queue()
+        second_outbox = asyncio.Queue()
+        ae._connections.update(
+            {
+                "first": {
+                    "api_id": "api-first",
+                    "subscriptions": {"sub-first": "/default/room"},
+                    "outbox": first_outbox,
+                },
+                "second": {
+                    "api_id": "api-second",
+                    "subscriptions": {"sub-second": "/default/room"},
+                    "outbox": second_outbox,
+                },
+            }
+        )
+
+        event = json.dumps({"message": "first-only"})
+        successful, failed = await ae._fanout_publish(
+            "api-first", "/default/room", [event]
+        )
+        assert len(successful) == 1
+        assert failed == []
+        assert await first_outbox.get() == {
+            "type": "data",
+            "id": "sub-first",
+            "event": [event],
+        }
+        assert second_outbox.empty()
+
+    ae.reset()
+    try:
+        asyncio.run(_run())
+    finally:
+        ae.reset()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -259,6 +259,163 @@ def test_account_scoped_dict_helpers_remain_account_only():
         set_request_account_id(original_account)
 
 
+def test_appsync_events_legacy_children_follow_parent_api_region():
+    from ministack.core.responses import (
+        AccountScopedDict,
+        get_account_id,
+        get_region,
+        set_request_account_id,
+        set_request_region,
+    )
+    from ministack.services import appsync_events as service
+
+    original_account = get_account_id()
+    original_region = get_region()
+    account_id = "111111111111"
+    boot_region = "us-east-1"
+    api_region = "us-west-2"
+    api_id = "legacy-regional-api"
+    orphan_api_id = "legacy-orphan-api"
+
+    apis = AccountScopedDict()
+    apis._data[(account_id, api_id)] = {
+        "name": "legacy-api",
+        "apiArn": f"arn:aws:appsync:{api_region}:{account_id}:apis/{api_id}",
+    }
+    namespaces = AccountScopedDict()
+    namespaces._data[(account_id, api_id)] = {
+        "default": {"created": 1},
+    }
+    namespaces._data[(account_id, orphan_api_id)] = {
+        "orphan": {"created": 2},
+    }
+    api_keys = AccountScopedDict()
+    api_keys._data[(account_id, api_id)] = {
+        "da2-legacy": {"description": "legacy"},
+    }
+
+    service.reset()
+    try:
+        set_request_account_id(account_id)
+        set_request_region(boot_region)
+        service.restore_state(
+            {
+                "apis": apis,
+                "channel_namespaces": namespaces,
+                "api_keys": api_keys,
+            }
+        )
+
+        assert service._apis.get_scoped(account_id, api_region, api_id)[
+            "apiArn"
+        ].startswith(f"arn:aws:appsync:{api_region}:")
+        assert service._channel_namespaces.get_scoped(
+            account_id, api_region, api_id
+        ) == {"default": {"created": 1}}
+        assert service._api_keys.get_scoped(account_id, api_region, api_id) == {
+            "da2-legacy": {"description": "legacy"},
+        }
+        assert (
+            service._channel_namespaces.get_scoped(
+                account_id, boot_region, api_id
+            )
+            is None
+        )
+        assert (
+            service._api_keys.get_scoped(account_id, boot_region, api_id) is None
+        )
+        assert service._channel_namespaces.get_scoped(
+            account_id, boot_region, orphan_api_id
+        ) == {"orphan": {"created": 2}}
+    finally:
+        service.reset()
+        set_request_account_id(original_account)
+        set_request_region(original_region)
+
+
+def test_appsync_events_v2_region_scoped_state_round_trip(monkeypatch, tmp_path):
+    import json as _json
+
+    from ministack.core.responses import (
+        AccountRegionScopedDict,
+        get_account_id,
+        get_region,
+        set_request_account_id,
+        set_request_region,
+    )
+    from ministack.services import appsync_events as service
+
+    original_account = get_account_id()
+    original_region = get_region()
+    account_id = "111111111111"
+    boot_region = "us-east-1"
+    api_region = "us-west-2"
+    api_id = "current-regional-api"
+
+    apis = AccountRegionScopedDict()
+    apis.set_scoped(
+        account_id,
+        api_region,
+        api_id,
+        {
+            "name": "current-api",
+            "apiArn": f"arn:aws:appsync:{api_region}:{account_id}:apis/{api_id}",
+        },
+    )
+    namespaces = AccountRegionScopedDict()
+    namespaces.set_scoped(
+        account_id,
+        api_region,
+        api_id,
+        {"default": {"created": 1}},
+    )
+    api_keys = AccountRegionScopedDict()
+    api_keys.set_scoped(
+        account_id,
+        api_region,
+        api_id,
+        {"da2-current": {"description": "current"}},
+    )
+
+    monkeypatch.setattr(persistence, "PERSIST_STATE", True)
+    monkeypatch.setattr(persistence, "STATE_DIR", str(tmp_path))
+    (tmp_path / "appsync_events.json").write_text(
+        _json.dumps(
+            {
+                "__ministack_format__": 2,
+                "payload": {
+                    "apis": apis,
+                    "channel_namespaces": namespaces,
+                    "api_keys": api_keys,
+                },
+            },
+            default=persistence._json_default,
+        )
+    )
+
+    loaded = persistence.load_state("appsync_events")
+    service.reset()
+    try:
+        set_request_account_id(account_id)
+        set_request_region(boot_region)
+        service.restore_state(loaded)
+
+        assert service._apis.get_scoped(account_id, api_region, api_id)[
+            "apiArn"
+        ].startswith(f"arn:aws:appsync:{api_region}:")
+        assert service._channel_namespaces.get_scoped(
+            account_id, api_region, api_id
+        ) == {"default": {"created": 1}}
+        assert service._api_keys.get_scoped(account_id, api_region, api_id) == {
+            "da2-current": {"description": "current"},
+        }
+        assert service._apis.get_scoped(account_id, boot_region, api_id) is None
+    finally:
+        service.reset()
+        set_request_account_id(original_account)
+        set_request_region(original_region)
+
+
 @pytest.mark.parametrize("svc_key,mod_name", ALL_PERSISTED_SERVICES)
 def test_service_has_restore_path(svc_key, mod_name):
     """Every service in `_state_map` must expose a way to restore its own state.
@@ -2255,6 +2412,43 @@ def test_appsync_region_scoped_state_is_rejected_by_v2_reader(
     # Simulate the previous binary, whose highest understood format is v2.
     monkeypatch.setattr(persistence, "SERVICE_STATE_FORMAT_VERSIONS", {})
     assert persistence.load_state("appsync") is None
+
+
+def test_appsync_events_region_scoped_state_is_rejected_by_v2_reader(
+    monkeypatch, tmp_path
+):
+    """A rollback binary must reject AppSync Events' regional schema instead
+    of accepting it as v2 and silently dropping APIs, namespaces, and keys."""
+    import json as _json
+
+    from ministack.core.responses import AccountRegionScopedDict
+
+    monkeypatch.setattr(persistence, "PERSIST_STATE", True)
+    monkeypatch.setattr(persistence, "STATE_DIR", str(tmp_path))
+
+    apis = AccountRegionScopedDict()
+    apis.set_scoped(
+        "000000000000",
+        "us-west-2",
+        "regional-events-api",
+        {
+            "apiArn": (
+                "arn:aws:appsync:us-west-2:000000000000:"
+                "apis/regional-events-api"
+            ),
+        },
+    )
+    persistence.save_state("appsync_events", {"apis": apis})
+
+    raw = _json.loads((tmp_path / "appsync_events.json").read_text())
+    assert raw["__ministack_format__"] == 3
+    loaded_apis = persistence.load_state("appsync_events")["apis"]
+    assert loaded_apis.get_scoped(
+        "000000000000", "us-west-2", "regional-events-api"
+    )["apiArn"].endswith("apis/regional-events-api")
+
+    monkeypatch.setattr(persistence, "SERVICE_STATE_FORMAT_VERSIONS", {})
+    assert persistence.load_state("appsync_events") is None
 
 
 def test_eks_region_scoped_state_is_rejected_by_v2_reader(monkeypatch, tmp_path):


### PR DESCRIPTION
## Why
AppSync Events identity state was account-scoped, allowing same-name resources to collide or leak across regions. Regionalizing that state also requires the WebSocket and HTTP data planes to resolve an API's creation region without weakening account or SigV4 boundaries.

## What
- Scope Event APIs, channel namespaces, and API keys by account and region
- Resolve and temporarily pin same-account API scope for WebSocket sessions and unsigned API-key publishes
- Preserve signed credential-region enforcement, advertised custom hosts, host-region validation, and per-API fan-out isolation
- Migrate legacy child records with their parent API, bump persisted state to v3, and reject unsafe v2 rollback

## Risk Assessment
Medium — this changes AppSync Events control-plane lookups, data-plane routing, and persistence restoration. Same-account discovery and advertised-host validation constrain the blast radius, with focused cross-region, authorization, fan-out, migration, and rollback coverage.

## References
- Buzz channel: `ministack-development` (`043f6d73-be10-4e53-b178-9305eecbb774`)
- Clean Codex review at `e355daaa21ded3134a67639d45424a598f786e32`

## Validation
* `uv run --extra dev ruff check ministack/services/appsync_events.py ministack/core/persistence.py tests/test_appsync_events.py`
* `uv run --extra dev pytest tests/test_appsync_events.py -q` with local MiniStack server (`36 passed, 1 skipped`)
* `uv run --extra dev pytest tests/test_persistence.py -q` (`188 passed`)
