### PR TITLE
fix(lambda): normalize SDK client stub lookup

### DIFF
--- a/ministack/core/lambda_runtime.py
+++ b/ministack/core/lambda_runtime.py
@@ -438,41 +438,41 @@ fs.write = function(fd, ...args) {
   // Most AWS SDK v3 packages use awsJson1.x: POST / with X-Amz-Target header.
   // Ministack's router maps target prefixes to service modules.
   const _JSON_RPC_TARGETS = {
-    // JSON-RPC (awsJson1.x) services — keyed by @aws-sdk/client-{key} suffix.
+    // JSON-RPC (awsJson1.x) services — keyed by full module specifier.
     // Target prefixes match Ministack's router.py SERVICE_PATTERNS target_prefixes.
-    "ssm":                         "AmazonSSM",
-    "sfn":                         "AWSStepFunctions",
+    "@aws-sdk/client-ssm":                         "AmazonSSM",
+    "@aws-sdk/client-sfn":                         "AWSStepFunctions",
     // sts, sns: query protocol — @aws-sdk/client-{sts,sns} sends Action= form-encoded POST
     // cloudwatch: smithy-rpc-v2-cbor — @aws-sdk/client-cloudwatch sends path-based requests
     // All three are handled by Ministack's native query/path routing when the real SDK is present
-    "cloudwatch-logs":             "Logs_20140328",
-    "logs":                        "Logs_20140328",
-    "secretsmanager":              "secretsmanager",
-    "events":                      "AmazonEventBridge",
-    "eventbridge":                 "AmazonEventBridge",
-    "kinesis":                     "Kinesis_20131202",
-    "ecs":                         "AmazonEC2ContainerServiceV20141113",
-    "dynamodb":                    "DynamoDB_20120810",
-    "dynamodb-streams":            "DynamoDBStreams_20120810",
-    "sqs":                         "AmazonSQS",
-    "glue":                        "AWSGlue",
-    "athena":                      "AmazonAthena",
-    "firehose":                    "Firehose_20150804",
-    "cognito-identity-provider":   "AWSCognitoIdentityProviderService",
-    "cognito-identity":            "AWSCognitoIdentityService",
-    "emr":                         "ElasticMapReduce",
-    "ecr":                         "AmazonEC2ContainerRegistry_V20150921",
-    "acm":                         "CertificateManager",
-    "wafv2":                       "AWSWAF_20190729",
-    "waf":                         "AWSWAF_20150824",
-    "waf-regional":                "AWSWAF_Regional_20161128",
-    "organizations":               "AWSOrganizationsV20161128",
-    "kms":                         "TrentService",
-    "codebuild":                   "CodeBuild_20161006",
-    "transfer":                    "TransferService",
-    "servicediscovery":            "Route53AutoNaming_v20170314",
-    "resource-groups-tagging-api": "ResourceGroupsTaggingAPI_20170126",
-    "cloudtrail":                  "com.amazonaws.cloudtrail.v20131101.CloudTrail_20131101",
+    "@aws-sdk/client-cloudwatch-logs":             "Logs_20140328",
+    "@aws-sdk/client-logs":                        "Logs_20140328",
+    "@aws-sdk/client-secrets-manager":             "secretsmanager",
+    "@aws-sdk/client-events":                      "AmazonEventBridge",
+    "@aws-sdk/client-eventbridge":                 "AmazonEventBridge",
+    "@aws-sdk/client-kinesis":                     "Kinesis_20131202",
+    "@aws-sdk/client-ecs":                         "AmazonEC2ContainerServiceV20141113",
+    "@aws-sdk/client-dynamodb":                    "DynamoDB_20120810",
+    "@aws-sdk/client-dynamodb-streams":            "DynamoDBStreams_20120810",
+    "@aws-sdk/client-sqs":                         "AmazonSQS",
+    "@aws-sdk/client-glue":                        "AWSGlue",
+    "@aws-sdk/client-athena":                      "AmazonAthena",
+    "@aws-sdk/client-firehose":                    "Firehose_20150804",
+    "@aws-sdk/client-cognito-identity-provider":   "AWSCognitoIdentityProviderService",
+    "@aws-sdk/client-cognito-identity":            "AWSCognitoIdentityService",
+    "@aws-sdk/client-emr":                         "ElasticMapReduce",
+    "@aws-sdk/client-ecr":                         "AmazonEC2ContainerRegistry_V20150921",
+    "@aws-sdk/client-acm":                         "CertificateManager",
+    "@aws-sdk/client-wafv2":                       "AWSWAF_20190729",
+    "@aws-sdk/client-waf":                         "AWSWAF_20150824",
+    "@aws-sdk/client-waf-regional":                "AWSWAF_Regional_20161128",
+    "@aws-sdk/client-organizations":               "AWSOrganizationsV20161128",
+    "@aws-sdk/client-kms":                         "TrentService",
+    "@aws-sdk/client-codebuild":                   "CodeBuild_20161006",
+    "@aws-sdk/client-transfer":                    "TransferService",
+    "@aws-sdk/client-servicediscovery":            "Route53AutoNaming_v20170314",
+    "@aws-sdk/client-resource-groups-tagging-api": "ResourceGroupsTaggingAPI_20170126",
+    "@aws-sdk/client-cloudtrail":                  "com.amazonaws.cloudtrail.v20131101.CloudTrail_20131101",
   };
 
   function _jsonRpcRequest(targetPrefix, opName, params) {
@@ -582,11 +582,25 @@ fs.write = function(fd, ...args) {
       return specific;
     }
     // 2. Generic JSON-RPC stubs for known @aws-sdk/client-* packages
-    const m = id.match(_SDK_CLIENT_RE);
-    if (m) {
-      try { return _origRequire.apply(this, arguments); } catch (_) {}
-      const prefix = _JSON_RPC_TARGETS[m[1]];
+    if (_SDK_CLIENT_RE.test(id)) {
+      let requireError;
+      try {
+        return _origRequire.apply(this, arguments);
+      } catch (err) {
+        requireError = err;
+      }
+      const prefix = _JSON_RPC_TARGETS[id];
       if (prefix) return _makeGenericJsonServiceModule(prefix);
+      if (
+        requireError.code !== "MODULE_NOT_FOUND"
+        || !requireError.message.includes("'" + id + "'")
+      ) {
+        throw requireError;
+      }
+      throw new Error(
+        "MiniStack local executor has no stub for '" + id
+        + "'; bundle the module with your function or use LAMBDA_EXECUTOR=docker."
+      );
     }
     return _origRequire.apply(this, arguments);
   };

--- a/tests/test_lambda_runtime_worker.py
+++ b/tests/test_lambda_runtime_worker.py
@@ -13,8 +13,11 @@ Python worker. No Docker or running Ministack instance is required.
 
 import io
 import json
+import shutil
 import zipfile
 from unittest.mock import MagicMock, mock_open, patch
+
+import pytest
 
 from ministack.core.lambda_runtime import Worker
 
@@ -31,6 +34,17 @@ def _config():
         "FunctionArn": "arn:aws:lambda:us-east-1:123456789012:function:test-fn",
         "Timeout": 30,
     }
+
+
+def _node_worker(code, extra_files=None):
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as archive:
+        archive.writestr("index.js", code)
+        for path, contents in (extra_files or {}).items():
+            archive.writestr(path, contents)
+    config = _config()
+    config["Runtime"] = "nodejs20.x"
+    return Worker("test-fn", config, buf.getvalue())
 
 
 def _spawn_proc():
@@ -290,3 +304,104 @@ def test_invoke_gives_up_after_max_lines():
 
     assert result["status"] == "error"
     assert "No JSON response" in result["error"]
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="Node.js is not installed")
+def test_node_worker_resolves_hyphenated_sdk_client_stub():
+    worker = _node_worker(
+        """
+const sdk = require("@aws-sdk/client-secrets-manager");
+exports.handler = async () => ({
+  client: typeof sdk.SecretsManagerClient,
+  command: typeof sdk.GetSecretValueCommand,
+});
+"""
+    )
+    try:
+        result = worker.invoke({}, request_id="sdk-stub")
+    finally:
+        worker.kill()
+
+    assert result["status"] == "ok"
+    assert result["result"] == {"client": "function", "command": "function"}
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="Node.js is not installed")
+def test_node_worker_resolves_expected_sdk_client_stubs():
+    worker = _node_worker(
+        """
+const packages = [
+  "@aws-sdk/client-secrets-manager",
+  "@aws-sdk/client-dynamodb",
+  "@aws-sdk/client-sqs",
+  "@aws-sdk/client-cloudwatch-logs",
+  "@aws-sdk/client-eventbridge",
+  "@aws-sdk/client-cognito-identity-provider",
+  "@aws-sdk/client-dynamodb-streams",
+  "@aws-sdk/client-events",
+  "@aws-sdk/client-logs",
+];
+exports.handler = async () => Object.fromEntries(
+  packages.map((id) => [id, typeof require(id).ContractClient])
+);
+"""
+    )
+    try:
+        result = worker.invoke({}, request_id="sdk-stub-contract")
+    finally:
+        worker.kill()
+
+    assert result["status"] == "ok"
+    assert result["result"] == {
+        "@aws-sdk/client-secrets-manager": "function",
+        "@aws-sdk/client-dynamodb": "function",
+        "@aws-sdk/client-sqs": "function",
+        "@aws-sdk/client-cloudwatch-logs": "function",
+        "@aws-sdk/client-eventbridge": "function",
+        "@aws-sdk/client-cognito-identity-provider": "function",
+        "@aws-sdk/client-dynamodb-streams": "function",
+        "@aws-sdk/client-events": "function",
+        "@aws-sdk/client-logs": "function",
+    }
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="Node.js is not installed")
+def test_node_worker_prefers_bundled_sdk_client_module():
+    worker = _node_worker(
+        """
+const sdk = require("@aws-sdk/client-custom");
+exports.handler = async () => ({ source: sdk.source });
+""",
+        {
+            "node_modules/@aws-sdk/client-custom/index.js": (
+                'module.exports = { source: "bundle" };\n'
+            )
+        },
+    )
+    try:
+        result = worker.invoke({}, request_id="bundled-sdk")
+    finally:
+        worker.kill()
+
+    assert result["status"] == "ok"
+    assert result["result"] == {"source": "bundle"}
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="Node.js is not installed")
+def test_node_worker_reports_missing_sdk_client_stub():
+    worker = _node_worker(
+        """
+require("@aws-sdk/client-no-local-stub");
+exports.handler = async () => ({ ok: true });
+"""
+    )
+    try:
+        with pytest.raises(RuntimeError) as exc:
+            worker.invoke({}, request_id="missing-sdk")
+    finally:
+        worker.kill()
+
+    message = str(exc.value)
+    assert "@aws-sdk/client-no-local-stub" in message
+    assert "LAMBDA_EXECUTOR=docker" in message
+    assert "Cannot find module" not in message


### PR DESCRIPTION
## Summary
- key JSON-RPC SDK stubs by exact full module specifier, including the intentional `events` and `logs` aliases
- preserve bundled-module precedence and the actionable local-executor error for missing stubs
- cover `client-secrets-manager` plus an independent hardcoded contract fixture for canonical and alias package names

Exact matching was chosen over hyphen normalization because it is simpler and prevents distinct package names from collapsing onto the same lookup key.

## Tests
- `.venv/bin/pytest tests/test_lambda_runtime_worker.py -v` (17 passed)
- `.venv/bin/ruff check ministack/core/lambda_runtime.py tests/test_lambda_runtime_worker.py`

Fixes #1281