### PR TITLE
Prevent Docker operations from blocking the event loop

### DIFF
--- a/ministack/app.py
+++ b/ministack/app.py
@@ -21,6 +21,7 @@ import sys
 import tempfile
 import time
 import uuid
+from contextlib import AsyncExitStack
 from urllib.parse import parse_qs, unquote
 
 _MINISTACK_HOST = os.environ.get("MINISTACK_HOST", "localhost")
@@ -161,6 +162,7 @@ _NON_S3_VHOST_NAMES = frozenset({
     "inspector2",
 })
 
+from ministack.core.concurrency import LoopLocal, run_in_thread_to_completion
 from ministack.core.hypercorn_compat import install as _install_hypercorn_compat
 from ministack.core.persistence import PERSIST_STATE, load_state, save_all
 from ministack.core.responses import _12_DIGIT_RE, set_request_account_id, set_request_region
@@ -423,14 +425,158 @@ BANNER = r"""
 """
 
 
-_reset_lock: "asyncio.Lock | None" = None
+class _RequestResetBarrier:
+    """Let ordinary requests run concurrently while giving reset priority."""
+
+    def __init__(self):
+        self._active_requests = 0
+        self._resetting = False
+        self._requests_drained = asyncio.Event()
+        self._requests_drained.set()
+        self._reset_finished = asyncio.Event()
+        self._reset_finished.set()
+
+    async def enter_request(self):
+        while self._resetting:
+            await self._reset_finished.wait()
+        self._active_requests += 1
+        if self._active_requests == 1:
+            self._requests_drained.clear()
+
+    def leave_request(self):
+        self._active_requests -= 1
+        if self._active_requests == 0:
+            self._requests_drained.set()
+
+    async def enter_reset(self):
+        self._resetting = True
+        self._reset_finished.clear()
+        try:
+            await self._requests_drained.wait()
+        except BaseException:
+            self.leave_reset()
+            raise
+
+    def leave_reset(self):
+        self._resetting = False
+        self._reset_finished.set()
+
+
+_reset_locks = LoopLocal(asyncio.Lock)
+_ordinary_request_reset_barriers = LoopLocal(_RequestResetBarrier)
+
+# These routers move synchronous Docker work to worker threads. Reset acquires
+# their admission locks before wiping state so it cannot overlap an in-flight
+# worker or mapped CloudFormation provisioner. Keeping the guard at the service
+# seam avoids a global HTTP reader barrier, which would deadlock an admitted
+# Lambda/custom-resource request that calls back into MiniStack while reset is
+# waiting for that outer request to finish.
+# Reset and Resource Groups Tagging are the only multi-admission-lock holders.
+# Tagging's ECS/ElastiCache pair is a subsequence of this fixed global order.
+_RESET_SERIALIZED_SERVICE_MODULES = (
+    "rds",
+    "ecs",
+    "eks",
+    "elasticache",
+    "opensearch",
+)
 
 
 def _get_reset_lock() -> asyncio.Lock:
-    global _reset_lock
-    if _reset_lock is None:
-        _reset_lock = asyncio.Lock()
-    return _reset_lock
+    return _reset_locks.get()
+
+
+def _get_ordinary_request_reset_barrier() -> _RequestResetBarrier:
+    return _ordinary_request_reset_barriers.get()
+
+
+async def _reset_all_state_after_service_dispatch_drains():
+    """Quiesce stack work and requests before wiping mutable service state."""
+    from ministack.services.cloudformation import stacks as cfn_stacks
+
+    stack_tasks = cfn_stacks._get_stack_task_lifecycle()
+    barrier = _get_ordinary_request_reset_barrier()
+
+    # Hold no request or service lock while cancelling stack tasks: unwinding
+    # provisioners may themselves need an admission lock or callback request.
+    try:
+        await stack_tasks.begin_reset()
+    except BaseException:
+        stack_tasks.finish_reset()
+        raise
+    barrier_entered = False
+    try:
+        await barrier.enter_reset()
+        barrier_entered = True
+        async with AsyncExitStack() as stack:
+            for module_name in _RESET_SERIALIZED_SERVICE_MODULES:
+                module = _get_module(module_name)
+                if isinstance(module, _ErrorModule):
+                    # A failed import has no state or in-flight worker to
+                    # serialize. Healthy modules missing this seam remain a
+                    # loud wiring error rather than being silently skipped.
+                    continue
+                await stack.enter_async_context(module._get_request_dispatch_lock())
+            await run_in_thread_to_completion(_reset_all_state)
+    finally:
+        # Re-open stack admission while ordinary CloudFormation requests are
+        # still held behind the writer barrier, then release readers.
+        stack_tasks.finish_reset()
+        if barrier_entered:
+            barrier.leave_reset()
+
+
+_RESET_ADMISSION_SERVICE_KEYS = {
+    "rds",
+    "ecs",
+    "eks",
+    "elasticache",
+    "opensearch",
+    "rds-data",
+}
+
+# These request handlers can synchronously wait for code that calls back into
+# MiniStack. Holding them as reset readers would recreate a parent-reader ->
+# reset-writer -> nested-reader deadlock. Their reset races match upstream main.
+_RESET_CALLBACK_SERVICE_KEYS = {
+    "lambda",          # invoked function may use an AWS SDK against the gateway
+    "states",          # sync executions invoke Lambda and SDK integrations
+    "cognito-idp",     # user-pool Lambda triggers
+    "cognito-identity",
+    "appsync",         # Lambda authorizers/resolvers
+    "appsync-events",  # Lambda authorizers
+    "firehose",        # transforms/delivery call back through the gateway
+    "sns",             # HTTP subscriptions and Lambda delivery callbacks
+}
+
+
+def _ordinary_request_uses_reset_barrier(method, path, headers, body, query_params):
+    """Classify HTTP readers after body-backed Query routing is available."""
+    if path.startswith("/_ministack/cfn-response/"):
+        return False
+
+    host = headers.get("host", "")
+    # API Gateway and ALB data planes may synchronously invoke Lambda, whose
+    # function can issue a nested request back to this gateway.
+    if _parse_execute_api_url(host, path) is not None or _is_potential_alb_request(host, path):
+        return False
+
+    routing_params = _routing_params(method, path, headers, body, query_params)
+    service = detect_service(method, path, headers, routing_params)
+    if service == "tagging":
+        from ministack.services import tagging
+
+        try:
+            _, _, locked_services = tagging.classify_request_admission(headers, body)
+        except (json.JSONDecodeError, tagging.InvalidRequestBody):
+            # Invalid requests hold no admission lock, so keep them behind the
+            # reset reader barrier even though they will fail in the router.
+            return True
+        # Empty means this request holds no service lock and therefore needs the
+        # ordinary reader barrier. A mixed locked + lockless request is safe to
+        # exclude because its synchronous body stays under the locked service.
+        return not locked_services
+    return service not in _RESET_ADMISSION_SERVICE_KEYS | _RESET_CALLBACK_SERVICE_KEYS
 
 
 # ---------------------------------------------------------------------------
@@ -688,7 +834,7 @@ async def _handle_admin_reset(path: str, method: str, query_params: dict):
         return None
 
     async with _get_reset_lock():
-        await asyncio.to_thread(_reset_all_state)
+        await _reset_all_state_after_service_dispatch_drains()
 
     run_init = query_params.get("init", [""])[0] == "1"
     if run_init:
@@ -1731,6 +1877,62 @@ async def _dispatch_service_request(
     return status, resp_headers, resp_body
 
 
+async def _handle_http_request(
+    method: str,
+    path: str,
+    headers: dict,
+    query_params: dict,
+    request_id: str,
+    receive,
+    send,
+    body=None,
+):
+    """Process one HTTP request after reset admission is decided."""
+    # Set per-request account ID from credentials (multi-tenancy support).
+    # If the access key is a 12-digit number, it becomes the account ID.
+    access_key = extract_access_key_id(headers, query_params)
+    if access_key:
+        set_request_account_id(access_key)
+
+    # Set per-request region from SigV4 Credential scope so CFN's AWS::Region
+    # pseudo-param and ARN-building use the caller's region, not MINISTACK_REGION
+    # (issue #398). Falls back to MINISTACK_REGION env. Presigned (SigV4 query)
+    # requests carry the credential in query params, not the header.
+    set_request_region(extract_region(headers, query_params))
+
+    if await _send_if_handled(
+        send,
+        await _handle_pre_body_request(method, path, headers, query_params, request_id),
+    ):
+        return
+
+    if body is None:
+        body = await _read_request_body(receive, method, headers)
+
+    if await _send_if_handled(
+        send,
+        await _handle_post_body_shortcuts(
+            method, path, headers, body, query_params, request_id
+        ),
+    ):
+        return
+
+    if await _send_if_handled(
+        send,
+        await _handle_special_data_plane_request(
+            method, path, headers, body, query_params, request_id
+        ),
+    ):
+        return
+
+    await _send_response(
+        send,
+        *await _dispatch_service_request(
+            method, path, headers, body, query_params, request_id
+        ),
+    )
+
+
 # ---------------------------------------------------------------------------
 # ASGI entry point
 # ---------------------------------------------------------------------------
@@ -1817,40 +2019,31 @@ async def app(scope, receive, send):
 
     request_id = str(uuid.uuid4())
 
-    # If a /_ministack/reset is in flight, wait for it to finish before
-    # serving this request. The lock is uncontended in steady state
-    # (acquire/release is near-free); during a reset, new requests block
-    # until state-wipe completes so no test can observe a half-reset server.
-    if path != "/_ministack/reset":
-        async with _get_reset_lock():
-            pass
-
-    # Set per-request account ID from credentials (multi-tenancy support).
-    # If the access key is a 12-digit number, it becomes the account ID.
-    _access_key = extract_access_key_id(headers, query_params)
-    if _access_key:
-        set_request_account_id(_access_key)
-
-    # Set per-request region from SigV4 Credential scope so CFN's AWS::Region
-    # pseudo-param and ARN-building use the caller's region, not MINISTACK_REGION
-    # (issue #398). Falls back to MINISTACK_REGION env. Presigned (SigV4 query)
-    # requests carry the credential in query params, not the header.
-    set_request_region(extract_region(headers, query_params))
-
-    if await _send_if_handled(send, await _handle_pre_body_request(method, path, headers, query_params, request_id)):
+    if path == "/_ministack/reset":
+        await _handle_http_request(
+            method, path, headers, query_params, request_id, receive, send
+        )
         return
 
+    # Reading the wire body touches no service state. Preload it so unsigned
+    # Query requests can be classified by Action before either ordering domain
+    # is entered, then pass it through without a second receive.
     body = await _read_request_body(receive, method, headers)
 
-    if await _send_if_handled(send, await _handle_post_body_shortcuts(method, path, headers, body, query_params, request_id)):
+    if not _ordinary_request_uses_reset_barrier(method, path, headers, body, query_params):
+        await _handle_http_request(
+            method, path, headers, query_params, request_id, receive, send, body
+        )
         return
 
-    if await _send_if_handled(
-        send, await _handle_special_data_plane_request(method, path, headers, body, query_params, request_id)
-    ):
-        return
-
-    await _send_response(send, *await _dispatch_service_request(method, path, headers, body, query_params, request_id))
+    barrier = _get_ordinary_request_reset_barrier()
+    await barrier.enter_request()
+    try:
+        await _handle_http_request(
+            method, path, headers, query_params, request_id, receive, send, body
+        )
+    finally:
+        barrier.leave_request()
 
 
 # ---------------------------------------------------------------------------
@@ -1931,6 +2124,12 @@ async def _handle_lifespan(scope, receive, send):
             asyncio.create_task(_run_ready_scripts())
         elif message["type"] == "lifespan.shutdown":
             logger.info("MiniStack shutting down...")
+            try:
+                from ministack.services import eventbridge as _eb_mod
+
+                await asyncio.to_thread(_eb_mod.stop_scheduler)
+            except Exception as e:
+                logger.debug("EventBridge scheduler shutdown error: %s", e)
             if PERSIST_STATE:
                 save_all(_build_persistence_save_dict())
             try:

--- a/ministack/app.py
+++ b/ministack/app.py
@@ -600,6 +600,8 @@ def _ordinary_request_uses_reset_barrier(method, path, headers, body, query_para
     routing_params = _routing_params(method, path, headers, body, query_params)
     service = detect_service(method, path, headers, routing_params)
     if service == "tagging":
+        if service not in SERVICE_HANDLERS:
+            return True
         from ministack.services import tagging
 
         try:
@@ -637,6 +639,8 @@ async def _ensure_reset_admission_owner_modules(module_names) -> None:
 
 def _reset_admission_owner_modules_for_request(service, headers, body):
     """Return serialized owner modules first-touched by one HTTP request."""
+    if service not in SERVICE_HANDLERS:
+        return ()
     if service == "tagging":
         from ministack.services import tagging
 
@@ -1964,17 +1968,8 @@ async def _dispatch_service_request(
     return status, resp_headers, resp_body
 
 
-async def _handle_http_request(
-    method: str,
-    path: str,
-    headers: dict,
-    query_params: dict,
-    request_id: str,
-    receive,
-    send,
-    body=None,
-):
-    """Process one HTTP request after reset admission is decided."""
+def _establish_http_request_context(headers: dict, query_params: dict) -> None:
+    """Establish account and region context before request-time imports."""
     # Set per-request account ID from credentials (multi-tenancy support).
     # If the access key is a 12-digit number, it becomes the account ID.
     access_key = extract_access_key_id(headers, query_params)
@@ -1987,6 +1982,18 @@ async def _handle_http_request(
     # requests carry the credential in query params, not the header.
     set_request_region(extract_region(headers, query_params))
 
+
+async def _handle_http_request(
+    method: str,
+    path: str,
+    headers: dict,
+    query_params: dict,
+    request_id: str,
+    receive,
+    send,
+    body=None,
+):
+    """Process one HTTP request after reset admission is decided."""
     if await _send_if_handled(
         send,
         await _handle_pre_body_request(method, path, headers, query_params, request_id),
@@ -2104,6 +2111,7 @@ async def app(scope, receive, send):
         except UnicodeDecodeError:
             headers[name.decode("latin-1").lower()] = value.decode("latin-1")
 
+    _establish_http_request_context(headers, query_params)
     request_id = str(uuid.uuid4())
 
     if path == "/_ministack/reset":

--- a/ministack/app.py
+++ b/ministack/app.py
@@ -238,6 +238,19 @@ def _resolve_loaded_service_module(name: str):
     return _loaded_modules.get(name) or sys.modules.get(f"ministack.services.{name}")
 
 
+# Serialized service keys and every module whose first import establishes the
+# admission lock protecting that request. Keep this as the single source of
+# truth for HTTP dispatch and non-HTTP Step Functions SDK integrations.
+_RESET_ADMISSION_OWNER_MODULES = {
+    "rds": ("rds",),
+    "ecs": ("ecs",),
+    "eks": ("eks",),
+    "elasticache": ("elasticache",),
+    "opensearch": ("opensearch",),
+    "rds-data": ("rds_data", "rds"),
+}
+
+
 def _lazy_handler(module_name: str):
     """Return a callable that lazily imports module_name and delegates to handle_request."""
 
@@ -495,22 +508,14 @@ def _get_ordinary_request_reset_barrier() -> _RequestResetBarrier:
     return _ordinary_request_reset_barriers.get()
 
 
-async def _reset_all_state_after_service_dispatch_drains():
-    """Quiesce stack work and requests before wiping mutable service state."""
-    from ministack.services.cloudformation import lifecycle as cfn_lifecycle
-
-    stack_tasks = cfn_lifecycle._get_stack_task_lifecycle()
-    barrier = _get_ordinary_request_reset_barrier()
-
-    # Hold no request or service lock while cancelling stack tasks: unwinding
-    # provisioners may themselves need an admission lock or callback request.
-    try:
-        await stack_tasks.begin_reset()
-    except BaseException:
-        stack_tasks.finish_reset()
-        raise
+async def _complete_reset_after_stack_admission_closes(stack_tasks, barrier):
+    """Run the committed reset sequence and always reopen its admission."""
     barrier_entered = False
     try:
+        # Hold no request or service lock while cancelling stack tasks:
+        # unwinding provisioners may themselves need an admission lock or
+        # callback request.
+        await stack_tasks.begin_reset()
         await barrier.enter_reset()
         barrier_entered = True
         async with AsyncExitStack() as stack:
@@ -535,14 +540,32 @@ async def _reset_all_state_after_service_dispatch_drains():
             barrier.leave_reset()
 
 
-_RESET_ADMISSION_SERVICE_KEYS = {
-    "rds",
-    "ecs",
-    "eks",
-    "elasticache",
-    "opensearch",
-    "rds-data",
-}
+async def _reset_all_state_after_service_dispatch_drains():
+    """Quiesce stack work and requests before wiping mutable service state."""
+    from ministack.services.cloudformation import lifecycle as cfn_lifecycle
+
+    stack_tasks = cfn_lifecycle._get_stack_task_lifecycle()
+    barrier = _get_ordinary_request_reset_barrier()
+    reset = asyncio.create_task(
+        _complete_reset_after_stack_admission_closes(stack_tasks, barrier)
+    )
+    try:
+        await asyncio.shield(reset)
+    except asyncio.CancelledError as cancellation:
+        # Once stack admission begins closing, cancellation must not reopen it
+        # before the drain, barrier, service locks, and wipe all complete.
+        while not reset.done():
+            try:
+                await asyncio.shield(reset)
+            except asyncio.CancelledError:
+                continue
+        # Propagate an internal reset failure instead of misreporting a clean
+        # cancelled reset; otherwise preserve the caller's first cancellation.
+        reset.result()
+        raise cancellation
+
+
+_RESET_ADMISSION_SERVICE_KEYS = set(_RESET_ADMISSION_OWNER_MODULES)
 
 # These request handlers can synchronously wait for code that calls back into
 # MiniStack. Holding them as reset readers would recreate a parent-reader ->
@@ -592,23 +615,55 @@ def _ordinary_request_uses_reset_barrier(method, path, headers, body, query_para
     return service not in _RESET_ADMISSION_SERVICE_KEYS | _RESET_CALLBACK_SERVICE_KEYS
 
 
-async def _gate_first_touch_reset_admission_module(service: str) -> None:
-    """Import a serialized service under reset-reader status on first touch."""
-    if service not in _RESET_ADMISSION_SERVICE_KEYS or service not in SERVICE_HANDLERS:
-        return
-    module_name = SERVICE_REGISTRY[service]["module"]
-    if _resolve_loaded_service_module(module_name) is not None:
+async def _ensure_reset_admission_owner_modules(module_names) -> None:
+    """Import absent serialized owners under reset-reader status."""
+    module_names = tuple(dict.fromkeys(module_names))
+    if not module_names or all(
+        _resolve_loaded_service_module(name) is not None for name in module_names
+    ):
         return
 
     barrier = _get_ordinary_request_reset_barrier()
     await barrier.enter_request()
     try:
         # Recheck after admission: another first-touch request may have loaded
-        # the module while this request waited.
-        if _resolve_loaded_service_module(module_name) is None:
-            _get_module(module_name)
+        # an owner while this request waited.
+        for module_name in module_names:
+            if _resolve_loaded_service_module(module_name) is None:
+                _get_module(module_name)
     finally:
         barrier.leave_request()
+
+
+def _reset_admission_owner_modules_for_request(service, headers, body):
+    """Return serialized owner modules first-touched by one HTTP request."""
+    if service == "tagging":
+        from ministack.services import tagging
+
+        try:
+            _, _, locked_services = tagging.classify_request_admission(headers, body)
+        except (json.JSONDecodeError, tagging.InvalidRequestBody):
+            return ()
+        return tuple(locked_services)
+    return _RESET_ADMISSION_OWNER_MODULES.get(service, ())
+
+
+async def _gate_first_touch_reset_admission_modules(
+    service: str, headers: dict, body: bytes
+) -> None:
+    """Gate every serialized owner a request can first-touch."""
+    await _ensure_reset_admission_owner_modules(
+        _reset_admission_owner_modules_for_request(service, headers, body)
+    )
+
+
+async def _dispatch_serialized_service_request(service: str, *args):
+    """Gate, import, and dispatch a serialized service on the gateway loop."""
+    await _ensure_reset_admission_owner_modules(
+        _RESET_ADMISSION_OWNER_MODULES[service]
+    )
+    module_name = SERVICE_REGISTRY[service]["module"]
+    return await _get_module(module_name).handle_request(*args)
 
 
 # ---------------------------------------------------------------------------
@@ -2064,7 +2119,7 @@ async def app(scope, receive, send):
 
     routing_params = _routing_params(method, path, headers, body, query_params)
     service = detect_service(method, path, headers, routing_params)
-    await _gate_first_touch_reset_admission_module(service)
+    await _gate_first_touch_reset_admission_modules(service, headers, body)
 
     if not _ordinary_request_uses_reset_barrier(method, path, headers, body, query_params):
         await _handle_http_request(

--- a/ministack/app.py
+++ b/ministack/app.py
@@ -508,7 +508,9 @@ def _get_ordinary_request_reset_barrier() -> _RequestResetBarrier:
     return _ordinary_request_reset_barriers.get()
 
 
-async def _complete_reset_after_stack_admission_closes(stack_tasks, barrier):
+async def _complete_reset_after_stack_admission_closes(
+    stack_tasks, sync_actions, barrier
+):
     """Run the committed reset sequence and always reopen its admission."""
     barrier_entered = False
     try:
@@ -516,6 +518,10 @@ async def _complete_reset_after_stack_admission_closes(stack_tasks, barrier):
         # unwinding provisioners may themselves need an admission lock or
         # callback request.
         await stack_tasks.begin_reset()
+        # CloudFormation drains first: unwinding custom resources may start a
+        # synchronous execution. Once that work is quiescent, close and drain
+        # the dedicated SFN actions before taking the request writer barrier.
+        await sync_actions.begin_reset()
         await barrier.enter_reset()
         barrier_entered = True
         async with AsyncExitStack() as stack:
@@ -533,21 +539,27 @@ async def _complete_reset_after_stack_admission_closes(stack_tasks, barrier):
                 await stack.enter_async_context(module._get_request_dispatch_lock())
             await run_in_thread_to_completion(_reset_all_state)
     finally:
-        # Re-open stack admission while ordinary CloudFormation requests are
-        # still held behind the writer barrier, then release readers.
-        stack_tasks.finish_reset()
+        # Locks have already been released by AsyncExitStack. Re-open all
+        # admission in one non-awaiting sequence so excluded states requests
+        # cannot start between the wipe and reset completion.
         if barrier_entered:
             barrier.leave_reset()
+        sync_actions.finish_reset()
+        stack_tasks.finish_reset()
 
 
 async def _reset_all_state_after_service_dispatch_drains():
     """Quiesce stack work and requests before wiping mutable service state."""
+    from ministack.services import stepfunctions_lifecycle
     from ministack.services.cloudformation import lifecycle as cfn_lifecycle
 
     stack_tasks = cfn_lifecycle._get_stack_task_lifecycle()
+    sync_actions = stepfunctions_lifecycle._get_sync_action_lifecycle()
     barrier = _get_ordinary_request_reset_barrier()
     reset = asyncio.create_task(
-        _complete_reset_after_stack_admission_closes(stack_tasks, barrier)
+        _complete_reset_after_stack_admission_closes(
+            stack_tasks, sync_actions, barrier
+        )
     )
     try:
         await asyncio.shield(reset)
@@ -572,7 +584,9 @@ _RESET_ADMISSION_SERVICE_KEYS = set(_RESET_ADMISSION_OWNER_MODULES)
 # reset-writer -> nested-reader deadlock. Their reset races match upstream main.
 _RESET_CALLBACK_SERVICE_KEYS = {
     "lambda",          # invoked function may use an AWS SDK against the gateway
-    "states",          # sync executions invoke Lambda and SDK integrations
+    # StartSyncExecution/TestState use a dedicated reset lifecycle; background
+    # StartExecution threads remain the documented main-equivalent residual.
+    "states",
     "cognito-idp",     # user-pool Lambda triggers
     "cognito-identity",
     "appsync",         # Lambda authorizers/resolvers

--- a/ministack/app.py
+++ b/ministack/app.py
@@ -233,6 +233,11 @@ def _get_module(name: str):
     return mod
 
 
+def _resolve_loaded_service_module(name: str):
+    """Return an already-loaded service module without importing it."""
+    return _loaded_modules.get(name) or sys.modules.get(f"ministack.services.{name}")
+
+
 def _lazy_handler(module_name: str):
     """Return a callable that lazily imports module_name and delegates to handle_request."""
 
@@ -492,9 +497,9 @@ def _get_ordinary_request_reset_barrier() -> _RequestResetBarrier:
 
 async def _reset_all_state_after_service_dispatch_drains():
     """Quiesce stack work and requests before wiping mutable service state."""
-    from ministack.services.cloudformation import stacks as cfn_stacks
+    from ministack.services.cloudformation import lifecycle as cfn_lifecycle
 
-    stack_tasks = cfn_stacks._get_stack_task_lifecycle()
+    stack_tasks = cfn_lifecycle._get_stack_task_lifecycle()
     barrier = _get_ordinary_request_reset_barrier()
 
     # Hold no request or service lock while cancelling stack tasks: unwinding
@@ -510,7 +515,11 @@ async def _reset_all_state_after_service_dispatch_drains():
         barrier_entered = True
         async with AsyncExitStack() as stack:
             for module_name in _RESET_SERIALIZED_SERVICE_MODULES:
-                module = _get_module(module_name)
+                module = _resolve_loaded_service_module(module_name)
+                if module is None:
+                    # First-touch imports for these services hold reader status,
+                    # so none can appear after this writer-side absence check.
+                    continue
                 if isinstance(module, _ErrorModule):
                     # A failed import has no state or in-flight worker to
                     # serialize. Healthy modules missing this seam remain a
@@ -556,9 +565,13 @@ def _ordinary_request_uses_reset_barrier(method, path, headers, body, query_para
         return False
 
     host = headers.get("host", "")
-    # API Gateway and ALB data planes may synchronously invoke Lambda, whose
-    # function can issue a nested request back to this gateway.
-    if _parse_execute_api_url(host, path) is not None or _is_potential_alb_request(host, path):
+    # API Gateway, Lambda Function URL, and ALB data planes may synchronously
+    # invoke Lambda, whose function can issue a nested request back here.
+    if (
+        _parse_execute_api_url(host, path) is not None
+        or _parse_lambda_url(host, path) is not None
+        or _is_potential_alb_request(host, path)
+    ):
         return False
 
     routing_params = _routing_params(method, path, headers, body, query_params)
@@ -577,6 +590,25 @@ def _ordinary_request_uses_reset_barrier(method, path, headers, body, query_para
         # exclude because its synchronous body stays under the locked service.
         return not locked_services
     return service not in _RESET_ADMISSION_SERVICE_KEYS | _RESET_CALLBACK_SERVICE_KEYS
+
+
+async def _gate_first_touch_reset_admission_module(service: str) -> None:
+    """Import a serialized service under reset-reader status on first touch."""
+    if service not in _RESET_ADMISSION_SERVICE_KEYS or service not in SERVICE_HANDLERS:
+        return
+    module_name = SERVICE_REGISTRY[service]["module"]
+    if _resolve_loaded_service_module(module_name) is not None:
+        return
+
+    barrier = _get_ordinary_request_reset_barrier()
+    await barrier.enter_request()
+    try:
+        # Recheck after admission: another first-touch request may have loaded
+        # the module while this request waited.
+        if _resolve_loaded_service_module(module_name) is None:
+            _get_module(module_name)
+    finally:
+        barrier.leave_request()
 
 
 # ---------------------------------------------------------------------------
@@ -2030,6 +2062,10 @@ async def app(scope, receive, send):
     # is entered, then pass it through without a second receive.
     body = await _read_request_body(receive, method, headers)
 
+    routing_params = _routing_params(method, path, headers, body, query_params)
+    service = detect_service(method, path, headers, routing_params)
+    await _gate_first_touch_reset_admission_module(service)
+
     if not _ordinary_request_uses_reset_barrier(method, path, headers, body, query_params):
         await _handle_http_request(
             method, path, headers, query_params, request_id, receive, send, body
@@ -2130,6 +2166,12 @@ async def _handle_lifespan(scope, receive, send):
                 await asyncio.to_thread(_eb_mod.stop_scheduler)
             except Exception as e:
                 logger.debug("EventBridge scheduler shutdown error: %s", e)
+            try:
+                from ministack.services import scheduler as _sched_mod
+
+                await asyncio.to_thread(_sched_mod.stop_scheduler)
+            except Exception as e:
+                logger.debug("Scheduler shutdown error: %s", e)
             if PERSIST_STATE:
                 save_all(_build_persistence_save_dict())
             try:
@@ -2442,7 +2484,7 @@ def _reset_all_state():
         # Without the `sys.modules` fallback, those modules silently skip reset
         # — leaving state across `/_ministack/reset` calls and breaking test
         # isolation.
-        mod = _loaded_modules.get(mod_name) or sys.modules.get(f"ministack.services.{mod_name}")
+        mod = _resolve_loaded_service_module(mod_name)
         if mod is None or not hasattr(mod, "reset"):
             continue
         try:

--- a/ministack/core/concurrency.py
+++ b/ministack/core/concurrency.py
@@ -1,0 +1,126 @@
+"""Concurrency helpers shared by service routers."""
+
+import asyncio
+import contextvars
+import threading
+import weakref
+
+
+class LoopLocal:
+    """Lazily create weakly cached values for the running event loop.
+
+    Both keys and values must be weak: asyncio synchronization primitives bind
+    themselves to a loop after contention, so a strong value would keep its
+    weak-key loop alive through that back-reference.
+    """
+
+    def __init__(self, factory):
+        self._factory = factory
+        self._values = weakref.WeakKeyDictionary()
+
+    def get(self):
+        loop = asyncio.get_running_loop()
+        value_ref = self._values.get(loop)
+        value = value_ref() if value_ref is not None else None
+        if value is None:
+            value = self._factory()
+            self._values[loop] = weakref.ref(value)
+        return value
+
+
+async def run_in_thread_to_completion(func, *args, **kwargs):
+    """Run blocking work off-loop while deferring cancellation until it ends.
+
+    ``asyncio.to_thread`` workers cannot be cancelled once running. Letting the
+    awaiting task unwind immediately would release admission/reset guards while
+    the worker still mutates service state. Shield the worker, absorb repeated
+    cancellation while it finishes, then re-raise the original cancellation.
+    """
+    worker = asyncio.create_task(asyncio.to_thread(func, *args, **kwargs))
+    try:
+        return await asyncio.shield(worker)
+    except asyncio.CancelledError as cancellation:
+        while not worker.done():
+            try:
+                await asyncio.shield(worker)
+            except asyncio.CancelledError:
+                continue
+            except Exception:
+                break
+
+        # Retrieve a failed worker's exception so asyncio does not report an
+        # unobserved task failure after the HTTP request has been cancelled.
+        if worker.done() and not worker.cancelled():
+            try:
+                worker.result()
+            except Exception:
+                pass
+        raise cancellation
+
+
+def _complete_thread_future(future, result=None, error=None):
+    if future.done():
+        return
+    if error is not None:
+        future.set_exception(error)
+    else:
+        future.set_result(result)
+
+
+async def run_in_dedicated_thread_to_completion(
+    func, *args, thread_name=None, context_setup=None
+):
+    """Run blocking work in its own context-preserving daemon thread.
+
+    This has the same cancellation contract as ``run_in_thread_to_completion``
+    without consuming the shared executor. ``context_setup`` runs only in the
+    copied worker context before ``func`` and can install per-operation loop
+    handles without retaining them globally.
+    """
+    loop = asyncio.get_running_loop()
+    result_future = loop.create_future()
+    ctx_snapshot = contextvars.copy_context()
+
+    def run():
+        try:
+            if context_setup is not None:
+                ctx_snapshot.run(context_setup)
+            result = ctx_snapshot.run(func, *args)
+        except BaseException as exc:
+            loop.call_soon_threadsafe(
+                _complete_thread_future,
+                result_future,
+                None,
+                exc,
+            )
+        else:
+            loop.call_soon_threadsafe(
+                _complete_thread_future,
+                result_future,
+                result,
+                None,
+            )
+
+    threading.Thread(
+        target=run,
+        name=thread_name,
+        daemon=True,
+    ).start()
+
+    try:
+        return await asyncio.shield(result_future)
+    except asyncio.CancelledError as cancellation:
+        while not result_future.done():
+            try:
+                await asyncio.shield(result_future)
+            except asyncio.CancelledError:
+                continue
+            except Exception:
+                break
+
+        if result_future.done() and not result_future.cancelled():
+            try:
+                result_future.result()
+            except Exception:
+                pass
+        raise cancellation

--- a/ministack/services/athena.py
+++ b/ministack/services/athena.py
@@ -27,6 +27,7 @@ from datetime import date
 from urllib.parse import urlparse
 
 from ministack.core.arn import ArnParseError, parse_arn
+from ministack.core.concurrency import run_in_thread_to_completion
 from ministack.core.persistence import PERSIST_STATE, load_state
 from ministack.core.responses import (
     AccountRegionScopedDict,
@@ -466,7 +467,7 @@ async def _run_duckdb(query, database):
         finally:
             conn.close()
 
-    return await asyncio.to_thread(_execute_blocking)
+    return await run_in_thread_to_completion(_execute_blocking)
 
 
 async def _rewrite_data_paths(query, database):

--- a/ministack/services/bedrock_runtime.py
+++ b/ministack/services/bedrock_runtime.py
@@ -48,6 +48,7 @@ from datetime import datetime, timezone
 from urllib.parse import unquote
 
 from ministack.core.arn import ArnParseError, parse_arn
+from ministack.core.concurrency import run_in_thread_to_completion
 from ministack.core.persistence import load_state
 from ministack.core.responses import (
     AccountRegionScopedDict,
@@ -1021,23 +1022,31 @@ async def handle_request(method, path, headers, body, query_params):
     if path == "/v1/chat/completions":
         if method != "POST":
             return _openai_error(f"Unsupported method {method}.", status=405)
-        return await asyncio.to_thread(_openai_chat_completion, headers, body)
+        return await run_in_thread_to_completion(_openai_chat_completion, headers, body)
 
     # Proxy-capable handlers run in a worker thread: a slow
     # MINISTACK_BEDROCK_PROXY_URL must never block the single-port event loop.
     if method == "POST":
         m = _CONVERSE_STREAM_RE.match(path)
         if m:
-            return await asyncio.to_thread(_converse_stream, unquote(m.group(1)), headers, body)
+            return await run_in_thread_to_completion(
+                _converse_stream, unquote(m.group(1)), headers, body
+            )
         m = _CONVERSE_RE.match(path)
         if m:
-            return await asyncio.to_thread(_converse, unquote(m.group(1)), headers, body)
+            return await run_in_thread_to_completion(
+                _converse, unquote(m.group(1)), headers, body
+            )
         m = _INVOKE_STREAM_RE.match(path)
         if m:
-            return await asyncio.to_thread(_invoke_model_with_response_stream, unquote(m.group(1)), headers, body)
+            return await run_in_thread_to_completion(
+                _invoke_model_with_response_stream, unquote(m.group(1)), headers, body
+            )
         m = _INVOKE_RE.match(path)
         if m:
-            return await asyncio.to_thread(_invoke_model, unquote(m.group(1)), headers, body)
+            return await run_in_thread_to_completion(
+                _invoke_model, unquote(m.group(1)), headers, body
+            )
         m = _APPLY_GUARDRAIL_RE.match(path)
         if m:
             return _apply_guardrail(unquote(m.group(1)), unquote(m.group(2)), body)

--- a/ministack/services/cloudformation/__init__.py
+++ b/ministack/services/cloudformation/__init__.py
@@ -41,6 +41,11 @@ from .helpers import _p  # noqa: E402
 
 async def handle_request(method: str, path: str, headers: dict,
                          body: bytes, query_params: dict) -> tuple:
+    # Keep the provisioner graph lazy: reset imports only the lightweight
+    # stack-task lifecycle submodule, while real CloudFormation traffic loads
+    # the action registry on first dispatch.
+    from .handlers import _ACTION_HANDLERS
+
     params = dict(query_params)
     content_type = headers.get("content-type", "")
     target = headers.get("x-amz-target", "")
@@ -78,7 +83,8 @@ def reset():
     _cr.reset()
 
 
-# Must be last — handlers imports from this module
-from ministack.core.responses import get_account_id
+def _validate_template(params):
+    """Compatibility wrapper that preserves lazy action-handler loading."""
+    from .handlers import _validate_template as validate_template
 
-from .handlers import _ACTION_HANDLERS, _validate_template  # noqa: E402
+    return validate_template(params)

--- a/ministack/services/cloudformation/changesets.py
+++ b/ministack/services/cloudformation/changesets.py
@@ -16,7 +16,16 @@ from .engine import (
     _resolve_parameters,
     _resolve_refs,
 )
-from .helpers import CFN_NS, _error, _esc, _extract_members, _p, _resolve_template, _xml
+from .helpers import (
+    CFN_NS,
+    _error,
+    _esc,
+    _extract_members,
+    _mutation_admission_error,
+    _p,
+    _resolve_template,
+    _xml,
+)
 from .stacks import (
     _add_event,
     _create_stack_task_in_region,
@@ -75,6 +84,8 @@ def _resolve_props_for_diff(template, params, stack_name, stack_id):
 
 
 def _create_change_set(params):
+    if admission_error := _mutation_admission_error():
+        return admission_error
     from ministack.services.cloudformation import _change_sets, _stack_events, _stacks
     stack_name = _p(params, "StackName")
     cs_name = _p(params, "ChangeSetName")
@@ -259,6 +270,8 @@ def _describe_change_set(params):
 # --- ExecuteChangeSet ---
 
 def _execute_change_set(params):
+    if admission_error := _mutation_admission_error():
+        return admission_error
     from ministack.services.cloudformation import _stacks
     cs_name = _p(params, "ChangeSetName")
     stack_name = _p(params, "StackName")
@@ -333,6 +346,8 @@ def _execute_change_set(params):
 # --- DeleteChangeSet ---
 
 def _delete_change_set(params):
+    if admission_error := _mutation_admission_error():
+        return admission_error
     from ministack.services.cloudformation import _change_sets
     cs_name = _p(params, "ChangeSetName")
     stack_name = _p(params, "StackName")

--- a/ministack/services/cloudformation/handlers.py
+++ b/ministack/services/cloudformation/handlers.py
@@ -23,7 +23,17 @@ from .engine import (
     _resolve_parameters,
     _resolve_refs,
 )
-from .helpers import CFN_NS, _error, _esc, _extract_members, _extract_stack_status_filters, _p, _resolve_template, _xml
+from .helpers import (
+    CFN_NS,
+    _error,
+    _esc,
+    _extract_members,
+    _extract_stack_status_filters,
+    _mutation_admission_error,
+    _p,
+    _resolve_template,
+    _xml,
+)
 from .provisioners import _provision_resource
 from .stacks import (
     _add_event,
@@ -40,6 +50,8 @@ logger = logging.getLogger("cloudformation")
 # --- CreateStack ---
 
 def _create_stack(params):
+    if admission_error := _mutation_admission_error():
+        return admission_error
     from ministack.services.cloudformation import _change_sets, _exports, _stack_events, _stacks
     stack_name = _p(params, "StackName")
     if not stack_name:
@@ -418,6 +430,8 @@ def _get_template(params):
 # --- DeleteStack ---
 
 def _delete_stack(params):
+    if admission_error := _mutation_admission_error():
+        return admission_error
     from ministack.services.cloudformation import _stacks
     stack_name = _p(params, "StackName")
     if not stack_name:
@@ -460,6 +474,8 @@ def _delete_stack(params):
 # --- UpdateStack ---
 
 def _update_stack(params):
+    if admission_error := _mutation_admission_error():
+        return admission_error
     from ministack.services.cloudformation import _stacks
     stack_name = _p(params, "StackName")
     if not stack_name:

--- a/ministack/services/cloudformation/helpers.py
+++ b/ministack/services/cloudformation/helpers.py
@@ -43,6 +43,19 @@ def _error(code, message, status=400):
     return status, {"Content-Type": "application/xml"}, body
 
 
+def _mutation_admission_error():
+    """Return a 503 while reset has closed stack-task admission."""
+    from .lifecycle import _get_stack_task_lifecycle
+
+    if _get_stack_task_lifecycle().is_accepting():
+        return None
+    return _error(
+        "ServiceUnavailableException",
+        "CloudFormation mutations are unavailable while MiniStack resets.",
+        503,
+    )
+
+
 def _extract_members(params, prefix):
     """Extract Parameters.member.N.Key/Value or Tags.member.N.Key/Value."""
     result = []

--- a/ministack/services/cloudformation/lifecycle.py
+++ b/ministack/services/cloudformation/lifecycle.py
@@ -5,6 +5,10 @@ import asyncio
 from ministack.core.concurrency import LoopLocal
 
 
+class StackTaskAdmissionClosed(RuntimeError):
+    """Raised when code tries to spawn stack work during reset."""
+
+
 class _StackTaskLifecycle:
     """Track stack lifecycle tasks and close their admission during reset."""
 
@@ -16,16 +20,19 @@ class _StackTaskLifecycle:
         # Check and insertion are synchronous on the server loop: reset cannot
         # close admission between them.
         if not self._accepting:
-            # The enclosing request may already have written stack metadata;
-            # reset's subsequent state wipe removes it after task quiescence.
             coro.close()
-            return None
+            raise StackTaskAdmissionClosed(
+                "CloudFormation stack task admission is closed for reset"
+            )
         task = asyncio.get_running_loop().create_task(coro)
         self._tasks.add(task)
         # Keep this lifecycle alive for as long as one of its tasks exists;
         # LoopLocal intentionally stores only weak values for loop collection.
         task.add_done_callback(self._task_finished)
         return task
+
+    def is_accepting(self):
+        return self._accepting
 
     def _task_finished(self, task):
         self._tasks.discard(task)

--- a/ministack/services/cloudformation/lifecycle.py
+++ b/ministack/services/cloudformation/lifecycle.py
@@ -1,0 +1,63 @@
+"""CloudFormation stack-task admission and reset lifecycle."""
+
+import asyncio
+
+from ministack.core.concurrency import LoopLocal
+
+
+class _StackTaskLifecycle:
+    """Track stack lifecycle tasks and close their admission during reset."""
+
+    def __init__(self):
+        self._accepting = True
+        self._tasks = set()
+
+    def create_task(self, coro):
+        # Check and insertion are synchronous on the server loop: reset cannot
+        # close admission between them.
+        if not self._accepting:
+            # The enclosing request may already have written stack metadata;
+            # reset's subsequent state wipe removes it after task quiescence.
+            coro.close()
+            return None
+        task = asyncio.get_running_loop().create_task(coro)
+        self._tasks.add(task)
+        # Keep this lifecycle alive for as long as one of its tasks exists;
+        # LoopLocal intentionally stores only weak values for loop collection.
+        task.add_done_callback(self._task_finished)
+        return task
+
+    def _task_finished(self, task):
+        self._tasks.discard(task)
+
+    async def begin_reset(self):
+        """Close admission, cancel active tasks, and await full unwinding."""
+        self._accepting = False
+        tasks = tuple(self._tasks)
+        for task in tasks:
+            task.cancel()
+        if not tasks:
+            return
+
+        waiter = asyncio.ensure_future(asyncio.gather(*tasks, return_exceptions=True))
+        try:
+            await asyncio.shield(waiter)
+        except asyncio.CancelledError as cancellation:
+            # Stack tasks may be inside an uncancellable worker. Repeated reset
+            # cancellation must not let the state wipe overtake that worker.
+            while not waiter.done():
+                try:
+                    await asyncio.shield(waiter)
+                except asyncio.CancelledError:
+                    continue
+            raise cancellation
+
+    def finish_reset(self):
+        self._accepting = True
+
+
+_stack_task_lifecycles = LoopLocal(_StackTaskLifecycle)
+
+
+def _get_stack_task_lifecycle() -> _StackTaskLifecycle:
+    return _stack_task_lifecycles.get()

--- a/ministack/services/cloudformation/provisioners.py
+++ b/ministack/services/cloudformation/provisioners.py
@@ -1587,6 +1587,80 @@ def _cfn_wait_condition_handle_create(logical_id, props, stack_name):
 
 # --- CloudFormation Nested Stack (AWS::CloudFormation::Stack) ---
 
+def _nested_stack_provision_child(resource_type, logical_id, props, stack_name):
+    from ministack.services.cloudformation.stacks import (
+        _STANDARD_PROVISIONER_SERVICES,
+        _run_locked_standard_provisioner_sync,
+    )
+
+    if resource_type in _STANDARD_PROVISIONER_SERVICES:
+        return _run_locked_standard_provisioner_sync(
+            resource_type,
+            _provision_resource,
+            resource_type,
+            logical_id,
+            props,
+            stack_name,
+        )
+    return _provision_resource(resource_type, logical_id, props, stack_name)
+
+
+def _nested_stack_update_child(
+    resource_type, physical_id, old_props, new_props, stack_name, logical_id
+):
+    from ministack.services.cloudformation.stacks import (
+        _STANDARD_PROVISIONER_SERVICES,
+        _run_locked_standard_provisioner_sync,
+    )
+
+    if resource_type in _STANDARD_PROVISIONER_SERVICES:
+        return _run_locked_standard_provisioner_sync(
+            resource_type,
+            _update_resource,
+            resource_type,
+            physical_id,
+            old_props,
+            new_props,
+            stack_name,
+            logical_id,
+        )
+    return _update_resource(
+        resource_type,
+        physical_id,
+        old_props,
+        new_props,
+        stack_name,
+        logical_id,
+    )
+
+
+def _nested_stack_delete_child(
+    resource_type, physical_id, props, stack_name, logical_id
+):
+    from ministack.services.cloudformation.stacks import (
+        _STANDARD_PROVISIONER_SERVICES,
+        _run_locked_standard_provisioner_sync,
+    )
+
+    if resource_type in _STANDARD_PROVISIONER_SERVICES:
+        return _run_locked_standard_provisioner_sync(
+            resource_type,
+            _delete_resource,
+            resource_type,
+            physical_id,
+            props,
+            stack_name,
+            logical_id,
+        )
+    return _delete_resource(
+        resource_type,
+        physical_id,
+        props,
+        stack_name,
+        logical_id,
+    )
+
+
 def _cfn_nested_stack_deploy(logical_id, props, parent_stack_name, *,
                              previous_physical_id=None, previous_props=None):
     """Provision an `AWS::CloudFormation::Stack` nested-stack resource.
@@ -1729,13 +1803,13 @@ def _cfn_nested_stack_deploy(logical_id, props, parent_stack_name, *,
         try:
             prev = prev_resources.get(child_logical_id)
             if prev:
-                physical_id, attrs = _update_resource(
+                physical_id, attrs = _nested_stack_update_child(
                     resource_type, prev.get("PhysicalResourceId", child_logical_id),
                     prev.get("Properties", {}), resolved_props, child_name,
                     child_logical_id,
                 )
             else:
-                physical_id, attrs = _provision_resource(
+                physical_id, attrs = _nested_stack_provision_child(
                     resource_type, child_logical_id, resolved_props, child_name,
                 )
         except Exception as exc:
@@ -1763,10 +1837,13 @@ def _cfn_nested_stack_deploy(logical_id, props, parent_stack_name, *,
         for stale_id in set(prev_resources) - set(provisioned):
             old = prev_resources[stale_id]
             try:
-                _delete_resource(old.get("ResourceType", ""),
-                                 old.get("PhysicalResourceId", ""),
-                                 old.get("Properties", {}),
-                                 child_name, stale_id)
+                _nested_stack_delete_child(
+                    old.get("ResourceType", ""),
+                    old.get("PhysicalResourceId", ""),
+                    old.get("Properties", {}),
+                    child_name,
+                    stale_id,
+                )
             except Exception as exc:
                 logger.warning("Nested-stack %s: failed to delete pruned %s: %s",
                                child_name, stale_id, exc)
@@ -1854,7 +1931,7 @@ def _cfn_nested_stack_delete(physical_id, props):
         if not res:
             continue
         try:
-            _delete_resource(
+            _nested_stack_delete_child(
                 res.get("ResourceType", ""),
                 res.get("PhysicalResourceId", ""),
                 res.get("Properties", {}),

--- a/ministack/services/cloudformation/stacks.py
+++ b/ministack/services/cloudformation/stacks.py
@@ -3,12 +3,18 @@ CloudFormation stacks — async stack lifecycle (deploy, delete, update, diff).
 """
 
 import asyncio
+import contextvars
 import copy
 import json
 import logging
 import time
 from contextlib import contextmanager
 
+from ministack.core.concurrency import (
+    LoopLocal,
+    run_in_dedicated_thread_to_completion,
+    run_in_thread_to_completion,
+)
 from ministack.core.responses import get_account_id, get_region, new_uuid, now_iso, set_request_region
 
 from .engine import (
@@ -49,14 +55,147 @@ def _stack_region_context(stack: dict | None, stack_id: str | None = None):
         set_request_region(previous_region)
 
 
+class _StackTaskLifecycle:
+    """Track stack lifecycle tasks and close their admission during reset."""
+
+    def __init__(self):
+        self._accepting = True
+        self._tasks = set()
+
+    def create_task(self, coro):
+        # Check and insertion are synchronous on the server loop: reset cannot
+        # close admission between them.
+        if not self._accepting:
+            # The enclosing request may already have written stack metadata;
+            # reset's subsequent state wipe removes it after task quiescence.
+            coro.close()
+            return None
+        task = asyncio.get_running_loop().create_task(coro)
+        self._tasks.add(task)
+        # Keep this lifecycle alive for as long as one of its tasks exists;
+        # LoopLocal intentionally stores only weak values for loop collection.
+        task.add_done_callback(self._task_finished)
+        return task
+
+    def _task_finished(self, task):
+        self._tasks.discard(task)
+
+    async def begin_reset(self):
+        """Close admission, cancel active tasks, and await full unwinding."""
+        self._accepting = False
+        tasks = tuple(self._tasks)
+        for task in tasks:
+            task.cancel()
+        if not tasks:
+            return
+
+        waiter = asyncio.ensure_future(asyncio.gather(*tasks, return_exceptions=True))
+        try:
+            await asyncio.shield(waiter)
+        except asyncio.CancelledError as cancellation:
+            # Stack tasks may be inside an uncancellable worker. Repeated reset
+            # cancellation must not let the state wipe overtake that worker.
+            while not waiter.done():
+                try:
+                    await asyncio.shield(waiter)
+                except asyncio.CancelledError:
+                    continue
+            raise cancellation
+
+    def finish_reset(self):
+        self._accepting = True
+
+
+_stack_task_lifecycles = LoopLocal(_StackTaskLifecycle)
+
+
+def _get_stack_task_lifecycle() -> _StackTaskLifecycle:
+    return _stack_task_lifecycles.get()
+
+
 def _create_stack_task_in_region(coro, stack: dict | None, stack_id: str | None = None):
-    """Schedule a stack lifecycle coroutine in the stack's owning region."""
+    """Schedule a tracked stack lifecycle coroutine in its owning region."""
     with _stack_region_context(stack, stack_id):
-        asyncio.get_event_loop().create_task(coro)
+        return _get_stack_task_lifecycle().create_task(coro)
 
 
 def _is_custom_resource(resource_type: str) -> bool:
     return resource_type.startswith("Custom::") or resource_type == "AWS::CloudFormation::CustomResource"
+
+
+_STANDARD_PROVISIONER_SERVICES = {
+    "AWS::ECS::Cluster": "ecs",
+    "AWS::ECS::TaskDefinition": "ecs",
+    "AWS::ECS::Service": "ecs",
+    "AWS::RDS::DBCluster": "rds",
+    "AWS::RDS::DBInstance": "rds",
+    "AWS::EKS::Cluster": "eks",
+    "AWS::EKS::Nodegroup": "eks",
+    "AWS::OpenSearchService::Domain": "opensearch",
+}
+
+_NESTED_STACK_RESOURCE_TYPE = "AWS::CloudFormation::Stack"
+_nested_stack_server_loop = contextvars.ContextVar(
+    "cloudformation_nested_stack_server_loop",
+    default=None,
+)
+
+
+def _standard_provisioner_admission_lock(resource_type: str):
+    service_name = _STANDARD_PROVISIONER_SERVICES[resource_type]
+    if service_name == "ecs":
+        from ministack.services import ecs as service
+    elif service_name == "rds":
+        from ministack.services import rds as service
+    elif service_name == "eks":
+        from ministack.services import eks as service
+    else:
+        from ministack.services import opensearch as service
+    return service._get_request_dispatch_lock()
+
+
+async def _run_locked_standard_provisioner(resource_type, operation, *args):
+    """Run a Docker-backed standard provisioner under its service admission lock."""
+    async with _standard_provisioner_admission_lock(resource_type):
+        return await run_in_thread_to_completion(operation, *args)
+
+
+def _run_locked_standard_provisioner_sync(resource_type, operation, *args):
+    """Marshal one nested-stack child onto the server admission seam."""
+    server_loop = _nested_stack_server_loop.get()
+    if server_loop is None:
+        raise RuntimeError("nested CloudFormation provisioner has no server loop")
+    try:
+        running_loop = asyncio.get_running_loop()
+    except RuntimeError:
+        running_loop = None
+    if running_loop is server_loop:
+        raise RuntimeError("nested CloudFormation provisioner cannot marshal from the server loop")
+    if server_loop.is_closed():
+        raise RuntimeError("nested CloudFormation server loop is closed")
+
+    coro = _run_locked_standard_provisioner(resource_type, operation, *args)
+    try:
+        future = asyncio.run_coroutine_threadsafe(coro, server_loop)
+    except BaseException:
+        coro.close()
+        raise
+    return future.result()
+
+
+async def _run_nested_stack_provisioner(operation, *args):
+    """Run the top-level nested core off-loop; deeper recursion stays inline."""
+    server_loop = asyncio.get_running_loop()
+
+    def install_server_loop():
+        _nested_stack_server_loop.set(server_loop)
+
+    return await run_in_dedicated_thread_to_completion(
+        operation,
+        *args,
+        thread_name="ministack-cfn-nested-stack",
+        context_setup=install_server_loop,
+    )
 
 
 # ===========================================================================
@@ -161,9 +300,19 @@ async def _deploy_stack_async(stack_name: str, stack_id: str, template: dict,
                 old_pid = prev_resource.get("PhysicalResourceId", logical_id)
                 old_props = prev_resource.get("Properties", {})
                 if _is_custom_resource(resource_type):
-                    physical_id, attrs = await asyncio.to_thread(
+                    physical_id, attrs = await run_in_thread_to_completion(
                         _update_resource, resource_type, old_pid, old_props,
                         resolved_props, stack_name, logical_id
+                    )
+                elif resource_type == _NESTED_STACK_RESOURCE_TYPE:
+                    physical_id, attrs = await _run_nested_stack_provisioner(
+                        _update_resource, resource_type, old_pid, old_props,
+                        resolved_props, stack_name, logical_id
+                    )
+                elif resource_type in _STANDARD_PROVISIONER_SERVICES:
+                    physical_id, attrs = await _run_locked_standard_provisioner(
+                        resource_type, _update_resource, resource_type, old_pid,
+                        old_props, resolved_props, stack_name, logical_id
                     )
                 else:
                     physical_id, attrs = _update_resource(
@@ -172,8 +321,18 @@ async def _deploy_stack_async(stack_name: str, stack_id: str, template: dict,
                     )
             else:
                 if _is_custom_resource(resource_type):
-                    physical_id, attrs = await asyncio.to_thread(
+                    physical_id, attrs = await run_in_thread_to_completion(
                         _provision_resource, resource_type, logical_id, resolved_props, stack_name
+                    )
+                elif resource_type == _NESTED_STACK_RESOURCE_TYPE:
+                    physical_id, attrs = await _run_nested_stack_provisioner(
+                        _provision_resource, resource_type, logical_id,
+                        resolved_props, stack_name
+                    )
+                elif resource_type in _STANDARD_PROVISIONER_SERVICES:
+                    physical_id, attrs = await _run_locked_standard_provisioner(
+                        resource_type, _provision_resource, resource_type,
+                        logical_id, resolved_props, stack_name
                     )
                 else:
                     physical_id, attrs = _provision_resource(
@@ -212,8 +371,18 @@ async def _deploy_stack_async(stack_name: str, stack_id: str, template: dict,
             old_props = old_res.get("Properties", {})
             try:
                 if _is_custom_resource(rtype):
-                    await asyncio.to_thread(
+                    await run_in_thread_to_completion(
                         _delete_resource, rtype, pid, old_props,
+                        stack_name, logical_id
+                    )
+                elif rtype == _NESTED_STACK_RESOURCE_TYPE:
+                    await _run_nested_stack_provisioner(
+                        _delete_resource, rtype, pid, old_props,
+                        stack_name, logical_id
+                    )
+                elif rtype in _STANDARD_PROVISIONER_SERVICES:
+                    await _run_locked_standard_provisioner(
+                        rtype, _delete_resource, rtype, pid, old_props,
                         stack_name, logical_id
                     )
                 else:
@@ -246,8 +415,18 @@ async def _deploy_stack_async(stack_name: str, stack_id: str, template: dict,
                 res_props = res.get("Properties", {})
                 try:
                     if _is_custom_resource(rtype):
-                        await asyncio.to_thread(
+                        await run_in_thread_to_completion(
                             _delete_resource, rtype, pid, res_props,
+                            stack_name, logical_id
+                        )
+                    elif rtype == _NESTED_STACK_RESOURCE_TYPE:
+                        await _run_nested_stack_provisioner(
+                            _delete_resource, rtype, pid, res_props,
+                            stack_name, logical_id
+                        )
+                    elif rtype in _STANDARD_PROVISIONER_SERVICES:
+                        await _run_locked_standard_provisioner(
+                            rtype, _delete_resource, rtype, pid, res_props,
                             stack_name, logical_id
                         )
                     else:
@@ -354,8 +533,18 @@ async def _delete_stack_async(stack_name: str, stack_id: str):
                    "DELETE_IN_PROGRESS", physical_id=pid)
         try:
             if _is_custom_resource(rtype):
-                await asyncio.to_thread(
+                await run_in_thread_to_completion(
                     _delete_resource, rtype, pid, res_props,
+                    stack_name, logical_id
+                )
+            elif rtype == _NESTED_STACK_RESOURCE_TYPE:
+                await _run_nested_stack_provisioner(
+                    _delete_resource, rtype, pid, res_props,
+                    stack_name, logical_id
+                )
+            elif rtype in _STANDARD_PROVISIONER_SERVICES:
+                await _run_locked_standard_provisioner(
+                    rtype, _delete_resource, rtype, pid, res_props,
                     stack_name, logical_id
                 )
             else:

--- a/ministack/services/cloudformation/stacks.py
+++ b/ministack/services/cloudformation/stacks.py
@@ -11,7 +11,6 @@ import time
 from contextlib import contextmanager
 
 from ministack.core.concurrency import (
-    LoopLocal,
     run_in_dedicated_thread_to_completion,
     run_in_thread_to_completion,
 )
@@ -25,6 +24,7 @@ from .engine import (
     _resolve_refs,
     _topological_sort,
 )
+from .lifecycle import _get_stack_task_lifecycle
 from .provisioners import _delete_resource, _provision_resource, _update_resource
 
 logger = logging.getLogger("cloudformation")
@@ -53,64 +53,6 @@ def _stack_region_context(stack: dict | None, stack_id: str | None = None):
         yield
     finally:
         set_request_region(previous_region)
-
-
-class _StackTaskLifecycle:
-    """Track stack lifecycle tasks and close their admission during reset."""
-
-    def __init__(self):
-        self._accepting = True
-        self._tasks = set()
-
-    def create_task(self, coro):
-        # Check and insertion are synchronous on the server loop: reset cannot
-        # close admission between them.
-        if not self._accepting:
-            # The enclosing request may already have written stack metadata;
-            # reset's subsequent state wipe removes it after task quiescence.
-            coro.close()
-            return None
-        task = asyncio.get_running_loop().create_task(coro)
-        self._tasks.add(task)
-        # Keep this lifecycle alive for as long as one of its tasks exists;
-        # LoopLocal intentionally stores only weak values for loop collection.
-        task.add_done_callback(self._task_finished)
-        return task
-
-    def _task_finished(self, task):
-        self._tasks.discard(task)
-
-    async def begin_reset(self):
-        """Close admission, cancel active tasks, and await full unwinding."""
-        self._accepting = False
-        tasks = tuple(self._tasks)
-        for task in tasks:
-            task.cancel()
-        if not tasks:
-            return
-
-        waiter = asyncio.ensure_future(asyncio.gather(*tasks, return_exceptions=True))
-        try:
-            await asyncio.shield(waiter)
-        except asyncio.CancelledError as cancellation:
-            # Stack tasks may be inside an uncancellable worker. Repeated reset
-            # cancellation must not let the state wipe overtake that worker.
-            while not waiter.done():
-                try:
-                    await asyncio.shield(waiter)
-                except asyncio.CancelledError:
-                    continue
-            raise cancellation
-
-    def finish_reset(self):
-        self._accepting = True
-
-
-_stack_task_lifecycles = LoopLocal(_StackTaskLifecycle)
-
-
-def _get_stack_task_lifecycle() -> _StackTaskLifecycle:
-    return _stack_task_lifecycles.get()
 
 
 def _create_stack_task_in_region(coro, stack: dict | None, stack_id: str | None = None):

--- a/ministack/services/ecs.py
+++ b/ministack/services/ecs.py
@@ -23,6 +23,7 @@ Supports 47 operations:
 Container execution: if Docker socket is available, RunTask actually runs containers.
 """
 
+import asyncio
 import copy
 import json
 import logging
@@ -32,6 +33,7 @@ import threading
 import time
 
 from ministack.core.arn import ArnParseError, parse_arn
+from ministack.core.concurrency import LoopLocal, run_in_thread_to_completion
 from ministack.core.persistence import load_state
 from ministack.core.responses import (
     AccountRegionScopedDict,
@@ -68,6 +70,13 @@ _capacity_providers = AccountRegionScopedDict()
 _attributes = AccountRegionScopedDict()
 
 _docker = None
+# Requests previously ran synchronously on the shared event loop. Keep that
+# one-at-a-time state ordering without occupying worker threads while queued.
+_request_dispatch_locks = LoopLocal(asyncio.Lock)
+
+
+def _get_request_dispatch_lock():
+    return _request_dispatch_locks.get()
 
 # ECS exited-container reaper. Every ministack=ecs container we start via
 # RunTask lingers after its command exits (docker-py detach=True without
@@ -296,6 +305,18 @@ def _finalize_ecs_response(response):
 
 
 async def handle_request(method, path, headers, body, query_params):
+    async with _get_request_dispatch_lock():
+        return await run_in_thread_to_completion(
+            _handle_request_unlocked,
+            method,
+            path,
+            headers,
+            body,
+            query_params,
+        )
+
+
+def _handle_request_unlocked(method, path, headers, body, query_params):
     try:
         data = json.loads(body) if body else {}
     except json.JSONDecodeError:

--- a/ministack/services/eks.py
+++ b/ministack/services/eks.py
@@ -13,6 +13,7 @@ Supports:
   Tags:       TagResource, UntagResource, ListTagsForResource
 """
 
+import asyncio
 import base64
 import copy
 import importlib
@@ -25,6 +26,7 @@ import time
 import urllib.parse
 
 from ministack.core.arn import ArnParseError, parse_arn
+from ministack.core.concurrency import LoopLocal, run_in_thread_to_completion
 from ministack.core.persistence import load_state
 from ministack.core.responses import (
     AccountRegionScopedDict,
@@ -68,6 +70,13 @@ _port_counter_lock = threading.Lock()
 _port_counter = [EKS_BASE_PORT]
 _oidc_keypair_lock = threading.Lock()
 _oidc_keypair = None                  # (private_key, jwk_dict, kid)
+# Requests previously ran synchronously on the shared event loop. Keep that
+# one-at-a-time state ordering without occupying worker threads while queued.
+_request_dispatch_locks = LoopLocal(asyncio.Lock)
+
+
+def _get_request_dispatch_lock():
+    return _request_dispatch_locks.get()
 
 
 def _ministack_issuer_base():
@@ -1455,6 +1464,18 @@ def _sanitize(cluster):
 # ---------------------------------------------------------------------------
 
 async def handle_request(method, path, headers, body_bytes, query_params):
+    async with _get_request_dispatch_lock():
+        return await run_in_thread_to_completion(
+            _handle_request_unlocked,
+            method,
+            path,
+            headers,
+            body_bytes,
+            query_params,
+        )
+
+
+def _handle_request_unlocked(method, path, headers, body_bytes, query_params):
     try:
         body = json.loads(body_bytes) if body_bytes else {}
     except json.JSONDecodeError:

--- a/ministack/services/elasticache.py
+++ b/ministack/services/elasticache.py
@@ -20,6 +20,7 @@ When Docker is available, CreateCacheCluster spins up a real Redis/Valkey/Memcac
 container. Otherwise returns localhost:6379 (assumes Redis sidecar in docker-compose).
 """
 
+import asyncio
 import copy
 import logging
 import os
@@ -27,6 +28,7 @@ import time
 from urllib.parse import parse_qs
 
 from ministack.core.arn import ArnParseError, parse_arn
+from ministack.core.concurrency import LoopLocal, run_in_thread_to_completion
 from ministack.core.persistence import load_state
 from ministack.core.responses import (
     AccountRegionScopedDict,
@@ -148,6 +150,13 @@ _pending_rg_respawn: set = set()
 import threading as _threading
 
 _respawn_lock = _threading.Lock()
+# Requests previously ran synchronously on the shared event loop. Keep that
+# one-at-a-time state ordering without occupying worker threads while queued.
+_request_dispatch_locks = LoopLocal(asyncio.Lock)
+
+
+def _get_request_dispatch_lock():
+    return _request_dispatch_locks.get()
 
 
 def _as_region_scoped(incoming):
@@ -811,6 +820,18 @@ def _record_event(source_id, source_type, message):
 
 
 async def handle_request(method, path, headers, body, query_params):
+    async with _get_request_dispatch_lock():
+        return await run_in_thread_to_completion(
+            _handle_request_unlocked,
+            method,
+            path,
+            headers,
+            body,
+            query_params,
+        )
+
+
+def _handle_request_unlocked(method, path, headers, body, query_params):
     # Lazy-respawn any clusters / replication groups that were restored
     # from disk (issue #853). Cheap fast-path when nothing's pending.
     _ensure_live_containers()

--- a/ministack/services/eventbridge.py
+++ b/ministack/services/eventbridge.py
@@ -20,7 +20,9 @@ Supports: CreateEventBus, UpdateEventBus, DeleteEventBus, ListEventBuses, Descri
           ListEventSources, PutPartnerEvents.
 """
 
+import asyncio
 import calendar
+import contextvars
 import copy
 import fnmatch
 import hashlib
@@ -913,6 +915,10 @@ def _resolve_taggable_events_arn(arn):
 
 
 def _put_events(data):
+    try:
+        server_loop = asyncio.get_running_loop()
+    except RuntimeError:
+        server_loop = None
     entries = data.get("Entries", [])
     # AWS spec: PutEvents.Entries list min=1 max=10. Real AWS rejects with
     # ValidationException; matching that here so SDKs see the same constraint.
@@ -953,7 +959,7 @@ def _put_events(data):
         results.append({"EventId": event_id})
         logger.debug("EventBridge event: %s / %s", entry.get('Source'), entry.get('DetailType'))
 
-        _dispatch_event(event_record)
+        _dispatch_event(event_record, server_loop=server_loop)
         _archive_event(event_record)
 
     return json_response({"FailedEntryCount": failed, "Entries": results})
@@ -972,7 +978,7 @@ def _archive_event(event):
         archive["EventCount"] = archive.get("EventCount", 0) + 1
 
 
-def _dispatch_event(event):
+def _dispatch_event(event, *, server_loop):
     bus_name = event.get("EventBusName", "default")
     event_path = set(event.get("_DispatchPath") or [])
 
@@ -990,7 +996,10 @@ def _dispatch_event(event):
         if _matches_pattern(rule["EventPattern"], event):
             rule_targets = _targets.get(key, [])
             for target in rule_targets:
-                _invoke_target(target, event, rule)
+                if server_loop is None:
+                    _invoke_target(target, event, rule)
+                else:
+                    _invoke_target(target, event, rule, server_loop=server_loop)
 
 
 def _matches_pattern(pattern_str, event):
@@ -1140,7 +1149,7 @@ def _matches_content_filter(value, filter_rule):
     return False
 
 
-def _invoke_target(target, event, rule):
+def _invoke_target(target, event, rule, *, server_loop=None):
     arn = target.get("Arn", "")
     event_path = set(event.get("_DispatchPath") or [])
 
@@ -1191,9 +1200,16 @@ def _invoke_target(target, event, rule):
             return
 
         if spec.service == "events":
-            _dispatch_to_event_bus(spec, event, rule, event_path, target_input_payload)
+            _dispatch_to_event_bus(
+                spec,
+                event,
+                rule,
+                event_path,
+                target_input_payload,
+                server_loop=server_loop,
+            )
         elif spec.service == "states":
-            _dispatch_to_stepfunctions(arn, event_payload)
+            _dispatch_to_stepfunctions(arn, event_payload, server_loop)
         elif not _target_matches_request_scope(spec):
             # AWS parity: EventBridge accepts cross-region SNS/SQS targets at PutTargets, then records a
             # FailedInvocations delivery failure without cross-region delivery. MiniStack does not model
@@ -1222,7 +1238,15 @@ def _target_matches_request_scope(spec) -> bool:
     return spec.account_id == get_account_id() and spec.region == get_region()
 
 
-def _dispatch_to_event_bus(spec, event, rule, event_path, target_input_payload=None):
+def _dispatch_to_event_bus(
+    spec,
+    event,
+    rule,
+    event_path,
+    target_input_payload=None,
+    *,
+    server_loop=None,
+):
     if spec.service != "events" or not spec.resource.startswith("event-bus/"):
         logger.warning("EventBridge -> Event bus: unsupported event target ARN %s", spec)
         return
@@ -1245,7 +1269,7 @@ def _dispatch_to_event_bus(spec, event, rule, event_path, target_input_payload=N
     forwarded["_DispatchPath"] = [*event_path, source_rule_key]
     if target_input_payload is not None:
         forwarded["Detail"] = target_input_payload
-    _dispatch_event(forwarded)
+    _dispatch_event(forwarded, server_loop=server_loop)
     archived = dict(forwarded)
     archived.pop("_DispatchPath", None)
     _archive_event(archived)
@@ -1407,7 +1431,7 @@ def _dispatch_to_sns(arn, payload):
     logger.info("EventBridge → SNS %s", arn)
 
 
-def _dispatch_to_stepfunctions(arn, payload):
+def _dispatch_to_stepfunctions(arn, payload, server_loop=None):
     from ministack.services import stepfunctions as _sfn
 
     # Accept all three SFN target ARN shapes EventBridge supports in real
@@ -1419,10 +1443,13 @@ def _dispatch_to_stepfunctions(arn, payload):
         return
 
     sm_name = arn.rsplit(":", 1)[-1]
-    _sfn._start_execution({
-        "stateMachineArn": arn,
-        "input": payload,
-    })
+    _sfn._start_execution_with_server_loop(
+        {
+            "stateMachineArn": arn,
+            "input": payload,
+        },
+        server_loop,
+    )
     logger.info("EventBridge → Step Functions %s: dispatched", sm_name)
 
 
@@ -1563,6 +1590,10 @@ def _list_archives(data):
 # ---------------------------------------------------------------------------
 
 def _start_replay(data):
+    try:
+        server_loop = asyncio.get_running_loop()
+    except RuntimeError:
+        server_loop = None
     name = data.get("ReplayName")
     if not name:
         return error_response_json("ValidationException", "ReplayName is required", 400)
@@ -1635,14 +1666,15 @@ def _start_replay(data):
                     continue
                 replayed = dict(event)
                 replayed["EventBusName"] = dest_bus_name
-                _dispatch_event(replayed)
+                _dispatch_event(replayed, server_loop=server_loop)
             replay["State"] = "COMPLETED"
             replay["ReplayEndTime"] = _now_ts()
         finally:
             set_request_account_id(previous_account)
             set_request_region(previous_region)
 
-    t = threading.Thread(target=_run, daemon=True)
+    replay_context = contextvars.copy_context()
+    t = threading.Thread(target=replay_context.run, args=(_run,), daemon=True)
     t.start()
 
     # Real AWS StartReplay returns the initial state STARTING; the
@@ -2454,7 +2486,7 @@ def _cron_next_fire(fields, after_dt: datetime) -> datetime | None:
     return None
 
 
-def _tick_scheduled_rules():
+def _tick_scheduled_rules(server_loop=None):
     """Fire any enabled scheduled rule whose interval has elapsed."""
     now = _now_ts()
     now_dt = datetime.fromtimestamp(now, tz=timezone.utc)
@@ -2535,7 +2567,15 @@ def _tick_scheduled_rules():
             }
             for target in targets:
                 try:
-                    _invoke_target(target, event, rule)
+                    if server_loop is None:
+                        _invoke_target(target, event, rule)
+                    else:
+                        _invoke_target(
+                            target,
+                            event,
+                            rule,
+                            server_loop=server_loop,
+                        )
                 except Exception:
                     logger.exception(
                         "EventBridge scheduler: dispatch error for rule %s account %s",
@@ -2546,29 +2586,55 @@ def _tick_scheduled_rules():
             set_request_region(previous_region)
 
 
-def _scheduler_loop():
-    while True:
-        time.sleep(_SCHEDULER_TICK_INTERVAL)
+def _scheduler_loop(server_loop, stop_event):
+    while not stop_event.wait(_SCHEDULER_TICK_INTERVAL):
         try:
-            _tick_scheduled_rules()
+            _tick_scheduled_rules(server_loop)
         except Exception:
             logger.exception("EventBridge scheduler tick error")
 
 
 _scheduler_thread: "threading.Thread | None" = None
+_scheduler_stop_event: "threading.Event | None" = None
 
 
 def start_scheduler() -> None:
     """Start the eb-scheduler daemon thread (idempotent). Called from the
     gateway lifespan.startup. Kept out of module-import scope so unit tests
     that patch ``_invoke_target`` don't race against a background tick."""
-    global _scheduler_thread
+    global _scheduler_stop_event, _scheduler_thread
     if _scheduler_thread is not None and _scheduler_thread.is_alive():
         return
+    try:
+        server_loop = asyncio.get_running_loop()
+    except RuntimeError:
+        # Direct unit callers may start the ticker without an ASGI lifecycle.
+        # Any SFN target then retains the defined States.Runtime backstop.
+        server_loop = None
+    _scheduler_stop_event = threading.Event()
     _scheduler_thread = threading.Thread(
-        target=_scheduler_loop, daemon=True, name="eb-scheduler"
+        target=_scheduler_loop,
+        args=(server_loop, _scheduler_stop_event),
+        daemon=True,
+        name="eb-scheduler",
     )
     _scheduler_thread.start()
+
+
+def stop_scheduler() -> None:
+    """Stop the lifecycle-owned scheduler so a new app gets a fresh loop."""
+    global _scheduler_stop_event, _scheduler_thread
+    thread = _scheduler_thread
+    stop_event = _scheduler_stop_event
+    if stop_event is not None:
+        stop_event.set()
+    if thread is not None and thread is not threading.current_thread():
+        # Lifespan shutdown runs this helper off the event loop.  Retain
+        # ownership until the prior scheduler has fully exited so a restarted
+        # app cannot overlap a stale thread carrying the closed loop.
+        thread.join()
+    _scheduler_thread = None
+    _scheduler_stop_event = None
 
 
 def reset():

--- a/ministack/services/mwaa.py
+++ b/ministack/services/mwaa.py
@@ -22,6 +22,7 @@ import threading
 import time
 
 from ministack.core.arn import ArnParseError, parse_arn
+from ministack.core.concurrency import run_in_thread_to_completion
 from ministack.core.persistence import load_state
 from ministack.core.responses import (
     AccountRegionScopedDict,
@@ -657,7 +658,7 @@ async def _invoke_rest_api(method, path, headers, body, query_params):
         return req_lib.delete(url, headers=req_headers, timeout=30)
 
     try:
-        resp = await asyncio.to_thread(_do_call)
+        resp = await run_in_thread_to_completion(_do_call)
         ctype = resp.headers.get("content-type", "")
         payload = resp.json() if ctype.startswith("application/json") else {"body": resp.text}
         return json_response({

--- a/ministack/services/opensearch.py
+++ b/ministack/services/opensearch.py
@@ -18,6 +18,7 @@ State is account- and region-scoped via AccountRegionScopedDict, except tags
 which stay account-scoped because their ARN keys embed region.
 """
 
+import asyncio
 import copy
 import json
 import logging
@@ -27,6 +28,7 @@ import threading
 import time
 
 from ministack.core.arn import ArnParseError, parse_arn
+from ministack.core.concurrency import LoopLocal, run_in_thread_to_completion
 from ministack.core.persistence import load_state
 from ministack.core.responses import (
     AccountRegionScopedDict,
@@ -115,6 +117,13 @@ _port_counter = [BASE_PORT]
 _dashboards_port_counter = [DASHBOARDS_BASE_PORT]
 _state_lock = threading.Lock()
 _docker_client = None
+# Requests previously ran synchronously on the shared event loop. Keep that
+# one-at-a-time state ordering without occupying worker threads while queued.
+_request_dispatch_locks = LoopLocal(asyncio.Lock)
+
+
+def _get_request_dispatch_lock():
+    return _request_dispatch_locks.get()
 
 
 class OpenSearchServiceError(ValueError):
@@ -1199,6 +1208,18 @@ def _list_packages_for_domain(domain_name, query_params):
 # ---------------------------------------------------------------------------
 
 async def handle_request(method, path, headers, body_bytes, query_params):
+    async with _get_request_dispatch_lock():
+        return await run_in_thread_to_completion(
+            _handle_request_unlocked,
+            method,
+            path,
+            headers,
+            body_bytes,
+            query_params,
+        )
+
+
+def _handle_request_unlocked(method, path, headers, body_bytes, query_params):
     body_text = body_bytes.decode("utf-8") if body_bytes else ""
     try:
         payload = json.loads(body_text) if body_text else {}

--- a/ministack/services/rds.py
+++ b/ministack/services/rds.py
@@ -32,6 +32,7 @@ clients can call DescribeDBInstances and other operations without ``Action=`` qu
 parameters.
 """
 
+import asyncio
 import contextvars
 import copy
 import datetime
@@ -46,6 +47,7 @@ from urllib.parse import parse_qs
 from xml.sax.saxutils import escape as _esc
 
 from ministack.core.arn import ArnParseError, parse_arn
+from ministack.core.concurrency import LoopLocal, run_in_thread_to_completion
 from ministack.core.persistence import load_state
 from ministack.core.responses import (
     AccountRegionScopedDict,
@@ -86,6 +88,13 @@ _port_counter = [BASE_PORT]
 _docker = None
 _ministack_network = None
 _shared_container_lock = threading.RLock()
+# Requests previously ran synchronously on the shared event loop. Keep that
+# one-at-a-time state ordering without occupying worker threads while queued.
+_request_dispatch_locks = LoopLocal(asyncio.Lock)
+
+
+def _get_request_dispatch_lock():
+    return _request_dispatch_locks.get()
 
 _MYSQL_REPLICATION_USER = "rdsrepladmin"
 _MYSQL_REPLICATION_PASSWORD = "ministack-rds-replication"
@@ -2030,6 +2039,18 @@ def _flatten_json_request_params(params, data):
 
 
 async def handle_request(method, path, headers, body, query_params):
+    async with _get_request_dispatch_lock():
+        return await run_in_thread_to_completion(
+            _handle_request_unlocked,
+            method,
+            path,
+            headers,
+            body,
+            query_params,
+        )
+
+
+def _handle_request_unlocked(method, path, headers, body, query_params):
     params = dict(query_params)
     if method == "POST" and body:
         raw = body if isinstance(body, str) else body.decode("utf-8-sig", errors="replace")
@@ -2467,8 +2488,8 @@ def _create_db_instance(p):
         pending_rotation = parent.get("_pending_master_password_rotation")
         if pending_rotation:
             readiness_master_pass = pending_rotation["old_password"]
-        # RDS action dispatch is synchronous and await-free, so this check and
-        # the shared metadata update cannot interleave with another create.
+        # The per-service async admission lock serializes API dispatch, keeping
+        # this check and update from interleaving with another API-driven create.
         resume_control_plane_only = (
             not docker_client
             and not parent.get("DBClusterMembers")

--- a/ministack/services/rds_data.py
+++ b/ministack/services/rds_data.py
@@ -11,6 +11,7 @@ import threading
 import uuid
 
 from ministack.core.arn import ArnParseError, parse_arn
+from ministack.core.concurrency import run_in_thread_to_completion
 from ministack.core.responses import AccountRegionScopedDict, error_response_json, get_account_id, json_response
 
 logger = logging.getLogger("rds-data")
@@ -489,7 +490,26 @@ def _convert_parameters(parameters):
 
 
 async def handle_request(method, path, headers, body, query_params):
-    """Route RDS Data API requests by path."""
+    """Route RDS Data API requests under the RDS admission lock."""
+    # RDS control-plane dispatch now runs in a worker. RDS Data reads cluster
+    # and member records directly (and may fill a member endpoint from its
+    # cluster), so share the RDS admission lock to preserve the event loop's
+    # former serialization with those mutations.
+    from ministack.services import rds
+
+    async with rds._get_request_dispatch_lock():
+        return await run_in_thread_to_completion(
+            _handle_request_unlocked,
+            method,
+            path,
+            headers,
+            body,
+            query_params,
+        )
+
+
+def _handle_request_unlocked(method, path, headers, body, query_params):
+    """Synchronous RDS Data router for locked HTTP and Step Functions paths."""
     try:
         data = json.loads(body) if body else {}
     except (json.JSONDecodeError, TypeError):
@@ -506,6 +526,7 @@ async def handle_request(method, path, headers, body, query_params):
     handler = handlers.get(path)
     if not handler:
         return _error("BadRequestException", f"Unknown RDS Data API path: {path}")
+
     return handler(data)
 
 

--- a/ministack/services/s3.py
+++ b/ministack/services/s3.py
@@ -22,6 +22,7 @@ Supports: CreateBucket, DeleteBucket, ListBuckets, HeadBucket,
 Storage: In-memory (optionally backed by S3_DATA_DIR).
 """
 
+import asyncio
 import base64
 import contextvars
 import copy
@@ -2085,6 +2086,7 @@ def _fire_s3_event(
     size: int = 0,
     etag: str = "",
     deletion_type: str | None = None,
+    server_loop=None,
 ) -> None:
     """Build and deliver an S3 event notification. Best-effort — errors are logged."""
     try:
@@ -2191,7 +2193,7 @@ def _fire_s3_event(
                 previous_region = get_region()
                 set_request_region(bucket_region)
                 try:
-                    _eb._dispatch_event(eb_event)
+                    _eb._dispatch_event(eb_event, server_loop=server_loop)
                 finally:
                     set_request_region(previous_region)
                 logger.debug("S3→EventBridge: %s (%s) for %s/%s", detail_type, event_name, bucket_name, key)
@@ -2301,6 +2303,12 @@ def _fire_s3_event_async(
     """Fire S3 event notification in a background thread (non-blocking)."""
     if bucket_name not in _bucket_notifications:
         return
+    try:
+        server_loop = asyncio.get_running_loop()
+    except RuntimeError:
+        # When S3 is invoked from a Step Functions execution worker, the
+        # copied execution ContextVar remains the downstream fallback.
+        server_loop = None
     # threading.Thread does not copy contextvars, so without this snapshot the
     # worker runs under the default account (000000000000): the account-scoped
     # _bucket_notifications lookup comes back empty and the event is silently
@@ -2310,7 +2318,16 @@ def _fire_s3_event_async(
     ctx = contextvars.copy_context()
     t = threading.Thread(
         target=ctx.run,
-        args=(_fire_s3_event, bucket_name, key, event_name, size, etag, deletion_type),
+        args=(
+            _fire_s3_event,
+            bucket_name,
+            key,
+            event_name,
+            size,
+            etag,
+            deletion_type,
+            server_loop,
+        ),
         daemon=True,
     )
     t.start()

--- a/ministack/services/scheduler.py
+++ b/ministack/services/scheduler.py
@@ -10,6 +10,7 @@ Supports:
   Tags:       TagResource, UntagResource, ListTagsForResource
 """
 
+import asyncio
 import copy
 import json
 import logging
@@ -525,7 +526,7 @@ def _at_time_epoch(expr: str):
     return dt.timestamp()
 
 
-def _tick_schedules():
+def _tick_schedules(server_loop=None):
     """Fire every ENABLED schedule that is due, honoring State, Start/EndDate,
     at()/rate()/cron() expressions and ActionAfterCompletion one-shot delete."""
     from ministack.services import eventbridge as _eb
@@ -599,7 +600,12 @@ def _tick_schedules():
                 "Region": get_region(),
             }
             try:
-                _eb._invoke_target(target, event, sched)
+                _eb._invoke_target(
+                    target,
+                    event,
+                    sched,
+                    server_loop=server_loop,
+                )
             except Exception:
                 logger.exception(
                     "Scheduler dispatch error for %s (account %s, region %s)",
@@ -619,22 +625,47 @@ def _tick_schedules():
         set_request_region(previous_region)
 
 
-def _ticker_loop():
-    while True:
-        time.sleep(_SCHEDULE_TICK_INTERVAL)
+def _ticker_loop(server_loop, stop_event):
+    while not stop_event.wait(_SCHEDULE_TICK_INTERVAL):
         try:
-            _tick_schedules()
+            _tick_schedules(server_loop)
         except Exception:
             logger.exception("Scheduler ticker error")
+
+
+_ticker_stop_event: "threading.Event | None" = None
 
 
 def start_scheduler() -> None:
     """Start the schedule-firing daemon (idempotent). Wired from the gateway
     lifespan.startup, mirroring ``eventbridge.start_scheduler``."""
-    global _ticker_thread
+    global _ticker_stop_event, _ticker_thread
     if _ticker_thread is not None and _ticker_thread.is_alive():
         return
+    try:
+        server_loop = asyncio.get_running_loop()
+    except RuntimeError:
+        # Direct unit callers may start the ticker without an ASGI lifecycle.
+        # Any SFN target then retains the defined States.Runtime backstop.
+        server_loop = None
+    _ticker_stop_event = threading.Event()
     _ticker_thread = threading.Thread(
-        target=_ticker_loop, daemon=True, name="evb-scheduler-ticker"
+        target=_ticker_loop,
+        args=(server_loop, _ticker_stop_event),
+        daemon=True,
+        name="evb-scheduler-ticker",
     )
     _ticker_thread.start()
+
+
+def stop_scheduler() -> None:
+    """Stop the lifecycle-owned scheduler so a new app gets a fresh loop."""
+    global _ticker_stop_event, _ticker_thread
+    thread = _ticker_thread
+    stop_event = _ticker_stop_event
+    if stop_event is not None:
+        stop_event.set()
+    if thread is not None and thread is not threading.current_thread():
+        thread.join()
+    _ticker_thread = None
+    _ticker_stop_event = None

--- a/ministack/services/stepfunctions.py
+++ b/ministack/services/stepfunctions.py
@@ -53,6 +53,15 @@ from ministack.core.responses import (
 
 logger = logging.getLogger("states")
 
+# The loop that owns the admission locks for the current execution.  The value
+# is captured in the request context before an execution thread is spawned, so
+# background and nested execution threads inherit the correct server loop
+# without retaining one globally across app/event-loop lifecycles.
+_execution_server_loop = contextvars.ContextVar(
+    "stepfunctions_execution_server_loop",
+    default=None,
+)
+
 # Scale factor for Wait state durations and retry intervals.
 # 0 = skip all waits, 0.01 = 1% of normal, 1 = normal (default).
 # Set via SFN_WAIT_SCALE environment variable.
@@ -286,7 +295,95 @@ async def handle_request(method, path, headers, body, query_params):
         return error_response_json("InvalidAction", f"Unknown action: {action}", 400)
     if action == "GetActivityTask":
         return _finalize_response(await _get_activity_task(data))
+
+    if action in {"StartExecution", "StartSyncExecution", "TestState"}:
+        try:
+            server_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            # Nested SDK integrations synchronously send-drive this router from
+            # an existing execution thread.  They inherit the outer execution's
+            # server-loop context and must remain inline (especially nested
+            # StartSyncExecution), rather than spawning another thread.
+            return _finalize_response(handler(data))
+
+        loop_token = _execution_server_loop.set(server_loop)
+        try:
+            if action in {"StartSyncExecution", "TestState"}:
+                return _finalize_response(
+                    await _run_sync_action_in_dedicated_thread(handler, data)
+                )
+            return _finalize_response(handler(data))
+        finally:
+            _execution_server_loop.reset(loop_token)
+
     return _finalize_response(handler(data))
+
+
+def _complete_thread_future(future, result=None, error=None):
+    if future.done():
+        return
+    if error is not None:
+        future.set_exception(error)
+    else:
+        future.set_result(result)
+
+
+async def _run_sync_action_in_dedicated_thread(handler, data):
+    """Run a synchronous execution action without consuming the shared pool.
+
+    Execution threads can block while a service integration is marshalled back
+    to the server loop, whose admission wrapper in turn needs a default-executor
+    slot.  A dedicated daemon thread prevents pool-size concurrent synchronous
+    executions from consuming every slot needed by those inner service calls.
+    """
+    loop = asyncio.get_running_loop()
+    result_future = loop.create_future()
+    ctx_snapshot = contextvars.copy_context()
+
+    def run():
+        try:
+            result = ctx_snapshot.run(handler, data)
+        except BaseException as exc:
+            loop.call_soon_threadsafe(
+                _complete_thread_future,
+                result_future,
+                None,
+                exc,
+            )
+        else:
+            loop.call_soon_threadsafe(
+                _complete_thread_future,
+                result_future,
+                result,
+                None,
+            )
+
+    threading.Thread(
+        target=run,
+        name=f"ministack-sfn-{handler.__name__}",
+        daemon=True,
+    ).start()
+
+    try:
+        return await asyncio.shield(result_future)
+    except asyncio.CancelledError as cancellation:
+        # The execution thread cannot be cancelled.  Keep the request task
+        # alive until it finishes so context and completion semantics are not
+        # released early; absorb repeated disconnect cancellations too.
+        while not result_future.done():
+            try:
+                await asyncio.shield(result_future)
+            except asyncio.CancelledError:
+                continue
+            except Exception:
+                break
+
+        if result_future.done() and not result_future.cancelled():
+            try:
+                result_future.result()
+            except Exception:
+                pass
+        raise cancellation
 
 
 # ---------------------------------------------------------------------------
@@ -587,6 +684,27 @@ def _start_execution(data):
 
     logger.info("Step Functions execution started: %s", exec_arn)
     return json_response({"executionArn": exec_arn, "startDate": start_date})
+
+
+def _start_execution_with_server_loop(data, server_loop):
+    """Start an execution from the sanctioned non-HTTP entry point.
+
+    Event sources run outside the Step Functions HTTP router, so seed the
+    server loop explicitly before ``_start_execution`` snapshots context for
+    its execution thread.  A missing or closed loop is intentionally retained
+    in that snapshot: locked-service integrations then fail with the defined
+    ``States.Runtime`` backstop instead of deadlocking or raising an unrelated
+    attribute error.
+    """
+    if server_loop is None:
+        # A nested non-HTTP source (for example aws-sdk:events PutEvents from
+        # an existing execution thread) inherits the outer execution context.
+        server_loop = _execution_server_loop.get()
+    loop_token = _execution_server_loop.set(server_loop)
+    try:
+        return _start_execution(data)
+    finally:
+        _execution_server_loop.reset(loop_token)
 
 
 def _stop_execution(data):
@@ -4159,7 +4277,11 @@ def _invoke_ecs_run_task(resource, input_data):
         logger.warning("ecs module unavailable; returning passthrough")
         return input_data
     ecs_data = _pascal_to_camel(input_data)
-    status, _, body = ecs._run_task(ecs_data)
+    status, _, body = _invoke_ecs_action_through_admission(
+        ecs,
+        "RunTask",
+        ecs_data,
+    )
     result = json.loads(body) if body else {}
     if status >= 400:
         raise _ExecutionError("ECS.RunTaskFailed", result.get("message", str(result)))
@@ -4168,22 +4290,44 @@ def _invoke_ecs_run_task(resource, input_data):
     if is_sync and result.get("tasks"):
         task_arns = [t["taskArn"] for t in result["tasks"]]
         cluster = ecs_data.get("cluster", "default")
-        result = _poll_ecs_tasks(cluster, task_arns)
+        result = _poll_ecs_tasks(ecs, cluster, task_arns)
 
     return result
 
 
-def _poll_ecs_tasks(cluster, task_arns):
+def _invoke_ecs_action_through_admission(ecs_module, action, data):
+    headers = {
+        "x-amz-target": f"AmazonEC2ContainerServiceV20141113.{action}",
+        "content-type": "application/x-amz-json-1.1",
+        "host": f"ecs.{get_region()}.amazonaws.com",
+        "authorization": (
+            f"AWS4-HMAC-SHA256 Credential=test/20260101/{get_region()}/ecs/aws4_request"
+        ),
+    }
+    return _drive_service_handler_sync(
+        "ecs",
+        ecs_module.handle_request,
+        "POST",
+        "/",
+        headers,
+        json.dumps(data),
+        {},
+    )
+
+
+def _poll_ecs_tasks(ecs_module, cluster, task_arns):
     """Poll DescribeTasks until all tasks are STOPPED (max 10 min).
 
     Returns the full DescribeTasks result including exit codes — the state
     machine definition decides how to handle success/failure via Choice or Catch.
     """
-    from ministack.services import ecs
-
     for _ in range(600):
         _scaled_sleep(1)
-        status, _, body = ecs._describe_tasks({"cluster": cluster, "tasks": task_arns})
+        status, _, body = _invoke_ecs_action_through_admission(
+            ecs_module,
+            "DescribeTasks",
+            {"cluster": cluster, "tasks": task_arns},
+        )
         result = json.loads(body) if body else {}
         tasks = result.get("tasks", [])
         if tasks and all(t.get("lastStatus") == "STOPPED" for t in tasks):
@@ -4318,6 +4462,82 @@ _REST_JSON_ACTION_PATHS = {
 }
 
 
+_SYNC_AWS_SDK_SERVICE_MODULES = {
+    "rds": "rds",
+    "ecs": "ecs",
+    "eks": "eks",
+    "elasticache": "elasticache",
+    "opensearch": "opensearch",
+    "rds-data": "rds_data",
+}
+
+
+def _drive_service_handler_sync(service_key, handler, *args, await_error=None):
+    """Drive one service entry from an SFN execution thread."""
+    module_name = _SYNC_AWS_SDK_SERVICE_MODULES.get(service_key)
+    if module_name is not None:
+        from ministack import app
+
+        module = app._get_module(module_name)
+        return _marshal_service_handler_to_execution_loop(
+            service_key,
+            module.handle_request,
+            *args,
+        )
+
+    coro = handler(*args)
+    try:
+        coro.send(None)
+    except StopIteration as stop:
+        return stop.value
+    else:
+        coro.close()
+        if await_error is not None:
+            raise await_error
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(handler(*args))
+        finally:
+            loop.close()
+
+
+def _marshal_service_handler_to_execution_loop(service_key, handler, *args):
+    """Run an admission-locked service handler on its execution's server loop."""
+    server_loop = _execution_server_loop.get()
+    if server_loop is None:
+        raise _ExecutionError(
+            "States.Runtime",
+            f"aws-sdk:{service_key} integration has no execution server loop",
+        )
+
+    try:
+        running_loop = asyncio.get_running_loop()
+    except RuntimeError:
+        running_loop = None
+    if running_loop is server_loop:
+        raise _ExecutionError(
+            "States.Runtime",
+            f"aws-sdk:{service_key} integration cannot synchronously marshal "
+            "from its target event loop",
+        )
+    if server_loop.is_closed():
+        raise _ExecutionError(
+            "States.Runtime",
+            f"aws-sdk:{service_key} integration server loop is closed",
+        )
+
+    try:
+        future = asyncio.run_coroutine_threadsafe(handler(*args), server_loop)
+        return future.result()
+    except _ExecutionError:
+        raise
+    except Exception as exc:
+        raise _ExecutionError(
+            "States.Runtime",
+            f"aws-sdk:{service_key} integration dispatch failed: {exc}",
+        ) from exc
+
+
 def _dispatch_aws_sdk_json(service_info, service_name, action, input_data):
     """Dispatch an aws-sdk integration call to a JSON-protocol MiniStack service."""
     from ministack import app
@@ -4350,25 +4570,9 @@ def _dispatch_aws_sdk_json(service_info, service_name, action, input_data):
         ),
     }
 
-    # Service handlers are async def but perform no real I/O, so we can
-    # drive the coroutine synchronously — this avoids conflicts with the
-    # already-running asyncio event loop.
-    coro = handler("POST", "/", headers, body, {})
-    try:
-        coro.send(None)
-    except StopIteration as stop:
-        status, resp_headers, resp_body = stop.value
-    else:
-        # If the coroutine didn't finish in one step it truly needs async;
-        # fall back to the event loop (only reachable if a handler awaits).
-        coro.close()
-        loop = asyncio.new_event_loop()
-        try:
-            status, resp_headers, resp_body = loop.run_until_complete(
-                handler("POST", "/", headers, body, {})
-            )
-        finally:
-            loop.close()
+    status, resp_headers, resp_body = _drive_service_handler_sync(
+        service_key, handler, "POST", "/", headers, body, {}
+    )
 
     decoded = resp_body.decode("utf-8") if isinstance(resp_body, bytes) else resp_body
     result = json.loads(decoded) if decoded else {}
@@ -4938,20 +5142,9 @@ def _dispatch_aws_sdk_query(service_info, service_name, action, input_data):
         ),
     }
 
-    coro = handler("POST", "/", headers, body, {})
-    try:
-        coro.send(None)
-    except StopIteration as stop:
-        status, resp_headers, resp_body = stop.value
-    else:
-        coro.close()
-        loop = asyncio.new_event_loop()
-        try:
-            status, resp_headers, resp_body = loop.run_until_complete(
-                handler("POST", "/", headers, body, {})
-            )
-        finally:
-            loop.close()
+    status, resp_headers, resp_body = _drive_service_handler_sync(
+        service_key, handler, "POST", "/", headers, body, {}
+    )
 
     decoded = resp_body.decode("utf-8") if isinstance(resp_body, bytes) else resp_body
 
@@ -5041,20 +5234,9 @@ def _dispatch_aws_sdk_rest_json(service_info, service_name, action, input_data):
         ),
     }
 
-    coro = handler("POST", path, headers, body, {})
-    try:
-        coro.send(None)
-    except StopIteration as stop:
-        status, resp_headers, resp_body = stop.value
-    else:
-        coro.close()
-        loop = asyncio.new_event_loop()
-        try:
-            status, resp_headers, resp_body = loop.run_until_complete(
-                handler("POST", path, headers, body, {})
-            )
-        finally:
-            loop.close()
+    status, resp_headers, resp_body = _drive_service_handler_sync(
+        service_key, handler, "POST", path, headers, body, {}
+    )
 
     decoded = resp_body.decode("utf-8") if isinstance(resp_body, bytes) else resp_body
 
@@ -5175,26 +5357,20 @@ def _dispatch_aws_sdk_lambda_rest(service_info, service_name, action, input_data
         ),
     }
 
-    # Drive the async handler synchronously. SFN state execution runs inside
-    # the request's event loop, so spawning a fresh loop here would raise
-    # "Cannot run the event loop while another loop is running". The Lambda
-    # REST handlers we dispatch to here only touch in-memory dicts and never
-    # await, so a single ``coro.send(None)`` completes via ``StopIteration``
-    # with the response tuple.
-    coro = handler(method, path, headers, body, query_params)
-    try:
-        coro.send(None)
-    except StopIteration as stop:
-        status, resp_headers, resp_body = stop.value
-    else:
-        # Fallback for an async handler that does await — extremely rare on
-        # this dispatch surface, but guard so we don't return None silently.
-        coro.close()
-        raise _ExecutionError(
+    status, resp_headers, resp_body = _drive_service_handler_sync(
+        service_key,
+        handler,
+        method,
+        path,
+        headers,
+        body,
+        query_params,
+        await_error=_ExecutionError(
             "States.Runtime",
             f"aws-sdk:{service_name}:{action} handler awaited unexpectedly; "
             "cannot drive from sync SFN executor",
-        )
+        ),
+    )
 
     decoded = resp_body.decode("utf-8") if isinstance(resp_body, bytes) else resp_body
     if status >= 400:
@@ -5482,20 +5658,9 @@ def _dispatch_aws_sdk_rest_xml(service_info, service_name, action, input_data):
     # passing the raw path with "?..." would treat "?list-type=2" as part of
     # the bucket name. Send the query-less path; the dict is the source of
     # truth for query routing.
-    coro = handler(method, path, headers, body, query_dict)
-    try:
-        coro.send(None)
-    except StopIteration as stop:
-        status, resp_headers, resp_body = stop.value
-    else:
-        coro.close()
-        loop = asyncio.new_event_loop()
-        try:
-            status, resp_headers, resp_body = loop.run_until_complete(
-                handler(method, path, headers, body, query_dict)
-            )
-        finally:
-            loop.close()
+    status, resp_headers, resp_body = _drive_service_handler_sync(
+        service_key, handler, method, path, headers, body, query_dict
+    )
 
     decoded = resp_body.decode("utf-8") if isinstance(resp_body, bytes) else (resp_body or "")
     norm_resp_headers = {k.lower(): v for k, v in (resp_headers or {}).items()}

--- a/ministack/services/stepfunctions.py
+++ b/ministack/services/stepfunctions.py
@@ -50,6 +50,7 @@ from ministack.core.responses import (
     new_uuid,
     now_iso,
 )
+from ministack.services import stepfunctions_lifecycle
 
 logger = logging.getLogger("states")
 
@@ -302,15 +303,29 @@ async def handle_request(method, path, headers, body, query_params):
         except RuntimeError:
             # Nested SDK integrations synchronously send-drive this router from
             # an existing execution thread.  They inherit the outer execution's
-            # server-loop context and must remain inline (especially nested
-            # StartSyncExecution), rather than spawning another thread.
+            # server-loop context and must remain inline rather than spawning
+            # another thread. Nested synchronous work is covered transitively by
+            # its registered dedicated-thread parent.
             return _finalize_response(handler(data))
 
         loop_token = _execution_server_loop.set(server_loop)
         try:
             if action in {"StartSyncExecution", "TestState"}:
+                lifecycle = stepfunctions_lifecycle._get_sync_action_lifecycle()
+                try:
+                    # Registration is synchronous on the server loop, with no
+                    # await before the dedicated thread starts below.
+                    lifecycle.enter_action()
+                except stepfunctions_lifecycle.SyncActionAdmissionClosed:
+                    return error_response_json(
+                        "ServiceUnavailableException",
+                        "Step Functions synchronous actions are unavailable during reset",
+                        503,
+                    )
                 return _finalize_response(
-                    await _run_sync_action_in_dedicated_thread(handler, data)
+                    await _run_sync_action_in_dedicated_thread(
+                        handler, data, lifecycle
+                    )
                 )
             return _finalize_response(handler(data))
         finally:
@@ -328,7 +343,7 @@ def _complete_thread_future(future, result=None, error=None):
         future.set_result(result)
 
 
-async def _run_sync_action_in_dedicated_thread(handler, data):
+async def _run_sync_action_in_dedicated_thread(handler, data, lifecycle):
     """Run a synchronous execution action without consuming the shared pool.
 
     Execution threads can block while a service integration is marshalled back
@@ -341,28 +356,43 @@ async def _run_sync_action_in_dedicated_thread(handler, data):
     ctx_snapshot = contextvars.copy_context()
 
     def run():
+        result = None
+        error = None
         try:
             result = ctx_snapshot.run(handler, data)
         except BaseException as exc:
-            loop.call_soon_threadsafe(
-                _complete_thread_future,
-                result_future,
-                None,
-                exc,
-            )
-        else:
+            error = exc
+        try:
             loop.call_soon_threadsafe(
                 _complete_thread_future,
                 result_future,
                 result,
-                None,
+                error,
+            )
+        except RuntimeError:
+            logger.debug(
+                "Step Functions action finished after its server loop closed"
+            )
+        try:
+            loop.call_soon_threadsafe(
+                lifecycle.leave_action,
+            )
+        except RuntimeError:
+            # LoopLocal state dies with the closing loop. The worker is already
+            # complete, so there is no live reset waiter left to notify.
+            logger.debug(
+                "Step Functions action lifecycle closed with its server loop"
             )
 
-    threading.Thread(
-        target=run,
-        name=f"ministack-sfn-{handler.__name__}",
-        daemon=True,
-    ).start()
+    try:
+        threading.Thread(
+            target=run,
+            name=f"ministack-sfn-{handler.__name__}",
+            daemon=True,
+        ).start()
+    except BaseException:
+        lifecycle.leave_action()
+        raise
 
     try:
         return await asyncio.shield(result_future)

--- a/ministack/services/stepfunctions.py
+++ b/ministack/services/stepfunctions.py
@@ -5891,8 +5891,13 @@ def _list_state_machine_versions(data):
             "stateMachineVersionArn": version_arn,
             "creationDate": version["creationDate"],
         })
-    # AWS returns versions in descending creationDate order (newest first).
-    matching.sort(key=lambda v: v["creationDate"], reverse=True)
+    # AWS returns versions newest first. Version numbers are the monotonic
+    # publish order; creationDate alone is nondeterministic when back-to-back
+    # publishes share the same millisecond timestamp.
+    matching.sort(
+        key=lambda v: int(v["stateMachineVersionArn"].rsplit(":", 1)[1]),
+        reverse=True,
+    )
 
     max_results = data.get("maxResults") or len(matching)
     return json_response({

--- a/ministack/services/stepfunctions.py
+++ b/ministack/services/stepfunctions.py
@@ -4271,14 +4271,8 @@ def _invoke_dynamodb(op_name, input_data):
 
 def _invoke_ecs_run_task(resource, input_data):
     """arn:aws:states:::ecs:runTask[.sync]"""
-    try:
-        from ministack.services import ecs
-    except ImportError:
-        logger.warning("ecs module unavailable; returning passthrough")
-        return input_data
     ecs_data = _pascal_to_camel(input_data)
     status, _, body = _invoke_ecs_action_through_admission(
-        ecs,
         "RunTask",
         ecs_data,
     )
@@ -4290,12 +4284,12 @@ def _invoke_ecs_run_task(resource, input_data):
     if is_sync and result.get("tasks"):
         task_arns = [t["taskArn"] for t in result["tasks"]]
         cluster = ecs_data.get("cluster", "default")
-        result = _poll_ecs_tasks(ecs, cluster, task_arns)
+        result = _poll_ecs_tasks(cluster, task_arns)
 
     return result
 
 
-def _invoke_ecs_action_through_admission(ecs_module, action, data):
+def _invoke_ecs_action_through_admission(action, data):
     headers = {
         "x-amz-target": f"AmazonEC2ContainerServiceV20141113.{action}",
         "content-type": "application/x-amz-json-1.1",
@@ -4306,7 +4300,7 @@ def _invoke_ecs_action_through_admission(ecs_module, action, data):
     }
     return _drive_service_handler_sync(
         "ecs",
-        ecs_module.handle_request,
+        None,
         "POST",
         "/",
         headers,
@@ -4315,7 +4309,7 @@ def _invoke_ecs_action_through_admission(ecs_module, action, data):
     )
 
 
-def _poll_ecs_tasks(ecs_module, cluster, task_arns):
+def _poll_ecs_tasks(cluster, task_arns):
     """Poll DescribeTasks until all tasks are STOPPED (max 10 min).
 
     Returns the full DescribeTasks result including exit codes — the state
@@ -4324,7 +4318,6 @@ def _poll_ecs_tasks(ecs_module, cluster, task_arns):
     for _ in range(600):
         _scaled_sleep(1)
         status, _, body = _invoke_ecs_action_through_admission(
-            ecs_module,
             "DescribeTasks",
             {"cluster": cluster, "tasks": task_arns},
         )
@@ -4462,26 +4455,13 @@ _REST_JSON_ACTION_PATHS = {
 }
 
 
-_SYNC_AWS_SDK_SERVICE_MODULES = {
-    "rds": "rds",
-    "ecs": "ecs",
-    "eks": "eks",
-    "elasticache": "elasticache",
-    "opensearch": "opensearch",
-    "rds-data": "rds_data",
-}
-
-
 def _drive_service_handler_sync(service_key, handler, *args, await_error=None):
     """Drive one service entry from an SFN execution thread."""
-    module_name = _SYNC_AWS_SDK_SERVICE_MODULES.get(service_key)
-    if module_name is not None:
-        from ministack import app
+    from ministack import app
 
-        module = app._get_module(module_name)
+    if service_key in app._RESET_ADMISSION_OWNER_MODULES:
         return _marshal_service_handler_to_execution_loop(
             service_key,
-            module.handle_request,
             *args,
         )
 
@@ -4501,7 +4481,7 @@ def _drive_service_handler_sync(service_key, handler, *args, await_error=None):
             loop.close()
 
 
-def _marshal_service_handler_to_execution_loop(service_key, handler, *args):
+def _marshal_service_handler_to_execution_loop(service_key, *args):
     """Run an admission-locked service handler on its execution's server loop."""
     server_loop = _execution_server_loop.get()
     if server_loop is None:
@@ -4527,7 +4507,15 @@ def _marshal_service_handler_to_execution_loop(service_key, handler, *args):
         )
 
     try:
-        future = asyncio.run_coroutine_threadsafe(handler(*args), server_loop)
+        from ministack import app
+
+        # One loop-side round trip owns the first-touch gate, module import,
+        # and handler dispatch. Serialized owners must never be imported on an
+        # execution thread where the reset writer cannot exclude them.
+        future = asyncio.run_coroutine_threadsafe(
+            app._dispatch_serialized_service_request(service_key, *args),
+            server_loop,
+        )
         return future.result()
     except _ExecutionError:
         raise

--- a/ministack/services/stepfunctions_lifecycle.py
+++ b/ministack/services/stepfunctions_lifecycle.py
@@ -1,0 +1,59 @@
+"""Step Functions synchronous-action admission and reset lifecycle."""
+
+import asyncio
+
+from ministack.core.concurrency import LoopLocal
+
+
+class SyncActionAdmissionClosed(RuntimeError):
+    """Raised when synchronous Step Functions work starts during reset."""
+
+
+class _SyncActionLifecycle:
+    """Track dedicated-thread actions and close their admission during reset."""
+
+    def __init__(self):
+        self._accepting = True
+        self._active_actions = 0
+        self._actions_drained = asyncio.Event()
+        self._actions_drained.set()
+
+    def enter_action(self):
+        """Synchronously register an action before its thread starts."""
+        if not self._accepting:
+            raise SyncActionAdmissionClosed(
+                "Step Functions synchronous-action admission is closed for reset"
+            )
+        self._active_actions += 1
+        if self._active_actions == 1:
+            self._actions_drained.clear()
+
+    def leave_action(self):
+        """Release an action only after its dedicated thread has finished."""
+        self._active_actions -= 1
+        if self._active_actions == 0:
+            self._actions_drained.set()
+
+    async def begin_reset(self):
+        """Close admission and await every active dedicated-thread action."""
+        self._accepting = False
+        waiter = asyncio.create_task(self._actions_drained.wait())
+        try:
+            await asyncio.shield(waiter)
+        except asyncio.CancelledError as cancellation:
+            while not waiter.done():
+                try:
+                    await asyncio.shield(waiter)
+                except asyncio.CancelledError:
+                    continue
+            raise cancellation
+
+    def finish_reset(self):
+        self._accepting = True
+
+
+_sync_action_lifecycles = LoopLocal(_SyncActionLifecycle)
+
+
+def _get_sync_action_lifecycle() -> _SyncActionLifecycle:
+    return _sync_action_lifecycles.get()

--- a/ministack/services/tagging.py
+++ b/ministack/services/tagging.py
@@ -23,6 +23,7 @@ denormalise on write.
 
 import json
 import logging
+from contextlib import AsyncExitStack
 
 from ministack.core.arn import Arn, ArnParseError, parse_arn
 from ministack.core.responses import get_region
@@ -31,6 +32,66 @@ logger = logging.getLogger("tagging")
 
 
 _GLOBAL_RESOURCE_SERVICES = {"cloudfront", "s3"}
+
+# Resource Groups Tagging reads and mutates tag state owned by these services.
+# Their API routers run in worker threads, so participate in the same admission
+# scheme to preserve the event loop's former serialization. Keep this order in
+# sync with app._RESET_SERIALIZED_SERVICE_MODULES to avoid lock-order cycles.
+_ADMISSION_LOCKED_SERVICE_MODULES = ("ecs", "elasticache")
+
+
+class InvalidRequestBody(ValueError):
+    """Raised when a tagging request body is valid JSON but not an object."""
+
+
+def _get_service_admission_lock(module_name):
+    if module_name == "ecs":
+        from ministack.services import ecs as service
+    else:
+        from ministack.services import elasticache as service
+    return service._get_request_dispatch_lock()
+
+
+def _admission_locked_services_for_request(action, data):
+    if action in {"TagResources", "UntagResources"} or data.get("ResourceARNList"):
+        services = set()
+        for arn in data.get("ResourceARNList", []):
+            try:
+                services.add(parse_arn(arn).service)
+            except ArnParseError:
+                continue
+    elif action == "GetResources" and data.get("ResourceTypeFilters"):
+        services = {value.split(":", 1)[0] for value in data["ResourceTypeFilters"]}
+    else:
+        # Unfiltered resource/key/value discovery visits every collector.
+        services = set(_ADMISSION_LOCKED_SERVICE_MODULES)
+
+    return tuple(
+        service for service in _ADMISSION_LOCKED_SERVICE_MODULES if service in services
+    )
+
+
+def classify_request_admission(headers, body):
+    """Parse one request and return its action, data, and admission locks.
+
+    This is the single classification seam shared by the HTTP reset barrier and
+    this router. A mixed request (for example ECS + S3 ARNs) is safe under the
+    ECS lock: reset acquires every service lock before wiping either service, so
+    the whole synchronous tagging operation completes before the wipe begins.
+    """
+    target = headers.get("x-amz-target", "")
+    action = target.split(".")[-1] if "." in target else ""
+    data = json.loads(body) if body else {}
+    if not isinstance(data, dict):
+        raise InvalidRequestBody("request body must be a JSON object")
+    return action, data, _admission_locked_services_for_request(action, data)
+
+
+async def _run_with_service_admission_locks(handler, data, module_names):
+    async with AsyncExitStack() as stack:
+        for module_name in module_names:
+            await stack.enter_async_context(_get_service_admission_lock(module_name))
+        return handler(data)
 
 
 class _ResourceNotFound(Exception):
@@ -1078,12 +1139,9 @@ _HANDLERS = {
 
 
 async def handle_request(method, path, headers, body, query_params):
-    target = headers.get("x-amz-target", "")
-    action = target.split(".")[-1] if "." in target else ""
-
     try:
-        data = json.loads(body) if body else {}
-    except json.JSONDecodeError:
+        action, data, locked_services = classify_request_admission(headers, body)
+    except (json.JSONDecodeError, InvalidRequestBody):
         return 400, {"Content-Type": "application/x-amz-json-1.1", "x-amzn-errortype": "SerializationException"}, json.dumps({
             "__type": "SerializationException",
             "message": "Invalid JSON",
@@ -1096,7 +1154,7 @@ async def handle_request(method, path, headers, body, query_params):
             "message": f"Unknown action: {action}",
         }).encode()
 
-    return handler(data)
+    return await _run_with_service_admission_locks(handler, data, locked_services)
 
 
 def reset():

--- a/tests/test_event_loop.py
+++ b/tests/test_event_loop.py
@@ -19,6 +19,7 @@ from ministack.core.responses import (
     set_request_region,
 )
 from ministack.services import (
+    cloudformation,
     dynamodb,
     ecs,
     eks,
@@ -71,6 +72,26 @@ async def _call_stepfunctions_action(action, data=None):
         json.dumps(data or {}).encode(),
         {},
     )
+
+
+async def _call_cloudformation_action(action, data=None):
+    return await cloudformation.handle_request(
+        "POST",
+        "/",
+        {
+            "content-type": "application/x-amz-json-1.0",
+            "x-amz-target": f"CloudFormation_20100515.{action}",
+        },
+        json.dumps(data or {}).encode(),
+        {},
+    )
+
+
+def _clear_cloudformation_state():
+    cloudformation._stacks.clear()
+    cloudformation._stack_events.clear()
+    cloudformation._exports.clear()
+    cloudformation._change_sets.clear()
 
 
 async def _create_rds_integration_state_machine(name):
@@ -656,7 +677,7 @@ def test_first_touch_serialized_import_waits_for_reset_writer(monkeypatch):
             await asyncio.sleep(0.001)
 
         first_touch = asyncio.create_task(
-            ministack_app._gate_first_touch_reset_admission_module("rds")
+            ministack_app._ensure_reset_admission_owner_modules(("rds",))
         )
         await asyncio.sleep(0.05)
         assert order == ["wipe-start"]
@@ -697,9 +718,11 @@ def test_first_touch_gate_maps_every_serialized_service_key(monkeypatch, service
         LoopLocal(ministack_app._RequestResetBarrier),
     )
 
-    asyncio.run(ministack_app._gate_first_touch_reset_admission_module(service))
+    asyncio.run(
+        ministack_app._gate_first_touch_reset_admission_modules(service, {}, b"")
+    )
 
-    assert imported == [ministack_app.SERVICE_REGISTRY[service]["module"]]
+    assert imported == list(ministack_app._RESET_ADMISSION_OWNER_MODULES[service])
 
 
 @pytest.mark.parametrize(
@@ -719,9 +742,229 @@ def test_first_touch_gate_does_not_import_callback_services(monkeypatch, service
         lambda name: imported.append(name),
     )
 
-    asyncio.run(ministack_app._gate_first_touch_reset_admission_module(service))
+    asyncio.run(
+        ministack_app._gate_first_touch_reset_admission_modules(service, {}, b"")
+    )
 
     assert imported == []
+
+
+@pytest.mark.parametrize(
+    ("owner", "headers", "body", "preloaded"),
+    [
+        (
+            "rds",
+            {
+                "host": "rds-data.us-east-1.amazonaws.com",
+                "x-amz-target": "RDSDataService.ExecuteStatement",
+            },
+            b"{}",
+            {"rds_data": object()},
+        ),
+        (
+            "ecs",
+            {
+                "host": "tagging.us-east-1.amazonaws.com",
+                "x-amz-target": "ResourceGroupsTaggingAPI_20170126.TagResources",
+            },
+            json.dumps(
+                {
+                    "ResourceARNList": [
+                        "arn:aws:ecs:us-east-1:000000000000:cluster/first-touch"
+                    ],
+                    "Tags": {"owner": "reset"},
+                }
+            ).encode(),
+            {},
+        ),
+    ],
+    ids=["rds-data-rds-owner", "tagging-ecs-owner"],
+)
+def test_indirect_http_first_touch_waits_for_reset_writer(
+    monkeypatch, owner, headers, body, preloaded
+):
+    wipe_started = threading.Event()
+    release_wipe = threading.Event()
+    mutation_started = threading.Event()
+    loaded = dict(preloaded)
+    order = []
+
+    def resolve_loaded(name):
+        return loaded.get(name)
+
+    def import_module(name):
+        order.append(f"import-{name}")
+        loaded[name] = object()
+        return loaded[name]
+
+    def slow_reset():
+        order.append("wipe-start")
+        wipe_started.set()
+        release_wipe.wait(timeout=2)
+        order.append("wipe-finish")
+
+    async def late_owner_mutation(*_args, **_kwargs):
+        ministack_app._get_module(owner)
+        order.append(f"mutate-{owner}")
+        mutation_started.set()
+
+    monkeypatch.setattr(
+        ministack_app, "_resolve_loaded_service_module", resolve_loaded
+    )
+    monkeypatch.setattr(ministack_app, "_get_module", import_module)
+    monkeypatch.setattr(ministack_app, "_reset_all_state", slow_reset)
+    monkeypatch.setattr(
+        ministack_app, "_RESET_SERIALIZED_SERVICE_MODULES", (owner,)
+    )
+    monkeypatch.setattr(ministack_app, "_handle_http_request", late_owner_mutation)
+    monkeypatch.setattr(
+        ministack_app,
+        "_ordinary_request_reset_barriers",
+        LoopLocal(ministack_app._RequestResetBarrier),
+    )
+    monkeypatch.setattr(
+        cfn_lifecycle,
+        "_stack_task_lifecycles",
+        LoopLocal(cfn_lifecycle._StackTaskLifecycle),
+    )
+
+    encoded_headers = [
+        (name.encode("latin-1"), value.encode("utf-8"))
+        for name, value in headers.items()
+    ]
+    request_scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/",
+        "query_string": b"",
+        "headers": encoded_headers,
+    }
+
+    async def receive():
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    async def send(_message):
+        pass
+
+    async def exercise():
+        reset = asyncio.create_task(
+            ministack_app._reset_all_state_after_service_dispatch_drains()
+        )
+        while not wipe_started.is_set():
+            await asyncio.sleep(0.001)
+
+        request = asyncio.create_task(
+            ministack_app.app(request_scope, receive, send)
+        )
+        await asyncio.sleep(0.05)
+        assert not mutation_started.is_set()
+
+        release_wipe.set()
+        await asyncio.gather(reset, request)
+        assert order.index("wipe-finish") < order.index(f"mutate-{owner}")
+
+    fallback = threading.Timer(1, release_wipe.set)
+    fallback.start()
+    try:
+        asyncio.run(exercise())
+    finally:
+        release_wipe.set()
+        fallback.cancel()
+
+
+def test_sfn_indirect_first_touch_imports_owner_loop_side_after_reset(monkeypatch):
+    wipe_started = threading.Event()
+    release_wipe = threading.Event()
+    mutation_started = threading.Event()
+    loaded = {}
+    order = []
+    import_thread_ids = []
+
+    class FakeRds:
+        async def handle_request(self, *_args):
+            order.append("mutate-rds")
+            mutation_started.set()
+            return 200, {}, b"{}"
+
+    def resolve_loaded(name):
+        return loaded.get(name)
+
+    def import_module(name):
+        if name in loaded:
+            return loaded[name]
+        import_thread_ids.append(threading.get_ident())
+        order.append(f"import-{name}")
+        loaded[name] = FakeRds()
+        return loaded[name]
+
+    def slow_reset():
+        order.append("wipe-start")
+        wipe_started.set()
+        release_wipe.wait(timeout=2)
+        order.append("wipe-finish")
+
+    async def unused_handler(*_args):
+        raise AssertionError("serialized SFN dispatch must use the loop-side module")
+
+    monkeypatch.setattr(
+        ministack_app, "_resolve_loaded_service_module", resolve_loaded
+    )
+    monkeypatch.setattr(ministack_app, "_get_module", import_module)
+    monkeypatch.setattr(ministack_app, "_reset_all_state", slow_reset)
+    monkeypatch.setattr(
+        ministack_app, "_RESET_SERIALIZED_SERVICE_MODULES", ("rds",)
+    )
+    monkeypatch.setattr(
+        ministack_app,
+        "_ordinary_request_reset_barriers",
+        LoopLocal(ministack_app._RequestResetBarrier),
+    )
+    monkeypatch.setattr(
+        cfn_lifecycle,
+        "_stack_task_lifecycles",
+        LoopLocal(cfn_lifecycle._StackTaskLifecycle),
+    )
+
+    async def exercise():
+        loop_thread_id = threading.get_ident()
+        reset = asyncio.create_task(
+            ministack_app._reset_all_state_after_service_dispatch_drains()
+        )
+        while not wipe_started.is_set():
+            await asyncio.sleep(0.001)
+
+        token = stepfunctions._execution_server_loop.set(asyncio.get_running_loop())
+        try:
+            integration = asyncio.create_task(
+                asyncio.to_thread(
+                    stepfunctions._drive_service_handler_sync,
+                    "rds",
+                    unused_handler,
+                    "POST",
+                    "/",
+                    {},
+                    b"{}",
+                    {},
+                )
+            )
+            await asyncio.sleep(0.05)
+            assert not mutation_started.is_set()
+
+            release_wipe.set()
+            await asyncio.gather(reset, integration)
+        finally:
+            stepfunctions._execution_server_loop.reset(token)
+
+        assert import_thread_ids == [loop_thread_id]
+        assert order.index("wipe-finish") < order.index("mutate-rds")
+
+    fallback = threading.Timer(1, release_wipe.set)
+    fallback.start()
+    try:
+        asyncio.run(exercise())
+    finally:
+        release_wipe.set()
+        fallback.cancel()
 
 
 @pytest.mark.parametrize(
@@ -2095,6 +2338,260 @@ def test_admin_reset_quiesces_multi_resource_cloudformation_task(monkeypatch):
     finally:
         release_first.set()
         fallback.cancel()
+
+
+def test_cloudformation_mutations_return_503_while_task_admission_is_closed(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        cfn_lifecycle,
+        "_stack_task_lifecycles",
+        LoopLocal(cfn_lifecycle._StackTaskLifecycle),
+    )
+    _clear_cloudformation_state()
+
+    async def exercise():
+        lifecycle = cfn_lifecycle._get_stack_task_lifecycle()
+        await lifecycle.begin_reset()
+        try:
+            for action in (
+                "CreateStack",
+                "DeleteStack",
+                "UpdateStack",
+                "CreateChangeSet",
+                "ExecuteChangeSet",
+                "DeleteChangeSet",
+            ):
+                status, _, body = await _call_cloudformation_action(action)
+                assert status == 503, action
+                assert b"ServiceUnavailableException" in body
+
+            read_status, _, _ = await _call_cloudformation_action("DescribeStacks")
+            assert read_status == 200
+        finally:
+            lifecycle.finish_reset()
+
+        assert not cloudformation._stacks
+        assert not cloudformation._stack_events
+        assert not cloudformation._change_sets
+
+    try:
+        asyncio.run(exercise())
+    finally:
+        _clear_cloudformation_state()
+
+
+def test_cloudformation_closed_task_admission_raises(monkeypatch):
+    monkeypatch.setattr(
+        cfn_lifecycle,
+        "_stack_task_lifecycles",
+        LoopLocal(cfn_lifecycle._StackTaskLifecycle),
+    )
+
+    async def no_op():
+        pass
+
+    async def exercise():
+        lifecycle = cfn_lifecycle._get_stack_task_lifecycle()
+        await lifecycle.begin_reset()
+        try:
+            with pytest.raises(cfn_lifecycle.StackTaskAdmissionClosed):
+                lifecycle.create_task(no_op())
+        finally:
+            lifecycle.finish_reset()
+
+    asyncio.run(exercise())
+
+
+def test_cancelled_reset_rejects_concurrent_create_then_reopens_admission(
+    monkeypatch,
+):
+    drain_started = asyncio.Event()
+    release_drain = asyncio.Event()
+    wipe_called = threading.Event()
+
+    monkeypatch.setattr(
+        cfn_lifecycle,
+        "_stack_task_lifecycles",
+        LoopLocal(cfn_lifecycle._StackTaskLifecycle),
+    )
+    monkeypatch.setattr(
+        ministack_app,
+        "_ordinary_request_reset_barriers",
+        LoopLocal(ministack_app._RequestResetBarrier),
+    )
+    monkeypatch.setattr(ministack_app, "_RESET_SERIALIZED_SERVICE_MODULES", ())
+
+    def reset_state():
+        _clear_cloudformation_state()
+        wipe_called.set()
+
+    monkeypatch.setattr(ministack_app, "_reset_all_state", reset_state)
+    _clear_cloudformation_state()
+
+    async def active_stack_task():
+        try:
+            await asyncio.Future()
+        except asyncio.CancelledError:
+            drain_started.set()
+            await release_drain.wait()
+            raise
+
+    async def exercise():
+        lifecycle = cfn_lifecycle._get_stack_task_lifecycle()
+        active = lifecycle.create_task(active_stack_task())
+        reset = asyncio.create_task(
+            ministack_app._reset_all_state_after_service_dispatch_drains()
+        )
+        await drain_started.wait()
+
+        status, _, _ = await _call_cloudformation_action(
+            "CreateStack",
+            {
+                "StackName": "rejected-during-reset",
+                "TemplateBody": json.dumps({"Resources": {}}),
+            },
+        )
+        assert status == 503
+        assert "rejected-during-reset" not in cloudformation._stacks
+
+        reset.cancel()
+        release_drain.set()
+        result = await asyncio.gather(reset, return_exceptions=True)
+        assert isinstance(result[0], asyncio.CancelledError)
+        assert wipe_called.is_set()
+        assert lifecycle.is_accepting()
+        assert isinstance(
+            (await asyncio.gather(active, return_exceptions=True))[0],
+            asyncio.CancelledError,
+        )
+
+        status, _, _ = await _call_cloudformation_action(
+            "CreateStack",
+            {
+                "StackName": "accepted-after-reset",
+                "TemplateBody": json.dumps({"Resources": {}}),
+            },
+        )
+        assert status == 200
+        await asyncio.sleep(0)
+
+    try:
+        asyncio.run(exercise())
+    finally:
+        _clear_cloudformation_state()
+
+
+def test_cancelled_reset_still_wipes_existing_stack_metadata(monkeypatch):
+    drain_started = asyncio.Event()
+    release_drain = asyncio.Event()
+    wipe_called = threading.Event()
+
+    monkeypatch.setattr(
+        cfn_lifecycle,
+        "_stack_task_lifecycles",
+        LoopLocal(cfn_lifecycle._StackTaskLifecycle),
+    )
+    monkeypatch.setattr(
+        ministack_app,
+        "_ordinary_request_reset_barriers",
+        LoopLocal(ministack_app._RequestResetBarrier),
+    )
+    monkeypatch.setattr(ministack_app, "_RESET_SERIALIZED_SERVICE_MODULES", ())
+
+    def reset_state():
+        _clear_cloudformation_state()
+        wipe_called.set()
+
+    monkeypatch.setattr(ministack_app, "_reset_all_state", reset_state)
+    _clear_cloudformation_state()
+    cloudformation._stacks["existing"] = {"StackStatus": "CREATE_IN_PROGRESS"}
+
+    async def active_stack_task():
+        try:
+            await asyncio.Future()
+        except asyncio.CancelledError:
+            drain_started.set()
+            await release_drain.wait()
+            raise
+
+    async def exercise():
+        lifecycle = cfn_lifecycle._get_stack_task_lifecycle()
+        active = lifecycle.create_task(active_stack_task())
+        reset = asyncio.create_task(
+            ministack_app._reset_all_state_after_service_dispatch_drains()
+        )
+        await drain_started.wait()
+        reset.cancel()
+        release_drain.set()
+
+        result = await asyncio.gather(reset, return_exceptions=True)
+        assert isinstance(result[0], asyncio.CancelledError)
+        assert wipe_called.is_set()
+        assert not cloudformation._stacks
+        assert lifecycle.is_accepting()
+        assert isinstance(
+            (await asyncio.gather(active, return_exceptions=True))[0],
+            asyncio.CancelledError,
+        )
+
+    try:
+        asyncio.run(exercise())
+    finally:
+        _clear_cloudformation_state()
+
+
+def test_reset_absorbs_repeated_cancellation_until_wipe_completes(monkeypatch):
+    drain_started = asyncio.Event()
+    release_drain = asyncio.Event()
+    wipe_called = threading.Event()
+
+    monkeypatch.setattr(
+        cfn_lifecycle,
+        "_stack_task_lifecycles",
+        LoopLocal(cfn_lifecycle._StackTaskLifecycle),
+    )
+    monkeypatch.setattr(
+        ministack_app,
+        "_ordinary_request_reset_barriers",
+        LoopLocal(ministack_app._RequestResetBarrier),
+    )
+    monkeypatch.setattr(ministack_app, "_RESET_SERIALIZED_SERVICE_MODULES", ())
+    monkeypatch.setattr(ministack_app, "_reset_all_state", wipe_called.set)
+
+    async def active_stack_task():
+        try:
+            await asyncio.Future()
+        except asyncio.CancelledError:
+            drain_started.set()
+            await release_drain.wait()
+            raise
+
+    async def exercise():
+        lifecycle = cfn_lifecycle._get_stack_task_lifecycle()
+        active = lifecycle.create_task(active_stack_task())
+        reset = asyncio.create_task(
+            ministack_app._reset_all_state_after_service_dispatch_drains()
+        )
+        await drain_started.wait()
+
+        reset.cancel()
+        await asyncio.sleep(0)
+        reset.cancel()
+        await asyncio.sleep(0.02)
+        assert not wipe_called.is_set()
+
+        release_drain.set()
+        result = await asyncio.gather(reset, return_exceptions=True)
+        assert isinstance(result[0], asyncio.CancelledError)
+        assert wipe_called.is_set()
+        assert lifecycle.is_accepting()
+        assert isinstance(
+            (await asyncio.gather(active, return_exceptions=True))[0],
+            asyncio.CancelledError,
+        )
+
+    asyncio.run(exercise())
 
 
 def test_cancelled_dispatch_holds_admission_and_reset_until_worker_finishes(

--- a/tests/test_event_loop.py
+++ b/tests/test_event_loop.py
@@ -1,6 +1,7 @@
 import asyncio
 import gc
 import json
+import os
 import subprocess
 import sys
 import threading
@@ -631,6 +632,229 @@ raise SystemExit(bool(unexpected))
     assert json.loads(result.stdout.strip().splitlines()[-1]) == []
 
 
+def test_asgi_establishes_caller_context_before_first_touch_import(monkeypatch):
+    loaded = {}
+    observed = []
+    sent = []
+
+    class FakeEcs:
+        async def handle_request(self, *_args):
+            return 200, {}, b"{}"
+
+    def import_module(name):
+        if name not in loaded:
+            observed.append((name, get_account_id(), get_region()))
+            loaded[name] = FakeEcs()
+        return loaded[name]
+
+    monkeypatch.setattr(
+        ministack_app, "_resolve_loaded_service_module", loaded.get
+    )
+    monkeypatch.setattr(ministack_app, "_get_module", import_module)
+    monkeypatch.setattr(
+        ministack_app,
+        "_ordinary_request_reset_barriers",
+        LoopLocal(ministack_app._RequestResetBarrier),
+    )
+
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/",
+        "query_string": b"",
+        "headers": [
+            (b"host", b"ecs.us-west-2.amazonaws.com"),
+            (
+                b"authorization",
+                b"AWS4-HMAC-SHA256 Credential=123456789012/20260804/"
+                b"us-west-2/ecs/aws4_request, SignedHeaders=host;x-amz-target, "
+                b"Signature=test",
+            ),
+            (
+                b"x-amz-target",
+                b"AmazonEC2ContainerServiceV20141113.ListClusters",
+            ),
+            (b"content-type", b"application/x-amz-json-1.1"),
+            (b"content-length", b"2"),
+        ],
+    }
+
+    async def receive():
+        return {"type": "http.request", "body": b"{}", "more_body": False}
+
+    async def send(message):
+        sent.append(message)
+
+    previous_scope = (get_account_id(), get_region())
+    set_request_account_id("000000000000")
+    set_request_region("us-east-1")
+    try:
+        asyncio.run(ministack_app.app(scope, receive, send))
+    finally:
+        set_request_account_id(previous_scope[0])
+        set_request_region(previous_scope[1])
+
+    assert observed == [("ecs", "123456789012", "us-west-2")]
+    assert sent[0]["status"] == 200
+
+
+def test_first_touch_legacy_restore_uses_asgi_caller_context(tmp_path):
+    (tmp_path / "ecs.json").write_text(
+        json.dumps({"task_def_latest": {"legacy-family": 7}})
+    )
+    script = """
+import asyncio
+import json
+
+import ministack.app as app
+
+scope = {
+    "type": "http",
+    "method": "POST",
+    "path": "/",
+    "query_string": b"",
+    "headers": [
+        (b"host", b"ecs.us-west-2.amazonaws.com"),
+        (
+            b"authorization",
+            b"AWS4-HMAC-SHA256 Credential=123456789012/20260804/"
+            b"us-west-2/ecs/aws4_request, SignedHeaders=host;x-amz-target, "
+            b"Signature=test",
+        ),
+        (
+            b"x-amz-target",
+            b"AmazonEC2ContainerServiceV20141113.ListClusters",
+        ),
+        (b"content-type", b"application/x-amz-json-1.1"),
+        (b"content-length", b"2"),
+    ],
+}
+sent = []
+
+async def receive():
+    return {"type": "http.request", "body": b"{}", "more_body": False}
+
+async def send(message):
+    sent.append(message)
+
+asyncio.run(app.app(scope, receive, send))
+
+from ministack.services import ecs
+
+expected = ("123456789012", "us-west-2", "legacy-family")
+default = ("000000000000", "us-east-1", "legacy-family")
+result = {
+    "status": sent[0]["status"],
+    "expected": ecs._task_def_latest._data.get(expected),
+    "default_present": default in ecs._task_def_latest._data,
+}
+print(json.dumps(result))
+raise SystemExit(
+    result != {"status": 200, "expected": 7, "default_present": False}
+)
+"""
+    env = {
+        **os.environ,
+        "PERSIST_STATE": "1",
+        "STATE_DIR": str(tmp_path),
+        "SERVICES": "ecs",
+    }
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=15,
+        env=env,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert json.loads(result.stdout.strip().splitlines()[-1]) == {
+        "status": 200,
+        "expected": 7,
+        "default_present": False,
+    }
+
+
+def test_services_filter_rejects_without_first_touch_imports():
+    script = """
+import asyncio
+import json
+import sys
+
+import ministack.app as app
+
+async def request(host, target, body=b"{}"):
+    sent = []
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/",
+        "query_string": b"",
+        "headers": [
+            (b"host", host.encode()),
+            (b"x-amz-target", target.encode()),
+            (b"content-type", b"application/x-amz-json-1.1"),
+            (b"content-length", str(len(body)).encode()),
+        ],
+    }
+
+    async def receive():
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    async def send(message):
+        sent.append(message)
+
+    await app.app(scope, receive, send)
+    return sent[0]["status"]
+
+async def exercise():
+    return [
+        await request("eks.us-east-1.amazonaws.com", "EKS.ListClusters"),
+        await request(
+            "tagging.us-east-1.amazonaws.com",
+            "ResourceGroupsTaggingAPI_20170126.TagResources",
+            json.dumps(
+                {
+                    "ResourceARNList": [
+                        "arn:aws:ecs:us-east-1:000000000000:cluster/disabled"
+                    ],
+                    "Tags": {"owner": "disabled"},
+                }
+            ).encode(),
+        ),
+        await request(
+            "rds-data.us-east-1.amazonaws.com",
+            "RDSDataService.ExecuteStatement",
+        ),
+    ]
+
+statuses = asyncio.run(exercise())
+names = [
+    "ministack.services.eks",
+    "ministack.services.tagging",
+    "ministack.services.ecs",
+    "ministack.services.elasticache",
+    "ministack.services.rds_data",
+    "ministack.services.rds",
+]
+unexpected = [name for name in names if name in sys.modules]
+print(json.dumps({"statuses": statuses, "unexpected": unexpected}))
+raise SystemExit(statuses != [400, 400, 400] or bool(unexpected))
+"""
+    env = {**os.environ, "SERVICES": "dynamodb"}
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=15,
+        env=env,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert json.loads(result.stdout.strip().splitlines()[-1]) == {
+        "statuses": [400, 400, 400],
+        "unexpected": [],
+    }
+
+
 def test_first_touch_serialized_import_waits_for_reset_writer(monkeypatch):
     wipe_started = threading.Event()
     release_wipe = threading.Event()
@@ -879,6 +1103,7 @@ def test_sfn_indirect_first_touch_imports_owner_loop_side_after_reset(monkeypatc
     loaded = {}
     order = []
     import_thread_ids = []
+    import_scopes = []
 
     class FakeRds:
         async def handle_request(self, *_args):
@@ -893,6 +1118,7 @@ def test_sfn_indirect_first_touch_imports_owner_loop_side_after_reset(monkeypatc
         if name in loaded:
             return loaded[name]
         import_thread_ids.append(threading.get_ident())
+        import_scopes.append((get_account_id(), get_region()))
         order.append(f"import-{name}")
         loaded[name] = FakeRds()
         return loaded[name]
@@ -927,6 +1153,9 @@ def test_sfn_indirect_first_touch_imports_owner_loop_side_after_reset(monkeypatc
 
     async def exercise():
         loop_thread_id = threading.get_ident()
+        previous_scope = (get_account_id(), get_region())
+        set_request_account_id("123456789012")
+        set_request_region("us-west-2")
         reset = asyncio.create_task(
             ministack_app._reset_all_state_after_service_dispatch_drains()
         )
@@ -954,8 +1183,11 @@ def test_sfn_indirect_first_touch_imports_owner_loop_side_after_reset(monkeypatc
             await asyncio.gather(reset, integration)
         finally:
             stepfunctions._execution_server_loop.reset(token)
+            set_request_account_id(previous_scope[0])
+            set_request_region(previous_scope[1])
 
         assert import_thread_ids == [loop_thread_id]
+        assert import_scopes == [("123456789012", "us-west-2")]
         assert order.index("wipe-finish") < order.index("mutate-rds")
 
     fallback = threading.Timer(1, release_wipe.set)

--- a/tests/test_event_loop.py
+++ b/tests/test_event_loop.py
@@ -40,6 +40,13 @@ from ministack.services.cloudformation import lifecycle as cfn_lifecycle
 from ministack.services.cloudformation import provisioners as cfn_provisioners
 from ministack.services.cloudformation import stacks as cfn_stacks
 
+try:
+    from ministack.services import stepfunctions_lifecycle
+except ImportError:
+    # Fail-before runs copy this test file onto the pre-v16 head, where the
+    # lifecycle intentionally does not exist yet.
+    stepfunctions_lifecycle = None
+
 
 class _SlowContainer:
     def stop(self, **_kwargs):
@@ -86,6 +93,26 @@ async def _call_cloudformation_action(action, data=None):
         json.dumps(data or {}).encode(),
         {},
     )
+
+
+def _reset_test_lifecycles(monkeypatch):
+    monkeypatch.setattr(
+        cfn_lifecycle,
+        "_stack_task_lifecycles",
+        LoopLocal(cfn_lifecycle._StackTaskLifecycle),
+    )
+    monkeypatch.setattr(
+        ministack_app,
+        "_ordinary_request_reset_barriers",
+        LoopLocal(ministack_app._RequestResetBarrier),
+    )
+    monkeypatch.setattr(ministack_app, "_RESET_SERIALIZED_SERVICE_MODULES", ())
+    if stepfunctions_lifecycle is not None:
+        monkeypatch.setattr(
+            stepfunctions_lifecycle,
+            "_sync_action_lifecycles",
+            LoopLocal(stepfunctions_lifecycle._SyncActionLifecycle),
+        )
 
 
 def _clear_cloudformation_state():
@@ -1819,6 +1846,7 @@ def test_cancelled_stepfunctions_sync_action_waits_for_dedicated_thread(
     action_started = threading.Event()
     release_action = threading.Event()
     action_finished = threading.Event()
+    wipe_called = threading.Event()
 
     def sync_execution(_data):
         action_started.set()
@@ -1827,6 +1855,10 @@ def test_cancelled_stepfunctions_sync_action_waits_for_dedicated_thread(
         return 200, {}, b"{}"
 
     monkeypatch.setattr(stepfunctions, "_start_sync_execution", sync_execution)
+    _reset_test_lifecycles(monkeypatch)
+    monkeypatch.setattr(
+        ministack_app, "_reset_all_state", lambda: wipe_called.set()
+    )
 
     async def exercise():
         request = asyncio.create_task(
@@ -1838,14 +1870,325 @@ def test_cancelled_stepfunctions_sync_action_waits_for_dedicated_thread(
         request.cancel()
         await asyncio.sleep(0.01)
         request.cancel()
+        reset = asyncio.create_task(
+            ministack_app._reset_all_state_after_service_dispatch_drains()
+        )
         await asyncio.sleep(0.05)
         assert not request.done()
         assert not action_finished.is_set()
+        assert not wipe_called.is_set()
 
         release_action.set()
         result = await asyncio.gather(request, return_exceptions=True)
+        await reset
         assert isinstance(result[0], asyncio.CancelledError)
         assert action_finished.is_set()
+        assert wipe_called.is_set()
+
+    fallback = threading.Timer(1, release_action.set)
+    fallback.start()
+    try:
+        asyncio.run(exercise())
+    finally:
+        release_action.set()
+        fallback.cancel()
+
+
+def test_reset_waits_for_start_sync_execution_thread(monkeypatch):
+    action_started = threading.Event()
+    release_action = threading.Event()
+    wipe_called = threading.Event()
+
+    def controlled_execution(exec_arn):
+        action_started.set()
+        release_action.wait(timeout=2)
+        execution = stepfunctions._executions[exec_arn]
+        execution["status"] = "SUCCEEDED"
+        execution["stopDate"] = "2026-01-01T00:00:00Z"
+        execution["output"] = "{}"
+
+    def reset_state():
+        stepfunctions.reset()
+        wipe_called.set()
+
+    _reset_test_lifecycles(monkeypatch)
+    monkeypatch.setattr(stepfunctions, "_run_execution", controlled_execution)
+    monkeypatch.setattr(ministack_app, "_reset_all_state", reset_state)
+    stepfunctions.reset()
+
+    async def exercise():
+        created = await _call_stepfunctions_action(
+            "CreateStateMachine",
+            {
+                "name": "sync-reset",
+                "definition": json.dumps(
+                    {"StartAt": "Done", "States": {"Done": {"Type": "Succeed"}}}
+                ),
+                "roleArn": "arn:aws:iam::000000000000:role/test",
+                "type": "EXPRESS",
+            },
+        )
+        state_machine_arn = json.loads(created[2])["stateMachineArn"]
+        request = asyncio.create_task(
+            _call_stepfunctions_action(
+                "StartSyncExecution", {"stateMachineArn": state_machine_arn}
+            )
+        )
+        while not action_started.is_set():
+            await asyncio.sleep(0.001)
+
+        reset = asyncio.create_task(
+            ministack_app._reset_all_state_after_service_dispatch_drains()
+        )
+        await asyncio.sleep(0.05)
+        wiped_before_completion = wipe_called.is_set()
+
+        release_action.set()
+        response, _ = await asyncio.gather(request, reset)
+        assert not wiped_before_completion
+        assert response[0] == 200
+        assert json.loads(response[2])["status"] == "SUCCEEDED"
+        assert wipe_called.is_set()
+        assert not stepfunctions._executions
+
+    fallback = threading.Timer(1, release_action.set)
+    fallback.start()
+    try:
+        asyncio.run(exercise())
+    finally:
+        release_action.set()
+        fallback.cancel()
+        stepfunctions.reset()
+
+
+def test_reset_waits_for_test_state_thread_and_wipes_its_mutation(monkeypatch):
+    action_started = threading.Event()
+    release_action = threading.Event()
+    wipe_called = threading.Event()
+    state = []
+
+    def test_state(_data):
+        action_started.set()
+        release_action.wait(timeout=2)
+        state.append("test-state-mutation")
+        return 200, {}, b'{"status":"SUCCEEDED"}'
+
+    def reset_state():
+        state.clear()
+        wipe_called.set()
+
+    _reset_test_lifecycles(monkeypatch)
+    monkeypatch.setattr(stepfunctions, "_test_state", test_state)
+    monkeypatch.setattr(ministack_app, "_reset_all_state", reset_state)
+
+    async def exercise():
+        request = asyncio.create_task(_call_stepfunctions_action("TestState"))
+        while not action_started.is_set():
+            await asyncio.sleep(0.001)
+
+        reset = asyncio.create_task(
+            ministack_app._reset_all_state_after_service_dispatch_drains()
+        )
+        await asyncio.sleep(0.05)
+        wiped_before_completion = wipe_called.is_set()
+
+        release_action.set()
+        response, _ = await asyncio.gather(request, reset)
+        assert not wiped_before_completion
+        assert response[0] == 200
+        assert wipe_called.is_set()
+        assert state == []
+
+    fallback = threading.Timer(1, release_action.set)
+    fallback.start()
+    try:
+        asyncio.run(exercise())
+    finally:
+        release_action.set()
+        fallback.cancel()
+
+
+def test_sync_action_started_during_reset_returns_503_without_residue(monkeypatch):
+    first_started = threading.Event()
+    release_first = threading.Event()
+    wipe_started = threading.Event()
+    release_wipe = threading.Event()
+    second_mutated = threading.Event()
+    call_count = 0
+    call_lock = threading.Lock()
+
+    def sync_execution(_data):
+        nonlocal call_count
+        with call_lock:
+            call_count += 1
+            this_call = call_count
+        if this_call == 1:
+            first_started.set()
+            release_first.wait(timeout=2)
+        else:
+            second_mutated.set()
+        return 200, {}, b"{}"
+
+    def reset_state():
+        wipe_started.set()
+        release_wipe.wait(timeout=2)
+
+    _reset_test_lifecycles(monkeypatch)
+    monkeypatch.setattr(stepfunctions, "_start_sync_execution", sync_execution)
+    monkeypatch.setattr(ministack_app, "_reset_all_state", reset_state)
+
+    async def exercise():
+        first = asyncio.create_task(
+            _call_stepfunctions_action("StartSyncExecution")
+        )
+        while not first_started.is_set():
+            await asyncio.sleep(0.001)
+
+        reset = asyncio.create_task(
+            ministack_app._reset_all_state_after_service_dispatch_drains()
+        )
+        if stepfunctions_lifecycle is None:
+            while not wipe_started.is_set():
+                await asyncio.sleep(0.001)
+        else:
+            lifecycle = stepfunctions_lifecycle._get_sync_action_lifecycle()
+            while lifecycle._accepting:
+                await asyncio.sleep(0.001)
+
+        second = await _call_stepfunctions_action("StartSyncExecution")
+        release_first.set()
+        while not wipe_started.is_set():
+            await asyncio.sleep(0.001)
+        release_wipe.set()
+        await asyncio.gather(first, reset)
+        return second
+
+    fallback = threading.Timer(1, release_first.set)
+    fallback.start()
+    try:
+        second = asyncio.run(exercise())
+        assert second[0] == 503
+        assert b"ServiceUnavailableException" in second[2]
+        assert call_count == 1
+        assert not second_mutated.is_set()
+    finally:
+        release_first.set()
+        release_wipe.set()
+        fallback.cancel()
+
+
+def test_nested_sync_action_is_covered_by_draining_parent(monkeypatch):
+    parent_started = threading.Event()
+    release_parent = threading.Event()
+    wipe_called = threading.Event()
+    state = []
+
+    def nested_test_state(_data):
+        state.append("nested")
+        return 200, {}, b'{"status":"SUCCEEDED"}'
+
+    def parent_sync_execution(_data):
+        nested = stepfunctions._drive_service_handler_sync(
+            "states",
+            stepfunctions.handle_request,
+            "POST",
+            "/",
+            {"x-amz-target": "AWSStepFunctions.TestState"},
+            b"{}",
+            {},
+        )
+        parent_started.set()
+        release_parent.wait(timeout=2)
+        state.append("parent")
+        return nested
+
+    def reset_state():
+        state.clear()
+        wipe_called.set()
+
+    _reset_test_lifecycles(monkeypatch)
+    monkeypatch.setattr(stepfunctions, "_test_state", nested_test_state)
+    monkeypatch.setattr(
+        stepfunctions, "_start_sync_execution", parent_sync_execution
+    )
+    monkeypatch.setattr(ministack_app, "_reset_all_state", reset_state)
+
+    async def exercise():
+        parent = asyncio.create_task(
+            _call_stepfunctions_action("StartSyncExecution")
+        )
+        while not parent_started.is_set():
+            await asyncio.sleep(0.001)
+        reset = asyncio.create_task(
+            ministack_app._reset_all_state_after_service_dispatch_drains()
+        )
+        await asyncio.sleep(0.05)
+        wiped_before_parent = wipe_called.is_set()
+
+        release_parent.set()
+        response, _ = await asyncio.gather(parent, reset)
+        assert not wiped_before_parent
+        assert response[0] == 200
+        assert wipe_called.is_set()
+        assert state == []
+
+    fallback = threading.Timer(1, release_parent.set)
+    fallback.start()
+    try:
+        asyncio.run(exercise())
+    finally:
+        release_parent.set()
+        fallback.cancel()
+
+
+def test_cancelled_reset_completes_sfn_drain_and_reopens_admission(monkeypatch):
+    action_started = threading.Event()
+    release_action = threading.Event()
+    wipe_called = threading.Event()
+    state = []
+
+    def test_state(_data):
+        action_started.set()
+        release_action.wait(timeout=2)
+        state.append("completed")
+        return 200, {}, b'{"status":"SUCCEEDED"}'
+
+    def reset_state():
+        state.clear()
+        wipe_called.set()
+
+    _reset_test_lifecycles(monkeypatch)
+    monkeypatch.setattr(stepfunctions, "_test_state", test_state)
+    monkeypatch.setattr(ministack_app, "_reset_all_state", reset_state)
+
+    async def exercise():
+        request = asyncio.create_task(_call_stepfunctions_action("TestState"))
+        while not action_started.is_set():
+            await asyncio.sleep(0.001)
+        reset = asyncio.create_task(
+            ministack_app._reset_all_state_after_service_dispatch_drains()
+        )
+        lifecycle = stepfunctions_lifecycle._get_sync_action_lifecycle()
+        while lifecycle._accepting:
+            await asyncio.sleep(0.001)
+
+        reset.cancel()
+        await asyncio.sleep(0.01)
+        reset.cancel()
+        await asyncio.sleep(0.05)
+        assert not reset.done()
+        assert not wipe_called.is_set()
+
+        release_action.set()
+        request_result = await request
+        reset_result = await asyncio.gather(reset, return_exceptions=True)
+        assert request_result[0] == 200
+        assert isinstance(reset_result[0], asyncio.CancelledError)
+        assert wipe_called.is_set()
+        assert state == []
+
+        reopened = await _call_stepfunctions_action("TestState")
+        assert reopened[0] == 200
 
     fallback = threading.Timer(1, release_action.set)
     fallback.start()
@@ -1883,7 +2226,7 @@ def test_stepfunctions_marshal_fails_fast_on_target_loop(monkeypatch):
     asyncio.run(exercise())
 
 
-def test_stepfunctions_marshaled_rds_waits_for_reset_and_sees_fresh_state(
+def test_stepfunctions_sync_request_during_wipe_returns_503(
     monkeypatch,
 ):
     reset_started = threading.Event()
@@ -1941,8 +2284,9 @@ def test_stepfunctions_marshaled_rds_waits_for_reset_and_sees_fresh_state(
 
         release_reset.set()
         _, result = await asyncio.gather(reset, integration)
-        assert integration_started.is_set()
-        assert json.loads(result[2]) == {"generation": "fresh"}
+        assert not integration_started.is_set()
+        assert result[0] == 503
+        assert b"ServiceUnavailableException" in result[2]
 
     fallback = threading.Timer(1, release_reset.set)
     fallback.start()

--- a/tests/test_event_loop.py
+++ b/tests/test_event_loop.py
@@ -1,0 +1,2007 @@
+import asyncio
+import gc
+import json
+import threading
+import time
+import weakref
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+import ministack.app as ministack_app
+from ministack.core.concurrency import LoopLocal
+from ministack.core.responses import (
+    get_account_id,
+    get_region,
+    set_request_account_id,
+    set_request_region,
+)
+from ministack.services import (
+    dynamodb,
+    ecs,
+    eks,
+    elasticache,
+    eventbridge,
+    opensearch,
+    rds,
+    rds_data,
+    s3,
+    stepfunctions,
+    tagging,
+)
+from ministack.services.cloudformation import provisioners as cfn_provisioners
+from ministack.services.cloudformation import stacks as cfn_stacks
+
+
+class _SlowContainer:
+    def stop(self, **_kwargs):
+        time.sleep(0.35)
+
+    def remove(self, **_kwargs):
+        pass
+
+
+class _SlowContainers:
+    def __init__(self, container_id):
+        self._container_id = container_id
+        self._container = _SlowContainer()
+
+    def get(self, container_id):
+        if container_id != self._container_id:
+            raise RuntimeError(f"unexpected container lookup: {container_id}")
+        return self._container
+
+
+class _SlowDocker:
+    def __init__(self, container_id):
+        self.containers = _SlowContainers(container_id)
+
+
+async def _call_stepfunctions_action(action, data=None):
+    return await stepfunctions.handle_request(
+        "POST",
+        "/",
+        {"x-amz-target": f"AWSStepFunctions.{action}"},
+        json.dumps(data or {}).encode(),
+        {},
+    )
+
+
+async def _create_rds_integration_state_machine(name):
+    response = await _call_stepfunctions_action(
+        "CreateStateMachine",
+        {
+            "name": name,
+            "roleArn": "arn:aws:iam::000000000000:role/sfn-role",
+            "definition": json.dumps(
+                {
+                    "StartAt": "Describe",
+                    "States": {
+                        "Describe": {
+                            "Type": "Task",
+                            "Resource": (
+                                "arn:aws:states:::aws-sdk:rds:DescribeDBClusters"
+                            ),
+                            "End": True,
+                        }
+                    },
+                }
+            ),
+        },
+    )
+    assert response[0] == 200
+    return json.loads(response[2])["stateMachineArn"]
+
+
+async def _wait_for_state_machine_terminal_success(state_machine_arn):
+    deadline = asyncio.get_running_loop().time() + 3
+    while asyncio.get_running_loop().time() < deadline:
+        matches = [
+            execution
+            for execution in stepfunctions._executions.values()
+            if execution["stateMachineArn"] == state_machine_arn
+        ]
+        if matches and matches[-1]["status"] != "RUNNING":
+            assert matches[-1]["status"] == "SUCCEEDED", matches[-1]
+            return matches[-1]
+        await asyncio.sleep(0.01)
+    pytest.fail(f"execution for {state_machine_arn} did not reach terminal success")
+
+
+def _configure_eventbridge_sfn_target(state_machine_arn, *, rule_name, source=None):
+    eventbridge._ensure_default_bus()
+    rule_data = {
+        "Name": rule_name,
+        "EventBusName": "default",
+        "State": "ENABLED",
+    }
+    if source is None:
+        rule_data["ScheduleExpression"] = "rate(1 minute)"
+    else:
+        rule_data["EventPattern"] = json.dumps({"source": [source]})
+    assert eventbridge._put_rule(rule_data)[0] == 200
+    assert eventbridge._put_targets(
+        {
+            "Rule": rule_name,
+            "EventBusName": "default",
+            "Targets": [{"Id": "sfn", "Arn": state_machine_arn}],
+        }
+    )[0] == 200
+
+
+async def _run_with_parallel_dynamodb_probe(slow_request):
+    async def probe():
+        started = time.perf_counter()
+        await asyncio.sleep(0.05)
+        response = await dynamodb.handle_request(
+            "POST",
+            "/",
+            {"x-amz-target": "DynamoDB_20120810.ListTables"},
+            b"{}",
+            {},
+        )
+        return response, time.perf_counter() - started
+
+    # Start the probe first so its timer is armed before the slow request.
+    # Without worker offload, the slow Docker call blocks that timer for 350ms.
+    probe_task = asyncio.create_task(probe())
+    slow_task = asyncio.create_task(slow_request())
+    probe_response, elapsed = await probe_task
+    slow_response = await slow_task
+
+    assert probe_response[0] == 200
+    assert elapsed < 0.2
+    assert slow_response[0] == 200
+
+
+@pytest.mark.parametrize(
+    "service",
+    [rds, ecs, eks, elasticache, opensearch],
+    ids=["rds", "ecs", "eks", "elasticache", "opensearch"],
+)
+def test_sync_service_dispatch_runs_off_loop_and_stays_serial(monkeypatch, service):
+    first_started = threading.Event()
+    release = threading.Event()
+    call_count = 0
+    count_lock = threading.Lock()
+
+    def slow_dispatch(*_args):
+        nonlocal call_count
+        with count_lock:
+            call_count += 1
+            if call_count == 1:
+                first_started.set()
+        release.wait(timeout=2)
+        return 200, {}, b"ok"
+
+    monkeypatch.setattr(service, "_handle_request_unlocked", slow_dispatch)
+
+    async def exercise():
+        first = asyncio.create_task(
+            service.handle_request("GET", "/", {}, b"", {})
+        )
+        while not first_started.is_set():
+            await asyncio.sleep(0.001)
+
+        # A fallback timer prevents a broken implementation from hanging the
+        # suite. If dispatch still runs on the event loop, it fires before this
+        # coroutine can resume and the assertion identifies the regression.
+        assert not release.is_set()
+
+        second = asyncio.create_task(
+            service.handle_request("GET", "/", {}, b"", {})
+        )
+        await asyncio.sleep(0.05)
+        with count_lock:
+            assert call_count == 1
+
+        release.set()
+        assert await asyncio.gather(first, second) == [
+            (200, {}, b"ok"),
+            (200, {}, b"ok"),
+        ]
+
+    fallback = threading.Timer(1, release.set)
+    fallback.start()
+    try:
+        asyncio.run(exercise())
+    finally:
+        release.set()
+        fallback.cancel()
+
+
+@pytest.mark.parametrize(
+    ("service_name", "service"),
+    [("ecs", ecs), ("elasticache", elasticache)],
+)
+def test_tagging_waits_for_service_dispatch(monkeypatch, service_name, service):
+    owner_started = threading.Event()
+    release_owner = threading.Event()
+    tagging_entered = threading.Event()
+
+    def slow_owner_dispatch(*_args):
+        owner_started.set()
+        release_owner.wait(timeout=2)
+        return 200, {}, b"ok"
+
+    def tagging_writer(_spec, _arn, _tags):
+        tagging_entered.set()
+
+    monkeypatch.setattr(service, "_handle_request_unlocked", slow_owner_dispatch)
+    monkeypatch.setitem(tagging._WRITERS, service_name, tagging_writer)
+
+    async def exercise():
+        owner = asyncio.create_task(service.handle_request("GET", "/", {}, b"", {}))
+        while not owner_started.is_set():
+            await asyncio.sleep(0.001)
+
+        arn = f"arn:aws:{service_name}:us-east-1:000000000000:resource/test"
+        cross_service = asyncio.create_task(
+            tagging.handle_request(
+                "POST",
+                "/",
+                {"x-amz-target": "ResourceGroupsTaggingAPI_20170126.TagResources"},
+                json.dumps({"ResourceARNList": [arn], "Tags": {"source": "rgta"}}).encode(),
+                {},
+            )
+        )
+        await asyncio.sleep(0.05)
+        assert not tagging_entered.is_set()
+
+        release_owner.set()
+        assert (await owner)[0] == 200
+        assert (await cross_service)[0] == 200
+        assert tagging_entered.is_set()
+
+    fallback = threading.Timer(1, release_owner.set)
+    fallback.start()
+    try:
+        asyncio.run(exercise())
+    finally:
+        release_owner.set()
+        fallback.cancel()
+
+
+def test_tagging_does_not_wait_for_unrelated_service_dispatch(monkeypatch):
+    owner_started = threading.Event()
+    release_owner = threading.Event()
+    tagging_entered = threading.Event()
+
+    def slow_owner_dispatch(*_args):
+        owner_started.set()
+        release_owner.wait(timeout=2)
+        return 200, {}, b"ok"
+
+    def tagging_writer(_spec, _arn, _tags):
+        tagging_entered.set()
+
+    monkeypatch.setattr(ecs, "_handle_request_unlocked", slow_owner_dispatch)
+    monkeypatch.setitem(tagging._WRITERS, "s3", tagging_writer)
+
+    async def exercise():
+        owner = asyncio.create_task(ecs.handle_request("GET", "/", {}, b"", {}))
+        while not owner_started.is_set():
+            await asyncio.sleep(0.001)
+
+        cross_service = asyncio.create_task(
+            tagging.handle_request(
+                "POST",
+                "/",
+                {"x-amz-target": "ResourceGroupsTaggingAPI_20170126.TagResources"},
+                json.dumps(
+                    {
+                        "ResourceARNList": ["arn:aws:s3:::event-loop-unrelated"],
+                        "Tags": {"source": "rgta"},
+                    }
+                ).encode(),
+                {},
+            )
+        )
+        await asyncio.wait_for(cross_service, timeout=0.2)
+        assert tagging_entered.is_set()
+
+        release_owner.set()
+        assert (await owner)[0] == 200
+
+    fallback = threading.Timer(1, release_owner.set)
+    fallback.start()
+    try:
+        asyncio.run(exercise())
+    finally:
+        release_owner.set()
+        fallback.cancel()
+
+
+@pytest.mark.parametrize("body", [b"[]", b"null", b'"str"', b"5"])
+def test_tagging_admission_classifier_rejects_non_object_json(body):
+    with pytest.raises(tagging.InvalidRequestBody):
+        tagging.classify_request_admission(
+            {"x-amz-target": "ResourceGroupsTaggingAPI_20170126.TagResources"},
+            body,
+        )
+
+
+@pytest.mark.parametrize("body", [b"[]", b"null", b'"str"', b"5"])
+def test_tagging_non_object_json_returns_serialization_error(body):
+    response = []
+    request_sent = False
+
+    async def receive():
+        nonlocal request_sent
+        if request_sent:
+            return {"type": "http.disconnect"}
+        request_sent = True
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    async def send(message):
+        response.append(message)
+
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/",
+        "query_string": b"",
+        "headers": [
+            (
+                b"x-amz-target",
+                b"ResourceGroupsTaggingAPI_20170126.TagResources",
+            ),
+            (
+                b"authorization",
+                b"AWS4-HMAC-SHA256 Credential=test/20260101/us-east-1/tagging/aws4_request",
+            ),
+        ],
+    }
+
+    asyncio.run(ministack_app.app(scope, receive, send))
+
+    assert response[0]["status"] == 400
+    assert json.loads(response[-1]["body"])["__type"] == "SerializationException"
+
+
+def test_rds_data_waits_for_rds_dispatch(monkeypatch):
+    owner_started = threading.Event()
+    release_owner = threading.Event()
+    data_handler_entered = threading.Event()
+
+    def slow_owner_dispatch(*_args):
+        owner_started.set()
+        release_owner.wait(timeout=2)
+        return 200, {}, b"ok"
+
+    def data_handler(_data):
+        data_handler_entered.set()
+        return 200, {}, b"ok"
+
+    monkeypatch.setattr(rds, "_handle_request_unlocked", slow_owner_dispatch)
+    monkeypatch.setattr(rds_data, "_execute_statement", data_handler)
+
+    async def exercise():
+        owner = asyncio.create_task(rds.handle_request("GET", "/", {}, b"", {}))
+        while not owner_started.is_set():
+            await asyncio.sleep(0.001)
+
+        cross_service = asyncio.create_task(
+            rds_data.handle_request("POST", "/Execute", {}, b"{}", {})
+        )
+        await asyncio.sleep(0.05)
+        assert not data_handler_entered.is_set()
+
+        release_owner.set()
+        assert (await owner)[0] == 200
+        assert (await cross_service)[0] == 200
+        assert data_handler_entered.is_set()
+
+    fallback = threading.Timer(1, release_owner.set)
+    fallback.start()
+    try:
+        asyncio.run(exercise())
+    finally:
+        release_owner.set()
+        fallback.cancel()
+
+
+def test_rds_data_does_not_block_parallel_dynamodb(monkeypatch):
+    def slow_statement(_data):
+        time.sleep(0.35)
+        return 200, {}, b"ok"
+
+    monkeypatch.setattr(rds_data, "_execute_statement", slow_statement)
+
+    asyncio.run(
+        _run_with_parallel_dynamodb_probe(
+            lambda: rds_data.handle_request("POST", "/Execute", {}, b"{}", {})
+        )
+    )
+
+
+def test_nested_cfn_standard_children_share_service_admission(monkeypatch):
+    current = {}
+
+    def slow_owner_dispatch(*_args):
+        current["owner_started"].set()
+        current["release_owner"].wait(timeout=2)
+        return 200, {}, b"ok"
+
+    def child_create(*_args):
+        current["child_entered"].set()
+        current["observed_scope"] = (get_account_id(), get_region())
+        return "child-id", {}
+
+    def child_update(*_args):
+        current["child_entered"].set()
+        current["observed_scope"] = (get_account_id(), get_region())
+        return "child-id", {}
+
+    def child_delete(*_args):
+        current["child_entered"].set()
+        current["observed_scope"] = (get_account_id(), get_region())
+
+    monkeypatch.setattr(eks, "_handle_request_unlocked", slow_owner_dispatch)
+    monkeypatch.setattr(cfn_provisioners, "_provision_resource", child_create)
+    monkeypatch.setattr(cfn_provisioners, "_update_resource", child_update)
+    monkeypatch.setattr(cfn_provisioners, "_delete_resource", child_delete)
+
+    def nested_operation(operation, depth):
+        if depth:
+            return nested_operation(operation, depth - 1)
+        if operation == "create":
+            return cfn_provisioners._nested_stack_provision_child(
+                "AWS::EKS::Cluster", "Child", {}, "nested"
+            )
+        if operation == "update":
+            return cfn_provisioners._nested_stack_update_child(
+                "AWS::EKS::Cluster",
+                "child-id",
+                {},
+                {},
+                "nested",
+                "Child",
+            )
+        return cfn_provisioners._nested_stack_delete_child(
+            "AWS::EKS::Cluster", "child-id", {}, "nested", "Child"
+        )
+
+    async def exercise():
+        previous_scope = (get_account_id(), get_region())
+        set_request_account_id("123456789012")
+        set_request_region("us-west-2")
+        try:
+            for operation in ("create", "update", "delete"):
+                current.update(
+                    owner_started=threading.Event(),
+                    release_owner=threading.Event(),
+                    child_entered=threading.Event(),
+                    observed_scope=None,
+                )
+                owner = asyncio.create_task(
+                    eks.handle_request("GET", "/", {}, b"", {})
+                )
+                while not current["owner_started"].is_set():
+                    await asyncio.sleep(0.001)
+
+                nested = asyncio.create_task(
+                    cfn_stacks._run_nested_stack_provisioner(
+                        nested_operation, operation, 2
+                    )
+                )
+                await asyncio.sleep(0.05)
+                assert not current["child_entered"].is_set()
+
+                current["release_owner"].set()
+                assert (await owner)[0] == 200
+                await nested
+                assert current["child_entered"].is_set()
+                assert current["observed_scope"] == (
+                    "123456789012",
+                    "us-west-2",
+                )
+        finally:
+            set_request_account_id(previous_scope[0])
+            set_request_region(previous_scope[1])
+
+    fallback = threading.Timer(
+        1,
+        lambda: current.get("release_owner", threading.Event()).set(),
+    )
+    fallback.start()
+    try:
+        asyncio.run(exercise())
+    finally:
+        if "release_owner" in current:
+            current["release_owner"].set()
+        fallback.cancel()
+
+
+def test_reset_skips_failed_serialized_lazy_module(monkeypatch):
+    reset_called = threading.Event()
+    real_get_module = ministack_app._get_module
+    failed_rds = ministack_app._ErrorModule("rds", "optional dependency missing")
+
+    def get_module(name):
+        if name == "rds":
+            return failed_rds
+        return real_get_module(name)
+
+    monkeypatch.setattr(ministack_app, "_get_module", get_module)
+    monkeypatch.setattr(ministack_app, "_reset_all_state", reset_called.set)
+    monkeypatch.setattr(ministack_app, "_reset_locks", LoopLocal(asyncio.Lock))
+    monkeypatch.setattr(
+        ministack_app,
+        "_ordinary_request_reset_barriers",
+        LoopLocal(ministack_app._RequestResetBarrier),
+    )
+    monkeypatch.setattr(
+        cfn_stacks,
+        "_stack_task_lifecycles",
+        LoopLocal(cfn_stacks._StackTaskLifecycle),
+    )
+
+    asyncio.run(ministack_app._reset_all_state_after_service_dispatch_drains())
+    assert reset_called.is_set()
+
+
+def test_reset_keeps_missing_healthy_admission_seam_loud(monkeypatch):
+    real_get_module = ministack_app._get_module
+
+    def get_module(name):
+        if name == "rds":
+            return object()
+        return real_get_module(name)
+
+    monkeypatch.setattr(ministack_app, "_get_module", get_module)
+    monkeypatch.setattr(ministack_app, "_reset_locks", LoopLocal(asyncio.Lock))
+    monkeypatch.setattr(
+        ministack_app,
+        "_ordinary_request_reset_barriers",
+        LoopLocal(ministack_app._RequestResetBarrier),
+    )
+    monkeypatch.setattr(
+        cfn_stacks,
+        "_stack_task_lifecycles",
+        LoopLocal(cfn_stacks._StackTaskLifecycle),
+    )
+
+    with pytest.raises(AttributeError, match="_get_request_dispatch_lock"):
+        asyncio.run(ministack_app._reset_all_state_after_service_dispatch_drains())
+
+
+@pytest.mark.parametrize(
+    "service",
+    [rds, ecs, eks, elasticache, opensearch],
+    ids=["rds", "ecs", "eks", "elasticache", "opensearch"],
+)
+def test_dispatch_lock_cache_does_not_retain_closed_event_loops(service):
+    def contend_once():
+        loop = asyncio.new_event_loop()
+
+        async def exercise():
+            lock = service._get_request_dispatch_lock()
+            await lock.acquire()
+            waiter = asyncio.create_task(lock.acquire())
+            await asyncio.sleep(0)
+            lock.release()
+            await waiter
+            lock.release()
+            return weakref.ref(lock)
+
+        try:
+            lock_ref = loop.run_until_complete(exercise())
+            return weakref.ref(loop), lock_ref
+        finally:
+            loop.close()
+
+    refs = [contend_once() for _ in range(3)]
+    gc.collect()
+    assert all(loop_ref() is None for loop_ref, _lock_ref in refs)
+    assert all(lock_ref() is None for _loop_ref, lock_ref in refs)
+
+
+def test_reset_lock_is_recreated_for_each_event_loop(monkeypatch):
+    monkeypatch.setattr(ministack_app, "_reset_locks", LoopLocal(asyncio.Lock))
+    monkeypatch.setattr(
+        ministack_app,
+        "_ordinary_request_reset_barriers",
+        LoopLocal(ministack_app._RequestResetBarrier),
+    )
+
+    async def exercise():
+        reset_lock = ministack_app._get_reset_lock()
+        await reset_lock.acquire()
+        lock_waiter = asyncio.create_task(reset_lock.acquire())
+        await asyncio.sleep(0)
+        reset_lock.release()
+        await lock_waiter
+        reset_lock.release()
+
+        barrier = ministack_app._get_ordinary_request_reset_barrier()
+        await barrier.enter_request()
+        reset_waiter = asyncio.create_task(barrier.enter_reset())
+        await asyncio.sleep(0)
+        barrier.leave_request()
+        await reset_waiter
+        barrier.leave_reset()
+
+    asyncio.run(exercise())
+    asyncio.run(exercise())
+
+
+def test_cloudformation_task_lifecycle_is_recreated_for_each_event_loop(monkeypatch):
+    monkeypatch.setattr(
+        cfn_stacks,
+        "_stack_task_lifecycles",
+        LoopLocal(cfn_stacks._StackTaskLifecycle),
+    )
+
+    def exercise_once():
+        async def exercise():
+            lifecycle = cfn_stacks._get_stack_task_lifecycle()
+
+            async def no_op():
+                return None
+
+            task = cfn_stacks._create_stack_task_in_region(no_op(), None)
+            await task
+            await asyncio.sleep(0)
+            return weakref.ref(lifecycle)
+
+        return asyncio.run(exercise())
+
+    refs = [exercise_once() for _ in range(3)]
+    gc.collect()
+    assert all(ref() is None for ref in refs)
+
+
+def test_stepfunctions_sync_sdk_dispatch_uses_rds_admission_router():
+    async def exercise():
+        loop_token = stepfunctions._execution_server_loop.set(
+            asyncio.get_running_loop()
+        )
+        try:
+            return await asyncio.to_thread(
+                stepfunctions._dispatch_aws_sdk_query,
+                stepfunctions._AWS_SDK_SERVICE_MAP["rds"],
+                "rds",
+                "DescribeDBClusters",
+                {},
+            )
+        finally:
+            stepfunctions._execution_server_loop.reset(loop_token)
+
+    result = asyncio.run(exercise())
+    assert isinstance(result["DbClusters"], list)
+
+
+def test_eventbridge_direct_sfn_rds_execution_reaches_terminal_success():
+    async def exercise():
+        eventbridge.reset()
+        stepfunctions.reset()
+        try:
+            state_machine_arn = await _create_rds_integration_state_machine(
+                "event-loop-eb-direct"
+            )
+            _configure_eventbridge_sfn_target(
+                state_machine_arn,
+                rule_name="event-loop-eb-direct-rule",
+                source="event-loop.direct",
+            )
+            response = eventbridge._put_events(
+                {
+                    "Entries": [
+                        {
+                            "Source": "event-loop.direct",
+                            "DetailType": "Regression",
+                            "Detail": "{}",
+                            "EventBusName": "default",
+                        }
+                    ]
+                }
+            )
+            assert response[0] == 200
+            await _wait_for_state_machine_terminal_success(state_machine_arn)
+        finally:
+            eventbridge.reset()
+            stepfunctions.reset()
+
+    asyncio.run(exercise())
+
+
+def test_eventbridge_scheduled_sfn_rds_execution_reaches_terminal_success():
+    async def exercise():
+        eventbridge.reset()
+        stepfunctions.reset()
+        try:
+            state_machine_arn = await _create_rds_integration_state_machine(
+                "event-loop-eb-scheduled"
+            )
+            rule_name = "event-loop-eb-scheduled-rule"
+            _configure_eventbridge_sfn_target(
+                state_machine_arn,
+                rule_name=rule_name,
+            )
+            eventbridge._rule_last_fired[
+                (get_account_id(), get_region(), eventbridge._rule_key(rule_name, "default"))
+            ] = 0
+            await asyncio.to_thread(
+                eventbridge._tick_scheduled_rules,
+                asyncio.get_running_loop(),
+            )
+            await _wait_for_state_machine_terminal_success(state_machine_arn)
+        finally:
+            eventbridge.reset()
+            stepfunctions.reset()
+
+    asyncio.run(exercise())
+
+
+def test_eventbridge_replay_sfn_rds_execution_reaches_terminal_success():
+    async def exercise():
+        eventbridge.reset()
+        stepfunctions.reset()
+        try:
+            eventbridge._ensure_default_bus()
+            bus_arn = (
+                f"arn:aws:events:{get_region()}:{get_account_id()}:event-bus/default"
+            )
+            archive_response = eventbridge._create_archive(
+                {
+                    "ArchiveName": "event-loop-eb-replay-archive",
+                    "EventSourceArn": bus_arn,
+                }
+            )
+            archive_arn = json.loads(archive_response[2])["ArchiveArn"]
+            eventbridge._put_events(
+                {
+                    "Entries": [
+                        {
+                            "Source": "event-loop.replay",
+                            "DetailType": "Regression",
+                            "Detail": "{}",
+                            "EventBusName": "default",
+                        }
+                    ]
+                }
+            )
+
+            state_machine_arn = await _create_rds_integration_state_machine(
+                "event-loop-eb-replay"
+            )
+            _configure_eventbridge_sfn_target(
+                state_machine_arn,
+                rule_name="event-loop-eb-replay-rule",
+                source="event-loop.replay",
+            )
+            replay_response = eventbridge._start_replay(
+                {
+                    "ReplayName": "event-loop-eb-replay",
+                    "EventSourceArn": archive_arn,
+                    "EventStartTime": 0,
+                    "EventEndTime": time.time() + 60,
+                    "Destination": {"Arn": bus_arn},
+                }
+            )
+            assert replay_response[0] == 200
+            await _wait_for_state_machine_terminal_success(state_machine_arn)
+            deadline = asyncio.get_running_loop().time() + 1
+            while asyncio.get_running_loop().time() < deadline:
+                if eventbridge._replays["event-loop-eb-replay"]["State"] == "COMPLETED":
+                    break
+                await asyncio.sleep(0.01)
+            assert eventbridge._replays["event-loop-eb-replay"]["State"] == "COMPLETED"
+        finally:
+            eventbridge.reset()
+            stepfunctions.reset()
+
+    asyncio.run(exercise())
+
+
+def test_s3_eventbridge_sfn_rds_execution_reaches_terminal_success():
+    async def exercise():
+        eventbridge.reset()
+        s3.reset()
+        stepfunctions.reset()
+        bucket_name = "event-loop-s3-eventbridge"
+        try:
+            state_machine_arn = await _create_rds_integration_state_machine(
+                "event-loop-s3-eventbridge"
+            )
+            _configure_eventbridge_sfn_target(
+                state_machine_arn,
+                rule_name="event-loop-s3-eventbridge-rule",
+                source="aws.s3",
+            )
+
+            create_response = await s3.handle_request(
+                "PUT", f"/{bucket_name}", {}, b"", {}
+            )
+            assert create_response[0] == 200
+            notification_xml = (
+                b'<NotificationConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">'
+                b"<EventBridgeConfiguration/>"
+                b"</NotificationConfiguration>"
+            )
+            notification_response = await s3.handle_request(
+                "PUT",
+                f"/{bucket_name}",
+                {},
+                notification_xml,
+                {"notification": ""},
+            )
+            assert notification_response[0] == 200
+
+            put_response = await s3.handle_request(
+                "PUT",
+                f"/{bucket_name}/object.txt",
+                {},
+                b"payload",
+                {},
+            )
+            assert put_response[0] == 200
+            await _wait_for_state_machine_terminal_success(state_machine_arn)
+        finally:
+            eventbridge.reset()
+            s3.reset()
+            stepfunctions.reset()
+
+    asyncio.run(exercise())
+
+
+def test_s3_eventbridge_inherits_loop_from_sfn_execution_worker():
+    async def exercise():
+        eventbridge.reset()
+        s3.reset()
+        stepfunctions.reset()
+        bucket_name = "event-loop-s3-sfn-worker"
+        try:
+            assert (
+                await s3.handle_request("PUT", f"/{bucket_name}", {}, b"", {})
+            )[0] == 200
+            assert (
+                await s3.handle_request(
+                    "PUT",
+                    f"/{bucket_name}/source.txt",
+                    {},
+                    b"payload",
+                    {},
+                )
+            )[0] == 200
+
+            target_state_machine_arn = await _create_rds_integration_state_machine(
+                "event-loop-s3-sfn-worker-target"
+            )
+            _configure_eventbridge_sfn_target(
+                target_state_machine_arn,
+                rule_name="event-loop-s3-sfn-worker-rule",
+                source="aws.s3",
+            )
+            notification_xml = (
+                b'<NotificationConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">'
+                b"<EventBridgeConfiguration/>"
+                b"</NotificationConfiguration>"
+            )
+            assert (
+                await s3.handle_request(
+                    "PUT",
+                    f"/{bucket_name}",
+                    {},
+                    notification_xml,
+                    {"notification": ""},
+                )
+            )[0] == 200
+
+            source_state_machine = await _call_stepfunctions_action(
+                "CreateStateMachine",
+                {
+                    "name": "event-loop-s3-sfn-worker-source",
+                    "roleArn": "arn:aws:iam::000000000000:role/sfn-role",
+                    "definition": json.dumps(
+                        {
+                            "StartAt": "Copy",
+                            "States": {
+                                "Copy": {
+                                    "Type": "Task",
+                                    "Resource": (
+                                        "arn:aws:states:::aws-sdk:s3:copyObject"
+                                    ),
+                                    "Parameters": {
+                                        "Bucket": bucket_name,
+                                        "Key": "copied.txt",
+                                        "CopySource": f"{bucket_name}/source.txt",
+                                    },
+                                    "End": True,
+                                }
+                            },
+                        }
+                    ),
+                },
+            )
+            assert source_state_machine[0] == 200
+            source_state_machine_arn = json.loads(source_state_machine[2])[
+                "stateMachineArn"
+            ]
+            start_response = await _call_stepfunctions_action(
+                "StartExecution",
+                {"stateMachineArn": source_state_machine_arn, "input": "{}"},
+            )
+            assert start_response[0] == 200
+            await _wait_for_state_machine_terminal_success(source_state_machine_arn)
+            await _wait_for_state_machine_terminal_success(target_state_machine_arn)
+        finally:
+            eventbridge.reset()
+            s3.reset()
+            stepfunctions.reset()
+
+    asyncio.run(exercise())
+
+
+def test_eventbridge_dispatch_requires_explicit_server_loop():
+    with pytest.raises(TypeError, match="server_loop"):
+        eventbridge._dispatch_event({})
+
+
+def test_eventbridge_scheduler_uses_fresh_loop_after_lifecycle_restart(monkeypatch):
+    captured_loops = []
+
+    def capture_loop(server_loop, stop_event):
+        captured_loops.append(server_loop)
+        stop_event.wait(timeout=1)
+
+    eventbridge.stop_scheduler()
+    monkeypatch.setattr(eventbridge, "_scheduler_loop", capture_loop)
+
+    def run_lifecycle():
+        async def exercise():
+            loop = asyncio.get_running_loop()
+            eventbridge.start_scheduler()
+            deadline = loop.time() + 1
+            while len(captured_loops) < expected_count:
+                if loop.time() >= deadline:
+                    pytest.fail("scheduler thread did not capture its lifecycle loop")
+                await asyncio.sleep(0.001)
+            await asyncio.to_thread(eventbridge.stop_scheduler)
+            return loop
+
+        return asyncio.run(exercise())
+
+    expected_count = 1
+    first_loop = run_lifecycle()
+    expected_count = 2
+    second_loop = run_lifecycle()
+
+    assert first_loop is not second_loop
+    assert first_loop.is_closed()
+    assert second_loop.is_closed()
+    assert captured_loops == [first_loop, second_loop]
+
+
+@pytest.mark.parametrize("loop_state", ["missing", "closed"])
+def test_stepfunctions_non_http_loop_backstop_is_states_runtime(loop_state):
+    server_loop = None
+    if loop_state == "closed":
+        server_loop = asyncio.new_event_loop()
+        server_loop.close()
+
+    loop_token = stepfunctions._execution_server_loop.set(server_loop)
+    try:
+        with pytest.raises(stepfunctions._ExecutionError, match="server loop") as exc:
+            stepfunctions._drive_service_handler_sync(
+                "rds",
+                rds.handle_request,
+                "POST",
+                "/",
+                {},
+                b"",
+                {},
+            )
+        assert exc.value.error == "States.Runtime"
+    finally:
+        stepfunctions._execution_server_loop.reset(loop_token)
+
+
+def test_stepfunctions_sync_rds_waits_for_http_rds_admission(monkeypatch):
+    http_started = threading.Event()
+    sfn_started = threading.Event()
+    release_http = threading.Event()
+    state_lock = threading.Lock()
+    call_count = 0
+
+    def controlled_dispatch(*_args):
+        nonlocal call_count
+        with state_lock:
+            call_count += 1
+            this_call = call_count
+        if this_call == 1:
+            http_started.set()
+            release_http.wait(timeout=2)
+        else:
+            sfn_started.set()
+        return 200, {}, json.dumps({"call": this_call}).encode()
+
+    def sync_execution(_data):
+        return stepfunctions._drive_service_handler_sync(
+            "rds",
+            rds.handle_request,
+            "POST",
+            "/",
+            {},
+            b"",
+            {},
+        )
+
+    monkeypatch.setattr(rds, "_handle_request_unlocked", controlled_dispatch)
+    monkeypatch.setattr(stepfunctions, "_start_sync_execution", sync_execution)
+
+    async def exercise():
+        http_request = asyncio.create_task(
+            rds.handle_request("POST", "/", {}, b"", {})
+        )
+        while not http_started.is_set():
+            await asyncio.sleep(0.001)
+
+        sync_request = asyncio.create_task(
+            _call_stepfunctions_action("StartSyncExecution")
+        )
+        await asyncio.sleep(0.05)
+        assert not sfn_started.is_set()
+
+        release_http.set()
+        http_result, sfn_result = await asyncio.gather(http_request, sync_request)
+        assert http_result[0] == 200
+        assert sfn_result[0] == 200
+        assert sfn_started.is_set()
+
+    fallback = threading.Timer(1, release_http.set)
+    fallback.start()
+    try:
+        asyncio.run(exercise())
+    finally:
+        release_http.set()
+        fallback.cancel()
+
+
+def test_stepfunctions_sync_executions_do_not_consume_service_worker_pool(
+    monkeypatch,
+):
+    def fast_dispatch(*_args):
+        time.sleep(0.01)
+        return 200, {}, b"{}"
+
+    def sync_execution(_data):
+        return stepfunctions._drive_service_handler_sync(
+            "rds",
+            rds.handle_request,
+            "POST",
+            "/",
+            {},
+            b"",
+            {},
+        )
+
+    monkeypatch.setattr(rds, "_handle_request_unlocked", fast_dispatch)
+    monkeypatch.setattr(stepfunctions, "_start_sync_execution", sync_execution)
+
+    async def exercise():
+        # If the four outer sync executions used this same four-slot pool,
+        # every worker would block on an inner RDS offload and none could run.
+        asyncio.get_running_loop().set_default_executor(
+            ThreadPoolExecutor(max_workers=4)
+        )
+        requests = [
+            asyncio.create_task(_call_stepfunctions_action("StartSyncExecution"))
+            for _ in range(4)
+        ]
+        results = await asyncio.wait_for(asyncio.gather(*requests), timeout=2)
+        assert all(result[0] == 200 for result in results)
+
+    asyncio.run(exercise())
+
+
+def test_cancelled_stepfunctions_sync_action_waits_for_dedicated_thread(
+    monkeypatch,
+):
+    action_started = threading.Event()
+    release_action = threading.Event()
+    action_finished = threading.Event()
+
+    def sync_execution(_data):
+        action_started.set()
+        release_action.wait(timeout=2)
+        action_finished.set()
+        return 200, {}, b"{}"
+
+    monkeypatch.setattr(stepfunctions, "_start_sync_execution", sync_execution)
+
+    async def exercise():
+        request = asyncio.create_task(
+            _call_stepfunctions_action("StartSyncExecution")
+        )
+        while not action_started.is_set():
+            await asyncio.sleep(0.001)
+
+        request.cancel()
+        await asyncio.sleep(0.01)
+        request.cancel()
+        await asyncio.sleep(0.05)
+        assert not request.done()
+        assert not action_finished.is_set()
+
+        release_action.set()
+        result = await asyncio.gather(request, return_exceptions=True)
+        assert isinstance(result[0], asyncio.CancelledError)
+        assert action_finished.is_set()
+
+    fallback = threading.Timer(1, release_action.set)
+    fallback.start()
+    try:
+        asyncio.run(exercise())
+    finally:
+        release_action.set()
+        fallback.cancel()
+
+
+def test_stepfunctions_marshal_fails_fast_on_target_loop(monkeypatch):
+    monkeypatch.setattr(rds, "_handle_request_unlocked", lambda *_args: (200, {}, b"{}"))
+
+    async def exercise():
+        loop_token = stepfunctions._execution_server_loop.set(
+            asyncio.get_running_loop()
+        )
+        try:
+            with pytest.raises(
+                stepfunctions._ExecutionError,
+                match="cannot synchronously marshal from its target event loop",
+            ):
+                stepfunctions._drive_service_handler_sync(
+                    "rds",
+                    rds.handle_request,
+                    "POST",
+                    "/",
+                    {},
+                    b"",
+                    {},
+                )
+        finally:
+            stepfunctions._execution_server_loop.reset(loop_token)
+
+    asyncio.run(exercise())
+
+
+def test_stepfunctions_marshaled_rds_waits_for_reset_and_sees_fresh_state(
+    monkeypatch,
+):
+    reset_started = threading.Event()
+    release_reset = threading.Event()
+    integration_started = threading.Event()
+    state = {"generation": "old"}
+
+    def reset_all_state():
+        state["generation"] = "fresh"
+        reset_started.set()
+        release_reset.wait(timeout=2)
+
+    def read_state(*_args):
+        integration_started.set()
+        return 200, {}, json.dumps(state).encode()
+
+    def sync_execution(_data):
+        return stepfunctions._drive_service_handler_sync(
+            "rds",
+            rds.handle_request,
+            "POST",
+            "/",
+            {},
+            b"",
+            {},
+        )
+
+    monkeypatch.setattr(ministack_app, "_reset_all_state", reset_all_state)
+    monkeypatch.setattr(ministack_app, "_reset_locks", LoopLocal(asyncio.Lock))
+    monkeypatch.setattr(
+        ministack_app,
+        "_ordinary_request_reset_barriers",
+        LoopLocal(ministack_app._RequestResetBarrier),
+    )
+    monkeypatch.setattr(
+        cfn_stacks,
+        "_stack_task_lifecycles",
+        LoopLocal(cfn_stacks._StackTaskLifecycle),
+    )
+    monkeypatch.setattr(rds, "_handle_request_unlocked", read_state)
+    monkeypatch.setattr(stepfunctions, "_start_sync_execution", sync_execution)
+
+    async def exercise():
+        reset = asyncio.create_task(
+            ministack_app._reset_all_state_after_service_dispatch_drains()
+        )
+        while not reset_started.is_set():
+            await asyncio.sleep(0.001)
+
+        integration = asyncio.create_task(
+            _call_stepfunctions_action("StartSyncExecution")
+        )
+        await asyncio.sleep(0.05)
+        assert not integration_started.is_set()
+
+        release_reset.set()
+        _, result = await asyncio.gather(reset, integration)
+        assert integration_started.is_set()
+        assert json.loads(result[2]) == {"generation": "fresh"}
+
+    fallback = threading.Timer(1, release_reset.set)
+    fallback.start()
+    try:
+        asyncio.run(exercise())
+    finally:
+        release_reset.set()
+        fallback.cancel()
+
+
+def test_eks_api_and_cloudformation_same_name_create_are_serialized(monkeypatch):
+    cluster_name = "event-loop-cfn-eks"
+    first_in_create = threading.Event()
+    release_first = threading.Event()
+    backend_started = threading.Event()
+    state_lock = threading.Lock()
+    next_port_calls = 0
+    backend_starts = 0
+
+    def controlled_next_port():
+        nonlocal next_port_calls
+        with state_lock:
+            next_port_calls += 1
+            this_call = next_port_calls
+        if this_call == 1:
+            first_in_create.set()
+            release_first.wait(timeout=2)
+        return 18000 + this_call
+
+    def no_docker():
+        nonlocal backend_starts
+        with state_lock:
+            backend_starts += 1
+        backend_started.set()
+        return None
+
+    monkeypatch.setattr(eks, "_next_port", controlled_next_port)
+    monkeypatch.setattr(eks, "_get_docker", no_docker)
+
+    async def exercise():
+        api_create = asyncio.create_task(
+            eks.handle_request(
+                "POST",
+                "/clusters",
+                {},
+                json.dumps(
+                    {
+                        "name": cluster_name,
+                        "roleArn": "arn:aws:iam::000000000000:role/api-role",
+                    }
+                ).encode(),
+                {},
+            )
+        )
+        while not first_in_create.is_set():
+            await asyncio.sleep(0.001)
+
+        cfn_create = asyncio.create_task(
+            cfn_stacks._run_locked_standard_provisioner(
+                "AWS::EKS::Cluster",
+                cfn_stacks._provision_resource,
+                "AWS::EKS::Cluster",
+                "Cluster",
+                {
+                    "Name": cluster_name,
+                    "RoleArn": "arn:aws:iam::000000000000:role/cfn-role",
+                },
+                "event-loop-stack",
+            )
+        )
+        await asyncio.sleep(0.05)
+        with state_lock:
+            assert next_port_calls == 1
+
+        release_first.set()
+        api_result, cfn_result = await asyncio.gather(api_create, cfn_create)
+        assert api_result[0] == 200
+        assert cfn_result[0] == cluster_name
+
+    try:
+        asyncio.run(exercise())
+        assert backend_started.wait(timeout=1)
+        with state_lock:
+            assert next_port_calls == 1
+            assert backend_starts == 1
+        assert eks._clusters[cluster_name]["roleArn"].endswith(":role/api-role")
+    finally:
+        release_first.set()
+        cluster = eks._clusters.pop(cluster_name, None)
+        if cluster:
+            eks._tags.pop(cluster.get("arn", ""), None)
+
+
+def test_serial_waiters_do_not_exhaust_shared_worker_pool(monkeypatch):
+    first_started = threading.Event()
+    release = threading.Event()
+
+    def slow_dispatch(*_args):
+        first_started.set()
+        release.wait(timeout=2)
+        return 200, {}, b"rds"
+
+    def fast_dispatch(*_args):
+        return 200, {}, b"ecs"
+
+    monkeypatch.setattr(rds, "_handle_request_unlocked", slow_dispatch)
+    monkeypatch.setattr(ecs, "_handle_request_unlocked", fast_dispatch)
+
+    async def exercise():
+        slow_tasks = [
+            asyncio.create_task(rds.handle_request("GET", "/", {}, b"", {}))
+            for _ in range(40)
+        ]
+        while not first_started.is_set():
+            await asyncio.sleep(0.001)
+        # Give queued RDS requests time to reach admission. Acquiring the lock
+        # in workers would fill Python's default executor (capped at 32).
+        await asyncio.sleep(0.05)
+
+        fast_task = asyncio.create_task(
+            ecs.handle_request("GET", "/", {}, b"", {})
+        )
+        try:
+            result = await asyncio.wait_for(asyncio.shield(fast_task), timeout=0.2)
+            assert result == (200, {}, b"ecs")
+        finally:
+            release.set()
+            await asyncio.gather(*slow_tasks, fast_task, return_exceptions=True)
+
+    fallback = threading.Timer(1, release.set)
+    fallback.start()
+    try:
+        asyncio.run(exercise())
+    finally:
+        release.set()
+        fallback.cancel()
+
+
+def test_admin_reset_waits_for_in_flight_request(monkeypatch):
+    request_started = threading.Event()
+    reset_called = threading.Event()
+    release_request = threading.Event()
+
+    def slow_dispatch(*_args):
+        request_started.set()
+        release_request.wait(timeout=2)
+        return 200, {}, b"request"
+
+    async def route_to_rds(*_args):
+        return await rds.handle_request("GET", "/", {}, b"", {})
+
+    def reset_all_state():
+        reset_called.set()
+
+    monkeypatch.setattr(rds, "_handle_request_unlocked", slow_dispatch)
+    monkeypatch.setattr(ministack_app, "_dispatch_service_request", route_to_rds)
+    monkeypatch.setattr(ministack_app, "_reset_all_state", reset_all_state)
+    monkeypatch.setattr(ministack_app, "_reset_locks", LoopLocal(asyncio.Lock))
+    monkeypatch.setattr(
+        ministack_app,
+        "_ordinary_request_reset_barriers",
+        LoopLocal(ministack_app._RequestResetBarrier),
+    )
+    monkeypatch.setattr(
+        cfn_stacks,
+        "_stack_task_lifecycles",
+        LoopLocal(cfn_stacks._StackTaskLifecycle),
+    )
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def exercise():
+        request_messages = []
+        reset_messages = []
+
+        async def send_request(message):
+            request_messages.append(message)
+
+        async def send_reset(message):
+            reset_messages.append(message)
+
+        request_scope = {
+            "type": "http",
+            "method": "GET",
+            "path": "/",
+            "query_string": b"",
+            "headers": [
+                (b"authorization", b"AWS4-HMAC-SHA256 Credential=test/20260101/us-east-1/rds/aws4_request"),
+            ],
+        }
+        reset_scope = {
+            "type": "http",
+            "method": "POST",
+            "path": "/_ministack/reset",
+            "query_string": b"",
+            "headers": [],
+        }
+
+        request_task = asyncio.create_task(
+            ministack_app.app(request_scope, receive, send_request)
+        )
+        while not request_started.is_set():
+            await asyncio.sleep(0.001)
+
+        reset_task = asyncio.create_task(
+            ministack_app.app(reset_scope, receive, send_reset)
+        )
+        await asyncio.sleep(0.05)
+        assert not reset_called.is_set()
+
+        release_request.set()
+        await asyncio.gather(request_task, reset_task)
+        assert reset_called.is_set()
+        assert request_messages[-1]["body"] == b"request"
+        assert json.loads(reset_messages[-1]["body"]) == {"reset": "ok"}
+
+    fallback = threading.Timer(1, release_request.set)
+    fallback.start()
+    try:
+        asyncio.run(exercise())
+    finally:
+        release_request.set()
+        fallback.cancel()
+
+
+def test_admin_reset_waits_for_ordinary_request(monkeypatch):
+    request_started = asyncio.Event()
+    release_request = asyncio.Event()
+    reset_called = asyncio.Event()
+
+    async def slow_dispatch(*_args):
+        request_started.set()
+        await release_request.wait()
+        return 200, {}, b"request"
+
+    def reset_all_state():
+        reset_called.set()
+
+    monkeypatch.setattr(ministack_app, "_dispatch_service_request", slow_dispatch)
+    monkeypatch.setattr(ministack_app, "_reset_all_state", reset_all_state)
+    monkeypatch.setattr(ministack_app, "_reset_locks", LoopLocal(asyncio.Lock))
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(_message):
+        pass
+
+    request_scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/",
+        "query_string": b"",
+        "headers": [
+            (b"x-amz-target", b"AmazonSQS.CreateQueue"),
+            (b"authorization", b"AWS4-HMAC-SHA256 Credential=test/20260101/us-east-1/sqs/aws4_request"),
+        ],
+    }
+    reset_scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/_ministack/reset",
+        "query_string": b"",
+        "headers": [],
+    }
+
+    async def exercise():
+        request = asyncio.create_task(
+            ministack_app.app(request_scope, receive, send)
+        )
+        await request_started.wait()
+        reset = asyncio.create_task(
+            ministack_app.app(reset_scope, receive, send)
+        )
+        await asyncio.sleep(0.05)
+        assert not reset_called.is_set()
+
+        release_request.set()
+        await asyncio.gather(request, reset)
+        assert reset_called.is_set()
+
+    asyncio.run(exercise())
+
+
+def test_admin_reset_waits_for_lockless_tagging_request(monkeypatch):
+    request_started = asyncio.Event()
+    release_request = asyncio.Event()
+    reset_called = asyncio.Event()
+
+    async def slow_dispatch(*_args):
+        request_started.set()
+        await release_request.wait()
+        return 200, {}, b"request"
+
+    def reset_all_state():
+        reset_called.set()
+
+    body = json.dumps(
+        {
+            "ResourceARNList": ["arn:aws:s3:::event-loop-reset-tags"],
+            "Tags": {"source": "rgta"},
+        }
+    ).encode()
+    monkeypatch.setattr(ministack_app, "_dispatch_service_request", slow_dispatch)
+    monkeypatch.setattr(ministack_app, "_reset_all_state", reset_all_state)
+    monkeypatch.setattr(ministack_app, "_reset_locks", LoopLocal(asyncio.Lock))
+
+    async def receive():
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    async def send(_message):
+        pass
+
+    request_scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/",
+        "query_string": b"",
+        "headers": [
+            (
+                b"x-amz-target",
+                b"ResourceGroupsTaggingAPI_20170126.TagResources",
+            ),
+            (
+                b"authorization",
+                b"AWS4-HMAC-SHA256 Credential=test/20260101/us-east-1/tagging/aws4_request",
+            ),
+        ],
+    }
+    reset_scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/_ministack/reset",
+        "query_string": b"",
+        "headers": [],
+    }
+
+    async def exercise():
+        request = asyncio.create_task(
+            ministack_app.app(request_scope, receive, send)
+        )
+        await request_started.wait()
+        reset = asyncio.create_task(
+            ministack_app.app(reset_scope, receive, send)
+        )
+        await asyncio.sleep(0.05)
+        assert not reset_called.is_set()
+
+        release_request.set()
+        await asyncio.gather(request, reset)
+        assert reset_called.is_set()
+
+    asyncio.run(exercise())
+
+
+def test_admin_reset_does_not_deadlock_nested_lambda_ministack_request(monkeypatch):
+    reset_admitted = asyncio.Event()
+    nested_finished = asyncio.Event()
+    reset_lock = asyncio.Lock()
+    dispatch_count = 0
+
+    class _SignalingResetLock:
+        async def __aenter__(self):
+            await reset_lock.acquire()
+            reset_admitted.set()
+
+        async def __aexit__(self, *_exc_info):
+            reset_lock.release()
+
+    monkeypatch.setattr(
+        ministack_app,
+        "_get_reset_lock",
+        lambda: _SignalingResetLock(),
+    )
+    monkeypatch.setattr(ministack_app, "_reset_all_state", lambda: None)
+    monkeypatch.setattr(
+        ministack_app,
+        "_ordinary_request_reset_barriers",
+        LoopLocal(ministack_app._RequestResetBarrier),
+    )
+    monkeypatch.setattr(
+        cfn_stacks,
+        "_stack_task_lifecycles",
+        LoopLocal(cfn_stacks._StackTaskLifecycle),
+    )
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(_message):
+        pass
+
+    def scope(path, service):
+        return {
+            "type": "http",
+            "method": "GET" if path != "/_ministack/reset" else "POST",
+            "path": path,
+            "query_string": b"",
+            "headers": [] if service is None else [
+                (
+                    b"authorization",
+                    (
+                        "AWS4-HMAC-SHA256 Credential=test/20260101/"
+                        f"us-east-1/{service}/aws4_request"
+                    ).encode(),
+                )
+            ],
+        }
+
+    async def nested_dispatch(*_args):
+        nonlocal dispatch_count
+        dispatch_count += 1
+        if dispatch_count == 1:
+            await reset_admitted.wait()
+            await ministack_app.app(scope("/nested", "dynamodb"), receive, send)
+            nested_finished.set()
+            return 200, {}, b"outer"
+        return 200, {}, b"nested"
+
+    monkeypatch.setattr(
+        ministack_app,
+        "_dispatch_service_request",
+        nested_dispatch,
+    )
+
+    async def exercise():
+        outer = asyncio.create_task(
+            ministack_app.app(
+                scope("/2015-03-31/functions/outer/invocations", "lambda"),
+                receive,
+                send,
+            )
+        )
+        await asyncio.sleep(0)
+        reset = asyncio.create_task(
+            ministack_app.app(scope("/_ministack/reset", None), receive, send)
+        )
+        await asyncio.wait_for(asyncio.gather(outer, reset), timeout=1)
+        assert nested_finished.is_set()
+        assert dispatch_count == 2
+
+    asyncio.run(exercise())
+
+
+def test_admin_reset_quiesces_multi_resource_cloudformation_task(monkeypatch):
+    first_started = threading.Event()
+    release_first = threading.Event()
+    reset_called = threading.Event()
+    orphan_created = threading.Event()
+    resources = []
+
+    def first_provisioner():
+        first_started.set()
+        release_first.wait(timeout=2)
+        return "first", {}
+
+    def second_provisioner():
+        orphan_created.set()
+        return "second", {}
+
+    async def deploy_stack():
+        await cfn_stacks._run_locked_standard_provisioner(
+            "AWS::EKS::Cluster", first_provisioner
+        )
+        resources.append("first")
+        await cfn_stacks._run_locked_standard_provisioner(
+            "AWS::EKS::Cluster", second_provisioner
+        )
+        resources.append("second")
+
+    def reset_all_state():
+        resources.clear()
+        reset_called.set()
+
+    monkeypatch.setattr(ministack_app, "_reset_all_state", reset_all_state)
+
+    async def exercise():
+        existing_tasks = asyncio.all_tasks()
+        task = cfn_stacks._create_stack_task_in_region(deploy_stack(), None)
+        if task is None:
+            # Pre-fix heads did not return the untracked task from the spawn
+            # seam. Recover it so the same regression exercises behavior.
+            await asyncio.sleep(0)
+            spawned = asyncio.all_tasks() - existing_tasks
+            task = next(
+                candidate
+                for candidate in spawned
+                if candidate.get_coro().__qualname__.endswith("deploy_stack")
+            )
+        while not first_started.is_set():
+            await asyncio.sleep(0.001)
+
+        reset = asyncio.create_task(
+            ministack_app._reset_all_state_after_service_dispatch_drains()
+        )
+        await asyncio.sleep(0.05)
+        assert not reset_called.is_set()
+
+        release_first.set()
+        await reset
+        result = await asyncio.gather(task, return_exceptions=True)
+        assert reset_called.is_set()
+        assert not orphan_created.is_set()
+        assert resources == []
+        assert isinstance(result[0], asyncio.CancelledError)
+
+    fallback = threading.Timer(1, release_first.set)
+    fallback.start()
+    try:
+        asyncio.run(exercise())
+    finally:
+        release_first.set()
+        fallback.cancel()
+
+
+def test_cancelled_dispatch_holds_admission_and_reset_until_worker_finishes(
+    monkeypatch,
+):
+    first_started = threading.Event()
+    second_started = threading.Event()
+    reset_called = threading.Event()
+    release_first = threading.Event()
+    state_lock = threading.Lock()
+    overlaps = []
+    active_workers = 0
+    call_count = 0
+
+    def dispatch(*_args):
+        nonlocal active_workers, call_count
+        with state_lock:
+            call_count += 1
+            this_call = call_count
+            if active_workers:
+                overlaps.append(f"request-{this_call}")
+            active_workers += 1
+        try:
+            if this_call == 1:
+                first_started.set()
+                release_first.wait(timeout=2)
+            else:
+                second_started.set()
+            return 200, {}, f"request-{this_call}".encode()
+        finally:
+            with state_lock:
+                active_workers -= 1
+
+    async def route_to_rds(*_args):
+        return await rds.handle_request("GET", "/", {}, b"", {})
+
+    def reset_all_state():
+        with state_lock:
+            if active_workers:
+                overlaps.append("reset")
+        reset_called.set()
+
+    monkeypatch.setattr(rds, "_handle_request_unlocked", dispatch)
+    monkeypatch.setattr(ministack_app, "_dispatch_service_request", route_to_rds)
+    monkeypatch.setattr(ministack_app, "_reset_all_state", reset_all_state)
+    monkeypatch.setattr(ministack_app, "_reset_locks", LoopLocal(asyncio.Lock))
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(_message):
+        pass
+
+    request_scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/",
+        "query_string": b"",
+        "headers": [],
+    }
+    reset_scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/_ministack/reset",
+        "query_string": b"",
+        "headers": [],
+    }
+
+    async def exercise():
+        first = asyncio.create_task(
+            ministack_app.app(request_scope, receive, send)
+        )
+        while not first_started.is_set():
+            await asyncio.sleep(0.001)
+
+        first.cancel()
+        await asyncio.sleep(0.01)
+        # A repeated disconnect/cancellation must not cut short worker cleanup.
+        first.cancel()
+
+        second = asyncio.create_task(
+            ministack_app.app(request_scope, receive, send)
+        )
+        await asyncio.sleep(0.01)
+        reset = asyncio.create_task(
+            ministack_app.app(reset_scope, receive, send)
+        )
+        await asyncio.sleep(0.05)
+
+        assert not second_started.is_set()
+        assert not reset_called.is_set()
+        assert overlaps == []
+
+        release_first.set()
+        results = await asyncio.gather(first, second, reset, return_exceptions=True)
+        assert isinstance(results[0], asyncio.CancelledError)
+        assert second_started.is_set()
+        assert reset_called.is_set()
+        assert overlaps == []
+
+    fallback = threading.Timer(1, release_first.set)
+    fallback.start()
+    try:
+        asyncio.run(exercise())
+    finally:
+        release_first.set()
+        fallback.cancel()
+
+
+def test_rds_slow_docker_does_not_block_parallel_dynamodb(monkeypatch):
+    instance_id = "event-loop-rds"
+    container_id = "slow-rds-container"
+    monkeypatch.setattr(rds, "_get_docker", lambda: None)
+    response = rds._create_db_instance(
+        {
+            "DBInstanceIdentifier": [instance_id],
+            "Engine": ["postgres"],
+            "MasterUsername": ["admin"],
+            "MasterUserPassword": ["password"],
+        }
+    )
+    assert response[0] == 200
+    rds._instances[instance_id]["_docker_container_id"] = container_id
+    monkeypatch.setattr(rds, "_get_docker", lambda: _SlowDocker(container_id))
+
+    async def delete_instance():
+        return await rds.handle_request(
+            "POST",
+            "/",
+            {},
+            b"",
+            {
+                "Action": ["DeleteDBInstance"],
+                "DBInstanceIdentifier": [instance_id],
+                "SkipFinalSnapshot": ["true"],
+            },
+        )
+
+    try:
+        asyncio.run(_run_with_parallel_dynamodb_probe(delete_instance))
+    finally:
+        rds._instances.pop(instance_id, None)
+
+
+def test_ecs_slow_docker_does_not_block_parallel_dynamodb(monkeypatch):
+    cluster_name = "event-loop-ecs"
+    task_id = "event-loop-task"
+    container_id = "slow-ecs-container"
+    cluster_arn = (
+        f"arn:aws:ecs:{get_region()}:{get_account_id()}:cluster/{cluster_name}"
+    )
+    task_arn = (
+        f"arn:aws:ecs:{get_region()}:{get_account_id()}:"
+        f"task/{cluster_name}/{task_id}"
+    )
+    assert ecs._create_cluster({"clusterName": cluster_name})[0] == 200
+    ecs._tasks[task_arn] = {
+        "taskArn": task_arn,
+        "clusterArn": cluster_arn,
+        "lastStatus": "RUNNING",
+        "desiredStatus": "RUNNING",
+        "containers": [],
+        "_docker_ids": [container_id],
+        "_metadata_tokens": [],
+    }
+    monkeypatch.setattr(ecs, "_get_docker", lambda: _SlowDocker(container_id))
+
+    async def stop_task():
+        return await ecs.handle_request(
+            "POST",
+            "/",
+            {"x-amz-target": "AmazonEC2ContainerServiceV20141113.StopTask"},
+            json.dumps({"cluster": cluster_name, "task": task_arn}).encode(),
+            {},
+        )
+
+    try:
+        asyncio.run(_run_with_parallel_dynamodb_probe(stop_task))
+    finally:
+        ecs._tasks.pop(task_arn, None)
+        ecs._clusters.pop(cluster_name, None)
+
+
+def test_eks_slow_docker_does_not_block_parallel_dynamodb(monkeypatch):
+    cluster_name = "event-loop-eks"
+    container_id = "slow-eks-container"
+    arn = f"arn:aws:eks:{get_region()}:{get_account_id()}:cluster/{cluster_name}"
+    eks._clusters[cluster_name] = {
+        "name": cluster_name,
+        "arn": arn,
+        "status": "ACTIVE",
+        "_docker_id": container_id,
+    }
+    monkeypatch.setattr(eks, "_get_docker", lambda: _SlowDocker(container_id))
+
+    async def delete_cluster():
+        return await eks.handle_request(
+            "DELETE",
+            f"/clusters/{cluster_name}",
+            {},
+            b"",
+            {},
+        )
+
+    try:
+        asyncio.run(_run_with_parallel_dynamodb_probe(delete_cluster))
+    finally:
+        eks._clusters.pop(cluster_name, None)
+
+
+def test_elasticache_slow_docker_does_not_block_parallel_dynamodb(monkeypatch):
+    cluster_id = "event-loop-cache"
+    container_id = "slow-elasticache-container"
+    monkeypatch.setattr(elasticache, "_get_docker", lambda: None)
+    response = elasticache._create_cache_cluster(
+        {"CacheClusterId": [cluster_id], "Engine": ["redis"]}
+    )
+    assert response[0] == 200
+    elasticache._clusters[cluster_id]["_docker_container_id"] = container_id
+    monkeypatch.setattr(
+        elasticache,
+        "_get_docker",
+        lambda: _SlowDocker(container_id),
+    )
+
+    async def delete_cluster():
+        return await elasticache.handle_request(
+            "POST",
+            "/",
+            {},
+            f"Action=DeleteCacheCluster&CacheClusterId={cluster_id}".encode(),
+            {},
+        )
+
+    try:
+        asyncio.run(_run_with_parallel_dynamodb_probe(delete_cluster))
+    finally:
+        elasticache._clusters.pop(cluster_id, None)
+
+
+def test_opensearch_slow_docker_does_not_block_parallel_dynamodb(monkeypatch):
+    domain_name = "event-loop-search"
+    container_id = "slow-opensearch-container"
+    monkeypatch.setattr(opensearch, "_get_docker", lambda: None)
+    record = opensearch.create_domain_record({"DomainName": domain_name})
+    record["_ContainerId"] = container_id
+    monkeypatch.setattr(
+        opensearch,
+        "_get_docker",
+        lambda: _SlowDocker(container_id),
+    )
+
+    async def delete_domain():
+        return await opensearch.handle_request(
+            "DELETE",
+            f"/2021-01-01/domain/{domain_name}",
+            {},
+            b"",
+            {},
+        )
+
+    try:
+        asyncio.run(_run_with_parallel_dynamodb_probe(delete_domain))
+    finally:
+        opensearch._domains.pop(domain_name, None)

--- a/tests/test_event_loop.py
+++ b/tests/test_event_loop.py
@@ -1,6 +1,8 @@
 import asyncio
 import gc
 import json
+import subprocess
+import sys
 import threading
 import time
 import weakref
@@ -29,6 +31,10 @@ from ministack.services import (
     stepfunctions,
     tagging,
 )
+from ministack.services import (
+    scheduler as scheduler_service,
+)
+from ministack.services.cloudformation import lifecycle as cfn_lifecycle
 from ministack.services.cloudformation import provisioners as cfn_provisioners
 from ministack.services.cloudformation import stacks as cfn_stacks
 
@@ -515,15 +521,19 @@ def test_nested_cfn_standard_children_share_service_admission(monkeypatch):
 
 def test_reset_skips_failed_serialized_lazy_module(monkeypatch):
     reset_called = threading.Event()
-    real_get_module = ministack_app._get_module
+    real_resolve = ministack_app._resolve_loaded_service_module
     failed_rds = ministack_app._ErrorModule("rds", "optional dependency missing")
 
-    def get_module(name):
+    def resolve_loaded(name):
         if name == "rds":
             return failed_rds
-        return real_get_module(name)
+        return real_resolve(name)
 
-    monkeypatch.setattr(ministack_app, "_get_module", get_module)
+    monkeypatch.setattr(
+        ministack_app,
+        "_resolve_loaded_service_module",
+        resolve_loaded,
+    )
     monkeypatch.setattr(ministack_app, "_reset_all_state", reset_called.set)
     monkeypatch.setattr(ministack_app, "_reset_locks", LoopLocal(asyncio.Lock))
     monkeypatch.setattr(
@@ -532,9 +542,9 @@ def test_reset_skips_failed_serialized_lazy_module(monkeypatch):
         LoopLocal(ministack_app._RequestResetBarrier),
     )
     monkeypatch.setattr(
-        cfn_stacks,
+        cfn_lifecycle,
         "_stack_task_lifecycles",
-        LoopLocal(cfn_stacks._StackTaskLifecycle),
+        LoopLocal(cfn_lifecycle._StackTaskLifecycle),
     )
 
     asyncio.run(ministack_app._reset_all_state_after_service_dispatch_drains())
@@ -542,14 +552,18 @@ def test_reset_skips_failed_serialized_lazy_module(monkeypatch):
 
 
 def test_reset_keeps_missing_healthy_admission_seam_loud(monkeypatch):
-    real_get_module = ministack_app._get_module
+    real_resolve = ministack_app._resolve_loaded_service_module
 
-    def get_module(name):
+    def resolve_loaded(name):
         if name == "rds":
             return object()
-        return real_get_module(name)
+        return real_resolve(name)
 
-    monkeypatch.setattr(ministack_app, "_get_module", get_module)
+    monkeypatch.setattr(
+        ministack_app,
+        "_resolve_loaded_service_module",
+        resolve_loaded,
+    )
     monkeypatch.setattr(ministack_app, "_reset_locks", LoopLocal(asyncio.Lock))
     monkeypatch.setattr(
         ministack_app,
@@ -557,13 +571,157 @@ def test_reset_keeps_missing_healthy_admission_seam_loud(monkeypatch):
         LoopLocal(ministack_app._RequestResetBarrier),
     )
     monkeypatch.setattr(
-        cfn_stacks,
+        cfn_lifecycle,
         "_stack_task_lifecycles",
-        LoopLocal(cfn_stacks._StackTaskLifecycle),
+        LoopLocal(cfn_lifecycle._StackTaskLifecycle),
     )
 
     with pytest.raises(AttributeError, match="_get_request_dispatch_lock"):
         asyncio.run(ministack_app._reset_all_state_after_service_dispatch_drains())
+
+
+def test_cfn_untouched_reset_preserves_lazy_service_imports():
+    script = """
+import asyncio
+import json
+import sys
+
+import ministack.app as app
+
+asyncio.run(app._reset_all_state_after_service_dispatch_drains())
+names = [
+    "ministack.services.cloudformation.provisioners",
+    "ministack.services.rds",
+    "ministack.services.ecs",
+    "ministack.services.eks",
+    "ministack.services.opensearch",
+]
+unexpected = [name for name in names if name in sys.modules]
+print(json.dumps(unexpected))
+raise SystemExit(bool(unexpected))
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert json.loads(result.stdout.strip().splitlines()[-1]) == []
+
+
+def test_first_touch_serialized_import_waits_for_reset_writer(monkeypatch):
+    wipe_started = threading.Event()
+    release_wipe = threading.Event()
+    loaded = {}
+    order = []
+
+    def resolve_loaded(name):
+        return loaded.get(name)
+
+    def import_module(name):
+        order.append(f"import-{name}")
+        loaded[name] = object()
+        return loaded[name]
+
+    def slow_reset():
+        order.append("wipe-start")
+        wipe_started.set()
+        release_wipe.wait(timeout=2)
+        order.append("wipe-finish")
+
+    monkeypatch.setattr(
+        ministack_app,
+        "_resolve_loaded_service_module",
+        resolve_loaded,
+    )
+    monkeypatch.setattr(ministack_app, "_get_module", import_module)
+    monkeypatch.setattr(ministack_app, "_reset_all_state", slow_reset)
+    monkeypatch.setattr(
+        ministack_app,
+        "_ordinary_request_reset_barriers",
+        LoopLocal(ministack_app._RequestResetBarrier),
+    )
+    monkeypatch.setattr(
+        cfn_lifecycle,
+        "_stack_task_lifecycles",
+        LoopLocal(cfn_lifecycle._StackTaskLifecycle),
+    )
+
+    async def exercise():
+        reset = asyncio.create_task(
+            ministack_app._reset_all_state_after_service_dispatch_drains()
+        )
+        while not wipe_started.is_set():
+            await asyncio.sleep(0.001)
+
+        first_touch = asyncio.create_task(
+            ministack_app._gate_first_touch_reset_admission_module("rds")
+        )
+        await asyncio.sleep(0.05)
+        assert order == ["wipe-start"]
+
+        release_wipe.set()
+        await asyncio.gather(reset, first_touch)
+        assert order == ["wipe-start", "wipe-finish", "import-rds"]
+
+    fallback = threading.Timer(1, release_wipe.set)
+    fallback.start()
+    try:
+        asyncio.run(exercise())
+    finally:
+        release_wipe.set()
+        fallback.cancel()
+
+
+@pytest.mark.parametrize(
+    "service",
+    sorted(ministack_app._RESET_ADMISSION_SERVICE_KEYS),
+)
+def test_first_touch_gate_maps_every_serialized_service_key(monkeypatch, service):
+    imported = []
+
+    monkeypatch.setattr(
+        ministack_app,
+        "_resolve_loaded_service_module",
+        lambda _name: None,
+    )
+    monkeypatch.setattr(
+        ministack_app,
+        "_get_module",
+        lambda name: imported.append(name),
+    )
+    monkeypatch.setattr(
+        ministack_app,
+        "_ordinary_request_reset_barriers",
+        LoopLocal(ministack_app._RequestResetBarrier),
+    )
+
+    asyncio.run(ministack_app._gate_first_touch_reset_admission_module(service))
+
+    assert imported == [ministack_app.SERVICE_REGISTRY[service]["module"]]
+
+
+@pytest.mark.parametrize(
+    "service",
+    sorted(ministack_app._RESET_CALLBACK_SERVICE_KEYS),
+)
+def test_first_touch_gate_does_not_import_callback_services(monkeypatch, service):
+    imported = []
+    monkeypatch.setattr(
+        ministack_app,
+        "_resolve_loaded_service_module",
+        lambda _name: None,
+    )
+    monkeypatch.setattr(
+        ministack_app,
+        "_get_module",
+        lambda name: imported.append(name),
+    )
+
+    asyncio.run(ministack_app._gate_first_touch_reset_admission_module(service))
+
+    assert imported == []
 
 
 @pytest.mark.parametrize(
@@ -628,14 +786,14 @@ def test_reset_lock_is_recreated_for_each_event_loop(monkeypatch):
 
 def test_cloudformation_task_lifecycle_is_recreated_for_each_event_loop(monkeypatch):
     monkeypatch.setattr(
-        cfn_stacks,
+        cfn_lifecycle,
         "_stack_task_lifecycles",
-        LoopLocal(cfn_stacks._StackTaskLifecycle),
+        LoopLocal(cfn_lifecycle._StackTaskLifecycle),
     )
 
     def exercise_once():
         async def exercise():
-            lifecycle = cfn_stacks._get_stack_task_lifecycle()
+            lifecycle = cfn_lifecycle._get_stack_task_lifecycle()
 
             async def no_op():
                 return None
@@ -974,6 +1132,90 @@ def test_eventbridge_scheduler_uses_fresh_loop_after_lifecycle_restart(monkeypat
     assert captured_loops == [first_loop, second_loop]
 
 
+def test_scheduler_targeting_rds_state_machine_reaches_terminal_success(monkeypatch):
+    async def exercise():
+        scheduler_service.stop_scheduler()
+        scheduler_service.reset()
+        scheduler_service._schedule_last_fired.clear()
+        eventbridge.reset()
+        stepfunctions.reset()
+        previous_account = get_account_id()
+        previous_region = get_region()
+        set_request_account_id("000000000000")
+        set_request_region("us-east-1")
+        try:
+            state_machine_arn = await _create_rds_integration_state_machine(
+                "event-loop-scheduler-rds"
+            )
+            name = "event-loop-scheduler-rds"
+            key = f"default/{name}"
+            scheduler_service._schedules[key] = {
+                "Arn": (
+                    "arn:aws:scheduler:us-east-1:000000000000:"
+                    f"schedule/{key}"
+                ),
+                "Name": name,
+                "GroupName": "default",
+                "ScheduleExpression": "at(1970-01-01T00:00:01)",
+                "Target": {"Arn": state_machine_arn},
+                "State": "ENABLED",
+                "ActionAfterCompletion": "NONE",
+                "CreationDate": 1,
+            }
+            monkeypatch.setattr(
+                scheduler_service,
+                "_SCHEDULE_TICK_INTERVAL",
+                0.001,
+            )
+            scheduler_service.start_scheduler()
+            await _wait_for_state_machine_terminal_success(state_machine_arn)
+        finally:
+            await asyncio.to_thread(scheduler_service.stop_scheduler)
+            scheduler_service.reset()
+            scheduler_service._schedule_last_fired.clear()
+            eventbridge.reset()
+            stepfunctions.reset()
+            set_request_account_id(previous_account)
+            set_request_region(previous_region)
+
+    asyncio.run(exercise())
+
+
+def test_scheduler_uses_fresh_loop_after_lifecycle_restart(monkeypatch):
+    captured_loops = []
+
+    def capture_loop(server_loop, stop_event):
+        captured_loops.append(server_loop)
+        stop_event.wait(timeout=1)
+
+    scheduler_service.stop_scheduler()
+    monkeypatch.setattr(scheduler_service, "_ticker_loop", capture_loop)
+
+    def run_lifecycle():
+        async def exercise():
+            loop = asyncio.get_running_loop()
+            scheduler_service.start_scheduler()
+            deadline = loop.time() + 1
+            while len(captured_loops) < expected_count:
+                if loop.time() >= deadline:
+                    pytest.fail("scheduler thread did not capture its lifecycle loop")
+                await asyncio.sleep(0.001)
+            await asyncio.to_thread(scheduler_service.stop_scheduler)
+            return loop
+
+        return asyncio.run(exercise())
+
+    expected_count = 1
+    first_loop = run_lifecycle()
+    expected_count = 2
+    second_loop = run_lifecycle()
+
+    assert first_loop is not second_loop
+    assert first_loop.is_closed()
+    assert second_loop.is_closed()
+    assert captured_loops == [first_loop, second_loop]
+
+
 @pytest.mark.parametrize("loop_state", ["missing", "closed"])
 def test_stepfunctions_non_http_loop_backstop_is_states_runtime(loop_state):
     server_loop = None
@@ -1202,9 +1444,9 @@ def test_stepfunctions_marshaled_rds_waits_for_reset_and_sees_fresh_state(
         LoopLocal(ministack_app._RequestResetBarrier),
     )
     monkeypatch.setattr(
-        cfn_stacks,
+        cfn_lifecycle,
         "_stack_task_lifecycles",
-        LoopLocal(cfn_stacks._StackTaskLifecycle),
+        LoopLocal(cfn_lifecycle._StackTaskLifecycle),
     )
     monkeypatch.setattr(rds, "_handle_request_unlocked", read_state)
     monkeypatch.setattr(stepfunctions, "_start_sync_execution", sync_execution)
@@ -1390,9 +1632,9 @@ def test_admin_reset_waits_for_in_flight_request(monkeypatch):
         LoopLocal(ministack_app._RequestResetBarrier),
     )
     monkeypatch.setattr(
-        cfn_stacks,
+        cfn_lifecycle,
         "_stack_task_lifecycles",
-        LoopLocal(cfn_stacks._StackTaskLifecycle),
+        LoopLocal(cfn_lifecycle._StackTaskLifecycle),
     )
 
     async def receive():
@@ -1608,9 +1850,9 @@ def test_admin_reset_does_not_deadlock_nested_lambda_ministack_request(monkeypat
         LoopLocal(ministack_app._RequestResetBarrier),
     )
     monkeypatch.setattr(
-        cfn_stacks,
+        cfn_lifecycle,
         "_stack_task_lifecycles",
-        LoopLocal(cfn_stacks._StackTaskLifecycle),
+        LoopLocal(cfn_lifecycle._StackTaskLifecycle),
     )
 
     async def receive():
@@ -1667,6 +1909,119 @@ def test_admin_reset_does_not_deadlock_nested_lambda_ministack_request(monkeypat
         await asyncio.wait_for(asyncio.gather(outer, reset), timeout=1)
         assert nested_finished.is_set()
         assert dispatch_count == 2
+
+    asyncio.run(exercise())
+
+
+@pytest.mark.parametrize(
+    ("host", "path"),
+    [
+        (
+            "12345678-1234-1234-1234-123456789012.lambda-url.us-east-1.localhost",
+            "/outer",
+        ),
+        ("localhost", "/_aws/lambda-url/12345678-1234-1234-1234-123456789012/outer"),
+    ],
+    ids=["host", "path"],
+)
+def test_admin_reset_does_not_deadlock_nested_function_url_request(
+    monkeypatch,
+    host,
+    path,
+):
+    reset_admitted = asyncio.Event()
+    nested_finished = asyncio.Event()
+    reset_lock = asyncio.Lock()
+    nested_dispatches = 0
+
+    class _SignalingResetLock:
+        async def __aenter__(self):
+            await reset_lock.acquire()
+            reset_admitted.set()
+
+        async def __aexit__(self, *_exc_info):
+            reset_lock.release()
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(_message):
+        pass
+
+    def scope(request_path, service=None, request_host="localhost"):
+        headers = [(b"host", request_host.encode())]
+        if service is not None:
+            headers.append(
+                (
+                    b"authorization",
+                    (
+                        "AWS4-HMAC-SHA256 Credential=test/20260101/"
+                        f"us-east-1/{service}/aws4_request"
+                    ).encode(),
+                )
+            )
+        return {
+            "type": "http",
+            "method": "POST" if request_path == "/_ministack/reset" else "GET",
+            "path": request_path,
+            "query_string": b"",
+            "headers": headers,
+        }
+
+    class _FunctionUrlModule:
+        async def handle_function_url_request(self, *_args):
+            await reset_admitted.wait()
+            await ministack_app.app(
+                scope("/nested", "dynamodb"),
+                receive,
+                send,
+            )
+            nested_finished.set()
+            return 200, {}, b"outer"
+
+    async def nested_dispatch(*_args):
+        nonlocal nested_dispatches
+        nested_dispatches += 1
+        return 200, {}, b"nested"
+
+    monkeypatch.setattr(
+        ministack_app,
+        "_get_reset_lock",
+        lambda: _SignalingResetLock(),
+    )
+    monkeypatch.setattr(ministack_app, "_reset_all_state", lambda: None)
+    monkeypatch.setattr(
+        ministack_app,
+        "_ordinary_request_reset_barriers",
+        LoopLocal(ministack_app._RequestResetBarrier),
+    )
+    monkeypatch.setattr(
+        cfn_lifecycle,
+        "_stack_task_lifecycles",
+        LoopLocal(cfn_lifecycle._StackTaskLifecycle),
+    )
+    monkeypatch.setitem(
+        ministack_app._loaded_modules,
+        "lambda_svc",
+        _FunctionUrlModule(),
+    )
+    monkeypatch.setattr(
+        ministack_app,
+        "_dispatch_service_request",
+        nested_dispatch,
+    )
+
+    async def exercise():
+        outer = asyncio.create_task(
+            ministack_app.app(scope(path, request_host=host), receive, send)
+        )
+        await asyncio.sleep(0)
+        reset = asyncio.create_task(
+            ministack_app.app(scope("/_ministack/reset"), receive, send)
+        )
+        await asyncio.wait_for(asyncio.gather(outer, reset), timeout=1)
+        assert nested_finished.is_set()
+        assert nested_dispatches == 1
 
     asyncio.run(exercise())
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -627,10 +627,12 @@ def _reset_scheduler():
     scheduler_mod.reset()
     scheduler_mod._schedule_last_fired.clear()
     scheduler_mod._ticker_thread = None
+    scheduler_mod._ticker_stop_event = None
     yield
     scheduler_mod.reset()
     scheduler_mod._schedule_last_fired.clear()
     scheduler_mod._ticker_thread = None
+    scheduler_mod._ticker_stop_event = None
 
 
 def _request(method, path, body=None, query=None):
@@ -757,8 +759,17 @@ def test_scheduler_ticker_dispatches_in_schedule_region_and_restores_context(mon
 
     calls = []
 
-    def _capture_target(target, event, schedule):
-        calls.append((get_account_id(), get_region(), target, event, schedule))
+    def _capture_target(target, event, schedule, *, server_loop=None):
+        calls.append(
+            (
+                get_account_id(),
+                get_region(),
+                target,
+                event,
+                schedule,
+                server_loop,
+            )
+        )
 
     monkeypatch.setattr(eventbridge, "_invoke_target", _capture_target)
     monkeypatch.setattr(scheduler_mod.time, "time", lambda: 2.0)
@@ -769,13 +780,16 @@ def test_scheduler_ticker_dispatches_in_schedule_region_and_restores_context(mon
     calls_by_region = {call[1]: call for call in calls}
     assert set(calls_by_region) == set(expected)
     for region, (schedule_arn, target_arn) in expected.items():
-        dispatch_account, dispatch_region, target, event, schedule = calls_by_region[region]
+        dispatch_account, dispatch_region, target, event, schedule, server_loop = (
+            calls_by_region[region]
+        )
         assert (dispatch_account, dispatch_region) == (account_id, region)
         assert target["Arn"] == target_arn
         assert event["Account"] == account_id
         assert event["Region"] == region
         assert event["Resources"] == [schedule_arn]
         assert schedule["Arn"] == schedule_arn
+        assert server_loop is None
     assert (get_account_id(), get_region()) == ("111111111111", "eu-west-1")
 
 
@@ -783,8 +797,9 @@ def test_scheduler_start_scheduler_starts_daemon_once(monkeypatch):
     created_threads = []
 
     class _FakeThread:
-        def __init__(self, *, target, daemon, name):
+        def __init__(self, *, target, args, daemon, name):
             self.target = target
+            self.args = args
             self.daemon = daemon
             self.name = name
             self.started = False
@@ -804,6 +819,8 @@ def test_scheduler_start_scheduler_starts_daemon_once(monkeypatch):
     assert len(created_threads) == 1
     thread = created_threads[0]
     assert thread.target is scheduler_mod._ticker_loop
+    assert thread.args[0] is None
+    assert thread.args[1] is scheduler_mod._ticker_stop_event
     assert thread.daemon is True
     assert thread.name == "evb-scheduler-ticker"
     assert thread.started is True

--- a/tests/test_stepfunctions.py
+++ b/tests/test_stepfunctions.py
@@ -13,6 +13,8 @@ from botocore.config import Config
 from botocore.exceptions import ClientError
 from conftest import ENDPOINT
 
+from ministack.services import stepfunctions as stepfunctions_service
+
 
 def _make_zip(code: str) -> bytes:
     buf = io.BytesIO()
@@ -5779,6 +5781,45 @@ def test_sfn_wait_scale_zero_skips_wait(sfn):
 # ---------------------------------------------------------------------------
 # Step Functions versioning (PublishStateMachineVersion / List / Delete)
 # ---------------------------------------------------------------------------
+
+def test_sfn_list_versions_orders_equal_timestamps_by_numeric_publish_sequence(
+    monkeypatch,
+):
+    """Newest-first ordering uses numeric publish order, not timestamps or text."""
+    frozen_timestamp = "2026-08-04T00:00:00.000Z"
+    monkeypatch.setattr(stepfunctions_service, "now_iso", lambda: frozen_timestamp)
+
+    name = f"version-order-{_uuid_mod.uuid4().hex[:8]}"
+    create_response = stepfunctions_service._create_state_machine({
+        "name": name,
+        "definition": _pass_definition(),
+        "roleArn": "arn:aws:iam::000000000000:role/r",
+    })
+    sm_arn = json.loads(create_response[2])["stateMachineArn"]
+
+    version_arns = []
+    try:
+        for _ in range(10):
+            publish_response = stepfunctions_service._publish_state_machine_version({
+                "stateMachineArn": sm_arn,
+            })
+            version_arns.append(
+                json.loads(publish_response[2])["stateMachineVersionArn"]
+            )
+
+        listed_response = stepfunctions_service._list_state_machine_versions({
+            "stateMachineArn": sm_arn,
+        })
+        listed = json.loads(listed_response[2])["stateMachineVersions"]
+
+        assert {version["creationDate"] for version in listed} == {frozen_timestamp}
+        assert [version["stateMachineVersionArn"] for version in listed] == list(
+            reversed(version_arns)
+        )
+    finally:
+        for version_arn in version_arns:
+            stepfunctions_service._state_machine_versions.pop(version_arn, None)
+        stepfunctions_service._delete_state_machine({"stateMachineArn": sm_arn})
 
 def test_sfn_publish_state_machine_version(sfn):
     """Publish two versions, list them, delete one, re-list.


### PR DESCRIPTION
## Why
Blocking Docker API calls in RDS, ECS, EKS, ElastiCache, and OpenSearch currently run on MiniStack's asyncio event loop. A slow container operation can therefore freeze unrelated services and delay timing-sensitive work such as Glue crawler transitions.

## What
- Offload the five Docker-heavy service routers while preserving per-service request serialization and cancellation safety
- Make reset, CloudFormation, Step Functions, EventBridge, S3 notifications, RDS Data, and tagging explicit participants in the resulting concurrency model
- Preserve lazy service loading and caller account/region context across HTTP, scheduler, and execution-thread dispatch paths
- Add concurrency regressions for loop responsiveness, reset isolation, callback traffic, task lifecycles, and cross-service imports

## Behavior changes and risk
Slow Docker work no longer blocks unrelated gateway requests; requests within each affected service remain serialized. Reset now drains tracked CloudFormation work and synchronous Step Functions actions before taking the request barrier and service locks; mutating CloudFormation requests and new synchronous Step Functions actions may receive HTTP 503 while that admission is closed. During the CloudFormation drain phase, an ordinary request can still complete and then be cleanly wiped by the reset; blocking all ordinary traffic earlier would deadlock custom resources whose Lambda callbacks make nested SDK requests. Background Step Functions `StartExecution` threads retain their existing main-equivalent reset race. The change replaces implicit event-loop serialization with explicit locks and lifecycle tracking, so the primary risk is a missed non-HTTP or cross-service state consumer; the added regression matrix targets those boundaries.

## Validation
- Complete 20-file MiniStack matrix: 2,044 passed, 48 skipped
- Scheduler, CloudFormation, Step Functions, and app lane: 440 passed, 1 skipped
- Event-loop concurrency suite: 92 passed
- A downstream acceptance suite that runs MiniStack as its test backend passed against an image built from this exact commit
- Ruff, Python compilation, and diff checks passed for all changed Python files
- A same-machine main comparison was inconclusive because Docker/EKS cleanup variance dominated the sample; no aggregate throughput claim is made. The validated behavior is isolation: unrelated gateway requests remain responsive while a Docker worker is blocked.
