### PR TITLE
fix(s3tables): wire CFN table schema through for Iceberg delivery

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,19 @@ RUN pip install --no-cache-dir --no-compile \
         "boto3>=1.34" \
         "awscli"
 
+# duckdb publishes no musllinux wheels on PyPI, so it must be compiled from
+# source here — this is why it was excluded from the image previously (see
+# the original Dockerfile's now-removed "excluded intentionally" comment),
+# but the Firehose Iceberg-delivery path (added in 1.4.7) now hard-depends
+# on it at runtime, so the image needs to actually provide it.
+# CMAKE_BUILD_PARALLEL_LEVEL is capped at 3: an unbounded ninja job count
+# (one per core) can OOM-kill the compiler mid-build, since several of
+# DuckDB's unity-build translation units need multiple GB of RAM each on
+# their own; 3 keeps peak memory well under typical CI budgets at the cost
+# of a longer build.
+RUN apk add --no-cache gcc g++ make cmake ninja git python3-dev musl-dev linux-headers \
+    && CMAKE_BUILD_PARALLEL_LEVEL=3 pip install --no-cache-dir --no-compile duckdb
+
 # Strip awscli help examples (~25 MB) and Python cache files (~15 MB).
 RUN rm -rf /usr/local/lib/python3.13/site-packages/awscli/examples \
     && find /usr/local/lib/python3.13/site-packages -type d -name '__pycache__' -exec rm -rf {} + 2>/dev/null \
@@ -24,7 +37,10 @@ LABEL maintainer="MiniStack" \
       description="Local AWS Service Emulator — drop-in LocalStack replacement"
 
 # Upgrade base packages to pick up latest security patches.
-RUN apk upgrade --no-cache && apk add --no-cache nodejs bash openssl && rm -f /usr/bin/wget /bin/wget \
+# libstdc++/libgcc: runtime shared libraries the compiled duckdb extension
+# (see builder stage) needs — duckdb itself isn't installed in this stage,
+# only its runtime dependencies.
+RUN apk upgrade --no-cache && apk add --no-cache nodejs bash openssl libstdc++ libgcc && rm -f /usr/bin/wget /bin/wget \
     && rm -rf /usr/local/lib/python3.13/site-packages/pip* \
               /usr/local/bin/pip*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,19 +12,6 @@ RUN pip install --no-cache-dir --no-compile \
         "boto3>=1.34" \
         "awscli"
 
-# duckdb publishes no musllinux wheels on PyPI, so it must be compiled from
-# source here — this is why it was excluded from the image previously (see
-# the original Dockerfile's now-removed "excluded intentionally" comment),
-# but the Firehose Iceberg-delivery path (added in 1.4.7) now hard-depends
-# on it at runtime, so the image needs to actually provide it.
-# CMAKE_BUILD_PARALLEL_LEVEL is capped at 3: an unbounded ninja job count
-# (one per core) can OOM-kill the compiler mid-build, since several of
-# DuckDB's unity-build translation units need multiple GB of RAM each on
-# their own; 3 keeps peak memory well under typical CI budgets at the cost
-# of a longer build.
-RUN apk add --no-cache gcc g++ make cmake ninja git python3-dev musl-dev linux-headers \
-    && CMAKE_BUILD_PARALLEL_LEVEL=3 pip install --no-cache-dir --no-compile duckdb
-
 # Strip awscli help examples (~25 MB) and Python cache files (~15 MB).
 RUN rm -rf /usr/local/lib/python3.13/site-packages/awscli/examples \
     && find /usr/local/lib/python3.13/site-packages -type d -name '__pycache__' -exec rm -rf {} + 2>/dev/null \
@@ -37,10 +24,7 @@ LABEL maintainer="MiniStack" \
       description="Local AWS Service Emulator — drop-in LocalStack replacement"
 
 # Upgrade base packages to pick up latest security patches.
-# libstdc++/libgcc: runtime shared libraries the compiled duckdb extension
-# (see builder stage) needs — duckdb itself isn't installed in this stage,
-# only its runtime dependencies.
-RUN apk upgrade --no-cache && apk add --no-cache nodejs bash openssl libstdc++ libgcc && rm -f /usr/bin/wget /bin/wget \
+RUN apk upgrade --no-cache && apk add --no-cache nodejs bash openssl && rm -f /usr/bin/wget /bin/wget \
     && rm -rf /usr/local/lib/python3.13/site-packages/pip* \
               /usr/local/bin/pip*
 

--- a/ministack/services/cloudformation/provisioners.py
+++ b/ministack/services/cloudformation/provisioners.py
@@ -5194,7 +5194,20 @@ def _s3tables_table_create(logical_id, props, stack_name):
     table_name = props.get("TableName", "")
     bucket_name = bucket_arn.rsplit("/", 1)[-1]
     location = f"s3://{bucket_name}/{namespace}/{table_name}"
-    iceberg_metadata = _s3tables._initial_iceberg_metadata(table_name, [], location)
+    # IcebergMetadata.IcebergSchema.SchemaFieldList is how CFN (and CDK's
+    # Table L1/L2 constructs) declare the table's columns; without parsing it
+    # here every CFN-created table ends up with an empty Iceberg schema, which
+    # then fails downstream (e.g. a Firehose Iceberg-destination delivery
+    # errors with "does not have a column with name ...") even though the
+    # template clearly declares one.
+    schema_field_list = (
+        props.get("IcebergMetadata", {}).get("IcebergSchema", {}).get("SchemaFieldList", [])
+    )
+    schema_fields = [
+        {"name": f["Name"], "type": f.get("Type", "string"), "required": f.get("Required", False)}
+        for f in schema_field_list
+    ]
+    iceberg_metadata = _s3tables._initial_iceberg_metadata(table_name, schema_fields, location)
     metadata_location = f"s3://{bucket_name}/{namespace}/{table_name}/metadata/v0.metadata.json"
     table_arn = _s3tables._table_arn(bucket_arn, namespace, table_name)
     key = _s3tables._table_key(bucket_arn, namespace, table_name)
@@ -5205,7 +5218,7 @@ def _s3tables_table_create(logical_id, props, stack_name):
         "ownerAccountId": get_account_id(),
         "metadataLocation": metadata_location, "warehouseLocation": location,
         "_iceberg_metadata": iceberg_metadata, "_metadata_version": 0,
-        "_schema_fields": [],
+        "_schema_fields": schema_fields,
     }
     for b in _s3tables._table_buckets.values():
         if b["arn"] == bucket_arn:

--- a/tests/test_cfn.py
+++ b/tests/test_cfn.py
@@ -15,6 +15,25 @@ from botocore.exceptions import ClientError
 from ministack.services import pipes as _pipes
 
 
+def _cfn_iceberg_json(path):
+    """Hit the S3 Tables Iceberg REST catalog directly (LoadTable etc.) — the
+    boto3 s3tables client only exposes the control-plane view, not the actual
+    Iceberg schema/metadata a query engine like DuckDB reads."""
+    endpoint = os.environ.get("MINISTACK_ENDPOINT", "http://localhost:4566")
+    req = urllib.request.Request(
+        f"{endpoint}{path}",
+        headers={
+            "Authorization": (
+                "AWS4-HMAC-SHA256 "
+                "Credential=test/20260604/us-east-1/s3tables/aws4_request, "
+                "SignedHeaders=host, Signature=test"
+            ),
+        },
+    )
+    with urllib.request.urlopen(req) as resp:
+        return json.loads(resp.read().decode("utf-8") or "{}")
+
+
 def _wait_stack(cfn, name, timeout=30):
     """Poll until stack reaches terminal status."""
     deadline = time.time() + timeout
@@ -6551,6 +6570,69 @@ def test_cfn_s3tables_resources(cfn, s3tables):
     table = s3tables.get_table(tableBucketARN=bucket_arn, namespace="myns", name="mytable")
     assert table["name"] == "mytable"
     assert table["format"] == "ICEBERG"
+
+    cfn.delete_stack(StackName=stack_name)
+    _wait_stack(cfn, stack_name)
+
+
+def test_cfn_s3tables_table_schema_from_iceberg_metadata(cfn, s3tables):
+    """AWS::S3Tables::Table's IcebergMetadata.IcebergSchema.SchemaFieldList must
+    populate the table's actual Iceberg schema — not just be accepted and
+    discarded. A table created with an empty schema silently breaks any
+    consumer relying on the declared columns (e.g. a Firehose Iceberg
+    destination fails to insert with a "does not have a column" error even
+    though the CFN template clearly declares one)."""
+    template = {
+        "AWSTemplateFormatVersion": "2010-09-09",
+        "Resources": {
+            "Bucket": {
+                "Type": "AWS::S3Tables::TableBucket",
+                "Properties": {"TableBucketName": "cfn-s3tables-schema-test"},
+            },
+            "Ns": {
+                "Type": "AWS::S3Tables::Namespace",
+                "Properties": {
+                    "TableBucketARN": {"Fn::GetAtt": ["Bucket", "TableBucketARN"]},
+                    "Namespace": "myns",
+                },
+                "DependsOn": "Bucket",
+            },
+            "Table": {
+                "Type": "AWS::S3Tables::Table",
+                "Properties": {
+                    "TableBucketARN": {"Fn::GetAtt": ["Bucket", "TableBucketARN"]},
+                    "Namespace": "myns",
+                    "TableName": "mytable",
+                    "OpenTableFormat": "ICEBERG",
+                    "IcebergMetadata": {
+                        "IcebergSchema": {
+                            "SchemaFieldList": [
+                                {"Id": 1, "Name": "id", "Type": "string", "Required": True},
+                                {"Id": 2, "Name": "value", "Type": "string"},
+                            ],
+                        },
+                    },
+                },
+                "DependsOn": "Ns",
+            },
+        },
+    }
+
+    stack_name = "cfn-s3tables-schema-t01"
+    try:
+        cfn.delete_stack(StackName=stack_name)
+        _wait_stack(cfn, stack_name)
+    except Exception:
+        pass
+
+    cfn.create_stack(StackName=stack_name, TemplateBody=json.dumps(template))
+    stack = _wait_stack(cfn, stack_name)
+    assert stack["StackStatus"] == "CREATE_COMPLETE", stack.get("StackStatusReason")
+
+    resp = _cfn_iceberg_json(f"/iceberg/v1/namespaces/myns/tables/mytable")
+    fields = resp.get("metadata", {}).get("schemas", [{}])[0].get("fields", [])
+    field_names = {f["name"] for f in fields}
+    assert field_names == {"id", "value"}, f"expected columns id/value, got {field_names}"
 
     cfn.delete_stack(StackName=stack_name)
     _wait_stack(cfn, stack_name)


### PR DESCRIPTION
Fixes the second of two gaps blocking Firehose's Iceberg destination from actually delivering data (first gap — duckdb missing from the standard image — turned out to already be solved by the `:full` image variant, see comments below; that part of this PR has been dropped).

## The bug

With `ministackorg/ministack:full` (which already ships `duckdb`), Firehose delivery to an Iceberg destination still failed:
```
Binder Error: Table "spike_table" does not have a column with name "id"
```
`_s3tables_table_create` (the `AWS::S3Tables::Table` CFN provisioner, in `ministack/services/cloudformation/provisioners.py`) hardcodes the Iceberg schema to `[]` and never reads `IcebergMetadata.IcebergSchema.SchemaFieldList` from the template — so every table created via CloudFormation ends up with zero columns, regardless of what schema is declared. The direct `CreateTable` API path (`_create_table` in `s3tables.py`) already parses this correctly; the CFN provisioner was just never wired up to do the same.

## Fix

Parse `SchemaFieldList` the same way the API path does.

## Tests

Added `test_cfn_s3tables_table_schema_from_iceberg_metadata` in `tests/test_cfn.py`: creates a table via CFN with a declared schema, then asserts the columns actually show up via the Iceberg REST catalog's `LoadTable`. Confirmed it fails against unpatched `main` (`got set()`) and passes with the fix.

## End-to-end verification

Deployed a CDK stack with `AWS::S3Tables::TableBucket`/`Namespace`/`Table` + `AWS::KinesisFirehose::DeliveryStream` (Iceberg destination) + an EventBridge rule targeting it, against `ministackorg/ministack:full` with this fix applied. `PutRecord` → polled the underlying S3 bucket → confirmed real objects landed:
```
spike_ns/spike_table/data/<uuid>.parquet
spike_ns/spike_table/metadata/<uuid>-m0.avro
spike_ns/spike_table/metadata/snap-<id>-<uuid>.avro
```
Full `test_cfn.py` + `test_s3tables.py` suites also pass against the patched `:full` image (153 passed, 2 skipped, 1 pre-existing unrelated failure that reproduces identically on unpatched `main`).

Refs #1206.