### PR TITLE
fix(ec2): evaluate filters in DescribeVolumes

### DIFF
--- a/ministack/services/ec2.py
+++ b/ministack/services/ec2.py
@@ -2652,8 +2652,38 @@ def _delete_volume(p):
     return _xml(200, "DeleteVolumeResponse", "<return>true</return>")
 
 
+def _volume_matches_filters(vol, filters):
+    """Apply the DescribeVolumes filters, except the tag ones the shared helper handles."""
+    scalars = {
+        "volume-id": vol["VolumeId"],
+        "size": str(vol["Size"]),
+        "status": vol["State"],
+        "volume-type": vol["VolumeType"],
+        "availability-zone": vol["AvailabilityZone"],
+        "snapshot-id": vol.get("SnapshotId") or "",
+        "create-time": vol.get("CreateTime") or "",
+        "encrypted": "true" if vol.get("Encrypted") else "false",
+        "multi-attach-enabled": "true" if vol.get("MultiAttachEnabled") else "false",
+    }
+    for name, value in scalars.items():
+        if filters.get(name) and value not in filters[name]:
+            return False
+    # attachment.* matches when any one attachment matches, like the gateway describes.
+    attachments = vol.get("Attachments", [])
+    for name, key in (("attachment.instance-id", "InstanceId"), ("attachment.device", "Device"),
+                      ("attachment.status", "State"), ("attachment.attach-time", "AttachTime")):
+        if filters.get(name) and not any(a.get(key) in filters[name] for a in attachments):
+            return False
+    if filters.get("attachment.delete-on-termination") and not any(
+            ("true" if a.get("DeleteOnTermination") else "false")
+            in filters["attachment.delete-on-termination"] for a in attachments):
+        return False
+    return True
+
+
 def _describe_volumes(p):
     filter_ids = _parse_member_list(p, "VolumeId")
+    filters = _parse_filters(p)
     if filter_ids:
         for vid in filter_ids:
             if vid not in _volumes:
@@ -2661,6 +2691,10 @@ def _describe_volumes(p):
     items = ""
     for vol in _volumes.values():
         if filter_ids and vol["VolumeId"] not in filter_ids:
+            continue
+        if not _resource_matches_tag_filters(vol["VolumeId"], filters):
+            continue
+        if not _volume_matches_filters(vol, filters):
             continue
         items += f"<item>{_volume_inner_xml(vol)}</item>"
     return _xml(200, "DescribeVolumesResponse", f"<volumeSet>{items}</volumeSet>")

--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -2715,6 +2715,68 @@ def test_ebs_attach_detach_volume(ec2):
     assert desc2["Volumes"][0]["State"] == "available"
     assert desc2["Volumes"][0]["Attachments"] == []
 
+def test_ebs_describe_volumes_honors_filters(ec2):
+    """Filters must narrow the result. Ignoring them returns every volume in the account, so
+    "the volume I tagged for this run" resolves to somebody else's."""
+    tag = _uuid_mod.uuid4().hex[:8]
+    key = f"check-{tag}"          # unique, so other tests' volumes cannot match the tag filters
+    zone = ec2.describe_availability_zones()["AvailabilityZones"][0]["ZoneName"]
+    tagged = ec2.create_volume(
+        AvailabilityZone=zone, Size=77, VolumeType="gp3",
+        TagSpecifications=[{"ResourceType": "volume", "Tags": [{"Key": key, "Value": tag}]}],
+    )["VolumeId"]
+    # A second volume differing in size and type: with the filters ignored it comes back too.
+    spare = ec2.create_volume(AvailabilityZone=zone, Size=79, VolumeType="gp2")["VolumeId"]
+    instance_id = ec2.run_instances(ImageId="ami-00000001", MinCount=1, MaxCount=1,
+                                    )["Instances"][0]["InstanceId"]
+
+    def ids(**kwargs):
+        return sorted(v["VolumeId"] for v in ec2.describe_volumes(**kwargs)["Volumes"])
+
+    try:
+        assert ids(Filters=[{"Name": f"tag:{key}", "Values": [tag]}]) == [tagged]
+        assert ids(Filters=[{"Name": "tag-key", "Values": [key]}]) == [tagged]
+        assert ids(Filters=[{"Name": "size", "Values": ["77"]}]) == [tagged]
+        assert ids(Filters=[{"Name": "volume-id", "Values": [spare]}]) == [spare]
+        assert tagged in ids(Filters=[{"Name": "encrypted", "Values": ["false"]}])
+        # Other tests leave gp2 volumes behind, so this one asserts on membership.
+        by_type = ids(Filters=[{"Name": "volume-type", "Values": ["gp2"]}])
+        assert spare in by_type and tagged not in by_type
+        # Two filter names is an AND, two values for one name an OR.
+        assert ids(Filters=[{"Name": "size", "Values": ["77"]},
+                            {"Name": "volume-type", "Values": ["gp2"]}]) == []
+        assert ids(Filters=[{"Name": "volume-id", "Values": [tagged, spare]}]) == sorted(
+            [tagged, spare])
+        # A filter that matches nothing is an empty list, not "everything".
+        assert ids(Filters=[{"Name": "size", "Values": ["4096"]}]) == []
+
+        # attachment.* matches on any one attachment. The instance's own root volume is attached
+        # too, so these assert on membership rather than an exact list -- except the device, which
+        # only this attachment uses.
+        ec2.attach_volume(VolumeId=tagged, InstanceId=instance_id, Device="/dev/xvdz")
+        attached_here = ids(Filters=[{"Name": "attachment.instance-id", "Values": [instance_id]}])
+        assert tagged in attached_here and spare not in attached_here
+        assert ids(Filters=[{"Name": "attachment.device", "Values": ["/dev/xvdz"]}]) == [tagged]
+        in_use = ids(Filters=[{"Name": "status", "Values": ["in-use"]}])
+        assert tagged in in_use and spare not in in_use
+        assert spare in ids(Filters=[{"Name": "status", "Values": ["available"]}])
+    finally:
+        # Cleanup must not mask a failed assertion above: a volume still attached because an
+        # assertion raised first would fail to delete, and that error would be the one reported.
+        try:
+            ec2.detach_volume(VolumeId=tagged)
+        except ClientError:
+            pass
+        try:
+            ec2.terminate_instances(InstanceIds=[instance_id])
+        except ClientError:
+            pass
+        for volume_id in (tagged, spare):
+            try:
+                ec2.delete_volume(VolumeId=volume_id)
+            except ClientError:
+                pass
+
 def test_ebs_delete_volume(ec2):
     vol = ec2.create_volume(AvailabilityZone="us-east-1a", Size=5, VolumeType="gp2")
     vol_id = vol["VolumeId"]


### PR DESCRIPTION
### Issue

`DescribeVolumes` parsed only `VolumeId` and ignored `Filters` entirely, so every filtered call returned every volume in the account.

```python
>>> tagged = ec2.create_volume(AvailabilityZone=zone, Size=1, VolumeType="gp3",
...     TagSpecifications=[{"ResourceType": "volume",
...                         "Tags": [{"Key": "check-1a2b", "Value": "1a2b"}]}])["VolumeId"]
>>> spare = ec2.create_volume(AvailabilityZone=zone, Size=1, VolumeType="gp2")["VolumeId"]
>>> [v["VolumeId"] for v in ec2.describe_volumes(
...     Filters=[{"Name": "tag:check-1a2b", "Values": ["1a2b"]}])["Volumes"]]
['vol-2cd2542e0c0cc52f5', 'vol-3124489fda1b4cab5']      # AWS returns only the first
```

I needed it for a tag-filtered lookup  to dedup precheck asks "does a volume tagged with this id already exist?".

Similar to `DescribeInternetGateways` #1269

### Fix

Evaluate the filters the action documents — the tag filters through the shared helper, plus `volume-id`, `size`, `status`, `volume-type`, `availability-zone`, `snapshot-id`, `create-time`, `encrypted`, `multi-attach-enabled` and the `attachment.*` set. Each `attachment.*` filter matches when any one attachment matches. Implemented similar to `DescribeInternetGateways`, with the per-volume matching in a small helper since there are more filters than a gateway has.

Exact matching only, as elsewhere in the file: AWS also accepts `*` wildcards in filter values, which no handler here implements.

Code written with Claude Code

### Testing

New test with `test_ebs_describe_volumes_honors_filters`

144 passed in `test_ec2.py`, in file order and twice in random order.

Expected behaviour was confirmed on real AWS, then checked against MiniStack with the script below, which runs against either:

| target | result |
| --- | --- |
| MiniStack before | 0/4 |
| this branch | 4/4 |
| real AWS, eu-central-1 | 4/4 — same detail on every line |

```
                                 before                                          this branch / AWS
tag:<key> filter                 got 2: ['vol-2cd2…', 'vol-3124…']               only vol-9560…
tag-key filter                   got 2: ['vol-2cd2…', 'vol-3124…']               only vol-9560…
volume-id filter                 got 2: ['vol-2cd2…', 'vol-3124…']               only vol-281f…
AND, OR, and no match is empty   or=2 and=2 none=2                               2 matched, 0, 0
```

<details>
<summary>check_ec2_volume_filters.py</summary>

```python
#!/usr/bin/env python3
"""Check that DescribeVolumes honours Filters.

MiniStack parsed only VolumeId and ignored Filters entirely, so every filtered call returned every
volume in the account. A tag-filtered lookup -- "does a volume tagged with this id already exist?"
-- therefore matches somebody else's volume, so an adopt/dedup precheck adopts the wrong resource
and an orphan sweep reports every volume as an orphan. Nothing errors: the answer is just wrong.

This one needs no Step Functions: plain boto3 shows it.

Against MiniStack:
  python check_ec2_volume_filters.py --endpoint http://localhost:4566 --region eu-central-1

Against AWS, after `aws sso login --profile <profile>`:
  python check_ec2_volume_filters.py --profile <profile> --region eu-central-1

Creates and deletes two 1-GiB volumes, one tagged and one not, so a filter that is ignored is
visibly wrong rather than accidentally right. Pass --keep to leave them behind. Exit status is 0
when every check passes.

"""
import argparse
import sys
import time
import uuid
from contextlib import suppress

import boto3
from botocore.exceptions import ClientError


def options():
    parser = argparse.ArgumentParser(description=__doc__)
    parser.add_argument("--endpoint", help="Emulator endpoint, e.g. http://localhost:4566")
    parser.add_argument("--profile", help="AWS CLI/SSO profile; defaults to AWS_PROFILE")
    parser.add_argument("--region", default=None, help="AWS region; defaults to AWS_REGION")
    parser.add_argument("--keep", action="store_true", help="Leave resources behind")
    return parser.parse_args()


def main():
    args = options()
    if args.endpoint and not args.profile:
        session = boto3.Session(region_name=args.region, aws_access_key_id="test",
                                aws_secret_access_key="test")
    else:
        session = boto3.Session(profile_name=args.profile, region_name=args.region)
    ec2 = session.client("ec2", **({"endpoint_url": args.endpoint} if args.endpoint else {}))

    tag = uuid.uuid4().hex[:8]
    key = f"check-{tag}"          # unique, so nothing else in the account carries it
    created = []
    results = []

    def check(label, ok, detail):
        results.append((label, ok, detail))
        print(f"{'PASS' if ok else 'FAIL'}  {label:38} {detail}")

    def ids(**kwargs):
        return sorted(v["VolumeId"] for v in ec2.describe_volumes(**kwargs)["Volumes"])

    try:
        zone = ec2.describe_availability_zones()["AvailabilityZones"][0]["ZoneName"]
        tagged = ec2.create_volume(
            AvailabilityZone=zone, Size=1, VolumeType="gp3",
            TagSpecifications=[{"ResourceType": "volume",
                                "Tags": [{"Key": key, "Value": tag}]}])["VolumeId"]
        created.append(("volume", tagged))
        # A second, untagged volume: an ignored filter returns this one too.
        spare = ec2.create_volume(AvailabilityZone=zone, Size=1, VolumeType="gp2")["VolumeId"]
        created.append(("volume", spare))

        # 1. The lookup an adopt/dedup precheck does: "is there already a volume tagged with this?"
        got = ids(Filters=[{"Name": f"tag:{key}", "Values": [tag]}])
        check("tag:<key> filter", got == [tagged],
              f"only {tagged}" if got == [tagged] else f"got {len(got)}: {got[:3]}")

        # 2. The orphan sweep's filter: any volume carrying the key, whatever its value.
        got = ids(Filters=[{"Name": "tag-key", "Values": [key]}])
        check("tag-key filter", got == [tagged],
              f"only {tagged}" if got == [tagged] else f"got {len(got)}: {got[:3]}")

        # 3. A structural filter, and the id filter as a Filters entry rather than the VolumeIds
        #    parameter -- the same value by a different route, and only the parameter form worked.
        got = ids(Filters=[{"Name": "volume-id", "Values": [spare]}])
        check("volume-id filter", got == [spare],
              f"only {spare}" if got == [spare] else f"got {len(got)}: {got[:3]}")

        # 4. Two names is an AND, two values for one name an OR, and an unmatched filter is an
        #    empty list -- not "everything", which is what an ignored filter looks like.
        both = ids(Filters=[{"Name": "volume-id", "Values": [tagged, spare]}])
        conflicting = ids(Filters=[{"Name": "volume-id", "Values": [tagged]},
                                   {"Name": "volume-type", "Values": ["gp2"]}])
        empty = ids(Filters=[{"Name": "tag-key", "Values": [f"absent-{tag}"]}])
        ok = both == sorted([tagged, spare]) and conflicting == [] and empty == []
        check("AND, OR, and no match is empty", ok,
              "2 matched, 0, 0" if ok
              else f"or={len(both)} and={len(conflicting)} none={len(empty)}")
    finally:
        if not args.keep:
            for kind, ident in reversed(created):
                if kind == "volume":
                    with suppress(ClientError):
                        ec2.delete_volume(VolumeId=ident)
            # AWS deletes asynchronously; give it a moment so --keep-less runs leave nothing.
            if not args.endpoint:
                time.sleep(2)

    failed = [label for label, ok, _ in results if not ok]
    print(f"\n{len(results) - len(failed)}/{len(results)} checks passed"
          + (f"; failed: {', '.join(failed)}" if failed else ""))
    return 1 if failed else 0


if __name__ == "__main__":
    try:
        sys.exit(main())
    except ClientError as exc:
        print(f"ERROR: {exc}", file=sys.stderr)
        sys.exit(2)
```

</details>