### PR TITLE
fix(ec2): use real AZ ids, not a copy of the zone name

### DIFF
--- a/ministack/services/ec2.py
+++ b/ministack/services/ec2.py
@@ -2341,14 +2341,37 @@ def _describe_vpc_endpoint_services(p):
 # Availability Zones
 # ---------------------------------------------------------------------------
 
+_AZ_ID_DIRECTIONS = {
+    "north": "n", "south": "s", "east": "e", "west": "w", "central": "c",
+    "northeast": "ne", "northwest": "nw", "southeast": "se", "southwest": "sw",
+}
+
+
+def _az_id_prefix(region):
+    """Region -> the AZ-id prefix AWS codes it with: eu-central-1 -> euc1, ap-southeast-2 -> apse2."""
+
+    parts = region.split("-")
+    if len(parts) < 3:
+        return region.replace("-", "")
+    geo, middles, index = parts[0], parts[1:-1], parts[-1]
+    coded = "".join(_AZ_ID_DIRECTIONS.get(part, part[:1]) for part in middles)
+    return f"{geo}{coded}{index}"
+
+
 def _describe_availability_zones(p):
-    azs = [f"{get_region()}a", f"{get_region()}b", f"{get_region()}c"]
+    """AZ ids are deliberately unlike the zone names: AWS shuffles names per account, so AZa is different,
+    while az1 is the same across accounts. The shuffle on AWS is per-account stable."""
+
+    region = get_region()
+    prefix = _az_id_prefix(region)
+    # 3 AZs with a=1, b=2, c=3 for ministack
+    zones = [(f"{region}{letter}", f"{prefix}-az{n}") for n, letter in enumerate("abc", start=1)]
     items = "".join(f"""<item>
-        <zoneName>{az}</zoneName>
+        <zoneName>{name}</zoneName>
         <zoneState>available</zoneState>
-        <regionName>{get_region()}</regionName>
-        <zoneId>{az}</zoneId>
-    </item>""" for az in azs)
+        <regionName>{region}</regionName>
+        <zoneId>{zone_id}</zoneId>
+    </item>""" for name, zone_id in zones)
     return _xml(200, "DescribeAvailabilityZonesResponse",
                 f"<availabilityZoneInfo>{items}</availabilityZoneInfo>")
 

--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -86,6 +86,29 @@ def test_ec2_describe_availability_zones(ec2):
     assert any("us-east-1" in az for az in azs)
 
 
+def test_ec2_availability_zone_ids_are_region_coded(ec2):
+    """ZoneId is the account-stable id ("use1-az1"), never the account-local ZoneName: code
+    handed an id has to resolve it here, and an id that equals the name hides that requirement
+    until it runs against real AWS."""
+    zones = ec2.describe_availability_zones()["AvailabilityZones"]
+    assert [z["ZoneId"] for z in zones] == ["use1-az1", "use1-az2", "use1-az3"]
+    assert all(z["ZoneId"] != z["ZoneName"] for z in zones)
+    assert [z["ZoneName"] for z in zones] == ["us-east-1a", "us-east-1b", "us-east-1c"]
+    assert all(z["RegionName"] == "us-east-1" and z["State"] == "available" for z in zones)
+
+    # The prefix follows AWS's own coding, including the compound directions.
+    from ministack.services.ec2 import _az_id_prefix
+    assert _az_id_prefix("eu-central-1") == "euc1"
+    assert _az_id_prefix("ap-southeast-2") == "apse2"
+    assert _az_id_prefix("ap-northeast-1") == "apne1"
+    assert _az_id_prefix("us-west-2") == "usw2"
+    assert _az_id_prefix("ca-central-1") == "cac1"
+    assert _az_id_prefix("sa-east-1") == "sae1"
+    # A partitioned region keeps every part between the geography and the index.
+    assert _az_id_prefix("us-gov-west-1") == "usgw1"
+    assert _az_id_prefix("cn-northwest-1") == "cnnw1"
+
+
 def test_ec2_describe_regions_returns_commercial_regions(ec2):
     """DescribeRegions must list at least the four legacy us-* regions
     with opt-in-not-required, and emit the shape AWS returns."""


### PR DESCRIPTION
### Issue

`DescribeAvailabilityZones` emits `<zoneId>` equal to `<zoneName>`, so every zone reports itself as `us-east-1a` under both. In AWS the two are deliberately different: names are shuffled per account, ids are not. `eu-central-1a` is different hardware in two accounts, while `euc1-az1` is the same hardware in both.

To land on the same physical AZ as another account, I have to map the id to this account's zone name: a control message carries euc1-az1, while `CreateVolume` and `RunInstances` want eu-central-1a. With the id equal to the name that mapping resolves to itself, so it passes locally and then fails on AWS, where the id resolves to nothing.

### Fix

Region-code the ids the way AWS codes them — `eu-central-1` → `euc1`, `ap-southeast-2` → `apse2`, compound directions included. Every part between the geography and the index is kept ( `us-gov-west-1` → `usgw1`).

The `a` → `az1` ordering is arbitrary but stable. The real per-account shuffle cannot be known from outside. We use 3 AZs with a=1,b=2,c=3 on describe.

Code written with Claude Code.

### Testing

Added a test with some AWS regions.

Expected behaviour was established on real AWS first, then checked against MiniStack with the script below, which runs against either and is read-only:

| target | result |
| --- | --- |
| MiniStack before | 1/3 |
| this branch | 3/3 |
| real AWS, eu-central-1 | 3/3 |

```
                                 before                                this branch / AWS
zone ids are region-coded        unmatched=['eu-central-1a', ...]      prefix=euc1
zone id differs from zone name   identical: ['eu-central-1a', ...]     all zones
zone names carry the region      all zones                             all zones
```

Only invariant detail is printed, so the two runs compare line by line: the zone count differs per region and the id → name pairing differs per account, but the prefix does not.

<details>
<summary>check_ec2_az_ids.py</summary>

```python
#!/usr/bin/env python3
"""Check EC2 availability-zone ids against AWS's own.

An AZ id is stable across accounts while the zone name is shuffled per account, so code that is
handed an id resolves it to a local name before it can place anything. An emulator that returns
the name as its own id lets that resolution pass locally and fail on AWS. Each check therefore
asserts a property that holds on both targets and prints the same detail on both, so the two runs
can be compared line by line.

Against MiniStack:
  python check_ec2_az_ids.py --endpoint http://localhost:4566 --region eu-central-1

Against AWS, after `aws sso login --profile <profile>`:
  python check_ec2_az_ids.py --profile <profile> --region eu-central-1

Read-only: nothing is created, so it costs nothing to run against a real account.
Exit status is 0 when every check passes.
"""

import argparse
import re
import sys

import boto3
from botocore.exceptions import ClientError

# AWS codes an id as <region prefix>-az<n>, e.g. use1-az1, apse2-az3, usgw1-az2.
AZ_ID = re.compile(r"^([a-z]{2}[a-z]*\d)-az(\d+)$")


def options():
    parser = argparse.ArgumentParser(description=__doc__)
    parser.add_argument("--endpoint", help="Emulator endpoint, e.g. http://localhost:4566")
    parser.add_argument("--profile", help="AWS CLI/SSO profile; defaults to AWS_PROFILE")
    parser.add_argument("--region", default=None, help="AWS region; defaults to AWS_REGION")
    return parser.parse_args()


def main():
    args = options()
    if args.endpoint and not args.profile:
        # An emulator needs no real credentials, and picking up an ambient profile only means
        # failing on an expired SSO token for a run that never leaves localhost.
        session = boto3.Session(region_name=args.region, aws_access_key_id="test",
                                aws_secret_access_key="test")
    else:
        session = boto3.Session(profile_name=args.profile, region_name=args.region)
    ec2 = session.client("ec2", **({"endpoint_url": args.endpoint} if args.endpoint else {}))
    region = session.region_name
    results = []

    def check(label, ok, detail):
        results.append((label, ok, detail))
        print(f"{'PASS' if ok else 'FAIL'}  {label:34} {detail}")

    try:
        # Local zones and opt-in zones are a different feature; the plain AZs are what MiniStack
        # emulates and what the id -> name resolution below applies to.
        zones = [z for z in ec2.describe_availability_zones()["AvailabilityZones"]
                 if z.get("ZoneType", "availability-zone") == "availability-zone"
                 and z["State"] == "available"]

        # 1. Ids are region-coded, and every zone in the region shares one prefix. The prefix is
        #    the whole point of the comparison: run both targets in one region and it must match.
        matches = [AZ_ID.match(z["ZoneId"] or "") for z in zones]
        prefixes = {m.group(1) for m in matches if m}
        ok = bool(zones) and all(matches) and len(prefixes) == 1
        check("zone ids are region-coded", ok,
              f"prefix={prefixes.pop()}" if ok
              else f"unmatched={[z['ZoneId'] for z, m in zip(zones, matches) if not m][:3] or sorted(prefixes)}")

        # 2. The bug this guards: an id equal to its zone name resolves to itself, so a resolver
        #    is never exercised. Count is not printed — AWS has more zones in some regions.
        same = [z["ZoneId"] for z in zones if z["ZoneId"] == z["ZoneName"]]
        check("zone id differs from zone name", not same and bool(zones),
              "all zones" if not same and zones else f"identical: {same[:3]}")

        # 3. Names are the region plus a letter, and the region is reported back.
        bad_names = [z["ZoneName"] for z in zones if not z["ZoneName"].startswith(region)
                     or z["RegionName"] != region]
        check("zone names carry the region", not bad_names and bool(zones),
              "all zones" if not bad_names and zones else f"unexpected: {bad_names[:3]}")
    except ClientError as exc:
        print(f"ERROR: {exc}", file=sys.stderr)
        return 2

    failed = [label for label, ok, _ in results if not ok]
    print(f"\n{len(results) - len(failed)}/{len(results)} checks passed"
          + (f"; failed: {', '.join(failed)}" if failed else ""))
    return 1 if failed else 0


if __name__ == "__main__":
    try:
        sys.exit(main())
    except (ClientError, TimeoutError) as exc:
        print(f"ERROR: {exc}", file=sys.stderr)
        sys.exit(2)
```

</details>
