### PR TITLE
Fix IoT rule Lambda region lookup

### DIFF
--- a/ministack/services/iot.py
+++ b/ministack/services/iot.py
@@ -1815,11 +1815,13 @@ def _rule_event(payload: bytes):
         return (payload or b"").decode("utf-8", "replace")
 
 
-def _dispatch_rule_to_lambda(account_id: str, function_arn: str, event) -> None:
+def _dispatch_rule_to_lambda(
+    account_id: str, region: str, function_arn: str, event
+) -> None:
     from ministack.services import lambda_svc
 
     func, config, name = lambda_svc._get_func_record_for_ref_in_scope(
-        function_arn, account_id=account_id
+        function_arn, account_id=account_id, region=region
     )
     if not func or not config:
         _broker_logger.warning("IoT rule → Lambda: function %s not found", function_arn)
@@ -1832,14 +1834,14 @@ def _dispatch_rule_to_lambda(account_id: str, function_arn: str, event) -> None:
     ).start()
 
 
-def _run_rule_actions(account_id: str, rule: dict, payload: bytes) -> None:
+def _run_rule_actions(account_id: str, region: str, rule: dict, payload: bytes) -> None:
     if not rule or rule.get("ruleDisabled"):
         return
     event = _rule_event(payload)
     for action in rule.get("actions", []) or []:
         lam = action.get("lambda")
         if lam and lam.get("functionArn"):
-            _dispatch_rule_to_lambda(account_id, lam["functionArn"], event)
+            _dispatch_rule_to_lambda(account_id, region, lam["functionArn"], event)
 
 
 def _evaluate_topic_rules(
@@ -1848,7 +1850,7 @@ def _evaluate_topic_rules(
     for rule in _rules_for_account(account_id, region):
         filter_ = _rule_topic_filter(rule.get("sql", ""))
         if filter_ and _topic_matches(filter_, topic):
-            _run_rule_actions(account_id, rule, payload)
+            _run_rule_actions(account_id, region, rule, payload)
 
 
 async def broker_publish(
@@ -1865,6 +1867,7 @@ async def broker_publish(
         rule_name = topic[len(_BASIC_INGEST_PREFIX):].split("/", 1)[0]
         _run_rule_actions(
             account_id,
+            region,
             _topic_rules.get_scoped(account_id, region, rule_name),
             payload,
         )

--- a/tests/test_iot.py
+++ b/tests/test_iot.py
@@ -958,8 +958,8 @@ def test_iot_topic_rules_and_basic_ingest_use_publish_region(monkeypatch):
     )
     dispatched = []
 
-    def _capture_rule_action(dispatched_account_id, rule, payload):
-        dispatched.append((dispatched_account_id, rule, payload))
+    def _capture_rule_action(dispatched_account_id, dispatched_region, rule, payload):
+        dispatched.append((dispatched_account_id, dispatched_region, rule, payload))
 
     monkeypatch.setattr(
         iot_module, "_run_rule_actions", _capture_rule_action
@@ -973,7 +973,7 @@ def test_iot_topic_rules_and_basic_ingest_use_publish_region(monkeypatch):
             b'{"value": 21}',
         )
         assert dispatched == [
-            (account_id, east_rule, b'{"value": 21}')
+            (account_id, "us-east-1", east_rule, b'{"value": 21}')
         ]
 
         dispatched.clear()
@@ -984,12 +984,90 @@ def test_iot_topic_rules_and_basic_ingest_use_publish_region(monkeypatch):
             b'{"value": 22}',
         )
         assert dispatched == [
-            (account_id, west_rule, b'{"value": 22}')
+            (account_id, "us-west-2", west_rule, b'{"value": 22}')
         ]
 
     try:
         asyncio.run(_run())
     finally:
+        iot_module._topic_rules.clear()
+        reset()
+
+
+@pytest.mark.parametrize("function_ref_kind", ["name", "full_arn"])
+def test_iot_rule_lambda_dispatch_uses_rule_region(function_ref_kind, monkeypatch):
+    from ministack.services import iot as iot_module
+    from ministack.services import lambda_svc
+
+    class _ImmediateThread:
+        def __init__(self, target, args=(), kwargs=None, daemon=None):
+            self._target = target
+            self._args = args
+            self._kwargs = kwargs or {}
+
+        def start(self):
+            self._target(*self._args, **self._kwargs)
+
+    account_id = "123456789012"
+    function_name = _unique("rulefn")
+    east_arn = f"arn:aws:lambda:us-east-1:{account_id}:function:{function_name}"
+    west_arn = f"arn:aws:lambda:us-west-2:{account_id}:function:{function_name}"
+
+    def _function_record(function_arn):
+        return {
+            "config": {
+                "FunctionName": function_name,
+                "FunctionArn": function_arn,
+            },
+            "aliases": {},
+            "versions": {},
+        }
+
+    dispatched = []
+
+    def _capture_execute(func, event):
+        dispatched.append((func["config"]["FunctionArn"], event))
+
+    monkeypatch.setattr(iot_module.threading, "Thread", _ImmediateThread)
+    monkeypatch.setattr(
+        lambda_svc, "_execute_function_with_config_scope", _capture_execute
+    )
+
+    lambda_svc._functions.clear()
+    iot_module._topic_rules.clear()
+    reset()
+    try:
+        lambda_svc._functions.set_scoped(
+            account_id, "us-east-1", function_name, _function_record(east_arn)
+        )
+        lambda_svc._functions.set_scoped(
+            account_id, "us-west-2", function_name, _function_record(west_arn)
+        )
+        function_ref = function_name if function_ref_kind == "name" else west_arn
+        iot_module._topic_rules.set_scoped(
+            account_id,
+            "us-west-2",
+            "regional_rule",
+            {
+                "ruleName": "regional_rule",
+                "sql": "SELECT * FROM 'sensors/#'",
+                "ruleDisabled": False,
+                "actions": [{"lambda": {"functionArn": function_ref}}],
+            },
+        )
+
+        async def _run():
+            await broker_publish(
+                account_id,
+                "us-west-2",
+                "sensors/temperature",
+                b'{"temperature": 22}',
+            )
+
+        asyncio.run(_run())
+        assert dispatched == [(west_arn, {"temperature": 22})]
+    finally:
+        lambda_svc._functions.clear()
         iot_module._topic_rules.clear()
         reset()
 


### PR DESCRIPTION
## Why
IoT topic rules already evaluate within the publish/rule region, but Lambda actions dropped that region before resolving non-ARN function references. A rule in one region that referenced a same-named Lambda function by name could resolve the ambient-region function instead of the rule-region function.

## What
- Thread the rule evaluation region through `_run_rule_actions` and `_dispatch_rule_to_lambda`
- Pass the rule region into Lambda function lookup while preserving full Lambda ARN self-scoping
- Add same-name cross-region Lambda dispatch coverage for bare function-name references and full-ARN no-regression coverage

## Risk Assessment
Low — this is a narrow call-path fix for IoT rule Lambda action lookup only. It does not change Lambda storage, execution scoping, persistence format, MQTT routing, or topic-rule selection.

## Validation
- Exact committed head: `88a3f6e508e76e645f7cfd3ec385bbd25b972133`
- `uv run --extra dev ruff check ministack/services/iot.py tests/test_iot.py`
- `uv run --extra dev pytest tests/test_iot.py tests/test_iot_data.py tests/test_persistence.py -q` with local MiniStack server (`292 passed`)
- `codex review --base upstream/main` (`exit 0`, no actionable defects)
