### PR TITLE
fix(stepfunctions): return S3 object Metadata from aws-sdk:s3:headObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- **Step Functions — `aws-sdk:s3:headObject` dropped the object's user `Metadata` map** — the S3 REST-XML SDK-integration spec maps response headers to output fields by exact name, which cannot express the N dynamic `x-amz-meta-*` headers, so the task result carried no `Metadata` key and an ASL reading `$.Metadata.<key>` (e.g. `States.StringToJson($.Metadata.shardcount)` to size a downstream fan-out) failed with `States.Runtime`. The dispatcher now collects `x-amz-meta-*` response headers into a `Metadata` map with the prefix stripped, attached after the SFN key-convention pass so the metadata keys stay verbatim (lowercase, as S3 stores them) instead of being title-cased like API member names. Contributed by @michael-denyer.
+
 ## [1.4.8] — 2026-07-28
 
 ### Added

--- a/ministack/services/stepfunctions.py
+++ b/ministack/services/stepfunctions.py
@@ -5077,6 +5077,10 @@ def _dispatch_aws_sdk_lambda_rest(service_info, service_name, action, input_data
 #                  not a wrapped list).
 #   header_outputs:{HTTP-header-name: OutputFieldPascalCase} response headers
 #                  to fold into the result dict (e.g. ETag from PUT/COPY).
+#   metadata_output: collect the dynamic x-amz-meta-* response headers into a
+#                  result "Metadata" map (prefix stripped). Needed because
+#                  header_outputs maps exact header names and user metadata
+#                  arrives as N dynamic headers.
 #
 # Phase 1 covers non-Body operations (no GetObject/PutObject). Body shape for
 # aws-sdk:s3:getObject/putObject is convention-based (Java SDK V2 → base64) and
@@ -5144,6 +5148,7 @@ _S3_OP_SPECS = {
             "last-modified": "LastModified",
             "x-amz-version-id": "VersionId",
         },
+        "metadata_output": True,
     },
     "CopyObject": {
         "method": "PUT", "path": "/{Bucket}/{Key+}",
@@ -5378,7 +5383,20 @@ def _dispatch_aws_sdk_rest_xml(service_info, service_name, action, input_data):
 
     result = _s3_normalize_lists(result, spec.get("list_fields") or ())
 
-    return _convert_keys_to_sfn_convention(result)
+    converted = _convert_keys_to_sfn_convention(result)
+
+    # User metadata keys are returned verbatim by AWS (S3 lowercases them on
+    # write), so they must be attached AFTER the SFN key conversion — running
+    # them through _api_name_to_sfn_key would turn "shardcount" into
+    # "Shardcount" and break $.Metadata.<key> paths.
+    if spec.get("metadata_output"):
+        converted["Metadata"] = {
+            hname[len("x-amz-meta-"):]: value
+            for hname, value in norm_resp_headers.items()
+            if hname.startswith("x-amz-meta-")
+        }
+
+    return converted
 
 
 def _invoke_aws_sdk_integration(resource, input_data):

--- a/tests/test_stepfunctions.py
+++ b/tests/test_stepfunctions.py
@@ -4624,6 +4624,119 @@ def test_sfn_aws_sdk_s3_copy_object(sfn_sync, s3):
             sfn_sync.delete_state_machine(stateMachineArn=sm_arn)
 
 
+def test_sfn_aws_sdk_s3_head_object_metadata(sfn_sync, s3):
+    """aws-sdk:s3:headObject returns the object's user Metadata map with keys verbatim."""
+    import uuid as _uuid
+
+    bucket = f"sfn-s3-head-{_uuid.uuid4().hex[:8]}"
+    sm_name = f"sdk-s3-head-{_uuid.uuid4().hex[:8]}"
+    sm_arn = None
+    try:
+        s3.create_bucket(Bucket=bucket)
+        s3.put_object(
+            Bucket=bucket,
+            Key="work/shard_manifest.json",
+            Body=b"{}",
+            Metadata={"shardcount": "2"},
+        )
+
+        definition = json.dumps({
+            "StartAt": "Head",
+            "States": {
+                "Head": {
+                    "Type": "Task",
+                    "Resource": "arn:aws:states:::aws-sdk:s3:headObject",
+                    "Parameters": {"Bucket": bucket, "Key": "work/shard_manifest.json"},
+                    "End": True,
+                },
+            },
+        })
+
+        sm_arn = sfn_sync.create_state_machine(
+            name=sm_name,
+            definition=definition,
+            roleArn="arn:aws:iam::000000000000:role/sfn-role",
+        )["stateMachineArn"]
+
+        resp = sfn_sync.start_sync_execution(stateMachineArn=sm_arn, input=json.dumps({}))
+        assert resp["status"] == "SUCCEEDED", f"{resp.get('error')} — {resp.get('cause')}"
+        output = json.loads(resp["output"])
+        # Keys must NOT be run through the SFN key convention: "shardcount",
+        # not "Shardcount". $.Metadata.shardcount is the path real ASLs use.
+        assert output["Metadata"] == {"shardcount": "2"}
+        assert output["ContentLength"] == 2
+    finally:
+        try:
+            s3.delete_object(Bucket=bucket, Key="work/shard_manifest.json")
+        except Exception:
+            pass
+        try:
+            s3.delete_bucket(Bucket=bucket)
+        except Exception:
+            pass
+        if sm_arn:
+            sfn_sync.delete_state_machine(stateMachineArn=sm_arn)
+
+
+def test_sfn_aws_sdk_s3_head_object_metadata_result_selector(sfn_sync, s3):
+    """States.StringToJson($.Metadata.<key>) works on headObject output.
+
+    This is the real-world consumer shape: an ASL sizing a downstream fan-out
+    from a manifest object's metadata. It catches both failure modes — a
+    missing Metadata map and metadata keys mangled by the SFN key convention.
+    """
+    import uuid as _uuid
+
+    bucket = f"sfn-s3-headrs-{_uuid.uuid4().hex[:8]}"
+    sm_name = f"sdk-s3-headrs-{_uuid.uuid4().hex[:8]}"
+    sm_arn = None
+    try:
+        s3.create_bucket(Bucket=bucket)
+        s3.put_object(
+            Bucket=bucket,
+            Key="work/shard_manifest.json",
+            Body=b"{}",
+            Metadata={"shardcount": "2"},
+        )
+
+        definition = json.dumps({
+            "StartAt": "Head",
+            "States": {
+                "Head": {
+                    "Type": "Task",
+                    "Resource": "arn:aws:states:::aws-sdk:s3:headObject",
+                    "Parameters": {"Bucket": bucket, "Key": "work/shard_manifest.json"},
+                    "ResultSelector": {
+                        "shard_count.$": "States.StringToJson($.Metadata.shardcount)",
+                    },
+                    "End": True,
+                },
+            },
+        })
+
+        sm_arn = sfn_sync.create_state_machine(
+            name=sm_name,
+            definition=definition,
+            roleArn="arn:aws:iam::000000000000:role/sfn-role",
+        )["stateMachineArn"]
+
+        resp = sfn_sync.start_sync_execution(stateMachineArn=sm_arn, input=json.dumps({}))
+        assert resp["status"] == "SUCCEEDED", f"{resp.get('error')} — {resp.get('cause')}"
+        output = json.loads(resp["output"])
+        assert output == {"shard_count": 2}
+    finally:
+        try:
+            s3.delete_object(Bucket=bucket, Key="work/shard_manifest.json")
+        except Exception:
+            pass
+        try:
+            s3.delete_bucket(Bucket=bucket)
+        except Exception:
+            pass
+        if sm_arn:
+            sfn_sync.delete_state_machine(stateMachineArn=sm_arn)
+
+
 def test_sfn_aws_sdk_s3_list_buckets(sfn_sync, s3):
     """aws-sdk:s3:listBuckets returns the bucket list via REST-XML."""
     import uuid as _uuid


### PR DESCRIPTION
## Problem

An ASL task calling `arn:aws:states:::aws-sdk:s3:headObject` gets no `Metadata` field in its result, so `$.Metadata.<key>` resolves to null. The pattern that hits this is sizing a downstream fan-out from a manifest object's metadata, without a Lambda in between:

```python
s3.put_object(Bucket="probe-bucket", Key="work/shard_manifest.json",
              Body=b"{}", Metadata={"shardcount": "2"})
```

With a one-state machine whose task resource is `arn:aws:states:::aws-sdk:s3:headObject`:

- boto3 `head_object` on the same object returns `Metadata: {'shardcount': '2'}`, so storage is fine.
- The SFN task output is `{"ETag", "ContentLength", "ContentType", "LastModified"}`. No `Metadata`.
- With `ResultSelector {"shard_count.$": "States.StringToJson($.Metadata.shardcount)"}` the execution fails with `States.Runtime: the JSON object must be str, bytes or bytearray, not NoneType`.

Reproduces identically on 1.3.56, 1.3.70 and 1.4.8.

## Root cause

`_S3_OP_SPECS` maps response headers to output fields by exact name (`header_outputs`). User metadata arrives as N dynamic `x-amz-meta-*` headers, which an exact-name map cannot express, so the dispatcher loop skips them.

The data already reaches the dispatcher. `_extract_user_metadata` in s3.py stores the metadata headers on the object record, and `_object_response_headers` folds them into every HEAD response. They were dropped only at result-mapping time. This is the same kind of gap #640 fixed for the Lambda SDK integration.

## Fix

A `metadata_output` flag on the `HeadObject` spec. When set, the dispatcher collects `x-amz-meta-*` response headers into `result["Metadata"]` with the prefix stripped.

The map is attached after `_convert_keys_to_sfn_convention` deliberately. That pass upper-cases the first character of every nested key, so running the metadata through it would turn `shardcount` into `Shardcount` and `$.Metadata.shardcount` would still be null. Real AWS returns user metadata keys verbatim, lowercase as S3 stores them.

The flag is reusable for `GetObject`/`CopyObject` when their body-shape work lands, but `HeadObject` alone closes this bug.

## Tests

Two cases in `tests/test_stepfunctions.py`, following the existing aws-sdk S3 test shape:

- Raw `headObject` output contains `Metadata == {"shardcount": "2"}`, keys lowercase.
- The `States.StringToJson($.Metadata.shardcount)` ResultSelector form reaches SUCCEEDED with `shard_count == 2`. This one exists specifically to catch the key-conversion mistake above, which a bare `"Metadata" in result` assertion would miss.

Full runs against a local server: `tests/test_stepfunctions.py` 165 parallel + 6 serial passed, `tests/test_s3.py` 191 passed / 1 skipped (pre-existing docker-dependent skip). `ruff check` clean. CHANGELOG entry added under Unreleased.
