### PR TITLE
Scope ECR state by region

### DIFF
--- a/ministack/core/persistence.py
+++ b/ministack/core/persistence.py
@@ -43,6 +43,7 @@ SERVICE_STATE_FORMAT_VERSIONS = {
     "resource_groups": 3,
     "codebuild": 3,
     "ec2": 3,
+    "ecr": 3,
     "cloudtrail": 3,
     "mq": 3,
     "mwaa": 3,

--- a/ministack/services/ecr.py
+++ b/ministack/services/ecr.py
@@ -9,34 +9,38 @@ import hashlib
 import json
 import logging
 import os
+import re
 import time
 
 from ministack.core.arn import ArnParseError, parse_arn
 from ministack.core.persistence import PERSIST_STATE, load_state
 from ministack.core.responses import (
+    AccountRegionScopedDict,
     AccountScopedDict,
     error_response_json,
     get_account_id,
     get_region,
     json_response,
     new_uuid,
+    set_request_account_id,
+    set_request_region,
 )
 
 logger = logging.getLogger("ecr")
 
 REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 
-_repositories = AccountScopedDict()
-_images = AccountScopedDict()
-_lifecycle_policies = AccountScopedDict()
-_repo_policies = AccountScopedDict()
+_repositories = AccountRegionScopedDict()
+_images = AccountRegionScopedDict()
+_lifecycle_policies = AccountRegionScopedDict()
+_repo_policies = AccountRegionScopedDict()
 # Docker Registry HTTP API V2 backing storage.
 # _layer_blobs[repo] = {digest: bytes}     — finalised layer + config bytes addressable by digest.
 # _manifest_blobs[repo] = {digest: bytes}  — raw manifest bytes addressable by digest (for HEAD/GET by digest).
 # _uploads[repo] = {upload_uuid: bytearray} — in-flight chunked uploads (cleared on PUT).
-_layer_blobs = AccountScopedDict()
-_manifest_blobs = AccountScopedDict()
-_uploads = AccountScopedDict()
+_layer_blobs = AccountRegionScopedDict()
+_manifest_blobs = AccountRegionScopedDict()
+_uploads = AccountRegionScopedDict()
 
 
 # ── Persistence ────────────────────────────────────────────
@@ -56,13 +60,60 @@ def get_state():
 
 
 def restore_state(data):
-    if data:
-        _repositories.update(data.get("repositories", {}))
-        _images.update(data.get("images", {}))
-        _lifecycle_policies.update(data.get("lifecycle_policies", {}))
-        _repo_policies.update(data.get("repo_policies", {}))
-        _layer_blobs.update(data.get("layer_blobs", {}))
-        _manifest_blobs.update(data.get("manifest_blobs", {}))
+    if not data:
+        return
+
+    restored_repositories = data.get("repositories", {})
+    legacy_repo_regions = {}
+    if isinstance(restored_repositories, AccountScopedDict):
+        legacy_repo_regions = {
+            (account_id, name): _repositories._region_for_legacy_value(
+                name, repository
+            )
+            for (account_id, name), repository in restored_repositories._data.items()
+        }
+    elif isinstance(restored_repositories, dict):
+        account_id = get_account_id()
+        legacy_repo_regions = {
+            (account_id, name): _repositories._region_for_legacy_value(
+                name, repository
+            )
+            for name, repository in restored_repositories.items()
+        }
+
+    _repositories.update(restored_repositories)
+    for store, key in (
+        (_images, "images"),
+        (_lifecycle_policies, "lifecycle_policies"),
+        (_repo_policies, "repo_policies"),
+        (_layer_blobs, "layer_blobs"),
+        (_manifest_blobs, "manifest_blobs"),
+    ):
+        _restore_repository_child_store(
+            store, data.get(key, {}), legacy_repo_regions
+        )
+
+
+def _restore_repository_child_store(store, restored, legacy_repo_regions):
+    """Adopt legacy name-keyed child state into its repository's region."""
+    if isinstance(restored, AccountRegionScopedDict):
+        store.update(restored)
+        return
+
+    if isinstance(restored, AccountScopedDict):
+        entries = restored._data.items()
+    elif isinstance(restored, dict):
+        account_id = get_account_id()
+        entries = (
+            ((account_id, name), value) for name, value in restored.items()
+        )
+    else:
+        store.update(restored)
+        return
+
+    for (account_id, name), value in entries:
+        region = legacy_repo_regions.get((account_id, name), get_region())
+        store.set_scoped(account_id, region, name, value)
 
 
 try:
@@ -667,6 +718,9 @@ def reset():
 _REGISTRY_API_VERSION_HEADER = ("Docker-Distribution-API-Version", "registry/2.0")
 _DEFAULT_MANIFEST_MEDIA_TYPE = "application/vnd.docker.distribution.manifest.v2+json"
 _UPLOAD_PART_SIZE = 10 * 1024 * 1024  # advisory chunk size; clients ignore for chunked uploads
+_ECR_REGISTRY_HOST_RE = re.compile(
+    r"^(\d{12})\.dkr\.ecr\.([a-z0-9-]+)\."
+)
 
 
 def _registry_error(status, code, message, detail=None):
@@ -771,6 +825,42 @@ def _query_first(query_params, key):
     if isinstance(val, list):
         return val[0] if val else None
     return val
+
+
+def _registry_scope_hint(value):
+    if not isinstance(value, str):
+        return None
+    match = _ECR_REGISTRY_HOST_RE.match(value.lower())
+    return match.groups() if match else None
+
+
+def _select_registry_request_scope(name, headers, query_params):
+    """Pin an unsigned Registry V2 request to its repository's tenant scope."""
+    scope_hint = _registry_scope_hint(headers.get("host"))
+    if scope_hint is None:
+        scope_hint = _registry_scope_hint(_query_first(query_params, "ns"))
+    if scope_hint is not None:
+        account_id, region = scope_hint
+        set_request_account_id(account_id)
+        set_request_region(region)
+        return
+
+    if not name:
+        return
+
+    # Preserve the ambient request scope when it already resolves the repo.
+    if name in _repositories:
+        return
+
+    account_id = get_account_id()
+    matches = [
+        region
+        for (stored_account, region, stored_name), _repository
+        in _repositories.all_items()
+        if stored_account == account_id and stored_name == name
+    ]
+    if len(matches) == 1:
+        set_request_region(matches[0])
 
 
 def _v2_ping():
@@ -1242,6 +1332,8 @@ async def handle_registry_request(method, path, headers, body, query_params):
     verb, name, ref = parsed
     method = method.upper()
     headers = {k.lower(): v for k, v in (headers or {}).items()}
+
+    _select_registry_request_scope(name, headers, query_params)
 
     if verb == "ping":
         if method not in ("GET", "HEAD"):

--- a/tests/test_ecr.py
+++ b/tests/test_ecr.py
@@ -24,6 +24,16 @@ ENDPOINT = os.environ.get("MINISTACK_ENDPOINT", "http://localhost:4566")
 REGION = os.environ.get("MINISTACK_REGION", "us-east-1")
 
 
+def _ecr_client(region, access_key="test"):
+    return boto3.client(
+        "ecr",
+        endpoint_url=ENDPOINT,
+        region_name=region,
+        aws_access_key_id=access_key,
+        aws_secret_access_key="test",
+    )
+
+
 def test_ecr_create_repository(ecr):
     resp = ecr.create_repository(repositoryName="test-app")
     repo = resp["repository"]
@@ -194,6 +204,60 @@ def test_ecr_describe_registry(ecr):
     assert "replicationConfiguration" in resp
 
 
+def test_ecr_repositories_are_region_scoped():
+    east = _ecr_client("us-east-1")
+    west = _ecr_client("us-west-2")
+    same_name = "regional-same-" + _uuid_mod.uuid4().hex[:8]
+    east_only = "regional-east-" + _uuid_mod.uuid4().hex[:8]
+    west_only = "regional-west-" + _uuid_mod.uuid4().hex[:8]
+
+    east_repo = east.create_repository(repositoryName=same_name)["repository"]
+    west_repo = west.create_repository(repositoryName=same_name)["repository"]
+    east.create_repository(repositoryName=east_only)
+    west.create_repository(repositoryName=west_only)
+
+    assert f":us-east-1:000000000000:repository/{same_name}" in east_repo["repositoryArn"]
+    assert f":us-west-2:000000000000:repository/{same_name}" in west_repo["repositoryArn"]
+    with pytest.raises(ClientError) as exc_info:
+        east.create_repository(repositoryName=same_name)
+    assert exc_info.value.response["Error"]["Code"] == (
+        "RepositoryAlreadyExistsException"
+    )
+
+    east_names = {
+        repo["repositoryName"] for repo in east.describe_repositories()["repositories"]
+    }
+    west_names = {
+        repo["repositoryName"] for repo in west.describe_repositories()["repositories"]
+    }
+    assert east_only in east_names
+    assert west_only not in east_names
+    assert west_only in west_names
+    assert east_only not in west_names
+
+    with pytest.raises(ClientError) as exc_info:
+        east.describe_repositories(repositoryNames=[west_only])
+    assert exc_info.value.response["Error"]["Code"] == "RepositoryNotFoundException"
+
+    catalog = requests.get(f"{ENDPOINT}/v2/_catalog")
+    assert catalog.status_code == 200
+    assert west_only not in catalog.json()["repositories"]
+
+    west_namespace = "000000000000.dkr.ecr.us-west-2.amazonaws.com"
+    catalog = requests.get(
+        f"{ENDPOINT}/v2/_catalog", headers={"Host": west_namespace}
+    )
+    assert catalog.status_code == 200
+    assert west_only in catalog.json()["repositories"]
+    assert east_only not in catalog.json()["repositories"]
+    catalog = requests.get(
+        f"{ENDPOINT}/v2/_catalog", params={"ns": west_namespace}
+    )
+    assert catalog.status_code == 200
+    assert west_only in catalog.json()["repositories"]
+    assert east_only not in catalog.json()["repositories"]
+
+
 # ──────────────────────────────────────────────────────────────────────────
 # Docker Registry HTTP API V2 — `docker push` / `docker pull` wire protocol.
 # Issue #606: paths starting with /v2/ were routing to S3 (which returned 405).
@@ -202,6 +266,20 @@ def test_ecr_describe_registry(ecr):
 
 def _digest(data: bytes) -> str:
     return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+def _v2_single_shot_upload(repo, payload, *, headers=None, namespace=None):
+    digest = _digest(payload)
+    params = {"digest": digest}
+    if namespace is not None:
+        params["ns"] = namespace
+    response = requests.post(
+        f"{ENDPOINT}/v2/{repo}/blobs/uploads/",
+        params=params,
+        data=payload,
+        headers=headers,
+    )
+    return response, digest
 
 
 def test_v2_version_probe():
@@ -215,6 +293,88 @@ def test_v2_unknown_repo_returns_404(ecr):
         f"{ENDPOINT}/v2/no-such-repo-{_uuid_mod.uuid4().hex[:8]}/blobs/sha256:" + "0" * 64
     )
     assert r.status_code == 404
+
+
+def test_v2_registry_scope_uses_host_ns_and_unique_region_fallback():
+    west = _ecr_client("us-west-2")
+    europe = _ecr_client("eu-west-1")
+    account = "000000000000"
+
+    host_repo = "v2-host-region-" + _uuid_mod.uuid4().hex[:8]
+    host_account = "111111111111"
+    host_account_west = _ecr_client("us-west-2", access_key=host_account)
+    host_account_west.create_repository(repositoryName=host_repo)
+    west_host = {"Host": f"{host_account}.dkr.ecr.us-west-2.amazonaws.com"}
+    response, digest = _v2_single_shot_upload(
+        host_repo, b"host-region", headers=west_host
+    )
+    assert response.status_code == 201, response.text
+    response = requests.get(
+        f"{ENDPOINT}/v2/{host_repo}/blobs/{digest}", headers=west_host
+    )
+    assert response.status_code == 200
+    assert response.content == b"host-region"
+
+    # Unique fallback never crosses accounts, so the same request without
+    # the host hint stays in the default account and cannot see this repo.
+    response = requests.get(f"{ENDPOINT}/v2/{host_repo}/blobs/{digest}")
+    assert response.status_code == 404
+
+    # Plain localhost requests model an EKS/containerd mirror without an
+    # original-host hint. A unique repository match selects its region.
+    unique_repo = "v2-unique-region-" + _uuid_mod.uuid4().hex[:8]
+    west.create_repository(repositoryName=unique_repo)
+    response, unique_digest = _v2_single_shot_upload(
+        unique_repo, b"unique-region"
+    )
+    assert response.status_code == 201, response.text
+    response = requests.get(f"{ENDPOINT}/v2/{unique_repo}/blobs/{unique_digest}")
+    assert response.status_code == 200
+    assert response.content == b"unique-region"
+
+    ns_repo = "v2-ns-region-" + _uuid_mod.uuid4().hex[:8]
+    europe.create_repository(repositoryName=ns_repo)
+    namespace = f"{account}.dkr.ecr.eu-west-1.amazonaws.com"
+    response, ns_digest = _v2_single_shot_upload(
+        ns_repo, b"namespace-region", namespace=namespace
+    )
+    assert response.status_code == 201, response.text
+    response = requests.get(
+        f"{ENDPOINT}/v2/{ns_repo}/blobs/{ns_digest}",
+        params={"ns": namespace},
+    )
+    assert response.status_code == 200
+    assert response.content == b"namespace-region"
+
+
+def test_v2_registry_scope_prefers_ambient_and_rejects_ambiguous_fallback():
+    east = _ecr_client("us-east-1")
+    west = _ecr_client("us-west-2")
+    europe = _ecr_client("eu-west-1")
+    account = "000000000000"
+
+    ambient_repo = "v2-ambient-region-" + _uuid_mod.uuid4().hex[:8]
+    east.create_repository(repositoryName=ambient_repo)
+    west.create_repository(repositoryName=ambient_repo)
+    response, digest = _v2_single_shot_upload(ambient_repo, b"ambient-region")
+    assert response.status_code == 201, response.text
+    east_host = {"Host": f"{account}.dkr.ecr.us-east-1.amazonaws.com"}
+    west_host = {"Host": f"{account}.dkr.ecr.us-west-2.amazonaws.com"}
+    assert requests.get(
+        f"{ENDPOINT}/v2/{ambient_repo}/blobs/{digest}", headers=east_host
+    ).status_code == 200
+    assert requests.get(
+        f"{ENDPOINT}/v2/{ambient_repo}/blobs/{digest}", headers=west_host
+    ).status_code == 404
+
+    ambiguous_repo = "v2-ambiguous-region-" + _uuid_mod.uuid4().hex[:8]
+    west.create_repository(repositoryName=ambiguous_repo)
+    europe.create_repository(repositoryName=ambiguous_repo)
+    response, _digest_value = _v2_single_shot_upload(
+        ambiguous_repo, b"ambiguous-region"
+    )
+    assert response.status_code == 404
+    assert response.json()["errors"][0]["code"] == "NAME_UNKNOWN"
 
 
 def test_v2_chunked_blob_upload_then_manifest_then_describe_images(ecr):
@@ -516,6 +676,44 @@ def test_ecr_tag_apis_require_request_scope_and_stored_repository_arn_match():
     assert _body(ecr_svc._list_tags_for_resource({"resourceArn": stored_arn}))["tags"] == [
         {"Key": "env", "Value": "east"}
     ]
+
+
+def test_ecr_child_stores_are_region_scoped_and_reset_clears_all_regions():
+    name = "direct-region-scope"
+    _create_repository(name)
+    ecr_svc._images[name].append({"scope": "east"})
+    ecr_svc._lifecycle_policies[name] = "east-lifecycle"
+    ecr_svc._repo_policies[name] = "east-policy"
+    ecr_svc._layer_blobs[name] = {"sha256:east": b"east-layer"}
+    ecr_svc._manifest_blobs[name] = {"sha256:east": b"east-manifest"}
+    ecr_svc._uploads[name] = {"east-upload": bytearray(b"east")}
+
+    set_request_region("us-west-2")
+    _create_repository(name)
+    ecr_svc._images[name].append({"scope": "west"})
+    ecr_svc._lifecycle_policies[name] = "west-lifecycle"
+    ecr_svc._repo_policies[name] = "west-policy"
+    ecr_svc._layer_blobs[name] = {"sha256:west": b"west-layer"}
+    ecr_svc._manifest_blobs[name] = {"sha256:west": b"west-manifest"}
+    ecr_svc._uploads[name] = {"west-upload": bytearray(b"west")}
+
+    assert ecr_svc._images[name] == [{"scope": "west"}]
+    assert ecr_svc._repo_policies[name] == "west-policy"
+    set_request_region("us-east-1")
+    assert ecr_svc._images[name] == [{"scope": "east"}]
+    assert ecr_svc._repo_policies[name] == "east-policy"
+
+    ecr_svc.reset()
+    for store in (
+        ecr_svc._repositories,
+        ecr_svc._images,
+        ecr_svc._lifecycle_policies,
+        ecr_svc._repo_policies,
+        ecr_svc._layer_blobs,
+        ecr_svc._manifest_blobs,
+        ecr_svc._uploads,
+    ):
+        assert not store.has_any()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -646,6 +646,105 @@ def test_backup_round_trip():
     _round_trip("backup", "backup", populate, observe)
 
 
+@pytest.mark.parametrize(
+    "legacy_account_scoped",
+    [True, False],
+    ids=["account-scoped", "plain-dict"],
+)
+def test_ecr_legacy_state_uses_parent_repository_region(
+    legacy_account_scoped,
+):
+    from ministack.core.responses import (
+        AccountScopedDict,
+        get_account_id,
+        get_region,
+        set_request_account_id,
+        set_request_region,
+    )
+    from ministack.services import ecr as mod
+
+    original_account = get_account_id()
+    original_region = get_region()
+    account_id = "000000000000"
+    boot_region = "us-east-1"
+    repository_region = "eu-west-1"
+    name = "legacy-repository"
+    orphan = "orphan-repository"
+
+    def legacy_store(values):
+        if not legacy_account_scoped:
+            return values
+        store = AccountScopedDict()
+        store._data.update(
+            {(account_id, key): value for key, value in values.items()}
+        )
+        return store
+
+    repositories = legacy_store(
+        {
+            name: {
+                "repositoryArn": (
+                    f"arn:aws:ecr:{repository_region}:{account_id}:repository/{name}"
+                ),
+                "repositoryName": name,
+            }
+        }
+    )
+    images = legacy_store(
+        {
+            name: [{"imageDigest": "sha256:image"}],
+            orphan: [{"imageDigest": "sha256:orphan"}],
+        }
+    )
+    lifecycle_policies = legacy_store({name: "legacy-lifecycle"})
+    repo_policies = legacy_store({name: "legacy-repository-policy"})
+    layer_blobs = legacy_store({name: {"sha256:layer": b"layer"}})
+    manifest_blobs = legacy_store(
+        {name: {"sha256:manifest": b"manifest"}}
+    )
+
+    mod.reset()
+    try:
+        set_request_account_id(account_id)
+        set_request_region(boot_region)
+        mod.restore_state(
+            {
+                "repositories": repositories,
+                "images": images,
+                "lifecycle_policies": lifecycle_policies,
+                "repo_policies": repo_policies,
+                "layer_blobs": layer_blobs,
+                "manifest_blobs": manifest_blobs,
+            }
+        )
+
+        assert mod._repositories.get_scoped(
+            account_id, repository_region, name
+        )["repositoryName"] == name
+        assert mod._images.get_scoped(account_id, repository_region, name) == [
+            {"imageDigest": "sha256:image"}
+        ]
+        assert mod._lifecycle_policies.get_scoped(
+            account_id, repository_region, name
+        ) == "legacy-lifecycle"
+        assert mod._repo_policies.get_scoped(
+            account_id, repository_region, name
+        ) == "legacy-repository-policy"
+        assert mod._layer_blobs.get_scoped(
+            account_id, repository_region, name
+        ) == {"sha256:layer": b"layer"}
+        assert mod._manifest_blobs.get_scoped(
+            account_id, repository_region, name
+        ) == {"sha256:manifest": b"manifest"}
+        assert mod._images.get_scoped(account_id, boot_region, orphan) == [
+            {"imageDigest": "sha256:orphan"}
+        ]
+    finally:
+        mod.reset()
+        set_request_account_id(original_account)
+        set_request_region(original_region)
+
+
 def test_eks_round_trip():
     def populate(mod):
         mod._clusters["cluster-test"] = {"name": "cluster-test", "status": "ACTIVE"}
@@ -2782,6 +2881,41 @@ def test_ecs_region_scoped_state_is_rejected_by_v2_reader(monkeypatch, tmp_path)
     # Simulate the previous binary, whose highest understood format is v2.
     monkeypatch.setattr(persistence, "SERVICE_STATE_FORMAT_VERSIONS", {})
     assert persistence.load_state("ecs") is None
+
+
+def test_ecr_region_scoped_state_is_rejected_by_v2_reader(monkeypatch, tmp_path):
+    """A rollback binary must reject ECR's regional schema instead of
+    accepting it as v2 and silently dropping every regional store."""
+    import json as _json
+
+    from ministack.core.responses import AccountRegionScopedDict
+
+    monkeypatch.setattr(persistence, "PERSIST_STATE", True)
+    monkeypatch.setattr(persistence, "STATE_DIR", str(tmp_path))
+
+    repositories = AccountRegionScopedDict()
+    repositories.set_scoped(
+        "000000000000",
+        "us-west-2",
+        "regional-repository",
+        {
+            "repositoryArn": (
+                "arn:aws:ecr:us-west-2:000000000000:"
+                "repository/regional-repository"
+            )
+        },
+    )
+    persistence.save_state("ecr", {"repositories": repositories})
+
+    raw = _json.loads((tmp_path / "ecr.json").read_text())
+    assert raw["__ministack_format__"] == 3
+    loaded_repositories = persistence.load_state("ecr")["repositories"]
+    assert loaded_repositories.get_scoped(
+        "000000000000", "us-west-2", "regional-repository"
+    )["repositoryArn"].endswith("repository/regional-repository")
+
+    monkeypatch.setattr(persistence, "SERVICE_STATE_FORMAT_VERSIONS", {})
+    assert persistence.load_state("ecr") is None
 
 
 def test_appsync_region_scoped_state_is_rejected_by_v2_reader(


### PR DESCRIPTION
## Why
ECR state was account-scoped, so same-named repositories and their images, policies, layers, manifests, and uploads collided across regions. Docker Registry V2 requests also lack SigV4 context and need an explicit region-selection path.

## What
- Scope all seven ECR stores by account and region, with v2-to-v3 persistence migration
- Pin Registry V2 requests by registry host, containerd `ns`, or same-account unique-repository fallback
- Add region-isolation, context-selection, reset, rollback, and legacy-migration regressions

## Behavior changes and risk
ECR API and Docker Registry V2 operations now see only the caller's regional repositories, so same-named repositories no longer collide across regions. This changes ECR state partitioning and persisted-state restoration: legacy snapshots migrate parent-first with orphan fallback to the boot region, and the new behavior is covered across API and Registry V2 paths.

## Validation

* `uv run --extra dev ruff check ministack/services/ecr.py tests/test_ecr.py`
* `uv run --extra dev pytest tests/test_ecr.py -q` with local MiniStack server (`42 passed`)
* `uv run --extra dev pytest tests/test_persistence.py -q` (`207 passed`)
