### PR TITLE
Regionalize Backup state

### DIFF
--- a/ministack/core/persistence.py
+++ b/ministack/core/persistence.py
@@ -30,6 +30,7 @@ SERVICE_STATE_FORMAT_VERSIONS = {
     "appsync": 3,
     "appsync_events": 3,
     "autoscaling": 3,
+    "backup": 3,
     "bedrock_agentcore": 3,
     "lambda_microvms": 3,
     "acm": 3,

--- a/ministack/services/backup.py
+++ b/ministack/services/backup.py
@@ -19,7 +19,13 @@ import time
 
 from ministack.core.arn import ArnParseError, parse_arn
 from ministack.core.persistence import load_state
-from ministack.core.responses import AccountScopedDict, get_account_id, get_region, new_uuid
+from ministack.core.responses import (
+    AccountRegionScopedDict,
+    AccountScopedDict,
+    get_account_id,
+    get_region,
+    new_uuid,
+)
 
 logger = logging.getLogger("backup")
 
@@ -27,10 +33,10 @@ logger = logging.getLogger("backup")
 # State
 # ---------------------------------------------------------------------------
 
-_vaults     = AccountScopedDict()     # vault_name -> vault record
-_plans      = AccountScopedDict()     # plan_id -> plan record
-_selections = AccountScopedDict()     # selection_id -> selection record
-_jobs       = AccountScopedDict()     # job_id -> job record
+_vaults     = AccountRegionScopedDict()     # vault_name -> vault record
+_plans      = AccountRegionScopedDict()     # plan_id -> plan record
+_selections = AccountRegionScopedDict()     # selection_id -> selection record
+_jobs       = AccountRegionScopedDict()     # job_id -> job record
 
 
 def reset():
@@ -41,10 +47,10 @@ def reset():
 
 
 def get_state():
-    # Preserve AccountScopedDict wrappers; casting to a plain dict drops
-    # the per-account scoping and would persist only the current request's
-    # tenants. AccountScopedDict has a JSON encoder hook that round-trips
-    # the (account, key) tuple correctly.
+    # Preserve scoped wrappers; casting to a plain dict drops the per-account
+    # and per-region scoping and would persist only the current request's
+    # tenants. Scoped dicts have JSON encoder hooks that round-trip the
+    # tuple keys correctly.
     return {
         "vaults":     copy.deepcopy(_vaults),
         "plans":      copy.deepcopy(_plans),
@@ -56,8 +62,35 @@ def get_state():
 def restore_state(data):
     _vaults.update(data.get("vaults", {}))
     _plans.update(data.get("plans", {}))
-    _selections.update(data.get("selections", {}))
+    _restore_selections(data.get("selections", {}))
     _jobs.update(data.get("jobs", {}))
+
+
+def _restore_selections(restored):
+    if isinstance(restored, AccountRegionScopedDict):
+        _selections.update(restored)
+        return
+
+    if isinstance(restored, AccountScopedDict):
+        selection_items = restored._data.items()
+    elif isinstance(restored, dict):
+        account_id = get_account_id()
+        selection_items = [((account_id, selection_id), record) for selection_id, record in restored.items()]
+    else:
+        return
+
+    plan_regions = {
+        (account_id, plan_id): region
+        for (account_id, region, _plan_id), plan in _plans.all_items()
+        for plan_id in (plan.get("BackupPlanId", _plan_id),)
+    }
+    fallback_region = get_region()
+    for (account_id, selection_id), record in selection_items:
+        region = plan_regions.get(
+            (account_id, record.get("BackupPlanId")),
+            fallback_region,
+        )
+        _selections.set_scoped(account_id, region, selection_id, record)
 
 
 def load_persisted_state(data):

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -1,8 +1,10 @@
+import os
+
 import boto3
 import pytest
 from botocore.exceptions import ClientError
 
-ENDPOINT = "http://localhost:4566"
+ENDPOINT = os.environ.get("MINISTACK_ENDPOINT", "http://localhost:4566")
 REGION = "us-east-1"
 
 
@@ -14,6 +16,17 @@ def backup():
         aws_access_key_id="test",
         aws_secret_access_key="test",
         region_name=REGION,
+    )
+
+
+@pytest.fixture(scope="module")
+def backup_west():
+    return boto3.client(
+        "backup",
+        endpoint_url=ENDPOINT,
+        aws_access_key_id="test",
+        aws_secret_access_key="test",
+        region_name="us-west-2",
     )
 
 
@@ -78,6 +91,29 @@ def test_backup_delete_vault_not_found(backup):
     with pytest.raises(ClientError) as exc:
         backup.delete_backup_vault(BackupVaultName="no-such-vault-xyz")
     assert exc.value.response["Error"]["Code"] == "ResourceNotFoundException"
+
+
+def test_backup_vaults_are_region_scoped(backup, backup_west):
+    name = f"region-vault-{_uid()}"
+
+    east = backup.create_backup_vault(BackupVaultName=name)
+    west_names_before = {
+        vault["BackupVaultName"]
+        for vault in backup_west.list_backup_vaults()["BackupVaultList"]
+    }
+    assert name not in west_names_before
+
+    west = backup_west.create_backup_vault(BackupVaultName=name)
+
+    assert f":{REGION}:" in east["BackupVaultArn"]
+    assert ":us-west-2:" in west["BackupVaultArn"]
+
+    backup.delete_backup_vault(BackupVaultName=name)
+    with pytest.raises(ClientError) as exc:
+        backup.describe_backup_vault(BackupVaultName=name)
+    assert exc.value.response["Error"]["Code"] == "ResourceNotFoundException"
+
+    assert backup_west.describe_backup_vault(BackupVaultName=name)["BackupVaultName"] == name
 
 
 # ---------------------------------------------------------------------------
@@ -180,6 +216,17 @@ def test_backup_delete_plan(backup):
     assert exc.value.response["Error"]["Code"] == "ResourceNotFoundException"
 
 
+def test_backup_plans_are_region_scoped(backup, backup_west):
+    plan_id = backup.create_backup_plan(BackupPlan=_plan_body(f"regional-plan-{_uid()}"))["BackupPlanId"]
+
+    with pytest.raises(ClientError) as exc:
+        backup_west.get_backup_plan(BackupPlanId=plan_id)
+    assert exc.value.response["Error"]["Code"] == "ResourceNotFoundException"
+
+    west_plans = backup_west.list_backup_plans()["BackupPlansList"]
+    assert plan_id not in {plan["BackupPlanId"] for plan in west_plans}
+
+
 # ---------------------------------------------------------------------------
 # Selection tests
 # ---------------------------------------------------------------------------
@@ -270,6 +317,25 @@ def test_backup_delete_selection(backup):
     assert exc.value.response["Error"]["Code"] == "ResourceNotFoundException"
 
 
+def test_backup_selections_are_plan_region_scoped(backup, backup_west):
+    plan_id = _make_plan(backup)
+    sel_id = backup.create_backup_selection(
+        BackupPlanId=plan_id,
+        BackupSelection={
+            "SelectionName": "sel-regional",
+            "IamRoleArn": "arn:aws:iam::000000000000:role/BackupRole",
+        },
+    )["SelectionId"]
+
+    with pytest.raises(ClientError) as exc:
+        backup_west.get_backup_selection(BackupPlanId=plan_id, SelectionId=sel_id)
+    assert exc.value.response["Error"]["Code"] == "ResourceNotFoundException"
+
+    with pytest.raises(ClientError) as exc:
+        backup_west.list_backup_selections(BackupPlanId=plan_id)
+    assert exc.value.response["Error"]["Code"] == "ResourceNotFoundException"
+
+
 # ---------------------------------------------------------------------------
 # Job tests
 # ---------------------------------------------------------------------------
@@ -340,6 +406,36 @@ def test_backup_start_job_increments_recovery_point_count(backup):
     )
     after = backup.describe_backup_vault(BackupVaultName=vault_name)["NumberOfRecoveryPoints"]
     assert after == before + 1
+
+
+def test_backup_jobs_are_region_scoped_and_increment_local_vault(backup, backup_west):
+    vault_name = f"job-region-vault-{_uid()}"
+    backup.create_backup_vault(BackupVaultName=vault_name)
+
+    with pytest.raises(ClientError) as exc:
+        backup_west.start_backup_job(
+            BackupVaultName=vault_name,
+            ResourceArn="arn:aws:dynamodb:us-west-2:000000000000:table/MyTable",
+            IamRoleArn="arn:aws:iam::000000000000:role/BackupRole",
+        )
+    assert exc.value.response["Error"]["Code"] == "ResourceNotFoundException"
+
+    before = backup.describe_backup_vault(BackupVaultName=vault_name)["NumberOfRecoveryPoints"]
+    job_id = backup.start_backup_job(
+        BackupVaultName=vault_name,
+        ResourceArn="arn:aws:dynamodb:us-east-1:000000000000:table/MyTable",
+        IamRoleArn="arn:aws:iam::000000000000:role/BackupRole",
+    )["BackupJobId"]
+    assert backup.describe_backup_vault(BackupVaultName=vault_name)["NumberOfRecoveryPoints"] == before + 1
+
+    with pytest.raises(ClientError) as exc:
+        backup_west.describe_backup_job(BackupJobId=job_id)
+    assert exc.value.response["Error"]["Code"] == "ResourceNotFoundException"
+    west_job_ids = {
+        job["BackupJobId"]
+        for job in backup_west.list_backup_jobs(ByBackupVaultName=vault_name)["BackupJobs"]
+    }
+    assert job_id not in west_job_ids
 
 
 def test_backup_stop_job_not_found(backup):
@@ -483,3 +579,38 @@ def test_backup_list_tags_empty(backup):
     arn = f"arn:aws:backup:{REGION}:000000000000:backup-vault:{name}"
     resp = backup.list_tags(ResourceArn=arn)
     assert resp["Tags"] == {}
+
+
+def test_backup_tags_are_region_scoped(backup, backup_west):
+    name = f"tag-region-vault-{_uid()}"
+    backup.create_backup_vault(BackupVaultName=name)
+    backup_west.create_backup_vault(BackupVaultName=name)
+
+    east_arn = f"arn:aws:backup:{REGION}:000000000000:backup-vault:{name}"
+    west_arn = f"arn:aws:backup:us-west-2:000000000000:backup-vault:{name}"
+    backup.tag_resource(ResourceArn=east_arn, Tags={"Env": "east"})
+
+    assert backup.list_tags(ResourceArn=east_arn)["Tags"] == {"Env": "east"}
+    assert backup_west.list_tags(ResourceArn=west_arn)["Tags"] == {}
+
+
+def test_backup_reset_clears_all_regions():
+    from ministack.core.responses import get_region, set_request_region
+    from ministack.services import backup as backup_service
+
+    original_region = get_region()
+    try:
+        set_request_region(REGION)
+        backup_service._vaults["reset-east"] = {"BackupVaultName": "reset-east"}
+        set_request_region("us-west-2")
+        backup_service._vaults["reset-west"] = {"BackupVaultName": "reset-west"}
+
+        backup_service.reset()
+
+        assert not backup_service._vaults.has_any()
+        assert not backup_service._plans.has_any()
+        assert not backup_service._selections.has_any()
+        assert not backup_service._jobs.has_any()
+    finally:
+        backup_service.reset()
+        set_request_region(original_region)

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -646,6 +646,190 @@ def test_backup_round_trip():
     _round_trip("backup", "backup", populate, observe)
 
 
+def test_backup_region_scoped_v3_state_is_idempotent(monkeypatch, tmp_path):
+    import json as _json
+
+    from ministack.core.responses import AccountRegionScopedDict
+
+    monkeypatch.setattr(persistence, "PERSIST_STATE", True)
+    monkeypatch.setattr(persistence, "STATE_DIR", str(tmp_path))
+
+    account_id = "123456789012"
+    region = "us-west-2"
+    vault_name = "regional-vault"
+    plan_id = "regional-plan"
+    selection_id = "regional-selection"
+    job_id = "regional-job"
+
+    def regional_store(key, value):
+        store = AccountRegionScopedDict()
+        store.set_scoped(account_id, region, key, value)
+        return store
+
+    state = {
+        "vaults": regional_store(
+            vault_name,
+            {
+                "BackupVaultName": vault_name,
+                "BackupVaultArn": f"arn:aws:backup:{region}:{account_id}:backup-vault:{vault_name}",
+            },
+        ),
+        "plans": regional_store(
+            plan_id,
+            {
+                "BackupPlanId": plan_id,
+                "BackupPlanArn": f"arn:aws:backup:{region}:{account_id}:backup-plan:{plan_id}",
+            },
+        ),
+        "selections": regional_store(
+            selection_id,
+            {
+                "SelectionId": selection_id,
+                "BackupPlanId": plan_id,
+                "Resources": [f"arn:aws:dynamodb:{region}:{account_id}:table/MyTable"],
+            },
+        ),
+        "jobs": regional_store(
+            job_id,
+            {
+                "BackupJobId": job_id,
+                "BackupJobArn": f"arn:aws:backup:{region}:{account_id}:backup-job:{job_id}",
+            },
+        ),
+    }
+
+    persistence.save_state("backup", state)
+    first_snapshot = _json.loads((tmp_path / "backup.json").read_text())
+    assert first_snapshot["__ministack_format__"] == 3
+
+    loaded = persistence.load_state("backup")
+    assert loaded is not None
+    persistence.save_state("backup", loaded)
+    second_snapshot = _json.loads((tmp_path / "backup.json").read_text())
+
+    assert second_snapshot == first_snapshot
+
+
+def test_backup_legacy_selection_migration_colocates_with_parent_plan():
+    from ministack.core.responses import (
+        AccountScopedDict,
+        get_account_id,
+        get_region,
+        set_request_account_id,
+        set_request_region,
+    )
+    from ministack.services import backup
+
+    original_account = get_account_id()
+    original_region = get_region()
+    account_id = "123456789012"
+    boot_region = "us-east-1"
+    plan_region = "us-west-2"
+    plan_id = "legacy-plan"
+    colocated_selection_id = "legacy-selection"
+    orphan_selection_id = "orphan-selection"
+    vault_name = "legacy-vault"
+    job_id = "legacy-job"
+
+    def scoped_store(key, value):
+        store = AccountScopedDict()
+        store._data[(account_id, key)] = value
+        return store
+
+    try:
+        set_request_account_id(account_id)
+        set_request_region(boot_region)
+        backup.reset()
+
+        legacy_state = {
+            "vaults": scoped_store(
+                vault_name,
+                {
+                    "BackupVaultName": vault_name,
+                    "BackupVaultArn": f"arn:aws:backup:{plan_region}:{account_id}:backup-vault:{vault_name}",
+                },
+            ),
+            "plans": scoped_store(
+                plan_id,
+                {
+                    "BackupPlanId": plan_id,
+                    "BackupPlanArn": f"arn:aws:backup:{plan_region}:{account_id}:backup-plan:{plan_id}",
+                },
+            ),
+            "selections": AccountScopedDict(),
+            "jobs": scoped_store(
+                job_id,
+                {
+                    "BackupJobId": job_id,
+                    "BackupJobArn": f"arn:aws:backup:{plan_region}:{account_id}:backup-job:{job_id}",
+                },
+            ),
+        }
+        legacy_state["selections"]._data[(account_id, colocated_selection_id)] = {
+            "SelectionId": colocated_selection_id,
+            "BackupPlanId": plan_id,
+            "Resources": [f"arn:aws:dynamodb:{boot_region}:{account_id}:table/EastTable"],
+        }
+        legacy_state["selections"]._data[(account_id, orphan_selection_id)] = {
+            "SelectionId": orphan_selection_id,
+            "BackupPlanId": "missing-plan",
+            "Resources": [f"arn:aws:dynamodb:{plan_region}:{account_id}:table/WestTable"],
+        }
+
+        backup.restore_state(legacy_state)
+
+        assert backup._vaults.get_scoped(account_id, plan_region, vault_name) is not None
+        assert backup._plans.get_scoped(account_id, plan_region, plan_id) is not None
+        assert backup._jobs.get_scoped(account_id, plan_region, job_id) is not None
+        assert backup._selections.get_scoped(
+            account_id, plan_region, colocated_selection_id
+        )["BackupPlanId"] == plan_id
+        assert backup._selections.get_scoped(
+            account_id, boot_region, colocated_selection_id
+        ) is None
+        assert backup._selections.get_scoped(
+            account_id, boot_region, orphan_selection_id
+        )["BackupPlanId"] == "missing-plan"
+        assert backup._selections.get_scoped(
+            account_id, plan_region, orphan_selection_id
+        ) is None
+    finally:
+        backup.reset()
+        set_request_account_id(original_account)
+        set_request_region(original_region)
+
+
+def test_backup_region_scoped_state_is_rejected_by_v2_reader(monkeypatch, tmp_path):
+    import json as _json
+
+    from ministack.core.responses import AccountRegionScopedDict
+
+    monkeypatch.setattr(persistence, "PERSIST_STATE", True)
+    monkeypatch.setattr(persistence, "STATE_DIR", str(tmp_path))
+
+    vaults = AccountRegionScopedDict()
+    vaults.set_scoped(
+        "123456789012",
+        "us-west-2",
+        "regional-vault",
+        {
+            "BackupVaultName": "regional-vault",
+            "BackupVaultArn": "arn:aws:backup:us-west-2:123456789012:backup-vault:regional-vault",
+        },
+    )
+    persistence.save_state("backup", {"vaults": vaults})
+
+    raw = _json.loads((tmp_path / "backup.json").read_text())
+    assert raw["__ministack_format__"] == 3
+    loaded_vaults = persistence.load_state("backup")["vaults"]
+    assert loaded_vaults.get_scoped(
+        "123456789012", "us-west-2", "regional-vault"
+    )["BackupVaultName"] == "regional-vault"
+
+    monkeypatch.setattr(persistence, "SERVICE_STATE_FORMAT_VERSIONS", {})
+    assert persistence.load_state("backup") is None
+
+
 @pytest.mark.parametrize(
     "legacy_account_scoped",
     [True, False],


### PR DESCRIPTION
## Why

Backup state was account-scoped: creating a vault with the same name in a second region was rejected with a 409, and vaults, plans, selections, and jobs created in one region were visible and mutable from every other region. This change makes Backup state region-scoped and marks its persisted schema as v3 so older binaries refuse incompatible snapshots instead of mis-parsing them.

## What

- Swapped Backup vault, plan, selection, and job stores to `AccountRegionScopedDict`.
- Added parent-first legacy selection migration so selections restore into their parent plan's region; orphaned legacy selections fall back to the boot/request region.
- Added `backup: 3` to `SERVICE_STATE_FORMAT_VERSIONS`.
- Added Backup region-isolation, tag/job/reset, v3 idempotence, legacy migration, and v2-reader refusal coverage.
- Updated `tests/test_backup.py` to honor `MINISTACK_ENDPOINT` while preserving the default `http://localhost:4566`.

## Behavior changes and risk

- Duplicate vault names across regions now succeed (previously 409).
- Cross-region describe/get/delete/start-job now return 404 (previously succeeded against the other region's resource).
- The tagging API collector now emits region-correct ARNs only for the request's region.

All are corrections toward real AWS semantics. The main risk is persisted-state restoration, covered by the legacy-migration and v2-reader refusal tests.

## Validation

* `uv run --extra dev ruff check ministack/services/backup.py ministack/core/persistence.py tests/test_backup.py tests/test_persistence.py`
* `uv run --extra dev pytest tests/test_backup.py -q` with local MiniStack server (`52 passed`)
* `uv run --extra dev pytest tests/test_persistence.py -q` (`207 passed`)
