### PR TITLE
fix(stepfunctions): return the SDK output shape for aws-sdk:ec2 tasks

### DIFF
--- a/ministack/services/stepfunctions.py
+++ b/ministack/services/stepfunctions.py
@@ -4758,30 +4758,6 @@ def _query_item_list(value):
     return value if isinstance(value, list) else [value]
 
 
-def _normalize_ec2_security_group(group):
-    if not isinstance(group, dict):
-        return group
-    if "groupDescription" in group:
-        group["Description"] = group.pop("groupDescription")
-    if "tagSet" in group:
-        group["Tags"] = _query_item_list(group.pop("tagSet"))
-
-    for permission_key in ("ipPermissions", "ipPermissionsEgress"):
-        if permission_key not in group:
-            continue
-        permissions = _query_item_list(group[permission_key])
-        for permission in permissions:
-            if not isinstance(permission, dict):
-                continue
-            for list_key in ("ipRanges", "ipv6Ranges", "prefixListIds"):
-                if list_key in permission:
-                    permission[list_key] = _query_item_list(permission[list_key])
-            if "groups" in permission:
-                permission["UserIdGroupPairs"] = _query_item_list(permission.pop("groups"))
-        group[permission_key] = permissions
-    return group
-
-
 def _normalize_sqs_attribute_map(result):
     """Repeated <Attribute><Name>/<Value> children as the SDK's Attributes map."""
     items = result if isinstance(result, list) else [result]
@@ -4791,6 +4767,120 @@ def _normalize_sqs_attribute_map(result):
             attributes[item["Name"]] = item.get("Value", "")
     return {"Attributes": attributes}
 
+# EC2 reuses some names depending on parent. Special case for flattening
+_EC2_FIELDS_BY_PARENT = {
+    ("attachmentSet", "status"): "State",
+    ("instancesSet", "groupSet"): "SecurityGroups",
+    ("instancesSet", "reason"): "StateTransitionReason",
+    ("ipPermissions", "groups"): "UserIdGroupPairs",
+    ("ipPermissionsEgress", "groups"): "UserIdGroupPairs",
+    ("productCodes", "productCode"): "ProductCodeId",
+    ("productCodes", "type"): "ProductCodeType",
+    ("volumeSet", "status"): "State",
+}
+
+# EC2 reuses some names depending on action. Special case for flattening
+_EC2_FIELDS_BY_ACTION = {
+    ("AttachVolume", "status"): "State",
+    ("CreateVolume", "status"): "State",
+    ("DetachVolume", "status"): "State",
+    ("StartInstances", "instancesSet"): "StartingInstances",
+    ("StopInstances", "instancesSet"): "StoppingInstances",
+    ("TerminateInstances", "instancesSet"): "TerminatingInstances",
+}
+
+
+# Elements whose SDK plural is not "<name minus Set> + s".
+_EC2_GENERIC_NAME_OVERRIDES = {
+    # Members that keep the Set suffix
+    "cidrBlockAssociationSet": "CidrBlockAssociationSet",
+    "ipv6CidrBlockAssociationSet": "Ipv6CidrBlockAssociationSet",
+    # Members whose SDK name the suffix rule cannot reach at all.
+    "keySet": "KeyPairs",
+    "volumeModificationSet": "VolumesModifications",
+    "fleetInstanceSet": "Instances",
+    "groupDescription": "Description",
+    "instanceState": "State",
+    "blockDeviceMapping": "BlockDeviceMappings",
+    "securityGroupInfo": "SecurityGroups",
+    "dnsName": "PublicDnsName",
+    "ipAddress": "PublicIpAddress",
+}
+
+_EC2_GENERIC_NUMERIC_FIELDS = frozenset({
+    "size", "iops", "throughput", "code", "coreCount", "threadsPerCore",
+    "amiLaunchIndex", "fromPort", "toPort", "volumeSize", "deviceIndex",
+    "partitionNumber", "ruleNumber", "port",
+})
+
+_EC2_GENERIC_BOOLEAN_FIELDS = frozenset({
+    "encrypted", "multiAttachEnabled", "deleteOnTermination", "sourceDestCheck",
+    "ebsOptimized", "enaSupport", "fastRestored", "isDefault", "default",
+    "mapPublicIpOnLaunch", "enableDnsSupport", "enableDnsHostnames", "primary",
+    "associatePublicIpAddress", "egress", "return", "requesterManaged",
+})
+
+# Members that are arrays even though they don't end with Set
+_EC2_LIST_FIELDS = frozenset({
+    "blockDeviceMapping", "groups", "ipPermissions", "ipPermissionsEgress",
+    "ipRanges", "ipv6Ranges", "prefixListIds", "productCodes", "securityGroupInfo",
+})
+
+def _ec2_generic_sdk_name(wire_name, action=None, parent=""):
+    """SDK member name for a wire element: context first, then the flat rules."""
+    if not wire_name:
+        return wire_name
+    # Special case for scoped fields
+    scoped = _EC2_FIELDS_BY_PARENT.get((parent, wire_name))
+    if scoped is None:
+        scoped = _EC2_FIELDS_BY_ACTION.get((action, wire_name)) if not parent else None
+    if scoped is not None:
+        return scoped
+
+    if wire_name in _EC2_GENERIC_NAME_OVERRIDES:
+        return _EC2_GENERIC_NAME_OVERRIDES[wire_name]
+    if wire_name.endswith("Set") and len(wire_name) > 3:
+        # The member is the base, pluralised. A base already in the plural is left alone
+        # (instancesSet -> Instances); the rest follow English, so Entry -> Entries and
+        # InstanceStatus -> InstanceStatuses rather than Entrys and InstanceStatus.
+        base = wire_name[:-3]
+        base = base[0].upper() + base[1:]
+        if base.endswith("y") and base[-2:-1].lower() not in "aeiou":
+            return base[:-1] + "ies"
+        if base.lower().endswith(("us", "ss", "x", "z", "ch", "sh")):
+            return base + "es"
+        return base if base.endswith("s") else base + "s"
+    return wire_name[0].upper() + wire_name[1:]
+
+def _apply_ec2_generic(wire_key, value, action=None, parent=""):
+    """Shape one wire element into its SDK form with the current type."""
+
+    # An empty element parses to {} with some XML readers and "" with others.
+    if not value and (wire_key.endswith("Set") or wire_key in _EC2_LIST_FIELDS):
+        return []
+    if isinstance(value, dict):
+        # Flatten wrapped list
+        if set(value) == {"item"}:
+            return [_apply_ec2_generic(wire_key, item, action, parent)
+                    for item in _query_item_list(value)]
+
+        return {_ec2_generic_sdk_name(k, action, wire_key): _apply_ec2_generic(k, v, action, wire_key)
+                for k, v in value.items()}
+    if isinstance(value, list):
+        return [_apply_ec2_generic(wire_key, item, action, parent) for item in value]
+
+    # Convert int and bool.
+    if wire_key in _EC2_GENERIC_NUMERIC_FIELDS and isinstance(value, str) and value.strip():
+        try:
+            return int(value)
+        except ValueError:
+            return value
+    if wire_key in _EC2_GENERIC_BOOLEAN_FIELDS:
+        return {"true": True, "false": False}.get(value, value)
+
+    # Return element as str is default
+    return value
+
 
 def _normalize_query_response(service_key, action, result):
     # GetQueueAttributes is the one Query result that arrives as a list, so it is
@@ -4799,18 +4889,14 @@ def _normalize_query_response(service_key, action, result):
         return _normalize_sqs_attribute_map(result)
     if not isinstance(result, dict):
         return result
-    if service_key == "ec2" and action == "DescribeSecurityGroups":
-        raw_groups = result.pop("securityGroupInfo", None)
-        if raw_groups is not None:
-            if isinstance(raw_groups, dict) and "item" in raw_groups:
-                raw_groups = raw_groups["item"]
-            if raw_groups == "":
-                groups = []
-            elif isinstance(raw_groups, list):
-                groups = raw_groups
-            else:
-                groups = [raw_groups]
-            result["SecurityGroups"] = [_normalize_ec2_security_group(group) for group in groups]
+    if service_key == "ec2":
+        shaped = {}
+        for wire_key, value in result.items():
+            if wire_key.lower() == "requestid":
+                continue
+            shaped[_ec2_generic_sdk_name(wire_key, action)] = _apply_ec2_generic(
+                wire_key, value, action)
+        return shaped
     return result
 
 

--- a/tests/test_stepfunctions.py
+++ b/tests/test_stepfunctions.py
@@ -1894,6 +1894,262 @@ def test_sfn_aws_sdk_ec2_irregular_list_params_reach_the_service(sfn_sync, ec2):
         ec2.delete_volume(VolumeId=volume_id)
 
 
+def _run_sdk_task(sfn_sync, name, action, params, role="arn:aws:iam::000000000000:role/sfn-role"):
+    """Run a single aws-sdk Task and return its result, for shape assertions."""
+    definition = json.dumps({
+        "StartAt": "Task",
+        "States": {"Task": {
+            "Type": "Task",
+            "Resource": f"arn:aws:states:::aws-sdk:{action}",
+            "Parameters": params,
+            "End": True,
+        }},
+    })
+    sm_arn = sfn_sync.create_state_machine(name=name, definition=definition, roleArn=role)["stateMachineArn"]
+    try:
+        resp = sfn_sync.start_sync_execution(stateMachineArn=sm_arn, input=json.dumps({}))
+        assert resp["status"] == "SUCCEEDED", f"{action} failed: {resp.get('error')} — {resp.get('cause')}"
+        return json.loads(resp["output"])
+    finally:
+        sfn_sync.delete_state_machine(stateMachineArn=sm_arn)
+
+
+def test_sfn_aws_sdk_ec2_describe_volumes_returns_sdk_shape(sfn_sync, ec2):
+    """aws-sdk:ec2:describeVolumes returns Volumes[0].State, not VolumeSet.Item.Status."""
+    suffix = _uuid_mod.uuid4().hex[:8]
+    az = ec2.describe_availability_zones()["AvailabilityZones"][0]["ZoneName"]
+    volume_ids = [
+        ec2.create_volume(
+            AvailabilityZone=az, Size=1, VolumeType="gp3",
+            TagSpecifications=[{"ResourceType": "volume",
+                                "Tags": [{"Key": "Name", "Value": f"sdk-shape-{suffix}"}]}],
+        )["VolumeId"]
+        for _ in range(2)
+    ]
+    try:
+        result = _run_sdk_task(sfn_sync, f"sdk-vol-{suffix}", "ec2:describeVolumes",
+                               {"VolumeIds": volume_ids})
+        # Wire-format leakage that an ASL written for AWS would trip over.
+        assert "VolumeSet" not in result
+        assert "RequestId" not in result
+        assert sorted(result) == ["Volumes"]
+        volumes = result["Volumes"]
+        assert isinstance(volumes, list)
+        assert {v["VolumeId"] for v in volumes} >= set(volume_ids)
+        volume = next(v for v in volumes if v["VolumeId"] == volume_ids[0])
+        assert volume["State"] == "available"
+        assert "Status" not in volume
+        assert volume["Size"] == 1                        # int, not "1"
+        assert volume["Iops"] == 3000
+        assert volume["Encrypted"] is False               # bool, not "false"
+        assert volume["MultiAttachEnabled"] is False
+        assert volume["Attachments"] == []                # empty list, not ""
+        assert volume["Tags"] == [{"Key": "Name", "Value": f"sdk-shape-{suffix}"}]
+        assert "TagSet" not in volume and "AttachmentSet" not in volume
+
+        # The empty result set is asserted directly: MiniStack's DescribeVolumes
+        # has no Filter.N support, so no request can return zero volumes here.
+        from ministack.services.stepfunctions import _normalize_query_response
+        assert _normalize_query_response(
+            "ec2", "DescribeVolumes", {"volumeSet": "", "requestId": "r"}
+        ) == {"Volumes": []}
+    finally:
+        for volume_id in volume_ids:
+            ec2.delete_volume(VolumeId=volume_id)
+
+
+def test_sfn_aws_sdk_ec2_instances_return_sdk_shape(sfn_sync, ec2):
+    """runInstances/describeInstances return Instances[0].State.Name, not InstanceState."""
+    suffix = _uuid_mod.uuid4().hex[:8]
+    run = _run_sdk_task(sfn_sync, f"sdk-run-{suffix}", "ec2:runInstances",
+                        {"ImageId": "ami-12345678", "MinCount": 1, "MaxCount": 1,
+                         "InstanceType": "t3.micro"})
+    instance_id = run["Instances"][0]["InstanceId"]
+    try:
+        assert "InstancesSet" not in run
+        assert run["Instances"][0]["State"]["Name"] == "running"
+        assert run["Instances"][0]["State"]["Code"] == 16          # int, not "16"
+        assert "InstanceState" not in run["Instances"][0]
+
+        described = _run_sdk_task(sfn_sync, f"sdk-desc-{suffix}", "ec2:describeInstances",
+                                  {"InstanceIds": [instance_id]})
+        assert sorted(described) == ["Reservations"]
+        assert "ReservationSet" not in described
+        reservation = next(r for r in described["Reservations"]
+                           if any(i["InstanceId"] == instance_id for i in r["Instances"]))
+        assert isinstance(reservation["Instances"], list)
+        instance = next(i for i in reservation["Instances"] if i["InstanceId"] == instance_id)
+        assert instance["State"]["Name"] == "running"
+        assert instance["AmiLaunchIndex"] == 0
+        assert instance["SourceDestCheck"] is True
+        assert isinstance(instance["SecurityGroups"], list)        # groupSet
+        assert "GroupSet" not in instance
+        mapping = instance["BlockDeviceMappings"][0]               # blockDeviceMapping
+        assert mapping["Ebs"]["VolumeId"].startswith("vol-")
+        assert mapping["Ebs"]["DeleteOnTermination"] is True
+    finally:
+        ec2.terminate_instances(InstanceIds=[instance_id])
+
+
+def test_sfn_aws_sdk_ec2_vpc_calls_shape_nested_sets(sfn_sync, ec2):
+    """VPC calls carry nested *Set structs, which the shaping has to descend without recursing."""
+    suffix = _uuid_mod.uuid4().hex[:8]
+    result = _run_sdk_task(sfn_sync, f"sdk-vpc-{suffix}", "ec2:createVpc",
+                           {"CidrBlock": "10.42.0.0/16"})
+    vpc_id = result["Vpc"]["VpcId"]
+    try:
+        assert vpc_id.startswith("vpc-")
+        assert result["Vpc"]["CidrBlock"] == "10.42.0.0/16"
+        assert result["Vpc"]["State"] == "available"
+        assert result["Vpc"]["IsDefault"] is False          # bool, not "false"
+        assert result["Vpc"]["Tags"] == []                  # <tagSet/> -> empty list
+        assert "vpcId" not in result["Vpc"] and "tagSet" not in result["Vpc"]
+
+        ec2.create_tags(Resources=[vpc_id],
+                        Tags=[{"Key": "Name", "Value": f"sdk-shape-{suffix}"}])
+        described = _run_sdk_task(sfn_sync, f"sdk-vpcs-{suffix}", "ec2:describeVpcs",
+                                  {"VpcIds": [vpc_id]})
+        assert "VpcSet" not in described
+        vpc = next(v for v in described["Vpcs"] if v["VpcId"] == vpc_id)
+        assert vpc["Tags"] == [{"Key": "Name", "Value": f"sdk-shape-{suffix}"}]
+
+        # The struct inside a *Set is shaped member by member, nested structs with it. This member
+        # is one whose SDK name keeps the Set suffix (see _EC2_GENERIC_NAME_OVERRIDES).
+        assoc = vpc["CidrBlockAssociationSet"]
+        assert "CidrBlockAssociations" not in vpc
+        assert assoc == [{"CidrBlock": "10.42.0.0/16",
+                          "AssociationId": assoc[0]["AssociationId"],
+                          "CidrBlockState": {"State": "associated"}}]
+
+        from ministack.services.stepfunctions import _apply_ec2_generic
+        assert _apply_ec2_generic("tagSet", {}) == []        # <tagSet/> read as {}, not ""
+    finally:
+        ec2.delete_vpc(VpcId=vpc_id)
+
+
+def test_sfn_aws_sdk_ec2_security_group_rules_shape_ports_and_empty_lists(sfn_sync, ec2):
+    """A rule's ports are numbers and its unused range lists are [], as the SDK returns them."""
+    suffix = _uuid_mod.uuid4().hex[:8]
+    group_id = ec2.create_security_group(
+        GroupName=f"sdk-rule-{suffix}", Description="rule shape", VpcId="vpc-00000001")["GroupId"]
+    try:
+        ec2.authorize_security_group_ingress(GroupId=group_id, IpPermissions=[{
+            "IpProtocol": "tcp", "FromPort": 443, "ToPort": 443,
+            "IpRanges": [{"CidrIp": "10.0.0.0/8"}]}])
+
+        result = _run_sdk_task(sfn_sync, f"sdk-rule-{suffix}", "ec2:describeSecurityGroups",
+                               {"GroupIds": [group_id]})
+        permission = result["SecurityGroups"][0]["IpPermissions"][0]
+        assert permission["FromPort"] == 443                  # int, not "443"
+        assert permission["ToPort"] == 443
+        assert permission["IpRanges"] == [{"CidrIp": "10.0.0.0/8"}]
+        assert permission["Ipv6Ranges"] == []                 # <ipv6Ranges/>, not a *Set name
+        assert permission["PrefixListIds"] == []
+        assert permission["UserIdGroupPairs"] == []           # groups, renamed and emptied
+        assert "ipPermissions" not in result["SecurityGroups"][0]
+    finally:
+        ec2.delete_security_group(GroupId=group_id)
+
+
+def test_sfn_aws_sdk_ec2_state_change_calls_use_per_action_member_names(sfn_sync, ec2):
+    """instancesSet is Instances after runInstances but Stopping/TerminatingInstances after these."""
+    suffix = _uuid_mod.uuid4().hex[:8]
+    instance_id = ec2.run_instances(ImageId="ami-0abcdef1234567890", MinCount=1, MaxCount=1,
+                                    InstanceType="t3.micro")["Instances"][0]["InstanceId"]
+    stopped = _run_sdk_task(sfn_sync, f"sdk-stop-{suffix}", "ec2:stopInstances",
+                            {"InstanceIds": [instance_id]})
+    assert sorted(stopped) == ["StoppingInstances"]
+    assert stopped["StoppingInstances"][0]["CurrentState"]["Code"] == 80      # int, not "80"
+    assert "Instances" not in stopped and "InstancesSet" not in stopped
+
+    terminated = _run_sdk_task(sfn_sync, f"sdk-term-{suffix}", "ec2:terminateInstances",
+                               {"InstanceIds": [instance_id]})
+    assert sorted(terminated) == ["TerminatingInstances"]
+    assert terminated["TerminatingInstances"][0]["InstanceId"] == instance_id
+
+
+def test_sfn_aws_sdk_ec2_context_scoped_names_stay_scoped():
+    """The names EC2 reuses resolve per context, so neither spelling can be made the flat rule."""
+    from ministack.services.stepfunctions import _ec2_generic_sdk_name
+
+    # status is the volume's State, but a block device's Status.
+    assert _ec2_generic_sdk_name("status", "DescribeVolumes", "volumeSet") == "State"
+    assert _ec2_generic_sdk_name("status", "DescribeVolumes", "attachmentSet") == "State"
+    assert _ec2_generic_sdk_name("status", "CreateVolume") == "State"
+    assert _ec2_generic_sdk_name("status", "DescribeInstances", "ebs") == "Status"
+    assert _ec2_generic_sdk_name("status", "DescribeInstanceStatus", "instanceStatus") == "Status"
+    # groupSet is the instance's SecurityGroups, but the reservation's Groups.
+    assert _ec2_generic_sdk_name("groupSet", "DescribeInstances", "instancesSet") == "SecurityGroups"
+    assert _ec2_generic_sdk_name("groupSet", "DescribeInstances", "reservationSet") == "Groups"
+    # instancesSet is per action, and groups only becomes UserIdGroupPairs inside a permission.
+    assert _ec2_generic_sdk_name("instancesSet", "RunInstances") == "Instances"
+    assert _ec2_generic_sdk_name("instancesSet", "StopInstances") == "StoppingInstances"
+    assert _ec2_generic_sdk_name("groups", "DescribeSecurityGroups", "ipPermissions") == "UserIdGroupPairs"
+    assert _ec2_generic_sdk_name("groups", "DescribeSecurityGroups") == "Groups"
+
+
+def test_sfn_aws_sdk_ec2_response_names_match_the_botocore_model():
+    """Every *Set element ec2.py emits carries the SDK member name botocore publishes for it."""
+    import pathlib
+    import re
+
+    import botocore.session
+
+    from ministack.services import ec2 as ec2_service
+    from ministack.services.stepfunctions import (
+        _EC2_FIELDS_BY_ACTION,
+        _EC2_FIELDS_BY_PARENT,
+        _EC2_GENERIC_NAME_OVERRIDES,
+        _ec2_generic_sdk_name,
+    )
+
+    shapes = botocore.session.get_session().get_component("data_loader").load_service_model(
+        "ec2", "service-2")["shapes"]
+    members = {name for shape in shapes.values() for name in (shape.get("members") or {})}
+    # locationName is the wire spelling; the member name is what the SDK returns.
+    by_wire = {}
+    for shape in shapes.values():
+        for name, member in (shape.get("members") or {}).items():
+            if member.get("locationName"):
+                by_wire.setdefault(member["locationName"], set()).add(name)
+
+    emitted = sorted(set(re.findall(r"<(\w+Set)/?>",
+                                    pathlib.Path(ec2_service.__file__).read_text())))
+    # Guard against the scan quietly matching nothing after a rewrite of the XML builders.
+    assert len(emitted) > 50
+    wrong = {wire: _ec2_generic_sdk_name(wire) for wire in emitted
+             if by_wire.get(wire) and _ec2_generic_sdk_name(wire) not in by_wire[wire]}
+    assert not wrong, f"not the SDK member name AWS publishes: {wrong}"
+
+    for table in (_EC2_GENERIC_NAME_OVERRIDES, _EC2_FIELDS_BY_PARENT, _EC2_FIELDS_BY_ACTION):
+        for key, sdk_name in table.items():
+            assert sdk_name in members, f"{key} -> {sdk_name} is not an EC2 member name"
+
+
+def test_sfn_aws_sdk_ec2_irregular_set_members_use_sdk_names(sfn_sync, ec2):
+    """A *Set element whose SDK member name the plural rule cannot produce is mapped by name."""
+    from ministack.services.stepfunctions import _ec2_generic_sdk_name
+
+    assert _ec2_generic_sdk_name("cidrBlockAssociationSet") == "CidrBlockAssociationSet"
+    assert _ec2_generic_sdk_name("keySet") == "KeyPairs"
+    assert _ec2_generic_sdk_name("volumeModificationSet") == "VolumesModifications"
+    assert _ec2_generic_sdk_name("fleetInstanceSet") == "Instances"
+    # The rest are the base pluralised, which is not always base + "s".
+    assert _ec2_generic_sdk_name("entrySet") == "Entries"
+    assert _ec2_generic_sdk_name("instanceStatusSet") == "InstanceStatuses"
+    assert _ec2_generic_sdk_name("addressSet") == "Addresses"
+    assert _ec2_generic_sdk_name("instancesSet") == "Instances"
+
+    suffix = _uuid_mod.uuid4().hex[:8]
+    ec2.create_key_pair(KeyName=f"sdk-key-{suffix}")
+    try:
+        result = _run_sdk_task(sfn_sync, f"sdk-keys-{suffix}", "ec2:describeKeyPairs", {})
+        assert sorted(result) == ["KeyPairs"]        # keySet -> KeyPairs, not "Keys"
+        assert any(k["KeyName"] == f"sdk-key-{suffix}" for k in result["KeyPairs"])
+    finally:
+        ec2.delete_key_pair(KeyName=f"sdk-key-{suffix}")
+
+
 def test_sfn_aws_sdk_rds_create_and_describe_instance(sfn, sfn_sync):
     """aws-sdk:rds CreateDBInstance + DescribeDBInstances via query-protocol dispatch."""
     import uuid as _uuid


### PR DESCRIPTION
### Issue

The adapter parsed EC2 Query XML into a near-wire structure **without re-shaping or typing** the result, so an ASL definition written correctly for AWS silently took the wrong branch locally:

Examples
- `describeVolumes` returned `VolumeSet.Item.Status` where AWS returns `Volumes[0].State`
- `describeInstances` returned `ReservationSet.Item.InstancesSet.Item.InstanceState.Name` where AWS returns `Reservations[0].Instances[0].State.Name`
- scalars were strings (`"1"`, `"false"`), empty collections were `""` instead of `[]`
- a `requestId` the SDK never returns was included

Only `DescribeSecurityGroups` had a separate normalizer.

### Fix

Generalize the normalizer to follow the wire name: PascalCase it, unwrap the `<item>` wrapper, pluralise a `*Set` wrapper's base, and coerce the leaves already listed as list, numeric or boolean. The shaping stays generic and only the exceptions are listed:
- Pluralizer following basic english rules: `Entry` -> `Entries`, `Address` -> `Addresses`
- Overrides for the names we cannot infer, like `keySet` -> `KeyPairs`
- Overrides by parent or action for the ambiguous ones like `status`, which is a volume's `State` but a block device's `Status`
- Field-type sets for list, int and bool

Code written with Claude Code

### Testing

New tests in `tests/test_stepfunctions.py`, one of which resolves every `*Set` element `ec2.py` emits (69 of them) against botocore's EC2 model, so a member name is looked up rather than invented. 327 passed across `test_stepfunctions.py` and `test_ec2.py`.

Expected behaviour was established on real AWS first, then checked against MiniStack with the script below, which runs against either:

| target | result |
| --- | --- |
| MiniStack before | 0/6 |
| this branch | 6/6 |
| real AWS, eu-central-1 | 6/6 — same detail on every line |

```
                                    before                                        this branch / AWS
describeVolumes SDK shape           wire=['VolumeSet', 'RequestId']                Volumes[].State str, Size int, Encrypted bool
describeInstances SDK shape         keys=['RequestId', 'ReservationSet']           Reservations=list
describeVpcs generic shape          keys=['RequestId', 'VpcSet'] vpc_keys=[]       Vpcs=list CidrBlockAssociationSet=list
describeKeyPairs SDK member name    keys=['KeySet', 'RequestId']                   KeyPairs=list
describeInstanceStatus plural       keys=['InstanceStatusSet', 'RequestId']        InstanceStatuses=list
describeSecurityGroups SDK shape    ports=['443']                                  FromPort=443 int, unused range lists []
```

The script asserts member names and leaf types, plus the one port value and the empty range lists — never a value that differs per account or per region.

<details>
<summary>check_sfn_ec2_output_shape.py</summary>

```python
#!/usr/bin/env python3
"""Check that aws-sdk:ec2 tasks return the SDK output shape, not the Query wire shape.

Step Functions exposes aws-sdk results in the SDK's output shape: describeVolumes yields
Volumes[0].State, not VolumeSet.Item.Status, with real ints and bools and no requestId. An ASL
definition written against AWS reads those paths, so a near-wire structure locally makes a Choice
take the other branch without any error to notice.

Each check asserts the structure both targets must produce and prints only what is invariant
between them, so the two runs compare line by line.

Against MiniStack:
  python check_sfn_ec2_output_shape.py --endpoint http://localhost:4566 --region eu-central-1

Against AWS, after `aws sso login --profile <profile>`:
  python check_sfn_ec2_output_shape.py --profile <profile> --region eu-central-1

Creates and deletes one 1-GiB EBS volume, one key pair, the state machines, and (on AWS only) a
scoped IAM role. Pass --keep to leave them behind. Exit status is 0 when every check passes.
"""

import argparse
import json
import sys
import time
import uuid
from contextlib import suppress

import boto3
from botocore.exceptions import ClientError

DUMMY_ROLE = "arn:aws:iam::000000000000:role/sfn-ec2-shape-check"
TRUST_POLICY = {
    "Version": "2012-10-17",
    "Statement": [{
        "Effect": "Allow",
        "Principal": {"Service": "states.amazonaws.com"},
        "Action": "sts:AssumeRole",
    }],
}
CHECK_POLICY = {
    "Version": "2012-10-17",
    "Statement": [{
        "Effect": "Allow",
        "Action": ["ec2:DescribeVolumes", "ec2:DescribeInstances", "ec2:DescribeVpcs",
                   "ec2:DescribeKeyPairs", "ec2:DescribeSecurityGroups",
                   "ec2:DescribeInstanceStatus"],
        "Resource": "*",
    }],
}


def options():
    parser = argparse.ArgumentParser(description=__doc__)
    parser.add_argument("--endpoint", help="Emulator endpoint, e.g. http://localhost:4566")
    parser.add_argument("--profile", help="AWS CLI/SSO profile; defaults to AWS_PROFILE")
    parser.add_argument("--region", default=None, help="AWS region; defaults to AWS_REGION")
    parser.add_argument("--keep", action="store_true", help="Leave resources behind")
    return parser.parse_args()


def run_task(sfn, name, role_arn, resource, params, created, timeout=60):
    """Run a one-state machine and return (status, parsed output, failure text)."""
    definition = json.dumps({
        "StartAt": "Task",
        "States": {"Task": {
            "Type": "Task",
            "Resource": resource,
            # AWS requires Parameters on every aws-sdk ARN, even when empty.
            "Parameters": params,
            "End": True,
        }},
    })
    arn = sfn.create_state_machine(name=name, definition=definition, roleArn=role_arn)["stateMachineArn"]
    created.append(("state_machine", arn))
    execution_arn = sfn.start_execution(stateMachineArn=arn, input="{}")["executionArn"]
    deadline = time.monotonic() + timeout
    execution = sfn.describe_execution(executionArn=execution_arn)
    while execution["status"] == "RUNNING" and time.monotonic() < deadline:
        time.sleep(0.25)
        execution = sfn.describe_execution(executionArn=execution_arn)
    if execution["status"] != "SUCCEEDED":
        return execution["status"], None, f"{execution.get('error')}: {execution.get('cause')}"
    return "SUCCEEDED", json.loads(execution.get("output") or "{}"), None


def main():
    args = options()
    if args.endpoint and not args.profile:
        session = boto3.Session(region_name=args.region, aws_access_key_id="test",
                                aws_secret_access_key="test")
    else:
        session = boto3.Session(profile_name=args.profile, region_name=args.region)
    client_args = {"endpoint_url": args.endpoint} if args.endpoint else {}
    sfn = session.client("stepfunctions", **client_args)
    ec2 = session.client("ec2", **client_args)
    iam = session.client("iam", **client_args)

    suffix = uuid.uuid4().hex[:8]
    prefix = f"sfn-ec2-shape-{suffix}"
    created = []
    results = []

    def check(label, ok, detail):
        results.append((label, ok, detail))
        print(f"{'PASS' if ok else 'FAIL'}  {label:38} {detail}")

    try:
        zone = ec2.describe_availability_zones()["AvailabilityZones"][0]["ZoneName"]
        volume_id = ec2.create_volume(AvailabilityZone=zone, Size=1, VolumeType="gp3")["VolumeId"]
        created.append(("volume", volume_id))
        ec2.create_key_pair(KeyName=prefix)
        created.append(("key_pair", prefix))
        # A group with a port, so the leaf-type check below has something to assert.
        vpcs = ec2.describe_vpcs()["Vpcs"]
        vpc_id = next((v["VpcId"] for v in vpcs if v.get("IsDefault")), vpcs[0]["VpcId"])
        group_id = ec2.create_security_group(
            GroupName=prefix, Description="sfn ec2 shape check", VpcId=vpc_id)["GroupId"]
        created.append(("group", group_id))
        ec2.authorize_security_group_ingress(GroupId=group_id, IpPermissions=[{
            "IpProtocol": "tcp", "FromPort": 443, "ToPort": 443,
            "IpRanges": [{"CidrIp": "10.0.0.0/8"}]}])

        if args.endpoint:
            role_arn = DUMMY_ROLE
        else:
            role = iam.create_role(RoleName=f"{prefix}-role",
                                   AssumeRolePolicyDocument=json.dumps(TRUST_POLICY))["Role"]
            iam.put_role_policy(RoleName=role["RoleName"], PolicyName="check",
                                PolicyDocument=json.dumps(CHECK_POLICY))
            created.append(("role", role["RoleName"]))
            role_arn = role["Arn"]
            time.sleep(15)  # IAM propagation before Step Functions accepts the role

        def task(name, resource, params):
            return run_task(sfn, f"{prefix}-{name}", role_arn, resource, params, created)

        # 1. The member names and leaf types an ASL definition reads. Values are not printed:
        #    a fresh volume is "creating" on AWS and may be "available" locally.
        status, out, failure = task("volumes", "arn:aws:states:::aws-sdk:ec2:describeVolumes",
                                    {"VolumeIds": [volume_id]})
        volume = (out or {}).get("Volumes", [{}])[0] if isinstance((out or {}).get("Volumes"), list) else {}
        shape = {
            "Volumes": isinstance((out or {}).get("Volumes"), list),
            "State": isinstance(volume.get("State"), str),
            "Size": isinstance(volume.get("Size"), int),
            "Encrypted": isinstance(volume.get("Encrypted"), bool),
        }
        wire = [k for k in ("VolumeSet", "RequestId", "requestId") if k in (out or {})]
        ok = all(shape.values()) and not wire
        check("describeVolumes SDK shape", ok,
              "Volumes[].State str, Size int, Encrypted bool" if ok
              else (f"missing={[k for k, v in shape.items() if not v]} wire={wire}" if out else failure))

        # 2. Reservations, never ReservationSet — the list is empty in a fresh account and that is
        #    still the SDK shape, so only the key and its type are asserted.
        status, out, failure = task("instances", "arn:aws:states:::aws-sdk:ec2:describeInstances", {})
        ok = bool(out) and isinstance(out.get("Reservations"), list) and "ReservationSet" not in out
        check("describeInstances SDK shape", ok,
              "Reservations=list" if ok else (f"keys={sorted(out)[:4]}" if out else failure))

        # 3. VPC calls have no per-shape table, so they exercise the generic path, including the
        #    member that keeps its Set suffix in the SDK name.
        status, out, failure = task("vpcs", "arn:aws:states:::aws-sdk:ec2:describeVpcs", {})
        vpcs = (out or {}).get("Vpcs")
        first = vpcs[0] if isinstance(vpcs, list) and vpcs else {}
        ok = (isinstance(vpcs, list) and "VpcSet" not in (out or {})
              and isinstance(first.get("CidrBlockAssociationSet"), list))
        check("describeVpcs generic shape", ok,
              "Vpcs=list CidrBlockAssociationSet=list" if ok
              else (f"keys={sorted(out)[:4]} vpc_keys={sorted(first)[:4]}" if out else failure))

        # 4. keySet is KeyPairs, which no plural rule produces.
        status, out, failure = task("keys", "arn:aws:states:::aws-sdk:ec2:describeKeyPairs", {})
        ok = bool(out) and isinstance(out.get("KeyPairs"), list) and not (
            {"Keys", "KeySet", "keySet"} & set(out))
        check("describeKeyPairs SDK member name", ok,
              "KeyPairs=list" if ok else (f"keys={sorted(out)}" if out else failure))

        # 5. instanceStatusSet pluralises to InstanceStatuses, not InstanceStatus. The list is
        #    empty without running instances, which is still the SDK shape.
        status, out, failure = task("instance-status",
                                    "arn:aws:states:::aws-sdk:ec2:describeInstanceStatus", {})
        ok = bool(out) and isinstance(out.get("InstanceStatuses"), list) and not (
            {"InstanceStatus", "InstanceStatusSet"} & set(out))
        check("describeInstanceStatus plural member", ok,
              "InstanceStatuses=list" if ok else (f"keys={sorted(out)}" if out else failure))

        # 6. Security groups used to have their own normalizer, which coerced no leaf: the ports
        #    came back as strings. Any port present has to be a number.
        status, out, failure = task("groups", "arn:aws:states:::aws-sdk:ec2:describeSecurityGroups",
                                    {"GroupIds": [group_id]})
        groups = (out or {}).get("SecurityGroups")
        perms = [p for g in groups or [] for p in g.get("IpPermissions", [])
                 if isinstance(g, dict)] if isinstance(groups, list) else []
        ports = [p["FromPort"] for p in perms if "FromPort" in p]
        # The group and its rule are asserted, not just the types: an empty SecurityGroups list
        # would otherwise satisfy every type check here. The unused range lists matter too --
        # ipv6Ranges and prefixListIds do not end in "Set", so an empty one is the case where a
        # wire "" has to become [].
        empties = [(p.get("Ipv6Ranges"), p.get("PrefixListIds"), p.get("UserIdGroupPairs"))
                   for p in perms]
        ok = (isinstance(groups, list) and len(groups) == 1
              and "securityGroupInfo" not in (out or {}) and ports == [443]
              and all(lists == ([], [], []) for lists in empties))
        check("describeSecurityGroups SDK shape", ok,
              "FromPort=443 int, unused range lists []" if ok
              else (f"keys={sorted(out)[:4]} groups={len(groups or [])} ports={ports[:3]} "
                    f"empties={empties[:1]}" if out else failure))
    finally:
        if not args.keep:
            for kind, ident in reversed(created):
                with suppress(ClientError):
                    if kind == "state_machine":
                        sfn.delete_state_machine(stateMachineArn=ident)
                    elif kind == "volume":
                        ec2.delete_volume(VolumeId=ident)
                    elif kind == "key_pair":
                        ec2.delete_key_pair(KeyName=ident)
                    elif kind == "group":
                        ec2.delete_security_group(GroupId=ident)
                    elif kind == "role":
                        iam.delete_role_policy(RoleName=ident, PolicyName="check")
                        iam.delete_role(RoleName=ident)

    failed = [label for label, ok, _ in results if not ok]
    print(f"\n{len(results) - len(failed)}/{len(results)} checks passed"
          + (f"; failed: {', '.join(failed)}" if failed else ""))
    return 1 if failed else 0


if __name__ == "__main__":
    try:
        sys.exit(main())
    except (ClientError, TimeoutError) as exc:
        print(f"ERROR: {exc}", file=sys.stderr)
        sys.exit(2)
```

</details>
