### PR TITLE
Regionalize WAFv2 state

### DIFF
--- a/ministack/core/persistence.py
+++ b/ministack/core/persistence.py
@@ -49,6 +49,7 @@ SERVICE_STATE_FORMAT_VERSIONS = {
     "ec2": 3,
     "ecr": 3,
     "cloudtrail": 3,
+    "waf": 3,
     "mq": 3,
     "mwaa": 3,
     "opensearch": 3,

--- a/ministack/services/cloudformation/provisioners.py
+++ b/ministack/services/cloudformation/provisioners.py
@@ -4656,25 +4656,13 @@ def _ses_email_identity_delete(physical_id, props):
 
 def _waf_web_acl_create(logical_id, props, stack_name):
     name = props.get("Name") or _physical_name(stack_name, logical_id, max_len=128)
-    uid = new_uuid()
-    lock_token = new_uuid()
     scope = props.get("Scope", "REGIONAL")
-    arn = f"arn:aws:wafv2:{get_region()}:{get_account_id()}:{scope.lower()}/webacl/{name}/{uid}"
-    _waf._web_acls[uid] = {
-        "ARN": arn, "Id": uid, "Name": name,
-        "Description": props.get("Description", ""),
-        "DefaultAction": props.get("DefaultAction", {"Allow": {}}),
-        "Rules": props.get("Rules", []),
-        "VisibilityConfig": props.get("VisibilityConfig", {}),
-        "Capacity": 0,
-        "LockToken": lock_token,
-        "Scope": scope,
-    }
+    uid, arn, _record = _waf.create_web_acl_record(name, scope, props)
     return uid, {"Arn": arn, "Id": uid}
 
 
 def _waf_web_acl_delete(physical_id, props):
-    _waf._web_acls.pop(physical_id, None)
+    _waf.delete_web_acl_record(physical_id, props.get("Scope", "REGIONAL"))
 
 
 # ---------------------------------------------------------------------------

--- a/ministack/services/cognito.py
+++ b/ministack/services/cognito.py
@@ -96,32 +96,96 @@ _JWKS_KEY: dict = {}
 # key to STATE_DIR so all processes share the same key.
 _STATE_DIR = os.environ.get("STATE_DIR", "/tmp/ministack-state")
 _RSA_KEY_PATH = os.path.join(_STATE_DIR, "cognito-rsa-key.pem")
+_RSA_KEY_LOCK_PATH = f"{_RSA_KEY_PATH}.lock"
 
 try:
     from cryptography.hazmat.primitives import serialization
     from cryptography.hazmat.primitives.asymmetric import rsa
 
-    _rsa_key = None
-    if os.path.exists(_RSA_KEY_PATH):
+    try:
+        import fcntl
+    except ImportError:
+        fcntl = None
+
+    def _load_rsa_key_from_disk():
         try:
             with open(_RSA_KEY_PATH, "rb") as _f:
-                _rsa_key = serialization.load_pem_private_key(_f.read(), password=None)
+                return serialization.load_pem_private_key(_f.read(), password=None)
         except Exception:
-            _rsa_key = None
-    if _rsa_key is None:
-        _rsa_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+            return None
+
+    def _open_rsa_key_lock_file():
+        while True:
+            try:
+                return open(_RSA_KEY_LOCK_PATH, "a")
+            except IsADirectoryError:
+                # Recover lock directories left by earlier MiniStack versions.
+                # rmdir only removes a directory, so a concurrent process that
+                # already converted the path to the new lock file cannot have
+                # its live lock stolen here.
+                try:
+                    os.rmdir(_RSA_KEY_LOCK_PATH)
+                except (FileNotFoundError, NotADirectoryError):
+                    continue
+                continue
+
+    def _persist_or_load_rsa_key(_key):
+        os.makedirs(_STATE_DIR, exist_ok=True)
+        _pem = _key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+        _tmp_path = f"{_RSA_KEY_PATH}.{os.getpid()}.{secrets.token_hex(8)}.tmp"
         try:
-            os.makedirs(_STATE_DIR, exist_ok=True)
-            _pem = _rsa_key.private_bytes(
-                encoding=serialization.Encoding.PEM,
-                format=serialization.PrivateFormat.PKCS8,
-                encryption_algorithm=serialization.NoEncryption(),
-            )
-            with open(_RSA_KEY_PATH, "wb") as _f:
+            # A file lock gives process-safe creation/repair without relying
+            # on hard links, and the OS releases it if a process exits mid-repair.
+            if fcntl is not None:
+                with _open_rsa_key_lock_file() as _lock_file:
+                    fcntl.flock(_lock_file.fileno(), fcntl.LOCK_EX)
+                    # Another process may have generated or repaired the shared
+                    # key first. Reload that winner so pytest workers and the
+                    # server expose the same JWKS.
+                    _disk_key = _load_rsa_key_from_disk()
+                    if _disk_key is not None:
+                        return _disk_key
+                    with open(_tmp_path, "xb") as _f:
+                        _f.write(_pem)
+                        _f.flush()
+                        os.fsync(_f.fileno())
+                    os.replace(_tmp_path, _RSA_KEY_PATH)
+                    _tmp_path = None
+                    return _key
+            # Platforms without fcntl still get a stable signing key in-process
+            # and best-effort atomic persistence across restarts.
+            _disk_key = _load_rsa_key_from_disk()
+            if _disk_key is not None:
+                return _disk_key
+            with open(_tmp_path, "xb") as _f:
                 _f.write(_pem)
+                _f.flush()
+                os.fsync(_f.fileno())
+            os.replace(_tmp_path, _RSA_KEY_PATH)
+            _tmp_path = None
+            return _key
+        finally:
+            if _tmp_path is not None:
+                try:
+                    os.unlink(_tmp_path)
+                except FileNotFoundError:
+                    pass
+
+    def _persist_or_load_rsa_key_best_effort(_key):
+        try:
+            return _persist_or_load_rsa_key(_key)
         except Exception:
             # Persistence is best-effort — if it fails, fall back to in-memory key.
-            pass
+            return _key
+
+    _rsa_key = _load_rsa_key_from_disk() if os.path.exists(_RSA_KEY_PATH) else None
+    if _rsa_key is None:
+        _rsa_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        _rsa_key = _persist_or_load_rsa_key_best_effort(_rsa_key)
     _RSA_PRIVATE_KEY = _rsa_key
 
     _pub = _rsa_key.public_key()

--- a/ministack/services/waf.py
+++ b/ministack/services/waf.py
@@ -17,6 +17,7 @@ import os
 from ministack.core.arn import ArnParseError, parse_arn
 from ministack.core.persistence import PERSIST_STATE, load_state
 from ministack.core.responses import (
+    AccountRegionScopedDict,
     AccountScopedDict,
     error_response_json,
     get_account_id,
@@ -29,11 +30,15 @@ from ministack.core.responses import (
 logger = logging.getLogger("wafv2")
 
 REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
+CLOUDFRONT_HOME_REGION = "us-east-1"
 
-_web_acls = AccountScopedDict()       # id -> webacl
-_ip_sets = AccountScopedDict()        # id -> ipset
-_rule_groups = AccountScopedDict()    # id -> rulegroup
-_associations = AccountScopedDict()   # resource_arn -> webacl_arn
+_web_acls = AccountRegionScopedDict()       # id -> webacl
+_ip_sets = AccountRegionScopedDict()        # id -> ipset
+_rule_groups = AccountRegionScopedDict()    # id -> rulegroup
+# AssociateWebACL is for regional application resources; CloudFront uses the
+# distribution configuration path. Keep this request-region scoped even though
+# the mock accepts CLOUDFRONT-scope WebACL ARNs for compatibility.
+_associations = AccountRegionScopedDict()   # resource_arn -> webacl_arn
 _waf_tags = AccountScopedDict()       # resource_arn -> [tags]
 
 _WAF_RESOURCE_SCOPES = {
@@ -44,21 +49,202 @@ _WAF_RESOURCE_SCOPES = {
 
 
 def get_state():
-    return copy.deepcopy({
-        "_web_acls": _web_acls,
-        "_ip_sets": _ip_sets,
-        "_rule_groups": _rule_groups,
-        "_associations": _associations,
-        "_waf_tags": _waf_tags,
-    })
+    return {
+        "_web_acls": copy.deepcopy(_web_acls),
+        "_ip_sets": copy.deepcopy(_ip_sets),
+        "_rule_groups": copy.deepcopy(_rule_groups),
+        "_associations": copy.deepcopy(_associations),
+        "_waf_tags": copy.deepcopy(_waf_tags),
+    }
 
 
 def restore_state(data):
-    _web_acls.update(data.get("_web_acls", {}))
-    _ip_sets.update(data.get("_ip_sets", {}))
-    _rule_groups.update(data.get("_rule_groups", {}))
-    _associations.update(data.get("_associations", {}))
-    _waf_tags.update(data.get("_waf_tags", {}))
+    if not isinstance(data, dict):
+        return
+    arn_rewrites = {}
+    _restore_resource_store(_web_acls, data.get("_web_acls", {}), "webacl", arn_rewrites)
+    _restore_resource_store(_ip_sets, data.get("_ip_sets", {}), "ipset", arn_rewrites)
+    _restore_resource_store(_rule_groups, data.get("_rule_groups", {}), "rulegroup", arn_rewrites)
+    _rewrite_nested_resource_arns(arn_rewrites)
+    _restore_associations(data.get("_associations", {}), arn_rewrites)
+    _restore_waf_tags(data.get("_waf_tags", {}), arn_rewrites)
+
+
+def _restore_resource_store(store, saved, resource_type, arn_rewrites):
+    if isinstance(saved, AccountRegionScopedDict):
+        store.update(saved)
+        return
+
+    boot_region = get_region()
+    for account_id, uid, resource in _legacy_account_items(saved):
+        resource_copy = copy.deepcopy(resource)
+        scope = _normalize_scope(resource_copy.get("Scope", "REGIONAL"))
+        resource_copy["Scope"] = scope
+        old_arn = resource_copy.get("ARN")
+        if scope == "CLOUDFRONT":
+            region = CLOUDFRONT_HOME_REGION
+            name = resource_copy.get("Name") or _name_from_waf_arn(old_arn) or uid
+            new_arn = _resource_arn(resource_type, name, uid, scope, account_id=account_id)
+            if old_arn and old_arn != new_arn:
+                arn_rewrites[old_arn] = new_arn
+            resource_copy["ARN"] = new_arn
+        else:
+            region = _region_from_arnish(old_arn, fallback=boot_region)
+        store.set_scoped(account_id, region, uid, resource_copy)
+
+
+def _restore_associations(saved, arn_rewrites):
+    boot_region = get_region()
+    if isinstance(saved, AccountRegionScopedDict):
+        for (account_id, region, resource_arn), web_acl_arn in saved.all_items():
+            _associations.set_scoped(
+                account_id,
+                region,
+                resource_arn,
+                arn_rewrites.get(web_acl_arn, web_acl_arn),
+            )
+        return
+    for account_id, resource_arn, web_acl_arn in _legacy_account_items(saved):
+        region = _region_from_arnish(resource_arn, fallback=boot_region)
+        _associations.set_scoped(
+            account_id,
+            region,
+            resource_arn,
+            arn_rewrites.get(web_acl_arn, web_acl_arn),
+        )
+
+
+def _restore_waf_tags(saved, arn_rewrites):
+    if isinstance(saved, AccountScopedDict):
+        for (account_id, arn), tags in saved._data.items():
+            _waf_tags.set_scoped(
+                account_id,
+                None,
+                arn_rewrites.get(arn, arn),
+                copy.deepcopy(tags),
+            )
+        return
+    if isinstance(saved, dict):
+        for arn, tags in saved.items():
+            _waf_tags[arn_rewrites.get(arn, arn)] = copy.deepcopy(tags)
+
+
+def _rewrite_nested_resource_arns(arn_rewrites):
+    if not arn_rewrites:
+        return
+    for store in (_web_acls, _ip_sets, _rule_groups):
+        for _scoped_key, resource in store.all_items():
+            _rewrite_nested_arn_values(resource, arn_rewrites)
+
+
+def _rewrite_nested_arn_values(value, arn_rewrites):
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            value[key] = _rewrite_nested_arn_values(nested, arn_rewrites)
+        return value
+    if isinstance(value, list):
+        for index, nested in enumerate(value):
+            value[index] = _rewrite_nested_arn_values(nested, arn_rewrites)
+        return value
+    if isinstance(value, str):
+        return arn_rewrites.get(value, value)
+    return value
+
+
+def _legacy_account_items(saved):
+    if isinstance(saved, AccountScopedDict):
+        for (account_id, key), value in saved._data.items():
+            yield account_id, key, value
+    elif isinstance(saved, dict):
+        account_id = get_account_id()
+        for key, value in saved.items():
+            yield account_id, key, value
+
+
+def _region_from_arnish(value, fallback):
+    if not isinstance(value, str) or not value.startswith("arn:"):
+        return fallback
+    try:
+        region = parse_arn(value).region
+    except ArnParseError:
+        return fallback
+    return region or fallback
+
+
+def _name_from_waf_arn(arn):
+    if not isinstance(arn, str):
+        return None
+    try:
+        spec = parse_arn(arn)
+    except ArnParseError:
+        return None
+    parts = spec.resource.split("/")
+    if len(parts) == 4:
+        return parts[2] or None
+    return None
+
+
+def _normalize_scope(scope):
+    return (scope or "REGIONAL").upper()
+
+
+def _scope_home_region(scope):
+    return CLOUDFRONT_HOME_REGION if _normalize_scope(scope) == "CLOUDFRONT" else get_region()
+
+
+def _scope_arn_region_and_segment(scope):
+    if _normalize_scope(scope) == "CLOUDFRONT":
+        return CLOUDFRONT_HOME_REGION, "global"
+    return get_region(), "regional"
+
+
+def _resource_arn(resource_type, name, uid, scope, account_id=None, region=None):
+    arn_region, segment = _scope_arn_region_and_segment(scope)
+    region = region or arn_region
+    account_id = account_id or get_account_id()
+    return f"arn:aws:wafv2:{region}:{account_id}:{segment}/{resource_type}/{name}/{uid}"
+
+
+def create_web_acl_record(name, scope, props):
+    scope = _normalize_scope(scope)
+    uid = new_uuid()
+    lock_token = new_uuid()
+    arn = _acl_arn(name, uid, scope)
+    record = {
+        "ARN": arn, "Id": uid, "Name": name,
+        "Description": props.get("Description", ""),
+        "DefaultAction": props.get("DefaultAction", {"Allow": {}}),
+        "Rules": props.get("Rules", []),
+        "VisibilityConfig": props.get("VisibilityConfig", {}),
+        "Capacity": 0,
+        "LockToken": lock_token,
+        "Scope": scope,
+    }
+    _web_acls.set_scoped(get_account_id(), _scope_home_region(scope), uid, record)
+    _waf_tags[arn] = props.get("Tags", [])
+    return uid, arn, record
+
+
+def delete_web_acl_record(uid, scope):
+    acl = _web_acls.pop_scoped(get_account_id(), _scope_home_region(scope), uid, None)
+    if acl:
+        _waf_tags.pop(acl["ARN"], None)
+
+
+def _resource_store(resource_type):
+    return {
+        "webacl": _web_acls,
+        "ipset": _ip_sets,
+        "rulegroup": _rule_groups,
+    }[resource_type]
+
+
+def _resource_from_scope(store, uid, scope):
+    return store.get_scoped(get_account_id(), _scope_home_region(scope), uid)
+
+
+def _values_for_scope(store, scope):
+    return store.values_scoped(get_account_id(), _scope_home_region(scope))
 
 
 try:
@@ -84,16 +270,16 @@ def _waf_not_found(arn):
     return _waf_err("WAFNonexistentItemException", f"WAFv2 resource {arn} not found")
 
 
-def _acl_arn(name, uid):
-    return f"arn:aws:wafv2:{get_region()}:{get_account_id()}:regional/webacl/{name}/{uid}"
+def _acl_arn(name, uid, scope="REGIONAL"):
+    return _resource_arn("webacl", name, uid, scope)
 
 
-def _ipset_arn(name, uid):
-    return f"arn:aws:wafv2:{get_region()}:{get_account_id()}:regional/ipset/{name}/{uid}"
+def _ipset_arn(name, uid, scope="REGIONAL"):
+    return _resource_arn("ipset", name, uid, scope)
 
 
-def _rg_arn(name, uid):
-    return f"arn:aws:wafv2:{get_region()}:{get_account_id()}:regional/rulegroup/{name}/{uid}"
+def _rg_arn(name, uid, scope="REGIONAL"):
+    return _resource_arn("rulegroup", name, uid, scope)
 
 
 def _parse_local_waf_arn(arn, allowed_types):
@@ -105,7 +291,6 @@ def _parse_local_waf_arn(arn, allowed_types):
     if (
         spec.partition != "aws"
         or spec.service != "wafv2"
-        or spec.region != get_region()
         or spec.account_id != get_account_id()
     ):
         return None, None, _waf_invalid_arn(arn)
@@ -118,20 +303,24 @@ def _parse_local_waf_arn(arn, allowed_types):
         return None, None, _waf_invalid_arn(arn)
     if scope not in _WAF_RESOURCE_SCOPES.get(resource_type, set()):
         return None, None, _waf_invalid_arn(arn)
-    return resource_type, uid, None
+    if scope == "regional":
+        if spec.region != get_region():
+            return None, None, _waf_invalid_arn(arn)
+        region = spec.region
+    else:
+        if spec.region != CLOUDFRONT_HOME_REGION:
+            return None, None, _waf_invalid_arn(arn)
+        region = CLOUDFRONT_HOME_REGION
+    return resource_type, (spec.account_id, region, uid), None
 
 
 def _resolve_local_waf_resource_arn(arn, allowed_types=("webacl", "ipset", "rulegroup")):
-    resource_type, uid, err = _parse_local_waf_arn(arn, allowed_types)
+    resource_type, scoped_key, err = _parse_local_waf_arn(arn, allowed_types)
     if err:
         return None, err
 
-    stores = {
-        "webacl": _web_acls,
-        "ipset": _ip_sets,
-        "rulegroup": _rule_groups,
-    }
-    resource = stores[resource_type].get(uid)
+    account_id, region, uid = scoped_key
+    resource = _resource_store(resource_type).get_scoped(account_id, region, uid)
     if not resource or resource.get("ARN") != arn:
         return None, _waf_not_found(arn)
     return arn, None
@@ -141,9 +330,13 @@ def _resolve_local_web_acl(web_acl_arn):
     arn, err = _resolve_local_waf_resource_arn(web_acl_arn, ("webacl",))
     if err:
         return None, err
-    for acl in _web_acls.values():
-        if acl["ARN"] == arn:
-            return acl, None
+    resource_type, scoped_key, err = _parse_local_waf_arn(arn, ("webacl",))
+    if err:
+        return None, err
+    account_id, region, uid = scoped_key
+    acl = _resource_store(resource_type).get_scoped(account_id, region, uid)
+    if acl and acl["ARN"] == arn:
+        return acl, None
     return None, _waf_not_found(web_acl_arn)
 
 
@@ -197,35 +390,22 @@ def _create_web_acl(data):
     name = data.get("Name", "")
     if not name:
         return _waf_err("WAFInvalidParameterException", "Name is required")
-    scope = data.get("Scope", "REGIONAL")
-    for existing in _web_acls.values():
+    scope = _normalize_scope(data.get("Scope", "REGIONAL"))
+    for existing in _values_for_scope(_web_acls, scope):
         if existing["Name"] == name and existing.get("Scope") == scope:
             return _waf_err("WAFDuplicateItemException", f"A WebACL with name '{name}' already exists.")
-    uid = new_uuid()
-    lock_token = new_uuid()
-    arn = _acl_arn(name, uid)
-    _web_acls[uid] = {
-        "ARN": arn, "Id": uid, "Name": name,
-        "Description": data.get("Description", ""),
-        "DefaultAction": data.get("DefaultAction", {"Allow": {}}),
-        "Rules": data.get("Rules", []),
-        "VisibilityConfig": data.get("VisibilityConfig", {}),
-        "Capacity": 0,
-        "LockToken": lock_token,
-        "Scope": data.get("Scope", "REGIONAL"),
-    }
-    _waf_tags[arn] = data.get("Tags", [])
+    uid, arn, acl = create_web_acl_record(name, scope, data)
     logger.info("CreateWebACL: %s (%s)", name, uid)
     return json_response({"Summary": {
         "ARN": arn, "Id": uid, "Name": name,
         "Description": data.get("Description", ""),
-        "LockToken": lock_token,
+        "LockToken": acl["LockToken"],
     }})
 
 
 def _get_web_acl(data):
     uid = data.get("Id", "")
-    acl = _web_acls.get(uid)
+    acl = _resource_from_scope(_web_acls, uid, data.get("Scope", "REGIONAL"))
     if not acl:
         return _waf_err("WAFNonexistentItemException", f"WebACL {uid} not found")
     acl_body = {k: v for k, v in acl.items() if k != "LockToken"}
@@ -234,7 +414,7 @@ def _get_web_acl(data):
 
 def _update_web_acl(data):
     uid = data.get("Id", "")
-    acl = _web_acls.get(uid)
+    acl = _resource_from_scope(_web_acls, uid, data.get("Scope", "REGIONAL"))
     if not acl:
         return _waf_err("WAFNonexistentItemException", f"WebACL {uid} not found")
     lock_token = data.get("LockToken", "")
@@ -249,24 +429,24 @@ def _update_web_acl(data):
 
 def _delete_web_acl(data):
     uid = data.get("Id", "")
-    if uid not in _web_acls:
+    scope = data.get("Scope", "REGIONAL")
+    acl = _resource_from_scope(_web_acls, uid, scope)
+    if not acl:
         return _waf_err("WAFNonexistentItemException", f"WebACL {uid} not found")
     lock_token = data.get("LockToken", "")
-    if lock_token != _web_acls[uid]["LockToken"]:
+    if lock_token != acl["LockToken"]:
         return _waf_err("WAFOptimisticLockException",
                         "The resource you are trying to update has changed. Please retry.")
-    arn = _web_acls[uid]["ARN"]
-    del _web_acls[uid]
-    _waf_tags.pop(arn, None)
+    delete_web_acl_record(uid, scope)
     return json_response({})
 
 
 def _list_web_acls(data):
-    scope = data.get("Scope", "REGIONAL")
+    scope = _normalize_scope(data.get("Scope", "REGIONAL"))
     acls = [
         {"ARN": a["ARN"], "Id": a["Id"], "Name": a["Name"],
          "Description": a.get("Description", ""), "LockToken": a["LockToken"]}
-        for a in _web_acls.values() if a.get("Scope", "REGIONAL") == scope
+        for a in _values_for_scope(_web_acls, scope) if a.get("Scope", "REGIONAL") == scope
     ]
     return json_response({"WebACLs": acls, "NextMarker": None})
 
@@ -296,11 +476,11 @@ def _get_web_acl_for_resource(data):
     web_acl_arn = _associations.get(resource_arn)
     if not web_acl_arn:
         return _waf_err("WAFNonexistentItemException", f"No WebACL associated with {resource_arn}")
-    for acl in _web_acls.values():
-        if acl["ARN"] == web_acl_arn:
-            acl_body = {k: v for k, v in acl.items() if k != "LockToken"}
-            return json_response({"WebACL": acl_body})
-    return _waf_err("WAFNonexistentItemException", f"WebACL {web_acl_arn} not found")
+    acl, err = _resolve_local_web_acl(web_acl_arn)
+    if err:
+        return err
+    acl_body = {k: v for k, v in acl.items() if k != "LockToken"}
+    return json_response({"WebACL": acl_body})
 
 
 def _list_resources_for_web_acl(data):
@@ -318,24 +498,25 @@ def _list_resources_for_web_acl(data):
 
 def _create_ip_set(data):
     name = data.get("Name", "")
+    scope = _normalize_scope(data.get("Scope", "REGIONAL"))
     uid = new_uuid()
     lock_token = new_uuid()
-    arn = _ipset_arn(name, uid)
-    _ip_sets[uid] = {
+    arn = _ipset_arn(name, uid, scope)
+    _ip_sets.set_scoped(get_account_id(), _scope_home_region(scope), uid, {
         "ARN": arn, "Id": uid, "Name": name,
         "Description": data.get("Description", ""),
         "IPAddressVersion": data.get("IPAddressVersion", "IPV4"),
         "Addresses": data.get("Addresses", []),
         "LockToken": lock_token,
-        "Scope": data.get("Scope", "REGIONAL"),
-    }
+        "Scope": scope,
+    })
     _waf_tags[arn] = data.get("Tags", [])
     return json_response({"Summary": {"ARN": arn, "Id": uid, "Name": name, "LockToken": lock_token}})
 
 
 def _get_ip_set(data):
     uid = data.get("Id", "")
-    ipset = _ip_sets.get(uid)
+    ipset = _resource_from_scope(_ip_sets, uid, data.get("Scope", "REGIONAL"))
     if not ipset:
         return _waf_err("WAFNonexistentItemException", f"IPSet {uid} not found")
     ipset_body = {k: v for k, v in ipset.items() if k != "LockToken"}
@@ -344,7 +525,7 @@ def _get_ip_set(data):
 
 def _update_ip_set(data):
     uid = data.get("Id", "")
-    ipset = _ip_sets.get(uid)
+    ipset = _resource_from_scope(_ip_sets, uid, data.get("Scope", "REGIONAL"))
     if not ipset:
         return _waf_err("WAFNonexistentItemException", f"IPSet {uid} not found")
     ipset["Addresses"] = data.get("Addresses", ipset["Addresses"])
@@ -354,20 +535,21 @@ def _update_ip_set(data):
 
 def _delete_ip_set(data):
     uid = data.get("Id", "")
-    if uid not in _ip_sets:
+    ipset = _resource_from_scope(_ip_sets, uid, data.get("Scope", "REGIONAL"))
+    if not ipset:
         return _waf_err("WAFNonexistentItemException", f"IPSet {uid} not found")
-    arn = _ip_sets[uid]["ARN"]
-    del _ip_sets[uid]
+    arn = ipset["ARN"]
+    _ip_sets.pop_scoped(get_account_id(), _scope_home_region(data.get("Scope", "REGIONAL")), uid, None)
     _waf_tags.pop(arn, None)
     return json_response({})
 
 
 def _list_ip_sets(data):
-    scope = data.get("Scope", "REGIONAL")
+    scope = _normalize_scope(data.get("Scope", "REGIONAL"))
     sets = [
         {"ARN": s["ARN"], "Id": s["Id"], "Name": s["Name"],
          "Description": s.get("Description", ""), "LockToken": s["LockToken"]}
-        for s in _ip_sets.values() if s.get("Scope", "REGIONAL") == scope
+        for s in _values_for_scope(_ip_sets, scope) if s.get("Scope", "REGIONAL") == scope
     ]
     return json_response({"IPSets": sets, "NextMarker": None})
 
@@ -378,25 +560,26 @@ def _list_ip_sets(data):
 
 def _create_rule_group(data):
     name = data.get("Name", "")
+    scope = _normalize_scope(data.get("Scope", "REGIONAL"))
     uid = new_uuid()
     lock_token = new_uuid()
-    arn = _rg_arn(name, uid)
-    _rule_groups[uid] = {
+    arn = _rg_arn(name, uid, scope)
+    _rule_groups.set_scoped(get_account_id(), _scope_home_region(scope), uid, {
         "ARN": arn, "Id": uid, "Name": name,
         "Description": data.get("Description", ""),
         "Capacity": data.get("Capacity", 0),
         "Rules": data.get("Rules", []),
         "VisibilityConfig": data.get("VisibilityConfig", {}),
         "LockToken": lock_token,
-        "Scope": data.get("Scope", "REGIONAL"),
-    }
+        "Scope": scope,
+    })
     _waf_tags[arn] = data.get("Tags", [])
     return json_response({"Summary": {"ARN": arn, "Id": uid, "Name": name, "LockToken": lock_token}})
 
 
 def _get_rule_group(data):
     uid = data.get("Id", "")
-    rg = _rule_groups.get(uid)
+    rg = _resource_from_scope(_rule_groups, uid, data.get("Scope", "REGIONAL"))
     if not rg:
         return _waf_err("WAFNonexistentItemException", f"RuleGroup {uid} not found")
     rg_body = {k: v for k, v in rg.items() if k != "LockToken"}
@@ -405,7 +588,7 @@ def _get_rule_group(data):
 
 def _update_rule_group(data):
     uid = data.get("Id", "")
-    rg = _rule_groups.get(uid)
+    rg = _resource_from_scope(_rule_groups, uid, data.get("Scope", "REGIONAL"))
     if not rg:
         return _waf_err("WAFNonexistentItemException", f"RuleGroup {uid} not found")
     rg["Rules"] = data.get("Rules", rg["Rules"])
@@ -416,20 +599,21 @@ def _update_rule_group(data):
 
 def _delete_rule_group(data):
     uid = data.get("Id", "")
-    if uid not in _rule_groups:
+    rg = _resource_from_scope(_rule_groups, uid, data.get("Scope", "REGIONAL"))
+    if not rg:
         return _waf_err("WAFNonexistentItemException", f"RuleGroup {uid} not found")
-    arn = _rule_groups[uid]["ARN"]
-    del _rule_groups[uid]
+    arn = rg["ARN"]
+    _rule_groups.pop_scoped(get_account_id(), _scope_home_region(data.get("Scope", "REGIONAL")), uid, None)
     _waf_tags.pop(arn, None)
     return json_response({})
 
 
 def _list_rule_groups(data):
-    scope = data.get("Scope", "REGIONAL")
+    scope = _normalize_scope(data.get("Scope", "REGIONAL"))
     groups = [
         {"ARN": r["ARN"], "Id": r["Id"], "Name": r["Name"],
          "Description": r.get("Description", ""), "LockToken": r["LockToken"]}
-        for r in _rule_groups.values() if r.get("Scope", "REGIONAL") == scope
+        for r in _values_for_scope(_rule_groups, scope) if r.get("Scope", "REGIONAL") == scope
     ]
     return json_response({"RuleGroups": groups, "NextMarker": None})
 

--- a/tests/test_cfn.py
+++ b/tests/test_cfn.py
@@ -1736,6 +1736,65 @@ def test_cfn_wait_condition(cfn):
     cfn.delete_stack(StackName="cfn-wait")
     _wait_stack(cfn, "cfn-wait")
 
+
+@pytest.mark.parametrize(
+    ("scope", "arn_region", "arn_segment"),
+    [
+        ("REGIONAL", "us-east-1", "regional"),
+        ("CLOUDFRONT", "us-east-1", "global"),
+    ],
+)
+def test_cfn_wafv2_web_acl_uses_canonical_arn(
+    cfn, wafv2, scope, arn_region, arn_segment
+):
+    scope_name = scope.lower()
+    stack_name = f"cfn-wafv2-{scope_name}"
+    acl_name = f"cfn-wafv2-{scope_name}-acl"
+    template = {
+        "Resources": {
+            "Acl": {
+                "Type": "AWS::WAFv2::WebACL",
+                "Properties": {
+                    "Name": acl_name,
+                    "Scope": scope,
+                    "DefaultAction": {"Allow": {}},
+                    "VisibilityConfig": {
+                        "SampledRequestsEnabled": False,
+                        "CloudWatchMetricsEnabled": False,
+                        "MetricName": acl_name,
+                    },
+                    "Tags": [{"Key": "from", "Value": "cfn"}],
+                },
+            },
+        },
+        "Outputs": {
+            "AclId": {"Value": {"Ref": "Acl"}},
+            "AclArn": {"Value": {"Fn::GetAtt": ["Acl", "Arn"]}},
+        },
+    }
+
+    try:
+        cfn.create_stack(StackName=stack_name, TemplateBody=json.dumps(template))
+        stack = _wait_stack(cfn, stack_name)
+        outputs = {item["OutputKey"]: item["OutputValue"] for item in stack["Outputs"]}
+
+        assert outputs["AclArn"] == (
+            f"arn:aws:wafv2:{arn_region}:000000000000:"
+            f"{arn_segment}/webacl/{acl_name}/{outputs['AclId']}"
+        )
+        acls = wafv2.list_web_acls(Scope=scope)["WebACLs"]
+        assert outputs["AclArn"] in {acl["ARN"] for acl in acls}
+        tags = wafv2.list_tags_for_resource(ResourceARN=outputs["AclArn"])
+        assert tags["TagInfoForResource"]["TagList"] == [
+            {"Key": "from", "Value": "cfn"}
+        ]
+    finally:
+        cfn.delete_stack(StackName=stack_name)
+        _wait_stack(cfn, stack_name)
+
+    acls = wafv2.list_web_acls(Scope=scope)["WebACLs"]
+    assert acl_name not in {acl["Name"] for acl in acls}
+
 def test_cfn_secretsmanager_generate_secret_string(cfn, sm):
     """CFN stack with SecretsManager::Secret + GenerateSecretString produces valid JSON secret."""
     template = {

--- a/tests/test_cognito.py
+++ b/tests/test_cognito.py
@@ -1384,6 +1384,136 @@ def test_cognito_jwks_endpoint():
     assert data["keys"][0]["kty"] == "RSA"
     assert data["keys"][0]["alg"] == "RS256"
 
+
+def _cognito_key_fingerprint_loader(state_dir, *, block_fcntl=False):
+    import subprocess
+    import sys
+    from pathlib import Path
+
+    repo_root = Path(__file__).resolve().parents[1]
+    env = os.environ.copy()
+    env["STATE_DIR"] = str(state_dir)
+    env["PYTHONPATH"] = (
+        f"{repo_root}{os.pathsep}{env['PYTHONPATH']}"
+        if env.get("PYTHONPATH")
+        else str(repo_root)
+    )
+    fcntl_blocker = (
+        "import importlib.abc\n"
+        "import sys\n"
+        "sys.modules.pop('fcntl', None)\n"
+        "class _BlockFcntl(importlib.abc.MetaPathFinder):\n"
+        "    def find_spec(self, fullname, path=None, target=None):\n"
+        "        if fullname == 'fcntl':\n"
+        "            raise ImportError('blocked fcntl')\n"
+        "        return None\n"
+        "sys.meta_path.insert(0, _BlockFcntl())\n"
+    ) if block_fcntl else ""
+    script = (
+        fcntl_blocker +
+        "import hashlib; "
+        "from cryptography.hazmat.primitives import serialization; "
+        "import ministack.services.cognito as c; "
+        "pem = c._RSA_PRIVATE_KEY.private_bytes("
+        "encoding=serialization.Encoding.PEM, "
+        "format=serialization.PrivateFormat.PKCS8, "
+        "encryption_algorithm=serialization.NoEncryption()); "
+        "print(hashlib.sha256(pem).hexdigest())"
+    )
+
+    def _load_key_fingerprint(_idx):
+        return subprocess.check_output(
+            [sys.executable, "-c", script],
+            env=env,
+            text=True,
+            timeout=10,
+        ).strip()
+
+    return _load_key_fingerprint
+
+
+def _load_concurrent_cognito_key_fingerprints(state_dir, workers=8):
+    import concurrent.futures
+
+    _load_key_fingerprint = _cognito_key_fingerprint_loader(state_dir)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
+        return list(executor.map(_load_key_fingerprint, range(workers)))
+
+
+def test_cognito_rsa_key_creation_is_process_safe(tmp_path):
+    """Concurrent server/test-worker imports must converge on one JWKS key."""
+    fingerprints = _load_concurrent_cognito_key_fingerprints(tmp_path)
+
+    assert len(set(fingerprints)) == 1
+    assert (tmp_path / "cognito-rsa-key.pem").exists()
+
+
+def test_cognito_rsa_key_corruption_repair_is_process_safe(tmp_path):
+    """Concurrent imports must converge after replacing an unreadable JWKS key."""
+    from cryptography.hazmat.primitives import serialization
+
+    key_path = tmp_path / "cognito-rsa-key.pem"
+    key_path.write_text("not a private key")
+
+    fingerprints = _load_concurrent_cognito_key_fingerprints(tmp_path)
+
+    assert len(set(fingerprints)) == 1
+    serialization.load_pem_private_key(key_path.read_bytes(), password=None)
+
+
+def test_cognito_rsa_key_stale_repair_lock_is_recovered(tmp_path):
+    """A crashed repairer must not permanently block shared JWKS key recovery."""
+    from cryptography.hazmat.primitives import serialization
+
+    key_path = tmp_path / "cognito-rsa-key.pem"
+    lock_path = tmp_path / "cognito-rsa-key.pem.lock"
+    key_path.write_text("not a private key")
+    lock_path.mkdir()
+
+    fingerprints = _load_concurrent_cognito_key_fingerprints(tmp_path)
+
+    assert len(set(fingerprints)) == 1
+    assert lock_path.is_file()
+    serialization.load_pem_private_key(key_path.read_bytes(), password=None)
+
+
+def test_cognito_rsa_key_repair_waits_for_live_file_lock(tmp_path):
+    """Concurrent importers must wait for a live repair lock, not steal it."""
+    import concurrent.futures
+    import fcntl
+
+    from cryptography.hazmat.primitives import serialization
+
+    key_path = tmp_path / "cognito-rsa-key.pem"
+    lock_path = tmp_path / "cognito-rsa-key.pem.lock"
+    key_path.write_text("not a private key")
+    lock_path.touch()
+    _load_key_fingerprint = _cognito_key_fingerprint_loader(tmp_path)
+
+    with open(lock_path, "a") as lock_file:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        with concurrent.futures.ThreadPoolExecutor(max_workers=8) as executor:
+            futures = [executor.submit(_load_key_fingerprint, idx) for idx in range(8)]
+            time.sleep(0.1)
+            assert not any(future.done() for future in futures)
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+            fingerprints = [future.result(timeout=10) for future in futures]
+
+    assert len(set(fingerprints)) == 1
+    serialization.load_pem_private_key(key_path.read_bytes(), password=None)
+
+
+def test_cognito_rsa_key_persists_when_fcntl_is_unavailable(tmp_path):
+    """Missing fcntl must not disable RSA signing or shared key persistence."""
+    loader = _cognito_key_fingerprint_loader(tmp_path, block_fcntl=True)
+
+    first_fingerprint = loader(0)
+    second_fingerprint = loader(1)
+
+    assert first_fingerprint == second_fingerprint
+    assert (tmp_path / "cognito-rsa-key.pem").exists()
+
+
 def test_cognito_openid_configuration():
     """/.well-known/openid-configuration returns valid discovery document."""
     import json as _json

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -3659,6 +3659,116 @@ def test_ec2_region_scoped_state_is_rejected_by_v2_reader(monkeypatch, tmp_path)
     assert persistence.load_state("ec2") is None
 
 
+def test_waf_region_scoped_state_is_rejected_by_v2_reader(monkeypatch, tmp_path):
+    """A rollback binary must reject WAF's regional schema instead of accepting
+    account-only stores that would collapse REGIONAL and CLOUDFRONT scopes."""
+    import json as _json
+
+    from ministack.core.responses import AccountRegionScopedDict
+
+    monkeypatch.setattr(persistence, "PERSIST_STATE", True)
+    monkeypatch.setattr(persistence, "STATE_DIR", str(tmp_path))
+
+    web_acls = AccountRegionScopedDict()
+    web_acls.set_scoped(
+        "000000000000",
+        "us-west-2",
+        "regional-acl",
+        {
+            "ARN": (
+                "arn:aws:wafv2:us-west-2:000000000000:"
+                "regional/webacl/regional-acl/regional-acl"
+            ),
+            "Id": "regional-acl",
+            "Name": "regional-acl",
+            "Scope": "REGIONAL",
+        },
+    )
+    persistence.save_state("waf", {"_web_acls": web_acls})
+
+    raw = _json.loads((tmp_path / "waf.json").read_text())
+    assert raw["__ministack_format__"] == 3
+    loaded_web_acls = persistence.load_state("waf")["_web_acls"]
+    assert loaded_web_acls.get_scoped(
+        "000000000000",
+        "us-west-2",
+        "regional-acl",
+    )["Name"] == "regional-acl"
+
+    monkeypatch.setattr(persistence, "SERVICE_STATE_FORMAT_VERSIONS", {})
+    assert persistence.load_state("waf") is None
+
+
+def test_waf_region_scoped_v3_state_round_trips_idempotently(monkeypatch, tmp_path):
+    import json as _json
+
+    from ministack.core.responses import AccountRegionScopedDict, AccountScopedDict
+
+    monkeypatch.setattr(persistence, "PERSIST_STATE", True)
+    monkeypatch.setattr(persistence, "STATE_DIR", str(tmp_path))
+
+    web_acls = AccountRegionScopedDict()
+    web_acls.set_scoped(
+        "000000000000",
+        "us-east-1",
+        "global-acl",
+        {
+            "ARN": (
+                "arn:aws:wafv2:us-east-1:000000000000:"
+                "global/webacl/global-acl/global-acl"
+            ),
+            "Id": "global-acl",
+            "Name": "global-acl",
+            "Scope": "CLOUDFRONT",
+        },
+    )
+    associations = AccountRegionScopedDict()
+    associations.set_scoped(
+        "000000000000",
+        "us-west-2",
+        "arn:aws:elasticloadbalancing:us-west-2:000000000000:loadbalancer/app/app/id",
+        (
+            "arn:aws:wafv2:us-east-1:000000000000:"
+            "global/webacl/global-acl/global-acl"
+        ),
+    )
+    tags = AccountScopedDict()
+    tags.set_scoped(
+        "000000000000",
+        "us-west-2",
+        (
+            "arn:aws:wafv2:us-east-1:000000000000:"
+            "global/webacl/global-acl/global-acl"
+        ),
+        [{"Key": "scope", "Value": "global"}],
+    )
+
+    persistence.save_state(
+        "waf",
+        {
+            "_web_acls": web_acls,
+            "_associations": associations,
+            "_waf_tags": tags,
+        },
+    )
+    first_snapshot = _json.loads((tmp_path / "waf.json").read_text())
+    loaded = persistence.load_state("waf")
+    assert loaded["_web_acls"].get_scoped(
+        "000000000000",
+        "us-east-1",
+        "global-acl",
+    )["Scope"] == "CLOUDFRONT"
+    assert loaded["_associations"].get_scoped(
+        "000000000000",
+        "us-west-2",
+        "arn:aws:elasticloadbalancing:us-west-2:000000000000:loadbalancer/app/app/id",
+    ).endswith("global/webacl/global-acl/global-acl")
+
+    persistence.save_state("waf", loaded)
+    second_snapshot = _json.loads((tmp_path / "waf.json").read_text())
+    assert second_snapshot == first_snapshot
+
+
 def test_ec2_legacy_state_restores_to_boot_region_without_arn_mining():
     """Legacy EC2 state is one coherent graph even when records embed foreign ARNs."""
     from ministack.core.responses import (

--- a/tests/test_waf.py
+++ b/tests/test_waf.py
@@ -10,12 +10,14 @@ import pytest
 from botocore.exceptions import ClientError
 
 from ministack.core.responses import (
+    AccountScopedDict,
     get_account_id,
     get_region,
     set_request_account_id,
     set_request_region,
 )
 from ministack.services import waf as waf_service
+from ministack.services.cloudformation import provisioners as cfn_provisioners
 
 
 def _waf_payload(response):
@@ -76,6 +78,22 @@ def _assert_waf_error(response, code):
     assert payload["__type"] == code
 
 
+def _create_direct_web_acl(name, scope="REGIONAL", tags=None):
+    status, payload = _waf_payload(waf_service._create_web_acl({
+        "Name": name,
+        "Scope": scope,
+        "DefaultAction": {"Allow": {}},
+        "VisibilityConfig": {
+            "SampledRequestsEnabled": False,
+            "CloudWatchMetricsEnabled": False,
+            "MetricName": name,
+        },
+        "Tags": tags or [],
+    }))
+    assert status == 200
+    return payload["Summary"]
+
+
 def test_waf_web_acl_crud(wafv2):
     resp = wafv2.create_web_acl(
         Name="test-acl",
@@ -97,6 +115,108 @@ def test_waf_web_acl_crud(wafv2):
     lst2 = wafv2.list_web_acls(Scope="REGIONAL")
     ids2 = [a["Id"] for a in lst2["WebACLs"]]
     assert uid not in ids2
+
+
+def test_wafv2_regional_web_acls_are_isolated_by_region_direct(direct_waf_scope):
+    east_acl = _create_direct_web_acl("same-regional-acl", "REGIONAL")
+    assert ":us-east-1:000000000000:regional/webacl/" in east_acl["ARN"]
+    _assert_waf_error(
+        waf_service._create_web_acl({
+            "Name": "same-regional-acl",
+            "Scope": "REGIONAL",
+        }),
+        "WAFDuplicateItemException",
+    )
+
+    set_request_region("us-west-2")
+    west_acl = _create_direct_web_acl("same-regional-acl", "REGIONAL")
+    assert west_acl["Id"] != east_acl["Id"]
+    assert ":us-west-2:000000000000:regional/webacl/" in west_acl["ARN"]
+
+    status, payload = _waf_payload(waf_service._list_web_acls({"Scope": "REGIONAL"}))
+    assert status == 200
+    assert [acl["Id"] for acl in payload["WebACLs"]] == [west_acl["Id"]]
+
+    _assert_waf_error(
+        waf_service._get_web_acl({
+            "Name": "same-regional-acl",
+            "Scope": "REGIONAL",
+            "Id": east_acl["Id"],
+        }),
+        "WAFNonexistentItemException",
+    )
+
+    set_request_region("us-east-1")
+    status, payload = _waf_payload(waf_service._list_web_acls({"Scope": "REGIONAL"}))
+    assert status == 200
+    assert [acl["Id"] for acl in payload["WebACLs"]] == [east_acl["Id"]]
+
+
+def test_wafv2_cloudfront_web_acl_is_homed_globally_direct(direct_waf_scope):
+    set_request_region("us-west-2")
+    acl = _create_direct_web_acl(
+        "global-acl",
+        "CLOUDFRONT",
+        tags=[{"Key": "scope", "Value": "global"}],
+    )
+
+    assert ":us-east-1:000000000000:global/webacl/" in acl["ARN"]
+    assert waf_service._web_acls.get_scoped(
+        "000000000000",
+        "us-east-1",
+        acl["Id"],
+    )["ARN"] == acl["ARN"]
+    assert waf_service._web_acls.get_scoped(
+        "000000000000",
+        "us-west-2",
+        acl["Id"],
+    ) is None
+
+    for region in ("us-west-2", "eu-west-1", "us-east-1"):
+        set_request_region(region)
+        status, payload = _waf_payload(waf_service._list_web_acls({"Scope": "CLOUDFRONT"}))
+        assert status == 200
+        assert [item["ARN"] for item in payload["WebACLs"]] == [acl["ARN"]]
+
+        status, payload = _waf_payload(waf_service._get_web_acl({
+            "Name": "global-acl",
+            "Scope": "CLOUDFRONT",
+            "Id": acl["Id"],
+        }))
+        assert status == 200
+        assert payload["WebACL"]["ARN"] == acl["ARN"]
+
+        status, payload = _waf_payload(waf_service._list_tags_for_resource({
+            "ResourceARN": acl["ARN"],
+        }))
+        assert status == 200
+        assert payload["TagInfoForResource"]["TagList"] == [
+            {"Key": "scope", "Value": "global"}
+        ]
+
+    status, payload = _waf_payload(waf_service._update_web_acl({
+        "Name": "global-acl",
+        "Scope": "CLOUDFRONT",
+        "Id": acl["Id"],
+        "LockToken": acl["LockToken"],
+        "DefaultAction": {"Block": {}},
+        "VisibilityConfig": {
+            "SampledRequestsEnabled": False,
+            "CloudWatchMetricsEnabled": False,
+            "MetricName": "global-acl",
+        },
+    }))
+    assert status == 200
+
+    status, _payload = _waf_payload(waf_service._delete_web_acl({
+        "Name": "global-acl",
+        "Scope": "CLOUDFRONT",
+        "Id": acl["Id"],
+        "LockToken": payload["NextLockToken"],
+    }))
+    assert status == 200
+    assert acl["ARN"] not in waf_service._waf_tags
+
 
 def test_waf_update_web_acl(wafv2):
     resp = wafv2.create_web_acl(
@@ -135,6 +255,60 @@ def test_waf_associate_disassociate(wafv2):
         assert False, "expected WAFNonexistentItemException"
     except wafv2.exceptions.WAFNonexistentItemException:
         pass
+
+
+def test_wafv2_associations_are_request_region_scoped_direct(direct_waf_scope):
+    acl = _create_direct_web_acl("regional-assoc-acl", "REGIONAL")
+    resource_arn = (
+        "arn:aws:elasticloadbalancing:us-east-1:000000000000:"
+        "loadbalancer/app/regional-assoc/abc"
+    )
+    status, _payload = _waf_payload(waf_service._associate_web_acl({
+        "WebACLArn": acl["ARN"],
+        "ResourceArn": resource_arn,
+    }))
+    assert status == 200
+
+    set_request_region("us-west-2")
+    _assert_waf_error(
+        waf_service._get_web_acl_for_resource({"ResourceArn": resource_arn}),
+        "WAFNonexistentItemException",
+    )
+
+    west_acl = _create_direct_web_acl("regional-assoc-acl", "REGIONAL")
+    status, payload = _waf_payload(waf_service._list_resources_for_web_acl({
+        "WebACLArn": west_acl["ARN"],
+    }))
+    assert status == 200
+    assert payload["ResourceArns"] == []
+
+
+def test_wafv2_cloudfront_associations_stay_request_region_scoped_direct(direct_waf_scope):
+    acl = _create_direct_web_acl("cloudfront-assoc-acl", "CLOUDFRONT")
+    resource_arn = "arn:aws:cloudfront::000000000000:distribution/cf-assoc"
+    status, _payload = _waf_payload(waf_service._associate_web_acl({
+        "WebACLArn": acl["ARN"],
+        "ResourceArn": resource_arn,
+    }))
+    assert status == 200
+
+    status, payload = _waf_payload(waf_service._get_web_acl_for_resource({
+        "ResourceArn": resource_arn,
+    }))
+    assert status == 200
+    assert payload["WebACL"]["ARN"] == acl["ARN"]
+
+    set_request_region("us-west-2")
+    _assert_waf_error(
+        waf_service._get_web_acl_for_resource({"ResourceArn": resource_arn}),
+        "WAFNonexistentItemException",
+    )
+    status, payload = _waf_payload(waf_service._list_resources_for_web_acl({
+        "WebACLArn": acl["ARN"],
+    }))
+    assert status == 200
+    assert payload["ResourceArns"] == []
+
 
 def test_waf_ip_set_crud(wafv2):
     resp = wafv2.create_ip_set(
@@ -198,6 +372,51 @@ def test_waf_rule_group_crud(wafv2):
     lst2 = wafv2.list_rule_groups(Scope="REGIONAL")
     ids2 = [r["Id"] for r in lst2["RuleGroups"]]
     assert uid not in ids2
+
+
+def test_wafv2_ip_sets_and_rule_groups_use_scope_aware_arns_direct(direct_waf_scope):
+    set_request_region("us-west-2")
+    status, ipset_payload = _waf_payload(waf_service._create_ip_set({
+        "Name": "cf-ipset",
+        "Scope": "CLOUDFRONT",
+        "IPAddressVersion": "IPV4",
+        "Addresses": ["192.0.2.0/24"],
+    }))
+    assert status == 200
+    ipset = ipset_payload["Summary"]
+    assert ":us-east-1:000000000000:global/ipset/" in ipset["ARN"]
+
+    status, rg_payload = _waf_payload(waf_service._create_rule_group({
+        "Name": "cf-rg",
+        "Scope": "CLOUDFRONT",
+        "Capacity": 10,
+        "VisibilityConfig": {
+            "SampledRequestsEnabled": False,
+            "CloudWatchMetricsEnabled": False,
+            "MetricName": "cf-rg",
+        },
+    }))
+    assert status == 200
+    rule_group = rg_payload["Summary"]
+    assert ":us-east-1:000000000000:global/rulegroup/" in rule_group["ARN"]
+
+    set_request_region("eu-west-1")
+    status, ipset_payload = _waf_payload(waf_service._get_ip_set({
+        "Name": "cf-ipset",
+        "Scope": "CLOUDFRONT",
+        "Id": ipset["Id"],
+    }))
+    assert status == 200
+    assert ipset_payload["IPSet"]["ARN"] == ipset["ARN"]
+
+    status, rg_payload = _waf_payload(waf_service._get_rule_group({
+        "Name": "cf-rg",
+        "Scope": "CLOUDFRONT",
+        "Id": rule_group["Id"],
+    }))
+    assert status == 200
+    assert rg_payload["RuleGroup"]["ARN"] == rule_group["ARN"]
+
 
 def test_waf_tags(wafv2):
     resp = wafv2.create_web_acl(
@@ -370,6 +589,214 @@ def test_waf_association_validates_web_acl_arn_but_not_resource_arn_direct(direc
         waf_service._list_resources_for_web_acl({"WebACLArn": wrong_service_arn}),
         "WAFInvalidParameterException",
     )
+
+
+def test_wafv2_restore_legacy_state_canonicalizes_cloudfront_arns_direct(direct_waf_scope):
+    account_id = "000000000000"
+    legacy_uid = "legacy-cf-acl"
+    legacy_arn = (
+        "arn:aws:wafv2:us-west-2:000000000000:"
+        "cloudfront/webacl/legacy-cf-acl/legacy-cf-acl"
+    )
+    regional_segment_uid = "legacy-regional-segment-cf-acl"
+    regional_segment_arn = (
+        "arn:aws:wafv2:ap-southeast-2:000000000000:"
+        "regional/webacl/legacy-regional-segment-cf-acl/"
+        "legacy-regional-segment-cf-acl"
+    )
+    legacy_cf_ipset_uid = "legacy-cf-ipset"
+    legacy_cf_ipset_arn = (
+        "arn:aws:wafv2:us-west-2:000000000000:"
+        "regional/ipset/legacy-cf-ipset/legacy-cf-ipset"
+    )
+    legacy_cf_rule_group_uid = "legacy-cf-rule-group"
+    legacy_cf_rule_group_arn = (
+        "arn:aws:wafv2:us-west-2:000000000000:"
+        "cloudfront/rulegroup/legacy-cf-rule-group/legacy-cf-rule-group"
+    )
+    regional_legacy_arn = (
+        "arn:aws:wafv2:eu-west-1:000000000000:"
+        "regional/ipset/legacy-regional-ipset/legacy-regional-ipset"
+    )
+    resource_arn = (
+        "arn:aws:elasticloadbalancing:us-west-2:000000000000:"
+        "loadbalancer/app/legacy/abc"
+    )
+    second_resource_arn = (
+        "arn:aws:elasticloadbalancing:ap-southeast-2:000000000000:"
+        "loadbalancer/app/legacy-regional-segment/def"
+    )
+
+    web_acls = AccountScopedDict()
+    web_acls._data[(account_id, legacy_uid)] = {
+        "ARN": legacy_arn,
+        "Id": legacy_uid,
+        "Name": "legacy-cf-acl",
+        "Scope": "CLOUDFRONT",
+        "LockToken": "lock",
+        "Rules": [{
+            "Name": "rg-ref",
+            "Statement": {
+                "RuleGroupReferenceStatement": {
+                    "ARN": legacy_cf_rule_group_arn,
+                },
+            },
+        }],
+    }
+    web_acls._data[(account_id, regional_segment_uid)] = {
+        "ARN": regional_segment_arn,
+        "Id": regional_segment_uid,
+        "Name": "legacy-regional-segment-cf-acl",
+        "Scope": "CLOUDFRONT",
+        "LockToken": "second-lock",
+    }
+    ip_sets = AccountScopedDict()
+    ip_sets._data[(account_id, "legacy-regional-ipset")] = {
+        "ARN": regional_legacy_arn,
+        "Id": "legacy-regional-ipset",
+        "Name": "legacy-regional-ipset",
+        "Scope": "REGIONAL",
+        "LockToken": "ip-lock",
+    }
+    ip_sets._data[(account_id, legacy_cf_ipset_uid)] = {
+        "ARN": legacy_cf_ipset_arn,
+        "Id": legacy_cf_ipset_uid,
+        "Name": "legacy-cf-ipset",
+        "Scope": "CLOUDFRONT",
+        "LockToken": "cf-ip-lock",
+    }
+    rule_groups = AccountScopedDict()
+    rule_groups._data[(account_id, legacy_cf_rule_group_uid)] = {
+        "ARN": legacy_cf_rule_group_arn,
+        "Id": legacy_cf_rule_group_uid,
+        "Name": "legacy-cf-rule-group",
+        "Scope": "CLOUDFRONT",
+        "LockToken": "cf-rg-lock",
+        "Rules": [{
+            "Name": "ipset-ref",
+            "Statement": {
+                "IPSetReferenceStatement": {
+                    "ARN": legacy_cf_ipset_arn,
+                },
+            },
+        }],
+    }
+    associations = AccountScopedDict()
+    associations._data[(account_id, resource_arn)] = legacy_arn
+    associations._data[(account_id, second_resource_arn)] = regional_segment_arn
+    tags = AccountScopedDict()
+    tags._data[(account_id, legacy_arn)] = [{"Key": "legacy", "Value": "yes"}]
+    tags._data[(account_id, regional_segment_arn)] = [
+        {"Key": "legacy-dialect", "Value": "regional"}
+    ]
+
+    waf_service.restore_state({
+        "_web_acls": web_acls,
+        "_ip_sets": ip_sets,
+        "_rule_groups": rule_groups,
+        "_associations": associations,
+        "_waf_tags": tags,
+    })
+
+    canonical_arn = (
+        "arn:aws:wafv2:us-east-1:000000000000:"
+        "global/webacl/legacy-cf-acl/legacy-cf-acl"
+    )
+    second_canonical_arn = (
+        "arn:aws:wafv2:us-east-1:000000000000:"
+        "global/webacl/legacy-regional-segment-cf-acl/"
+        "legacy-regional-segment-cf-acl"
+    )
+    canonical_ipset_arn = (
+        "arn:aws:wafv2:us-east-1:000000000000:"
+        "global/ipset/legacy-cf-ipset/legacy-cf-ipset"
+    )
+    canonical_rule_group_arn = (
+        "arn:aws:wafv2:us-east-1:000000000000:"
+        "global/rulegroup/legacy-cf-rule-group/legacy-cf-rule-group"
+    )
+    assert waf_service._web_acls.get_scoped(
+        account_id,
+        "us-east-1",
+        legacy_uid,
+    )["ARN"] == canonical_arn
+    assert waf_service._ip_sets.get_scoped(
+        account_id,
+        "eu-west-1",
+        "legacy-regional-ipset",
+    )["ARN"] == regional_legacy_arn
+    assert waf_service._web_acls.get_scoped(
+        account_id,
+        "us-east-1",
+        regional_segment_uid,
+    )["ARN"] == second_canonical_arn
+    assert waf_service._web_acls.get_scoped(
+        account_id,
+        "us-east-1",
+        legacy_uid,
+    )["Rules"][0]["Statement"]["RuleGroupReferenceStatement"]["ARN"] == (
+        canonical_rule_group_arn
+    )
+    assert waf_service._rule_groups.get_scoped(
+        account_id,
+        "us-east-1",
+        legacy_cf_rule_group_uid,
+    )["Rules"][0]["Statement"]["IPSetReferenceStatement"]["ARN"] == canonical_ipset_arn
+    assert waf_service._associations.get_scoped(
+        account_id,
+        "us-west-2",
+        resource_arn,
+    ) == canonical_arn
+    assert waf_service._associations.get_scoped(
+        account_id,
+        "ap-southeast-2",
+        second_resource_arn,
+    ) == second_canonical_arn
+    assert waf_service._waf_tags.get_scoped(
+        account_id,
+        "us-west-2",
+        canonical_arn,
+    ) == [{"Key": "legacy", "Value": "yes"}]
+    assert waf_service._waf_tags.get_scoped(
+        account_id,
+        "ap-southeast-2",
+        second_canonical_arn,
+    ) == [{"Key": "legacy-dialect", "Value": "regional"}]
+    assert waf_service._waf_tags.get_scoped(account_id, "us-west-2", legacy_arn) is None
+    assert waf_service._waf_tags.get_scoped(
+        account_id, "ap-southeast-2", regional_segment_arn
+    ) is None
+
+
+def test_wafv2_cloudformation_uses_canonical_web_acl_records_direct(direct_waf_scope):
+    set_request_region("us-west-2")
+    uid, attrs = cfn_provisioners._waf_web_acl_create(
+        "Acl",
+        {
+            "Name": "cfn-cf-acl",
+            "Scope": "CLOUDFRONT",
+            "DefaultAction": {"Allow": {}},
+            "VisibilityConfig": {
+                "SampledRequestsEnabled": False,
+                "CloudWatchMetricsEnabled": False,
+                "MetricName": "cfn-cf-acl",
+            },
+            "Tags": [{"Key": "from", "Value": "cfn"}],
+        },
+        "stack",
+    )
+    assert attrs["Arn"] == (
+        f"arn:aws:wafv2:us-east-1:000000000000:global/webacl/cfn-cf-acl/{uid}"
+    )
+    assert waf_service._web_acls.get_scoped("000000000000", "us-east-1", uid)[
+        "ARN"
+    ] == attrs["Arn"]
+    assert waf_service._waf_tags[attrs["Arn"]] == [{"Key": "from", "Value": "cfn"}]
+
+    cfn_provisioners._waf_web_acl_delete(uid, {"Scope": "CLOUDFRONT"})
+    assert waf_service._web_acls.get_scoped("000000000000", "us-east-1", uid) is None
+    assert attrs["Arn"] not in waf_service._waf_tags
+
 
 def test_waf_check_capacity(wafv2):
     resp = wafv2.check_capacity(


### PR DESCRIPTION
## Why
WAFv2 currently collapses regional resources across request regions and emits incorrect ARNs for CLOUDFRONT-scope resources.

The CI shard for this PR also exposed an existing Cognito race: source-backed server/test-worker imports can generate different JWT signing keys when they start concurrently against an empty `STATE_DIR`, causing API Gateway JWT tests to reject otherwise-valid tokens.

## What
- Scope REGIONAL WAFv2 resources by account and request region while homing CLOUDFRONT resources in the account's `us-east-1` global bucket
- Emit canonical `regional/` and `global/` ARNs and route CloudFormation WebACL provisioning through the same service helper
- Migrate legacy v2 state to v3, including both broken CLOUDFRONT ARN dialects, tag keys, association values, and nested rule references
- Keep `AssociateWebACL` state request-region scoped because that API is REGIONAL-only; CloudFront attaches WAF through the distribution path
- Make Cognito JWKS signing-key initialization and repair process-safe with a file lock so the source-backed server and pytest workers converge on one persisted RSA key during parallel CI startup
- Keep Cognito RSA signing available when `fcntl` is unavailable, with best-effort atomic persistence across restarts

## Behavior changes and risk
WAFv2 lookups now see only the caller's regional (or global CLOUDFRONT) resources, and ARNs use the canonical `regional/`/`global/` forms. Risk is medium — this changes WAFv2 lookup and persistence placement. Migration and CloudFormation round trips cover both scopes, both legacy ARN dialects, tag re-keying, association rewriting, and nested rule-reference rewriting. The Cognito change is limited to signing-key file creation/repair and has process-safety regressions, including corrupt-file repair, legacy lock-dir cleanup, waiting behind a live file lock, and no-`fcntl` fallback signing.

## Validation

* `uv run --extra dev ruff check ministack/services/cognito.py ministack/services/waf.py ministack/services/cloudformation/provisioners.py ministack/core/persistence.py tests/test_cognito.py tests/test_waf.py tests/test_persistence.py tests/test_cfn.py`
* `uv run --extra dev pytest tests/test_apigatewayv2.py::test_apigw_jwt_authorizer_enforced_in_data_plane tests/test_apigatewayv2.py::test_apigw_request_mapping_claims_to_headers tests/test_apigatewayv2.py::test_ws_connect_jwt_authorizer_rejects_missing_token tests/test_cognito.py::test_cognito_rsa_key_creation_is_process_safe tests/test_cognito.py::test_cognito_rsa_key_corruption_repair_is_process_safe tests/test_cognito.py::test_cognito_rsa_key_stale_repair_lock_is_recovered tests/test_cognito.py::test_cognito_rsa_key_repair_waits_for_live_file_lock tests/test_cognito.py::test_cognito_rsa_key_persists_when_fcntl_is_unavailable -q` with local MiniStack server (`8 passed`)
* `uv run --extra dev pytest -n 3 --dist=loadfile -m "not serial" tests/test_apigatewayv2.py tests/test_cfn.py tests/test_waf.py tests/test_waf_v1.py tests/test_cognito.py::test_cognito_rsa_key_creation_is_process_safe tests/test_cognito.py::test_cognito_rsa_key_corruption_repair_is_process_safe tests/test_cognito.py::test_cognito_rsa_key_stale_repair_lock_is_recovered tests/test_cognito.py::test_cognito_rsa_key_repair_waits_for_live_file_lock tests/test_cognito.py::test_cognito_rsa_key_persists_when_fcntl_is_unavailable -q` with local MiniStack server (`283 passed`)
* `uv run --extra dev pytest tests/test_cognito.py tests/test_apigatewayv2.py -q` with local MiniStack server (`305 passed`)
* `uv run --extra dev pytest tests/test_waf.py tests/test_waf_v1.py tests/test_persistence.py tests/test_cfn.py::test_cfn_wafv2_web_acl_uses_canonical_arn tests/test_cognito.py::test_cognito_rsa_key_creation_is_process_safe tests/test_cognito.py::test_cognito_rsa_key_corruption_repair_is_process_safe tests/test_cognito.py::test_cognito_rsa_key_stale_repair_lock_is_recovered tests/test_cognito.py::test_cognito_rsa_key_repair_waits_for_live_file_lock tests/test_cognito.py::test_cognito_rsa_key_persists_when_fcntl_is_unavailable -q` with local MiniStack server (`250 passed`)
