### PR TITLE
Regionalize CloudWatch Logs queries

### DIFF
--- a/ministack/core/persistence.py
+++ b/ministack/core/persistence.py
@@ -59,6 +59,7 @@ SERVICE_STATE_FORMAT_VERSIONS = {
     "ecs": 3,
     "resource_groups": 3,
     "codebuild": 3,
+    "cloudwatch_logs": 3,
     "ec2": 3,
     "ecr": 3,
     "cloudtrail": 3,

--- a/ministack/services/cloudwatch_logs.py
+++ b/ministack/services/cloudwatch_logs.py
@@ -61,7 +61,7 @@ _destinations = AccountRegionScopedDict()
 _metric_filters = AccountRegionScopedDict()
 # (log_group_name, filter_name) -> {filterName, logGroupName, filterPattern, metricTransformations, creationTime}
 
-_queries = AccountScopedDict()
+_queries = AccountRegionScopedDict()
 # query_id -> {queryId, logGroupName, startTime, endTime, queryString, status}
 
 _delivery_sources = AccountRegionScopedDict()
@@ -116,6 +116,19 @@ def _metric_filter_restore_region(account_id: str, key, value) -> str:
     )
 
 
+def _query_restore_region(account_id: str, value) -> str:
+    if isinstance(value, dict):
+        group_names = []
+        if value.get("logGroupName"):
+            group_names.append(value["logGroupName"])
+        group_names.extend(value.get("logGroupNames") or [])
+        for group_name in group_names:
+            region = _region_for_log_group(account_id, group_name)
+            if region:
+                return region
+    return get_region()
+
+
 def _restore_metric_filters(metric_filters):
     if isinstance(metric_filters, AccountRegionScopedDict):
         _metric_filters.update(metric_filters)
@@ -132,12 +145,31 @@ def _restore_metric_filters(metric_filters):
             _metric_filters.set_scoped(account_id, region, key, value)
 
 
+def _restore_queries(queries):
+    if isinstance(queries, AccountRegionScopedDict):
+        _queries.update(queries)
+        return
+    if isinstance(queries, AccountScopedDict):
+        for (account_id, key), value in queries._data.items():
+            _queries.set_scoped(account_id, _query_restore_region(account_id, value), key, value)
+        return
+    if isinstance(queries, dict):
+        account_id = get_account_id()
+        for key, value in queries.items():
+            if isinstance(key, tuple) and len(key) == 3:
+                _queries.set_scoped(key[0], key[1], key[2], value)
+            elif isinstance(key, tuple) and len(key) == 2:
+                _queries.set_scoped(key[0], _query_restore_region(key[0], value), key[1], value)
+            else:
+                _queries.set_scoped(account_id, _query_restore_region(account_id, value), key, value)
+
+
 def restore_state(data):
     if data:
         _log_groups.update(data.get("log_groups", {}))
         _destinations.update(data.get("destinations", {}))
         _restore_metric_filters(data.get("metric_filters", {}))
-        _queries.update(data.get("queries", {}))
+        _restore_queries(data.get("queries", {}))
         _delivery_sources.update(data.get("delivery_sources", {}))
         _delivery_destinations.update(data.get("delivery_destinations", {}))
         _deliveries.update(data.get("deliveries", {}))

--- a/tests/test_cfn.py
+++ b/tests/test_cfn.py
@@ -5999,6 +5999,7 @@ def test_cfn_nested_stack_basic(cfn, s3):
     }
     s3.put_object(Bucket=templates_bucket, Key="child.json",
                   Body=json.dumps(child_template).encode())
+    endpoint = os.environ.get("MINISTACK_ENDPOINT", "http://localhost:4566").rstrip("/")
 
     parent_template = {
         "AWSTemplateFormatVersion": "2010-09-09",
@@ -6006,7 +6007,7 @@ def test_cfn_nested_stack_basic(cfn, s3):
             "Nested": {
                 "Type": "AWS::CloudFormation::Stack",
                 "Properties": {
-                    "TemplateURL": f"{os.environ.get('MINISTACK_ENDPOINT', 'http://localhost:4566')}/{templates_bucket}/child.json",
+                    "TemplateURL": f"{endpoint}/{templates_bucket}/child.json",
                     "Parameters": {"BucketSuffix": suffix},
                 },
             },

--- a/tests/test_cloudwatch_logs.py
+++ b/tests/test_cloudwatch_logs.py
@@ -1056,6 +1056,89 @@ def test_queries_survive_warm_boot():
     mod.reset()
 
 
+def test_queries_are_region_scoped():
+    from ministack.core.responses import get_region, set_request_region
+
+    mod = _module()
+    mod.reset()
+    original_region = get_region()
+
+    try:
+        set_request_region("us-east-1")
+        east = mod._start_query({
+            "logGroupName": "/aws/lambda/query-east",
+            "startTime": 1,
+            "endTime": 2,
+            "queryString": "fields @message",
+        })
+        east_id = json.loads(east[2])["queryId"]
+
+        set_request_region("us-west-2")
+        west = mod._start_query({
+            "logGroupName": "/aws/lambda/query-west",
+            "startTime": 1,
+            "endTime": 2,
+            "queryString": "fields @message",
+        })
+        west_id = json.loads(west[2])["queryId"]
+
+        assert west_id in mod._queries
+        assert east_id not in mod._queries
+        missing = mod._get_query_results({"queryId": east_id})
+        assert missing[0] == 400
+
+        set_request_region("us-east-1")
+        assert east_id in mod._queries
+        assert west_id not in mod._queries
+        found = mod._get_query_results({"queryId": east_id})
+        assert json.loads(found[2])["status"] == "Complete"
+    finally:
+        set_request_region(original_region)
+        mod.reset()
+
+
+def test_legacy_queries_restore_to_log_group_region():
+    from ministack.core.responses import AccountScopedDict, get_region, set_request_region
+
+    mod = _module()
+    mod.reset()
+    original_region = get_region()
+    group = f"/aws/lambda/legacy-query-{_uuid_mod.uuid4().hex[:8]}"
+
+    legacy_queries = AccountScopedDict()
+    legacy_queries["q-legacy"] = {
+        "queryId": "q-legacy",
+        "logGroupName": group,
+        "startTime": 1700000000,
+        "endTime": 1700001000,
+        "queryString": "fields @message",
+        "status": "Complete",
+    }
+
+    try:
+        set_request_region("us-east-1")
+        mod.restore_state({
+            "log_groups": {
+                group: {
+                    "arn": f"arn:aws:logs:us-west-2:000000000000:log-group:{group}:*",
+                    "creationTime": 1700000000000,
+                    "retentionInDays": None,
+                    "tags": {},
+                    "subscriptionFilters": {},
+                    "streams": {},
+                },
+            },
+            "queries": legacy_queries,
+        })
+
+        assert "q-legacy" not in mod._queries
+        set_request_region("us-west-2")
+        assert "q-legacy" in mod._queries
+    finally:
+        set_request_region(original_region)
+        mod.reset()
+
+
 # ── subscription-filter ↔ destination consistency ──────────────────────
 
 def test_subscription_filter_destination_resolvable_after_warm_boot():


### PR DESCRIPTION
## Why

CloudWatch Logs Insights query IDs were stored at account scope, so a query started in one region could be read or stopped from another region. Logs Insights queries are regional, and persisted state should preserve that boundary when older snapshots are loaded.

## What

- Store CloudWatch Logs Insights queries in account-and-region scoped state.
- Migrate legacy account-scoped query records into the region of their referenced log group when that group is available.
- Stamp CloudWatch Logs persistence as format v3 for rollback safety.
- Normalize nested-stack `TemplateURL` construction so a trailing slash in the endpoint does not produce a double slash.

## Behavior changes and risk

Query IDs are now visible and stoppable only in the region where they were started. Legacy snapshots with a matching persisted log group keep the log group's region; legacy query records without a matching group continue to fall back to the boot/request region.

Risk is limited to the CloudWatch Logs Insights query stubs and persistence migration. Existing log group, metric filter, destination, and delivery handlers continue using the same scoped-dictionary interface.

## Validation

- `uv run --extra dev ruff check ministack/services/cloudwatch_logs.py ministack/core/persistence.py tests/test_cloudwatch_logs.py tests/test_cfn.py` — pass
- `uv run --extra dev pytest -q -p no:cacheprovider tests/test_cloudwatch_logs.py::test_queries_survive_warm_boot tests/test_cloudwatch_logs.py::test_queries_are_region_scoped tests/test_cloudwatch_logs.py::test_legacy_queries_restore_to_log_group_region tests/test_persistence.py` — 242 passed
- `uv run --extra dev pytest -q -p no:cacheprovider tests/test_cloudwatch_logs.py tests/test_cfn.py tests/test_persistence.py` — 448 passed
