### PR TITLE
Harden Glue and AppSync flaky tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,6 +103,12 @@ _SERIAL_TESTS = {
     "tests/test_appsync.py::test_appsync_lambda_failing_authorizer_returns_unauthorized",
     # AppSync Events service mutations; shared state racing under xdist.
     "tests/test_appsync_events.py::test_publish_with_appsync_sigv4_scope_on_events_vhost",
+    # AppSync Events realtime websocket fan-out uses shared subscriptions and
+    # connection delivery state; keep fan-out assertions out of the xdist lane.
+    "tests/test_appsync_events.py::test_websocket_subscribe_receives_published_event",
+    "tests/test_appsync_events.py::test_websocket_single_level_wildcard",
+    "tests/test_appsync_events.py::test_websocket_unsubscribe_stops_delivery",
+    "tests/test_appsync_events.py::test_websocket_publish_frame_acks_and_fans_out",
     # Credential report reflects all users in the account; run serially to avoid
     # parallel-test interference on the account-global CSV snapshot.
     "tests/test_iam.py::test_iam_credential_report_mfa_and_password",

--- a/tests/test_glue.py
+++ b/tests/test_glue.py
@@ -29,6 +29,22 @@ def _glue_client(region):
     )
 
 
+def _wait_for_crawler_completion(glue, name, timeout=10):
+    deadline = time.time() + timeout
+    while True:
+        crawler = glue.get_crawler(Name=name)["Crawler"]
+        last_crawl = crawler.get("LastCrawl") or {}
+        if crawler["State"] == "READY" and last_crawl.get("Status") == "SUCCEEDED":
+            return crawler
+        if time.time() >= deadline:
+            raise AssertionError(
+                f"Crawler {name} did not complete successfully; "
+                f"last state was {crawler['State']}, "
+                f"last crawl was {crawler.get('LastCrawl')}"
+            )
+        time.sleep(0.1)
+
+
 def test_glue_catalog(glue):
     glue.create_database(DatabaseInput={"Name": "test_db", "Description": "Test database"})
     glue.create_table(
@@ -356,8 +372,9 @@ def test_glue_crawler_v2(glue):
     assert cr["State"] == "READY"
 
     glue.start_crawler(Name="glue-cr-v2")
-    cr2 = glue.get_crawler(Name="glue-cr-v2")["Crawler"]
-    assert cr2["State"] == "RUNNING"
+    cr2 = _wait_for_crawler_completion(glue, "glue-cr-v2")
+    assert cr2["State"] == "READY"
+    assert cr2["LastCrawl"]["Status"] == "SUCCEEDED"
 
 def test_glue_tags_v2(glue):
     glue.create_database(DatabaseInput={"Name": "glue_tag_v2db"})
@@ -1022,17 +1039,55 @@ def test_glue_stop_crawler(glue):
         Targets={"S3Targets": [{"Path": "s3://b/d/"}]},
     )
     glue.start_crawler(Name=name)
-    cr = glue.get_crawler(Name=name)["Crawler"]
-    assert cr["State"] == "RUNNING"
-    glue.stop_crawler(Name=name)
-    cr2 = glue.get_crawler(Name=name)["Crawler"]
-    assert cr2["State"] == "READY"
+    try:
+        glue.stop_crawler(Name=name)
+    except ClientError as exc:
+        assert exc.response["Error"]["Code"] == "CrawlerNotRunningException"
+        cr2 = glue.get_crawler(Name=name)["Crawler"]
+        last_crawl = cr2.get("LastCrawl") or {}
+        assert cr2["State"] == "READY"
+        if last_crawl.get("Status") != "SUCCEEDED":
+            cr2 = _wait_for_crawler_completion(glue, name)
+        assert cr2["LastCrawl"]["Status"] == "SUCCEEDED"
+    else:
+        cr2 = glue.get_crawler(Name=name)["Crawler"]
+        assert cr2["State"] == "READY"
     # stopping a non-running crawler raises
     with pytest.raises(ClientError) as exc:
         glue.stop_crawler(Name=name)
     assert exc.value.response["Error"]["Code"] == "CrawlerNotRunningException"
     # cleanup
     glue.delete_crawler(Name=name)
+
+
+def test_glue_stop_crawler_service_stops_running_crawler():
+    from ministack.core import responses as respmod
+    from ministack.services import glue as gluemod
+
+    account = "000000000000"
+    region = "us-east-1"
+    name = "service-stop-cr"
+    account_token = respmod._request_account_id.set(account)
+    region_token = respmod._request_region.set(region)
+    try:
+        gluemod._crawlers.pop_scoped(account, region, name, None)
+        gluemod._create_crawler({
+            "Name": name,
+            "Role": "arn:aws:iam::000000000000:role/R",
+            "Targets": {"S3Targets": [{"Path": "s3://b/d/"}]},
+        })
+        gluemod._start_crawler({"Name": name})
+        assert gluemod._crawlers[name]["State"] == "RUNNING"
+
+        status, body = _glue_json(gluemod._stop_crawler({"Name": name}))
+
+        assert status == 200
+        assert body == {}
+        assert gluemod._crawlers[name]["State"] == "READY"
+    finally:
+        respmod._request_region.reset(region_token)
+        respmod._request_account_id.reset(account_token)
+        gluemod._crawlers.pop_scoped(account, region, name, None)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

The Glue crawler tests depended on observing short-lived asynchronous states, which can be missed under shared-server or parallel test scheduling. A few AppSync Events realtime fan-out tests also exercise shared websocket delivery behavior and can interfere with the parallel-safe test lane.

## What

- Update Glue crawler tests to wait for stable completion state instead of requiring the transient `RUNNING` state to be observed immediately.
- Keep race-safe handling for `StopCrawler` while preserving deterministic coverage that a running crawler can be stopped successfully.
- Move the four AppSync Events realtime fan-out websocket tests into the existing serial test phase.

## Behavior changes and risk

This is a test-only change. It does not modify MiniStack service behavior.

Risk is limited to test coverage shape: the Glue assertions now verify stable final crawler state and include direct service-level stop coverage, while the AppSync tests remain fully asserted but run serially.

## Validation

- `uv run --extra dev ruff check tests/test_glue.py tests/conftest.py` → passed
- `uv run --extra dev pytest -q tests/test_glue.py::test_glue_crawler_v2 tests/test_glue.py::test_glue_stop_crawler tests/test_glue.py::test_glue_stop_crawler_service_stops_running_crawler` → 3 passed
- `uv run --extra dev pytest -q -m serial tests/test_appsync_events.py::test_websocket_subscribe_receives_published_event tests/test_appsync_events.py::test_websocket_single_level_wildcard tests/test_appsync_events.py::test_websocket_unsubscribe_stops_delivery tests/test_appsync_events.py::test_websocket_publish_frame_acks_and_fans_out` → 4 passed
- `uv run --extra dev pytest --collect-only -q -m serial tests/test_appsync_events.py::test_websocket_subscribe_receives_published_event tests/test_appsync_events.py::test_websocket_single_level_wildcard tests/test_appsync_events.py::test_websocket_unsubscribe_stops_delivery tests/test_appsync_events.py::test_websocket_publish_frame_acks_and_fans_out` → 4 collected
- `uv run --extra dev pytest --collect-only -q -m "not serial" tests/test_appsync_events.py::test_websocket_subscribe_receives_published_event tests/test_appsync_events.py::test_websocket_single_level_wildcard tests/test_appsync_events.py::test_websocket_unsubscribe_stops_delivery tests/test_appsync_events.py::test_websocket_publish_frame_acks_and_fans_out` → no tests collected; 4 deselected
- `git diff --check upstream/main...HEAD` → passed
