### PR TITLE
Increase EC2 copy snapshot test timeout

### DIFF
--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -2732,7 +2732,7 @@ def test_ebs_copy_snapshot_respects_source_region():
         method="POST",
     )
     with pytest.raises(urllib.error.HTTPError) as exc:
-        urllib.request.urlopen(req, timeout=5)
+        urllib.request.urlopen(req, timeout=15)
     assert exc.value.code == 400
     assert b"InvalidSnapshot.NotFound" in exc.value.read()
 


### PR DESCRIPTION
## Why
The cross-region EBS CopySnapshot regression test can exceed its five-second raw HTTP timeout under parallel CI load even though the behavior is correct.

## What
- Increase the test-only urllib timeout from 5 seconds to 15 seconds

## Behavior changes and risk
None — this only widens a test timeout; successful and expected-error paths remain unchanged.

## Validation

* `uv run --extra dev ruff check tests/test_ec2.py`
* `uv run --extra dev pytest tests/test_ec2.py -q` with local MiniStack server (`142 passed`)
