### PR TITLE
fix(route53): DELETE must match the current record values exactly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to MiniStack will be documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Versioning follows [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- **Route 53 — `ChangeResourceRecordSets` `DELETE` now requires the values provided to match the current values** — a `DELETE` matched only on name, type, and set identifier, so a delete carrying a stale TTL or stale record values silently removed the live record. Real Route 53 requires the values in a `DELETE` to match the current record exactly and rejects the whole batch with `InvalidChangeBatch` otherwise — the compare-and-swap semantics that guarded-delete workflows (delete only if the record still holds the values I last observed) rely on to detect concurrent modification, which the emulator's silent success defeated. A mismatched `DELETE` now fails the batch atomically with the AWS-shaped message (`Tried to delete resource record set [name='…', type='…'] but the values provided do not match the current values`); record values are compared as an unordered set, so the same values in a different order still match. Contributed by @jayjanssen.
+
 ## [1.4.14] — 2026-08-07
 
 ### Added

--- a/ministack/services/route53.py
+++ b/ministack/services/route53.py
@@ -220,6 +220,16 @@ def _rs_key(rs: dict) -> tuple:
     return (rs["Name"], rs["Type"], rs.get("SetIdentifier", ""))
 
 
+def _rs_values(rs: dict) -> dict:
+    """The value-bearing fields of a record set — everything a DELETE must
+    match exactly, per the Route 53 API reference. Resource record values
+    are compared as an unordered set (order never matters to Route 53)."""
+    values = {k: v for k, v in rs.items() if k not in ("Name", "Type", "SetIdentifier")}
+    if "ResourceRecords" in values:
+        values["ResourceRecords"] = sorted(values["ResourceRecords"])
+    return values
+
+
 # ─── XML builders for common structures ───────────────────────────────────────
 
 def _build_hosted_zone_el(parent: Element, zone: dict):
@@ -629,6 +639,12 @@ def _change_resource_record_sets(zone_id: str, body: bytes):
                     return _error_response(
                         "InvalidChangeBatch",
                         f"Tried to delete resource record set {rs['Name']} type {rs['Type']} but it does not exist.",
+                    )
+                if _rs_values(existing) != _rs_values(rs):
+                    return _error_response(
+                        "InvalidChangeBatch",
+                        f"Tried to delete resource record set [name='{rs['Name']}', type='{rs['Type']}'] "
+                        "but the values provided do not match the current values",
                     )
                 current = [r for r in current if _rs_key(r) != key]
 

--- a/tests/test_route53.py
+++ b/tests/test_route53.py
@@ -334,6 +334,125 @@ def test_route53_delete_record(r53):
     a_records = [rrs for rrs in list_resp["ResourceRecordSets"] if rrs["Type"] == "A"]
     assert len(a_records) == 0
 
+def _create_zone_with_a_record(r53, zone_name, values, ttl=300):
+    resp = r53.create_hosted_zone(Name=zone_name, CallerReference=f"ref-{zone_name}")
+    zone_id = resp["HostedZone"]["Id"].split("/")[-1]
+    r53.change_resource_record_sets(
+        HostedZoneId=zone_id,
+        ChangeBatch={
+            "Changes": [
+                {
+                    "Action": "CREATE",
+                    "ResourceRecordSet": {
+                        "Name": f"www.{zone_name}",
+                        "Type": "A",
+                        "TTL": ttl,
+                        "ResourceRecords": [{"Value": v} for v in values],
+                    },
+                }
+            ]
+        },
+    )
+    return zone_id
+
+def _a_records(r53, zone_id):
+    list_resp = r53.list_resource_record_sets(HostedZoneId=zone_id)
+    return [rrs for rrs in list_resp["ResourceRecordSets"] if rrs["Type"] == "A"]
+
+def test_route53_delete_record_rejects_value_mismatch(r53):
+    # Real Route 53 requires DELETE to specify the record's current values
+    # exactly and rejects the whole batch otherwise:
+    # https://docs.aws.amazon.com/Route53/latest/APIReference/API_ChangeResourceRecordSets.html
+    zone_id = _create_zone_with_a_record(r53, "delmismatch.com", ["5.5.5.5"])
+
+    with pytest.raises(ClientError) as exc:
+        r53.change_resource_record_sets(
+            HostedZoneId=zone_id,
+            ChangeBatch={
+                "Changes": [
+                    {
+                        "Action": "CREATE",
+                        "ResourceRecordSet": {
+                            "Name": "other.delmismatch.com",
+                            "Type": "A",
+                            "TTL": 300,
+                            "ResourceRecords": [{"Value": "7.7.7.7"}],
+                        },
+                    },
+                    {
+                        "Action": "DELETE",
+                        "ResourceRecordSet": {
+                            "Name": "www.delmismatch.com",
+                            "Type": "A",
+                            "TTL": 300,
+                            "ResourceRecords": [{"Value": "6.6.6.6"}],
+                        },
+                    },
+                ]
+            },
+        )
+    assert exc.value.response["Error"]["Code"] == "InvalidChangeBatch"
+    assert (
+        "Tried to delete resource record set [name='www.delmismatch.com.', type='A'] "
+        "but the values provided do not match the current values"
+    ) in exc.value.response["Error"]["Message"]
+
+    # The batch is atomic: the record survives and the CREATE was not applied.
+    remaining = _a_records(r53, zone_id)
+    assert len(remaining) == 1
+    assert remaining[0]["Name"] == "www.delmismatch.com."
+    assert remaining[0]["ResourceRecords"] == [{"Value": "5.5.5.5"}]
+
+def test_route53_delete_record_rejects_ttl_mismatch(r53):
+    zone_id = _create_zone_with_a_record(r53, "delttl.com", ["5.5.5.5"], ttl=300)
+
+    with pytest.raises(ClientError) as exc:
+        r53.change_resource_record_sets(
+            HostedZoneId=zone_id,
+            ChangeBatch={
+                "Changes": [
+                    {
+                        "Action": "DELETE",
+                        "ResourceRecordSet": {
+                            "Name": "www.delttl.com",
+                            "Type": "A",
+                            "TTL": 60,
+                            "ResourceRecords": [{"Value": "5.5.5.5"}],
+                        },
+                    }
+                ]
+            },
+        )
+    assert exc.value.response["Error"]["Code"] == "InvalidChangeBatch"
+    assert (
+        "Tried to delete resource record set [name='www.delttl.com.', type='A'] "
+        "but the values provided do not match the current values"
+    ) in exc.value.response["Error"]["Message"]
+    assert len(_a_records(r53, zone_id)) == 1
+
+def test_route53_delete_record_accepts_reordered_values(r53):
+    # Route 53 compares resource record values as a set, so a DELETE listing
+    # the same values in a different order must match.
+    zone_id = _create_zone_with_a_record(r53, "delorder.com", ["5.5.5.5", "6.6.6.6"])
+
+    r53.change_resource_record_sets(
+        HostedZoneId=zone_id,
+        ChangeBatch={
+            "Changes": [
+                {
+                    "Action": "DELETE",
+                    "ResourceRecordSet": {
+                        "Name": "www.delorder.com",
+                        "Type": "A",
+                        "TTL": 300,
+                        "ResourceRecords": [{"Value": "6.6.6.6"}, {"Value": "5.5.5.5"}],
+                    },
+                }
+            ]
+        },
+    )
+    assert len(_a_records(r53, zone_id)) == 0
+
 def test_route53_get_change(r53):
     resp = r53.create_hosted_zone(Name="change-status.com", CallerReference="ref-cs-1")
     zone_id = resp["HostedZone"]["Id"].split("/")[-1]


### PR DESCRIPTION
## Problem

`ChangeResourceRecordSets` `DELETE` matches a record only on `(Name, Type, SetIdentifier)` and ignores the TTL and resource record values in the request. A `DELETE` carrying a stale TTL or stale values therefore silently removes the live record.

Real Route 53 requires the values in a `DELETE` to match the current record **exactly**, and rejects the whole batch otherwise:

> **DELETE**: Deletes an existing resource record set. To delete a resource record set, you must specify all the same values that are in the current resource record set.
> — [ChangeResourceRecordSets — Amazon Route 53 API Reference](https://docs.aws.amazon.com/Route53/latest/APIReference/API_ChangeResourceRecordSets.html)

The rejection is `InvalidChangeBatch` with the message shape:

```
Tried to delete resource record set [name='www.example.com.', type='A'] but the values provided do not match the current values
```

This matters beyond fidelity: exact-value `DELETE` is the compare-and-swap primitive that guarded-delete workflows rely on ("delete this record only if it still holds the values I last observed") to detect concurrent modification. The emulator's silent success defeats that guard, so races that real Route 53 catches pass undetected in tests. We hit this building a Terraform provider whose delete/retarget operations are CAS-guarded — the race-detection paths are untestable against MiniStack today.

## Fix

- `DELETE` now compares the value-bearing fields of the request against the current record (everything except `Name`/`Type`/`SetIdentifier`); on mismatch the batch fails atomically with `InvalidChangeBatch` and the AWS-shaped message above.
- Resource record values are compared as an unordered set — the same values in a different order still match, as in real Route 53.
- The existing not-found `DELETE` error and all other actions are untouched. CloudFormation's `AWS::Route53::RecordSet` delete provisioner manipulates zone state directly (not via the change-batch path), so it is unaffected.

## Tests

- `test_route53_delete_record_rejects_value_mismatch` — stale values are rejected with the exact error code + message shape, and the batch is atomic (a `CREATE` in the same batch is not applied).
- `test_route53_delete_record_rejects_ttl_mismatch` — a stale TTL alone is rejected.
- `test_route53_delete_record_accepts_reordered_values` — a multi-value record deletes successfully when the values are listed in a different order.

`pytest tests/test_route53.py` (25 passed), `tests/test_servicediscovery.py` (23 passed), and the CFN record-set test pass locally; `ruff check` is clean on the changed files. Changelog entry added under Unreleased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
