### PR TITLE
fix(stepfunctions): resolve indexed context paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- **Step Functions — context object paths now resolve array indexes** — JSONPath references such as `$$.Map.Item.Value.values[0].name` returned `null` because context paths used a separate dotted-key-only resolver. Context paths now retain their distinct `$$.` root while sharing the standard path traversal, so indexed references work in `ItemSelector` fields and intrinsic-function arguments. Contributed by @felixp-square.
+
 ## [1.4.7] — 2026-07-26
 
 ### Added

--- a/ministack/services/stepfunctions.py
+++ b/ministack/services/stepfunctions.py
@@ -3734,14 +3734,7 @@ def _resolve_params_obj(template, data, ctx=None):
 def _resolve_ctx_path(path, ctx):
     if not path.startswith("$$."):
         return None
-    parts = path[3:].split(".")
-    cur = ctx
-    for p in parts:
-        if isinstance(cur, dict) and p in cur:
-            cur = cur[p]
-        else:
-            return None
-    return cur
+    return _resolve_path(path[1:], ctx)
 
 
 # ===================================================================

--- a/tests/test_stepfunctions.py
+++ b/tests/test_stepfunctions.py
@@ -5694,6 +5694,61 @@ def test_sfn_map_iterations_proceed_under_non_default_account_id():
         sfn.delete_state_machine(stateMachineArn=sm)
 
 
+def test_sfn_map_item_selector_context_path_resolves_array_index(sfn):
+    """ItemSelector context paths must traverse arrays within the Map item."""
+    uid = _uuid_mod.uuid4().hex[:8]
+    sm = sfn.create_state_machine(
+        name=f"map-context-array-index-{uid}",
+        definition=json.dumps({
+            "StartAt": "ProjectItems",
+            "States": {
+                "ProjectItems": {
+                    "Type": "Map",
+                    "ItemsPath": "$.items",
+                    "ItemSelector": {
+                        "expected.$": "$.expected",
+                        "observed.$": (
+                            "$$.Map.Item.Value.values[0].name"
+                        ),
+                        "formattedObserved.$": (
+                            "States.Format('{}', "
+                            "$$.Map.Item.Value.values[0].name)"
+                        ),
+                    },
+                    "Iterator": {
+                        "StartAt": "Echo",
+                        "States": {"Echo": {"Type": "Pass", "End": True}},
+                    },
+                    "End": True,
+                }
+            },
+        }),
+        roleArn="arn:aws:iam::000000000000:role/r",
+    )["stateMachineArn"]
+    try:
+        exec_resp = sfn.start_execution(
+            stateMachineArn=sm,
+            name=f"e-{uid}",
+            input=json.dumps({
+                "expected": "first",
+                "items": [{
+                    "values": [{
+                        "name": "first",
+                    }],
+                }],
+            }),
+        )
+        desc = _wait_sfn(sfn, exec_resp["executionArn"], timeout=10)
+        assert desc["status"] == "SUCCEEDED"
+        assert json.loads(desc["output"]) == [{
+            "expected": "first",
+            "observed": "first",
+            "formattedObserved": "first",
+        }]
+    finally:
+        sfn.delete_state_machine(stateMachineArn=sm)
+
+
 # ---------------------------------------------------------------------------
 # JSONata variable assignment (`Assign` field + `$variable` refs) — issue #645
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
👋 I'm fixing a small issue I ran across when testing step functions:

 ## Issue

  Step Functions context-object paths only traversed dot-separated dictionaries. As a result, reference paths containing array
  indexes, such as `$$.Map.Item.Value.values[0].name`, resolved to `null` in a Map state's `ItemSelector`, including when
  supplied to an intrinsic function.

  For example, given:

  ```json
  {"values": [{"name": "first"}]}
```

  `$$.Map.Item.Value.values[0].name` should resolve to `"first"`.

  ## Fix

Preserve validation and root selection for `$$.` context-object paths and delegate the remaining traversal to the existing JSONPath resolver.

  ## Testing

  - Added regression test:
    - `test_sfn_map_item_selector_context_path_resolves_array_index`
    - Covers direct `ItemSelector` resolution and use as a `States.Format` argument
  - Reran existing context-path and intrinsic-function tests:
    - `test_sfn_pass_parameters_resolve_context_object`
    - `test_sfn_intrinsic_format`
  - Result: `3 passed`
  - `uv run ruff check ministack/services/stepfunctions.py tests/test_stepfunctions.py`

  Repository-wide `uv run ruff check ministack/` currently reports six unrelated violations in untouched `dynamodb.py` and
  `lambda_durable.py` files.

  ## References

  - https://docs.aws.amazon.com/step-functions/latest/dg/input-output-contextobject.html
  - https://docs.aws.amazon.com/step-functions/latest/dg/amazon-states-language-paths.html