### PR TITLE
fix(ec2): evaluate the cidr-block filter in DescribeSubnets

### DIFF
--- a/ministack/services/ec2.py
+++ b/ministack/services/ec2.py
@@ -1833,6 +1833,9 @@ def _matches_subnet_filters(subnet, filters):
         elif name == "subnet-id":
             if subnet["SubnetId"] not in vals:
                 return False
+        elif name in ("cidr-block", "cidr", "cidrBlock"):
+            if subnet["CidrBlock"] not in vals:
+                return False
         elif name == "default-for-az":
             val = "true" if subnet.get("DefaultForAz") else "false"
             if val not in vals:

--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -2472,6 +2472,38 @@ def test_ec2_describe_subnets_tags_filters(ec2):
     ec2.delete_vpc(VpcId=vpc_id)
 
 
+def test_ec2_describe_subnets_cidr_block_filter(ec2):
+    """cidr-block, and the cidr/cidrBlock spellings of it, match the CIDR exactly."""
+    vpc_id = ec2.create_vpc(CidrBlock="10.63.0.0/16")["Vpc"]["VpcId"]
+    first = ec2.create_subnet(VpcId=vpc_id, CidrBlock="10.63.0.0/20",
+                              AvailabilityZone="us-east-1a")["Subnet"]["SubnetId"]
+    second = ec2.create_subnet(VpcId=vpc_id, CidrBlock="10.63.16.0/20",
+                               AvailabilityZone="us-east-1b")["Subnet"]["SubnetId"]
+    in_vpc = {"Name": "vpc-id", "Values": [vpc_id]}
+
+    def subnets(*filters):
+        return sorted(s["SubnetId"] for s in ec2.describe_subnets(Filters=list(filters))["Subnets"])
+
+    # The per-AZ idempotency precheck: ignored, the filter returns the other AZ's subnet too, and a
+    # provisioner adopts it as this AZ's.
+    assert subnets(in_vpc, {"Name": "cidr-block", "Values": ["10.63.16.0/20"]}) == [second]
+    for alias in ("cidr", "cidrBlock"):
+        assert subnets(in_vpc, {"Name": alias, "Values": ["10.63.0.0/20"]}) == [first]
+    # Exact, not enclosing: the VPC's own /16 contains both subnets but is neither subnet's CIDR.
+    assert subnets(in_vpc, {"Name": "cidr-block", "Values": ["10.63.0.0/16"]}) == []
+    assert subnets(in_vpc, {"Name": "cidr-block", "Values": ["10.63.99.0/28"]}) == []
+    # Two values for one name is an OR, and the CIDRs are distinctive enough to filter account-wide.
+    assert subnets({"Name": "cidr-block",
+                    "Values": ["10.63.0.0/20", "10.63.16.0/20"]}) == sorted([first, second])
+    # Control: both subnets really are in the VPC, so the assertions above narrowed the result
+    # rather than emptying it for some unrelated reason.
+    assert subnets(in_vpc) == sorted([first, second])
+
+    ec2.delete_subnet(SubnetId=first)
+    ec2.delete_subnet(SubnetId=second)
+    ec2.delete_vpc(VpcId=vpc_id)
+
+
 def test_ec2_describe_tags_filters(ec2):
     """DescribeTags respects resource-id and key filters."""
     # Create two instances and tag them differently


### PR DESCRIPTION
### Issue

`_matches_subnet_filters` handles `vpc-id`, `availability-zone`, `subnet-id`, `default-for-az` and
the tag filters, but has no branch for `cidr-block`. An unknown filter name falls through the
`if/elif` chain, so the filter is silently ignored rather than rejected and every subnet is returned.

```python
>>> vpc = ec2.create_vpc(CidrBlock="10.63.0.0/16")["Vpc"]["VpcId"]
>>> for az, cidr in [("us-east-1a", "10.63.0.0/20"), ("us-east-1b", "10.63.16.0/20")]:
...     ec2.create_subnet(VpcId=vpc, CidrBlock=cidr, AvailabilityZone=az)
>>> [s["CidrBlock"] for s in ec2.describe_subnets(Filters=[
...     {"Name": "vpc-id", "Values": [vpc]},
...     {"Name": "cidr-block", "Values": ["10.63.16.0/20"]}])["Subnets"]]
['10.63.0.0/20', '10.63.16.0/20']       # AWS returns only the second
```

I needed it for an idempotency prechecks that lets a re-run adopt its own earlier subnet instead of
failing on a duplicate CIDR. 

Again similar to #1269 

### Fix

Match `cidr-block` exactly against the subnet's `CidrBlock`, and accept `cidr` and `cidrBlock`, which
[DescribeSubnets](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSubnets.html)
documents as alternative names for the same filter. 

Exact matching is what the reference specifies —
"The CIDR block you specify must exactly match the subnet's CIDR block for information to be returned
for the subnet" — so an enclosing block matches nothing, and I confirmed that against real AWS rather
than assuming it.

Code written with Claude Code.

### Testing

`test_ec2_describe_subnets_cidr_block_filter`  with a ip range unique to this test.

| mutation | result |
| --- | --- |
| drop the `cidr-block` branch | test fails |
| keep `cidr-block`, drop the two aliases | test fails |
| prefix match instead of exact | test fails |

144 passed in `test_ec2.py`, in file order and in random order.

The script below runs against MiniStack or real AWS:

| target | result |
| --- | --- |
| MiniStack before | 1/5 |
| this branch | 5/5 |
| real AWS, eu-central-1 | 5/5 — same detail on every line |

```
                                 before                             this branch / AWS
cidr-block filter                got 5: ['subnet-00000001', …]      only subnet-a90d…
vpc-id + cidr-block              got 2: ['subnet-ed5f…', …]         only subnet-a90d…
cidr and cidrBlock aliases       cidr=2 cidrBlock=2                 both only subnet-7cc9…
exact match, no match is empty   enclosing=5 absent=5               0, 0
controls: vpc-id, az, subnet-id  2 in the VPC, az and subnet-id narrow to 1   (unchanged)
```

The last line is a control: it passes before and after, so the four failures above are the filter and
not the fixture.

<details>
<summary>check_ec2_subnet_filters.py</summary>

```python
#!/usr/bin/env python3
"""Check that DescribeSubnets honours the cidr-block filter.

_matches_subnet_filters has branches for vpc-id, availability-zone, subnet-id, default-for-az and
tags, but none for cidr-block, so that filter is silently ignored and every subnet comes back. A
"does a subnet with this CIDR already exist?" precheck therefore adopts a subnet it did not plan,
which is how one AZ's subnet ended up serving three AZs. Nothing errors: the answer is just wrong.

This one needs no Step Functions: plain boto3 shows it.

Against MiniStack:
  python check_ec2_subnet_filters.py --endpoint http://localhost:4566 --region eu-central-1

Against AWS, after `aws sso login --profile <profile>`:
  python check_ec2_subnet_filters.py --profile <profile> --region eu-central-1

Creates one VPC with two subnets in different AZs, differing only in CIDR and AZ, so a filter that
is ignored is visibly wrong rather than accidentally right. The VPC CIDR is randomised because the
unqualified cidr-block check looks account-wide. Pass --keep to leave them behind. Exit status is 0
when every check passes.
"""

import argparse
import random
import sys
import uuid

import boto3
from botocore.exceptions import ClientError


def options():
    parser = argparse.ArgumentParser(description=__doc__)
    parser.add_argument("--endpoint", help="Emulator endpoint, e.g. http://localhost:4566")
    parser.add_argument("--profile", help="AWS CLI/SSO profile; defaults to AWS_PROFILE")
    parser.add_argument("--region", default=None, help="AWS region; defaults to AWS_REGION")
    parser.add_argument("--keep", action="store_true", help="Leave resources behind")
    return parser.parse_args()


def main():
    args = options()
    if args.endpoint and not args.profile:
        session = boto3.Session(region_name=args.region, aws_access_key_id="test",
                                aws_secret_access_key="test")
    else:
        session = boto3.Session(profile_name=args.profile, region_name=args.region)
    ec2 = session.client("ec2", **({"endpoint_url": args.endpoint} if args.endpoint else {}))

    tag = uuid.uuid4().hex[:8]
    # A random second octet: the unqualified cidr-block check has no vpc-id to scope it, so the
    # CIDRs have to be unlikely to exist elsewhere in the account.
    octet = random.Random(tag).randint(20, 250)
    vpc_cidr = f"10.{octet}.0.0/16"
    first_cidr = f"10.{octet}.0.0/20"
    second_cidr = f"10.{octet}.16.0/20"
    vpc_id = None
    results = []

    def check(label, ok, detail):
        results.append((label, ok, detail))
        print(f"{'PASS' if ok else 'FAIL'}  {label:38} {detail}")

    def ids(**kwargs):
        return sorted(s["SubnetId"] for s in ec2.describe_subnets(**kwargs)["Subnets"])

    def cidrs(**kwargs):
        return sorted(s["CidrBlock"] for s in ec2.describe_subnets(**kwargs)["Subnets"])

    try:
        zones = [z["ZoneName"] for z in ec2.describe_availability_zones()["AvailabilityZones"]]
        vpc_id = ec2.create_vpc(CidrBlock=vpc_cidr,
                                TagSpecifications=[{"ResourceType": "vpc",
                                                    "Tags": [{"Key": f"check-{tag}",
                                                              "Value": tag}]}])["Vpc"]["VpcId"]
        first = ec2.create_subnet(VpcId=vpc_id, CidrBlock=first_cidr,
                                  AvailabilityZone=zones[0])["Subnet"]["SubnetId"]
        second = ec2.create_subnet(VpcId=vpc_id, CidrBlock=second_cidr,
                                   AvailabilityZone=zones[1])["Subnet"]["SubnetId"]

        # 1. The filter on its own, account-wide: one subnet has this CIDR.
        got = ids(Filters=[{"Name": "cidr-block", "Values": [second_cidr]}])
        check("cidr-block filter", got == [second],
              f"only {second}" if got == [second] else f"got {len(got)}: {got[:3]}")

        # 2. The lookup the provisioner's per-AZ idempotency precheck does. Ignored, it returns the
        #    other AZ's subnet, which then gets adopted as this AZ's.
        got = ids(Filters=[{"Name": "vpc-id", "Values": [vpc_id]},
                           {"Name": "cidr-block", "Values": [second_cidr]}])
        check("vpc-id + cidr-block", got == [second],
              f"only {second}" if got == [second] else f"got {len(got)}: {got[:3]}")

        # 3. Both documented spellings of the same filter, per the DescribeSubnets reference:
        #    "You can also use cidr or cidrBlock as the filter names."
        by_alias = {alias: ids(Filters=[{"Name": "vpc-id", "Values": [vpc_id]},
                                        {"Name": alias, "Values": [first_cidr]}])
                    for alias in ("cidr", "cidrBlock")}
        ok = all(got == [first] for got in by_alias.values())
        check("cidr and cidrBlock aliases", ok,
              f"both only {first}" if ok
              else " ".join(f"{a}={len(g)}" for a, g in by_alias.items()))

        # 4. Exact match, not prefix or containment: the VPC's own /16 contains both subnets but is
        #    not either subnet's CIDR, and an unmatched value is an empty list -- not "everything",
        #    which is what an ignored filter looks like.
        contains = ids(Filters=[{"Name": "cidr-block", "Values": [vpc_cidr]}])
        absent = ids(Filters=[{"Name": "cidr-block", "Values": [f"10.{octet}.99.0/28"]}])
        ok = contains == [] and absent == []
        check("exact match, no match is empty", ok,
              "0, 0" if ok else f"enclosing={len(contains)} absent={len(absent)}")

        # 5. Controls, all working before this fix: two subnets in the VPC, and the two filters that
        #    narrow to one already. If these fail the fixture is wrong, not the filter.
        in_vpc = cidrs(Filters=[{"Name": "vpc-id", "Values": [vpc_id]}])
        by_az = ids(Filters=[{"Name": "vpc-id", "Values": [vpc_id]},
                             {"Name": "availability-zone", "Values": [zones[1]]}])
        by_id = ids(Filters=[{"Name": "vpc-id", "Values": [vpc_id]},
                             {"Name": "subnet-id", "Values": [second]}])
        ok = in_vpc == sorted([first_cidr, second_cidr]) and by_az == [second] == by_id
        check("controls: vpc-id, az, subnet-id", ok,
              "2 in the VPC, az and subnet-id narrow to 1" if ok
              else f"vpc={in_vpc} az={len(by_az)} id={len(by_id)}")
    finally:
        if not args.keep and vpc_id:
            for subnet in ids(Filters=[{"Name": "vpc-id", "Values": [vpc_id]}]):
                try:
                    ec2.delete_subnet(SubnetId=subnet)
                except ClientError:
                    pass
            try:
                ec2.delete_vpc(VpcId=vpc_id)
            except ClientError:
                pass

    failed = [label for label, ok, _ in results if not ok]
    print(f"\n{len(results) - len(failed)}/{len(results)} checks passed"
          + (f"; failed: {', '.join(failed)}" if failed else ""))
    return 1 if failed else 0


if __name__ == "__main__":
    try:
        sys.exit(main())
    except ClientError as exc:
        print(f"ERROR: {exc}", file=sys.stderr)
        sys.exit(2)
```

</details>

