### PR TITLE
fix(s3tables): make add-schema/add-spec/add-sort-order idempotent by id

### DIFF
--- a/ministack/services/s3tables.py
+++ b/ministack/services/s3tables.py
@@ -524,7 +524,13 @@ def _iceberg_commit_table(namespace, table_name, data, allow_cross_region):
                     "type": update.get("type", "branch")}
             elif action == "add-schema":
                 new_schema = update.get("schema", {})
-                metadata.setdefault("schemas", []).append(new_schema)
+                existing = metadata.setdefault("schemas", [])
+                # Idempotent by schema-id: a client re-declaring its current,
+                # unchanged schema on every write (Spark does this) must not pile
+                # up a second entry with the same id -- Iceberg's schemasById()
+                # crashes on load with "Multiple entries with same key" if it does.
+                if not any(s.get("schema-id") == new_schema.get("schema-id") for s in existing):
+                    existing.append(new_schema)
                 # Advance last-column-id to the highest field ID in the new
                 # schema, so a client allocating the next column's ID (e.g.
                 # DuckDB ALTER TABLE ADD COLUMN) doesn't collide with these.
@@ -537,11 +543,19 @@ def _iceberg_commit_table(namespace, table_name, data, allow_cross_region):
                 # "add-spec" is the Iceberg REST spec's action name (what
                 # duckdb-iceberg sends); "add-partition-spec" is a non-standard
                 # alias some hand-rolled callers use. Accept both.
-                metadata.setdefault("partition-specs", []).append(update.get("spec", {}))
+                new_spec = update.get("spec", {})
+                specs = metadata.setdefault("partition-specs", [])
+                # Idempotent by spec-id, for the same reason as add-schema above.
+                if not any(s.get("spec-id") == new_spec.get("spec-id") for s in specs):
+                    specs.append(new_spec)
             elif action == "set-default-spec":
                 metadata["default-spec-id"] = update.get("spec-id", 0)
             elif action == "add-sort-order":
-                metadata.setdefault("sort-orders", []).append(update.get("sort-order", {}))
+                new_order = update.get("sort-order", {})
+                orders = metadata.setdefault("sort-orders", [])
+                # Idempotent by order-id, for the same reason as add-schema above.
+                if not any(o.get("order-id") == new_order.get("order-id") for o in orders):
+                    orders.append(new_order)
             elif action == "set-default-sort-order":
                 metadata["default-sort-order-id"] = update.get("sort-order-id", 0)
             elif action == "set-properties":

--- a/tests/test_s3tables.py
+++ b/tests/test_s3tables.py
@@ -876,3 +876,135 @@ def test_s3tables_iceberg_create_table_honors_requested_partition_spec(s3tables)
         except Exception:
             pass
         s3tables.delete_table_bucket(tableBucketARN=bucket_arn)
+
+
+def test_s3tables_iceberg_add_schema_is_idempotent_by_schema_id(s3tables):
+    """A resent add-schema commit for an already-registered schema-id (Spark
+    re-declares its current schema on every write) must not append a second
+    entry -- Iceberg's own schemasById() crashes on load with "Multiple entries
+    with same key: <id>=table {...}" if the schemas list has a duplicate id."""
+    bucket_name = f"tb-schemadup-{_uuid_mod.uuid4().hex[:6]}"
+    bucket_arn = s3tables.create_table_bucket(name=bucket_name)["arn"]
+    ns = f"ns_{_uuid_mod.uuid4().hex[:6]}"
+    table = f"t_{_uuid_mod.uuid4().hex[:6]}"
+    try:
+        s3tables.create_namespace(tableBucketARN=bucket_arn, namespace=[ns])
+        s3tables.create_table(tableBucketARN=bucket_arn, namespace=ns, name=table, format="ICEBERG")
+
+        payload = {
+            "requirements": [],
+            "updates": [
+                {
+                    "action": "add-schema",
+                    "schema": {
+                        "type": "struct", "schema-id": 0,
+                        "fields": [{"id": 1, "name": "colA", "required": False, "type": "string"}],
+                    },
+                },
+                {"action": "set-current-schema", "schema-id": 0},
+            ],
+        }
+        # Send the identical commit twice, simulating Spark re-declaring its
+        # current schema on a second, unrelated write.
+        for _ in range(2):
+            _iceberg_json(f"/iceberg/v1/namespaces/{ns}/tables/{table}", method="POST", payload=payload)
+
+        loaded = _iceberg_json(f"/iceberg/v1/namespaces/{ns}/tables/{table}")
+        schema_ids = [s.get("schema-id") for s in loaded["metadata"]["schemas"]]
+        assert schema_ids.count(0) == 1, "resent add-schema must not duplicate the schema-id entry"
+    finally:
+        try:
+            s3tables.delete_table(tableBucketARN=bucket_arn, namespace=ns, name=table)
+        except Exception:
+            pass
+        try:
+            s3tables.delete_namespace(tableBucketARN=bucket_arn, namespace=ns)
+        except Exception:
+            pass
+        s3tables.delete_table_bucket(tableBucketARN=bucket_arn)
+
+
+def test_s3tables_iceberg_add_spec_is_idempotent_by_spec_id(s3tables):
+    """A resent add-spec commit for an already-registered spec-id must not
+    append a second entry -- Iceberg's own specsById() crashes the same way
+    schemasById() does on a duplicate id."""
+    bucket_name = f"tb-specdup-{_uuid_mod.uuid4().hex[:6]}"
+    bucket_arn = s3tables.create_table_bucket(name=bucket_name)["arn"]
+    ns = f"ns_{_uuid_mod.uuid4().hex[:6]}"
+    table = f"t_{_uuid_mod.uuid4().hex[:6]}"
+    try:
+        s3tables.create_namespace(tableBucketARN=bucket_arn, namespace=[ns])
+        s3tables.create_table(tableBucketARN=bucket_arn, namespace=ns, name=table, format="ICEBERG")
+
+        payload = {
+            "requirements": [],
+            "updates": [
+                {
+                    "action": "add-spec",
+                    "spec": {
+                        "spec-id": 1,
+                        "fields": [{"source-id": 1, "field-id": 1000, "name": "day_col", "transform": "day"}],
+                    },
+                },
+                {"action": "set-default-spec", "spec-id": 1},
+            ],
+        }
+        for _ in range(2):
+            _iceberg_json(f"/iceberg/v1/namespaces/{ns}/tables/{table}", method="POST", payload=payload)
+
+        loaded = _iceberg_json(f"/iceberg/v1/namespaces/{ns}/tables/{table}")
+        spec_ids = [s.get("spec-id") for s in loaded["metadata"]["partition-specs"]]
+        assert spec_ids.count(1) == 1, "resent add-spec must not duplicate the spec-id entry"
+    finally:
+        try:
+            s3tables.delete_table(tableBucketARN=bucket_arn, namespace=ns, name=table)
+        except Exception:
+            pass
+        try:
+            s3tables.delete_namespace(tableBucketARN=bucket_arn, namespace=ns)
+        except Exception:
+            pass
+        s3tables.delete_table_bucket(tableBucketARN=bucket_arn)
+
+
+def test_s3tables_iceberg_add_sort_order_is_idempotent_by_order_id(s3tables):
+    """A resent add-sort-order commit for an already-registered order-id must
+    not append a second entry -- Iceberg's own sortOrdersById() crashes the
+    same way schemasById() does on a duplicate id."""
+    bucket_name = f"tb-orderdup-{_uuid_mod.uuid4().hex[:6]}"
+    bucket_arn = s3tables.create_table_bucket(name=bucket_name)["arn"]
+    ns = f"ns_{_uuid_mod.uuid4().hex[:6]}"
+    table = f"t_{_uuid_mod.uuid4().hex[:6]}"
+    try:
+        s3tables.create_namespace(tableBucketARN=bucket_arn, namespace=[ns])
+        s3tables.create_table(tableBucketARN=bucket_arn, namespace=ns, name=table, format="ICEBERG")
+
+        payload = {
+            "requirements": [],
+            "updates": [
+                {
+                    "action": "add-sort-order",
+                    "sort-order": {
+                        "order-id": 1,
+                        "fields": [{"source-id": 1, "transform": "identity", "direction": "asc", "null-order": "nulls-first"}],
+                    },
+                },
+                {"action": "set-default-sort-order", "sort-order-id": 1},
+            ],
+        }
+        for _ in range(2):
+            _iceberg_json(f"/iceberg/v1/namespaces/{ns}/tables/{table}", method="POST", payload=payload)
+
+        loaded = _iceberg_json(f"/iceberg/v1/namespaces/{ns}/tables/{table}")
+        order_ids = [o.get("order-id") for o in loaded["metadata"]["sort-orders"]]
+        assert order_ids.count(1) == 1, "resent add-sort-order must not duplicate the order-id entry"
+    finally:
+        try:
+            s3tables.delete_table(tableBucketARN=bucket_arn, namespace=ns, name=table)
+        except Exception:
+            pass
+        try:
+            s3tables.delete_namespace(tableBucketARN=bucket_arn, namespace=ns)
+        except Exception:
+            pass
+        s3tables.delete_table_bucket(tableBucketARN=bucket_arn)


### PR DESCRIPTION
Hey @Nahuel990 - raising this because there's still some issues when trying to use spark / iceberg on my end with the 1.4.7. This PR resolves that. It introduces some of the changes again, but leaves the commit idempotency out. Details below.

That was something I added after a review, and wasn't the right approach. I believe the **add-schema/add-spec/add-sort-order** are good to keep in though.

## Problem

Spark's `compact.py` crashed with `IllegalArgumentException: Multiple entries with same key: 0=tabl...` — Iceberg's `schemasById()` found two `schema-id: 0` entries in the table's metadata (`0=tabl` is `Schema.toString()`, `"table {...}"`).

## Root cause

`_iceberg_commit_table` appended unconditionally on `add-schema`/`add-spec`/`add-sort-order`, with no check for an already-registered id. Spark re-declares the current, unchanged schema/spec/sort-order on ordinary writes (not retries), so a second commit duplicates the entry, and the next load crashes building the id-keyed map.

## Relation to #1204 / #1207

Most of #1204 landed via #1207. What was held back on AWS-parity grounds (server shouldn't dedup; client should retry via OCC) — was bucketed as "commit idempotency." That reasoning fits `add-snapshot` dedup, but not this:

- **add-schema/add-spec/add-sort-order dedup-by-id (this PR)** — not a parity question. It's a structural invariant of `TableMetadata` (no duplicate ids) that Iceberg's own builder enforces too, and it isn't retry-driven — Spark sends these on every write regardless of conflict, so OCC/requirements checking wouldn't prevent it either.
- **add-snapshot dedup — still deferred.** ministack validates zero commit `requirements`, so a real retry could hit the same crash via `snapshotsById()`. Correct fix is requirements validation (`assert-ref-snapshot-id`, etc. → 409), not blind dedup — separate follow-up.

## Change

`s3tables.py`: `add-schema`/`add-spec`/`add-partition-spec`/`add-sort-order` now no-op if the id is already present. `test_s3tables.py`: 3 new regression tests (resend same commit twice, assert no duplicate id) — reproduce the crash on unfixed code, pass with the fix. Full suite: 23/23 passing.