### PR TITLE
feat(ci): enforce ruff via GitHub Actions and add PR template

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,40 @@
+name: Lint
+
+# ── Triggers ──────────────────────────────────────────────────────────────
+# pull_request has no branch filter on purpose: every PR is linted, and the
+# run executes against the merge preview (refs/pull/N/merge — the PR merged
+# into the latest base at run time), so the would-be merge result is checked,
+# not just the branch tip. merge_group gates the final merged state when a
+# merge queue is in use; push to main/master is the post-merge safety net.
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+  merge_group:
+
+permissions:
+  contents: read
+
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+          cache: "pip"
+
+      # Pinned exactly (the dev extra only says ruff>=0.4) so CI results are
+      # reproducible; bumping the pin is a deliberate change.
+      - name: Install ruff
+        run: pip install ruff==0.16.2
+
+      # Canonical lint gate from CONTRIBUTING.md — scoped to ministack/
+      # (tests/ carries pre-existing violations tracked separately); config
+      # lives in [tool.ruff] in pyproject.toml. --output-format=github turns
+      # findings into inline PR annotations.
+      - name: ruff check
+        run: ruff check ministack/ --output-format=github


### PR DESCRIPTION
## Summary

- New `Lint` workflow runs `ruff check ministack/ --output-format=github` on every PR (merge-preview ref), in merge groups, and on pushes to main/master
- New PR template codifying the Summary / Issue / Fix / Validation shape already used by hand, with the CONTRIBUTING checklists (new-service items collapsed)

## Issue

Part of #1355: the documented lint gate had no CI enforcement.

## Fix

- Workflow follows ci.yml's conventions (checkout@v6, setup-python@v6, py 3.13, pip cache) with read-only `permissions`. ruff is pinned to 0.16.2 so results are reproducible, which makes bumping the pin an explicit change
- `pull_request` is left unfiltered on purpose: the run executes against `refs/pull/N/merge` (the PR merged into the latest base at run time), so the would-be merge result is checked, and PRs into non-main branches are covered too

## Scope

`tests/` is excluded; it has 31 pre-existing violations and wants a separate cleanup. To make the PR check gate on latest main, enable branch protection "Require branches to be up to date before merging" (or a merge queue) and mark the `ruff` job required. GitHub doesn't re-run checks when the base moves after a PR's last sync.

## Validation

- `actionlint` clean on the new workflow; `ruff check ministack/` green on this branch (the 7-error baseline fix merged upstream as #1354)
- Expected side effect: this PR touches `.github/`, so docker-publish-on-pr's guard skips the auto preview build and posts the pending-manual-build comment

## References

- Part of #1355
- [ruff GitHub output format](https://docs.astral.sh/ruff/settings/#output-format)