### PR TITLE
fix(stepfunctions): do not expand acronyms in EC2 aws-sdk parameter names

### DIFF
--- a/ministack/services/stepfunctions.py
+++ b/ministack/services/stepfunctions.py
@@ -4642,7 +4642,6 @@ _QUERY_PARAM_NAME_OVERRIDES = {
     },
     ("ec2", "CreateSecurityGroup"): {
         "Description": "GroupDescription",
-        "VpcId": "VpcId",
     },
 }
 
@@ -4669,19 +4668,24 @@ def _sfn_key_to_api_name(name):
     return "".join(t.upper() if t in _AWS_ACRONYMS else t for t in tokens)
 
 
-def _convert_params_to_api_names(data, name_overrides=None):
-    """Recursively convert SFN SDK-style param names to AWS wire-format names."""
+def _convert_params_to_api_names(data, name_overrides=None, expand_acronyms=True):
+    """Recursively convert SFN SDK-style param names to AWS wire-format names.
+
+    ``expand_acronyms=False`` for services like EC2 whose wire names carry no uppercase acronym.
+    """
     if isinstance(data, dict):
         converted = {}
         for key, value in data.items():
             if name_overrides and key in name_overrides:
                 wire_key = name_overrides[key]
-            else:
+            elif expand_acronyms:
                 wire_key = _sfn_key_to_api_name(key)
-            converted[wire_key] = _convert_params_to_api_names(value, name_overrides)
+            else:
+                wire_key = key
+            converted[wire_key] = _convert_params_to_api_names(value, name_overrides, expand_acronyms)
         return converted
     if isinstance(data, list):
-        return [_convert_params_to_api_names(item, name_overrides) for item in data]
+        return [_convert_params_to_api_names(item, name_overrides, expand_acronyms) for item in data]
     return data
 
 
@@ -4921,7 +4925,8 @@ def _dispatch_aws_sdk_query(service_info, service_name, action, input_data):
     # Convert SFN SDK-style param names (DbSubnetGroupName) to wire-format
     # names (DBSubnetGroupName) before flattening to query params.
     name_overrides = _QUERY_PARAM_NAME_OVERRIDES.get((service_key, pascal_action))
-    wire_data = _convert_params_to_api_names(input_data, name_overrides)
+    # EC2 is the exception: its serialiser only capitalises the first letter
+    wire_data = _convert_params_to_api_names(input_data, name_overrides, expand_acronyms=service_key != "ec2")
     form_params = {"Action": pascal_action}
     if service_key == "ec2":
         form_params.update(_flatten_ec2_query_params(wire_data, action=pascal_action))

--- a/tests/test_stepfunctions.py
+++ b/tests/test_stepfunctions.py
@@ -1991,6 +1991,102 @@ def test_sfn_aws_sdk_ec2_instances_return_sdk_shape(sfn_sync, ec2):
         ec2.terminate_instances(InstanceIds=[instance_id])
 
 
+def test_sfn_aws_sdk_ec2_params_keep_their_sdk_names(sfn_sync, ec2):
+    """EC2 input params are passed through, never acronym-expanded."""
+    suffix = _uuid_mod.uuid4().hex[:8]
+    vpc_id = ec2.create_vpc(CidrBlock="10.43.0.0/16")["Vpc"]["VpcId"]
+    group_id = None
+    try:
+        # Effects are read back from EC2, never from the task output: the task reported SUCCEEDED
+        # while changing nothing. Each attribute is set to the opposite of its default, so an
+        # argument that never arrived cannot pass by accident.
+        for param, attribute, value in (("EnableDnsHostnames", "enableDnsHostnames", True),
+                                        ("EnableDnsSupport", "enableDnsSupport", False)):
+            _run_sdk_task(sfn_sync, f"sdk-{attribute.lower()}-{suffix}", "ec2:modifyVpcAttribute",
+                          {"VpcId": vpc_id, param: {"Value": value}})
+            assert ec2.describe_vpc_attribute(
+                VpcId=vpc_id, Attribute=attribute)[param]["Value"] is value
+
+        # Skipping expansion must not skip override table (Description -> GroupDescription)
+        created = _run_sdk_task(sfn_sync, f"sdk-sg-{suffix}", "ec2:createSecurityGroup",
+                                {"GroupName": f"sdk-sg-{suffix}", "Description": "param name check",
+                                 "VpcId": vpc_id})
+        group_id = created["GroupId"]
+        group = ec2.describe_security_groups(GroupIds=[group_id])["SecurityGroups"][0]
+        assert group["VpcId"] == vpc_id
+        assert group["Description"] == "param name check"
+
+        # A list param, whose wire name is the singular locationName (VpcIds -> VpcId.N). That
+        # rename comes from the list-naming path, so it has to survive the expansion being off.
+        described = _run_sdk_task(sfn_sync, f"sdk-vpcs-{suffix}", "ec2:describeVpcs",
+                                  {"VpcIds": [vpc_id]})
+        assert [v["VpcId"] for v in described["Vpcs"]] == [vpc_id]
+    finally:
+        if group_id:
+            ec2.delete_security_group(GroupId=group_id)
+        ec2.delete_vpc(VpcId=vpc_id)
+
+
+def test_sfn_aws_sdk_ec2_param_names_never_need_the_acronym_expansion():
+    """Every param name EC2 accepts, from botocore rather than the handful exercised above.
+
+    For each member the expansion would rename, the wire name is either the name already (so the
+    expansion breaks it) or a third spelling the list-naming path handles (VpcIds -> VpcId.N) --
+    never the expansion itself, so skipping it for EC2 cannot lose anything.
+    """
+    import botocore.session
+
+    from ministack.services.ec2 import _ACTION_MAP
+    from ministack.services.stepfunctions import _sfn_key_to_api_name
+
+    model = botocore.session.get_session().get_service_model("ec2")
+    operations = set(model.operation_names)
+    broken_by_expansion, needs_expansion = set(), set()
+
+    def walk(shape, seen):
+        if shape is None or id(shape) in seen:
+            return
+        seen.add(id(shape))
+        if shape.type_name == "structure":
+            for name, member in shape.members.items():
+                serialized = member.serialization.get("queryName") or member.serialization.get("name")
+                wire = serialized[0].upper() + serialized[1:] if serialized else name
+                expanded = _sfn_key_to_api_name(name)
+                if expanded != name:
+                    if wire == name:
+                        broken_by_expansion.add(name)
+                    elif wire == expanded:
+                        needs_expansion.add(name)
+                walk(member, seen)
+        elif shape.type_name == "list":
+            walk(shape.member, seen)
+        elif shape.type_name == "map":
+            walk(shape.value, seen)
+
+    for action in _ACTION_MAP:
+        if action in operations:
+            walk(model.operation_model(action).input_shape, set())
+    assert not needs_expansion, (
+        f"these EC2 members have the expansion for their wire name, so EC2 must not skip it: "
+        f"{sorted(needs_expansion)}")
+
+    # Make sure we found some: a walk that stops descending still finds 22
+    assert len(broken_by_expansion) >= 25
+
+    # Spot-checks with the expansion each one would have produced.
+    for name, would_become in (("VpcId", "VPCId"),
+                               ("EnableDnsHostnames", "EnableDNSHostnames"),
+                               ("KmsKeyId", "KMSKeyId"),
+                               ("EbsOptimized", "EBSOptimized"),
+                               ("IamInstanceProfile", "IAMInstanceProfile"),
+                               ("NetworkAclId", "NetworkACLId"),
+                               ("PeerVpcId", "PeerVPCId"),
+                               ("Iops", "IOPS"),
+                               ("DnsOptions", "DNSOptions")):
+        assert _sfn_key_to_api_name(name) == would_become     # what EC2 would have been sent
+        assert name in broken_by_expansion, f"{name} is a wire name EC2 accepts as written"
+
+
 def test_sfn_aws_sdk_ec2_vpc_calls_shape_nested_sets(sfn_sync, ec2):
     """VPC calls carry nested *Set structs, which the shaping has to descend without recursing."""
     suffix = _uuid_mod.uuid4().hex[:8]


### PR DESCRIPTION
### Issue

`_dispatch_aws_sdk_query` runs every parameter name through `_sfn_key_to_api_name`, which expands uppercase acronym runs for the query services that need it (RDS: `DbClusterIdentifier` → `DBClusterIdentifier`). EC2 is the opposite case: its Query serialiser only capitalises a `locationName`'s first letter, so `VpcId` and `EnableDnsHostnames` already ARE the wire names.

```python
>>> from ministack.services.stepfunctions import _sfn_key_to_api_name
>>> _sfn_key_to_api_name("VpcId"), _sfn_key_to_api_name("EnableDnsHostnames")
('VPCId', 'EnableDNSHostnames')
```

No handler reads those, so the parameter silently vanished and the call ran with the argument absent instead of failing. `modifyVpcAttribute` from a state machine reported `SUCCEEDED` and changed nothing; the next state failed with `Ec2.InvalidVpcID.NotFound: The vpc ID '' does not exist`, while the identical boto3 call against the same server worked.

Checked against botocore over every action in `ec2._ACTION_MAP`: **36 input members would be corrupted** by the expansion (`VpcId`, `EnableDnsHostnames`, `KmsKeyId`, `EbsOptimized`, `IamInstanceProfile`, `NetworkAclId`, `PeerVpcId`, `Iops`, `DnsOptions`, …).

### Fix

Skip the expansion for EC2, via an `expand_acronyms` flag on `_convert_params_to_api_names`.

Shorten the override table so it only contains renames, like `Description` → `GroupDescription` 

Code written with Claude Code.

### Testing

Two tests, split by what they need:

- `test_sfn_aws_sdk_ec2_params_keep_their_sdk_names` — three live executions, each read back from EC2 rather than from the task output, since the task reported success while changing nothing.
- `test_sfn_aws_sdk_ec2_param_names_never_need_the_acronym_expansion` — walks botocore's EC2 model and asserts no member has the expansion for its wire name.

186 passed in `test_stepfunctions.py`.

Behaviour was confirmed on real AWS, then checked against MiniStack with the script below, which runs against either:

| target | result                           |
| --- |----------------------------------|
| MiniStack before | 2/3 (VPCId was handled manually) |
| this branch | 3/3                              |
| real AWS, eu-central-1 | 3/3 — same detail on every line  |

```
                                          before                                              this branch / AWS
modifyVpcAttribute applies EnableDnsHostnames  Ec2.InvalidVpcID.NotFound: The vpc ID '' ...   attribute is set
createSecurityGroup VpcId and Description      in the given VPC, description kept             in the given VPC, description kept
a param without acronyms still applies         narrowed to the one volume                     narrowed to the one volume
```

The middle row passing before the fix is the point: that action is the one the old `"VpcId": "VpcId"` shield covered.

<details>
<summary>check_sfn_ec2_param_names.py</summary>

```python
#!/usr/bin/env python3
"""Check that aws-sdk:ec2 task parameters reach EC2 under the names the caller wrote.

The SDK-key -> wire-name conversion expands uppercase acronym runs, which the other query
services need (RDS: DbClusterIdentifier -> DBClusterIdentifier). EC2 is the opposite case: its
Query serialiser only capitalises the first letter of a locationName, so `VpcId` and
`EnableDnsHostnames` already ARE the wire names. Expanding them to `VPCId` / `EnableDNSHostnames`
sends a parameter no handler reads, so the call runs with the argument absent instead of failing:
modifyVpcAttribute reported success and changed nothing, and the next state failed with
"The vpc ID '' does not exist".

Against MiniStack:
  python check_sfn_ec2_param_names.py --endpoint http://localhost:4566 --region eu-central-1

Against AWS, after `aws sso login --profile <profile>`:
  python check_sfn_ec2_param_names.py --profile <profile> --region eu-central-1

Creates and deletes one VPC, one security group, the state machines, and (on AWS only) a scoped
IAM role. Pass --keep to leave them behind. Exit status is 0 when every check passes.
"""

import argparse
import json
import sys
import time
import uuid
from contextlib import suppress

import boto3
from botocore.exceptions import ClientError

DUMMY_ROLE = "arn:aws:iam::000000000000:role/sfn-ec2-params-check"
TRUST_POLICY = {
    "Version": "2012-10-17",
    "Statement": [{
        "Effect": "Allow",
        "Principal": {"Service": "states.amazonaws.com"},
        "Action": "sts:AssumeRole",
    }],
}
CHECK_POLICY = {
    "Version": "2012-10-17",
    "Statement": [{
        "Effect": "Allow",
        "Action": ["ec2:ModifyVpcAttribute", "ec2:CreateSecurityGroup", "ec2:DescribeVolumes"],
        "Resource": "*",
    }],
}


def options():
    parser = argparse.ArgumentParser(description=__doc__)
    parser.add_argument("--endpoint", help="Emulator endpoint, e.g. http://localhost:4566")
    parser.add_argument("--profile", help="AWS CLI/SSO profile; defaults to AWS_PROFILE")
    parser.add_argument("--region", default=None, help="AWS region; defaults to AWS_REGION")
    parser.add_argument("--keep", action="store_true", help="Leave resources behind")
    return parser.parse_args()


def run_task(sfn, name, role_arn, action, params, created, timeout=60):
    """Run one aws-sdk:ec2 task and return (status, parsed output, failure text)."""
    definition = json.dumps({
        "StartAt": "Task",
        "States": {"Task": {
            "Type": "Task",
            "Resource": f"arn:aws:states:::aws-sdk:ec2:{action}",
            "Parameters": params,
            "End": True,
        }},
    })
    arn = sfn.create_state_machine(name=name, definition=definition, roleArn=role_arn)["stateMachineArn"]
    created.append(("state_machine", arn))
    execution_arn = sfn.start_execution(stateMachineArn=arn, input="{}")["executionArn"]
    deadline = time.monotonic() + timeout
    execution = sfn.describe_execution(executionArn=execution_arn)
    while execution["status"] == "RUNNING" and time.monotonic() < deadline:
        time.sleep(0.25)
        execution = sfn.describe_execution(executionArn=execution_arn)
    if execution["status"] != "SUCCEEDED":
        return execution["status"], None, f"{execution.get('error')}: {execution.get('cause')}"
    return "SUCCEEDED", json.loads(execution.get("output") or "{}"), None


def main():
    args = options()
    if args.endpoint and not args.profile:
        session = boto3.Session(region_name=args.region, aws_access_key_id="test",
                                aws_secret_access_key="test")
    else:
        session = boto3.Session(profile_name=args.profile, region_name=args.region)
    client_args = {"endpoint_url": args.endpoint} if args.endpoint else {}
    sfn = session.client("stepfunctions", **client_args)
    ec2 = session.client("ec2", **client_args)
    iam = session.client("iam", **client_args)

    prefix = f"sfn-ec2-params-{uuid.uuid4().hex[:8]}"
    created = []
    results = []

    def check(label, ok, detail):
        results.append((label, ok, detail))
        print(f"{'PASS' if ok else 'FAIL'}  {label:42} {detail}")

    try:
        vpc_id = ec2.create_vpc(CidrBlock="10.48.0.0/16")["Vpc"]["VpcId"]
        created.append(("vpc", vpc_id))

        if args.endpoint:
            role_arn = DUMMY_ROLE
        else:
            role = iam.create_role(RoleName=f"{prefix}-role",
                                   AssumeRolePolicyDocument=json.dumps(TRUST_POLICY))["Role"]
            iam.put_role_policy(RoleName=role["RoleName"], PolicyName="check",
                                PolicyDocument=json.dumps(CHECK_POLICY))
            created.append(("role", role["RoleName"]))
            role_arn = role["Arn"]
            time.sleep(15)  # IAM propagation before Step Functions accepts the role

        def task(name, action, params):
            return run_task(sfn, f"{prefix}-{name}", role_arn, action, params, created)

        # 1. Two acronym-carrying params in one call: the VPC id says which VPC, the attribute name
        #    says what to set. The effect is read back from EC2 rather than from the task output --
        #    the task reported SUCCEEDED while changing nothing.
        status, out, failure = task("dns", "modifyVpcAttribute",
                                    {"VpcId": vpc_id, "EnableDnsHostnames": {"Value": True}})
        applied = ec2.describe_vpc_attribute(
            VpcId=vpc_id, Attribute="enableDnsHostnames")["EnableDnsHostnames"]["Value"]
        ok = status == "SUCCEEDED" and applied is True
        check("modifyVpcAttribute applies EnableDnsHostnames", ok,
              "attribute is set" if ok
              else (f"task {status}: {failure}" if status != "SUCCEEDED"
                    else f"task SUCCEEDED but attribute is {applied}"))

        # 2. A param that decides where the resource lands, and one that is genuinely renamed:
        #    EC2 calls Description "GroupDescription" on the wire, which no rule derives, so an
        #    override supplies it. Skipping the expansion must not skip the overrides with it --
        #    without them the description silently becomes the group name and the call still
        #    succeeds. A dropped VpcId is equally quiet: the group lands in the default VPC.
        status, out, failure = task("group", "createSecurityGroup",
                                    {"GroupName": prefix, "Description": "param name check",
                                     "VpcId": vpc_id})
        group_id = (out or {}).get("GroupId")
        landed = description = None
        if group_id:
            created.append(("group", group_id))
            group = ec2.describe_security_groups(GroupIds=[group_id])["SecurityGroups"][0]
            landed, description = group["VpcId"], group.get("Description")
        ok = status == "SUCCEEDED" and landed == vpc_id and description == "param name check"
        check("createSecurityGroup VpcId and Description", ok,
              "in the given VPC, description kept" if ok
              else (f"task {status}: {failure}" if status != "SUCCEEDED"
                    else f"vpc={landed} description={description!r}"))

        # 3. A call whose params carry no acronym at all, to show the conversion is not simply off
        #    for everything: describeVolumes still narrows to the volume it was given.
        zone = ec2.describe_availability_zones()["AvailabilityZones"][0]["ZoneName"]
        volume_id = ec2.create_volume(AvailabilityZone=zone, Size=1, VolumeType="gp3")["VolumeId"]
        created.append(("volume", volume_id))
        status, out, failure = task("volumes", "describeVolumes", {"VolumeIds": [volume_id]})
        volumes = (out or {}).get("Volumes") or []
        ok = (status == "SUCCEEDED" and len(volumes) == 1
              and volumes[0].get("VolumeId") == volume_id)
        check("a param without acronyms still applies", ok,
              "narrowed to the one volume" if ok
              else (f"task {status}: {failure}" if status != "SUCCEEDED"
                    else f"{len(volumes)} volume(s): {[v.get('VolumeId') for v in volumes][:3]}"))
    finally:
        if not args.keep:
            for kind, ident in reversed(created):
                with suppress(ClientError):
                    if kind == "state_machine":
                        sfn.delete_state_machine(stateMachineArn=ident)
                    elif kind == "group":
                        ec2.delete_security_group(GroupId=ident)
                    elif kind == "volume":
                        ec2.delete_volume(VolumeId=ident)
                    elif kind == "vpc":
                        ec2.delete_vpc(VpcId=ident)
                    elif kind == "role":
                        iam.delete_role_policy(RoleName=ident, PolicyName="check")
                        iam.delete_role(RoleName=ident)

    failed = [label for label, ok, _ in results if not ok]
    print(f"\n{len(results) - len(failed)}/{len(results)} checks passed"
          + (f"; failed: {', '.join(failed)}" if failed else ""))
    return 1 if failed else 0


if __name__ == "__main__":
    try:
        sys.exit(main())
    except (ClientError, TimeoutError) as exc:
        print(f"ERROR: {exc}", file=sys.stderr)
        sys.exit(2)
```

</details>

