### PR TITLE
fix(s3): compute CRC64NVME checksums instead of refusing them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- **S3 — `CRC64NVME` checksums are computed instead of refused** — CRC-64/NVME is the algorithm current AWS SDKs and the CLI checksum uploads with by default, and MiniStack answered it with `InvalidRequest` ("requires optional native dependencies"), so a stock `aws s3 cp` or `aws s3api put-object` failed before it began unless the caller knew to set `AWS_REQUEST_CHECKSUM_CALCULATION=when_required`. The algorithm is plain arithmetic — the reflected form of polynomial `0xAD93D23594C93659` with all-ones init and xorout — so it is now computed from a byte-at-a-time table in the stdlib, adding no dependency: `PutObject` and `CopyObject` validate a client-supplied `x-amz-checksum-crc64nvme` (`BadDigest` on mismatch) and `GetObject` / `HeadObject` return it under `x-amz-checksum-mode: ENABLED`, typed `FULL_OBJECT`. The tests pin the implementation to the algorithm's published check value (`b"123456789"` → `0xAE8B14860A799888`) and to a bit-at-a-time reference rather than to itself. `CRC32C` still requires the native `google-crc32c` and is still refused.
+
 ## [1.4.19] — 2026-08-16
 
 ### Added

--- a/ministack/services/s3.py
+++ b/ministack/services/s3.py
@@ -722,14 +722,45 @@ def _build_object_record(body: bytes, headers: dict, etag: str = None,
 
 _S3_CHECKSUM_HEADERS = ("crc32", "crc32c", "crc64nvme", "sha1", "sha256")
 
+# CRC-64/NVME is the algorithm current AWS SDKs and the CLI checksum uploads
+# with by default, so refusing it fails a stock `aws s3 cp` before it starts.
+# It is plain arithmetic — the reflected form of polynomial 0xAD93D23594C93659
+# with all-ones init and xorout — so a byte-at-a-time table keeps it in the
+# stdlib instead of pulling in a native CRC library. Checked against the
+# algorithm's published check value in tests: b"123456789" hashes to
+# 0xAE8B14860A799888.
+_CRC64NVME_POLY = 0x9A6C9329AC4BC9B5
+_CRC64NVME_INIT = 0xFFFFFFFFFFFFFFFF
+
+
+def _build_crc64nvme_table() -> tuple:
+    table = []
+    for byte in range(256):
+        crc = byte
+        for _ in range(8):
+            crc = (crc >> 1) ^ _CRC64NVME_POLY if crc & 1 else crc >> 1
+        table.append(crc)
+    return tuple(table)
+
+
+_CRC64NVME_TABLE = _build_crc64nvme_table()
+
+
+def _crc64nvme(body: bytes) -> int:
+    crc = _CRC64NVME_INIT
+    table = _CRC64NVME_TABLE
+    for byte in body:
+        crc = table[(crc ^ byte) & 0xFF] ^ (crc >> 8)
+    return crc ^ _CRC64NVME_INIT
+
 
 def _compute_s3_checksum(algorithm: str, body: bytes) -> str | None:
     """Return base64-encoded checksum for the given AWS S3 algorithm name.
 
-    Supports SHA256 / SHA1 / CRC32 via stdlib. CRC32C / CRC64NVME require
-    optional native libs (`google-crc32c` / `crc64nvme-py`) that aren't part of
-    the stdlib; we return None for those, and the caller falls back to the
-    client-supplied value (if any) instead of failing the put.
+    SHA256 / SHA1 / CRC32 come from the stdlib and CRC64NVME from the table
+    above. CRC32C is the one left: it needs the optional native `google-crc32c`
+    that isn't bundled, so we return None for it and the caller refuses the
+    request rather than storing a value it could never verify.
     """
     algo = (algorithm or "").upper().replace("_", "")
     if algo == "SHA256":
@@ -739,6 +770,8 @@ def _compute_s3_checksum(algorithm: str, body: bytes) -> str | None:
     if algo == "CRC32":
         crc = zlib.crc32(body) & 0xFFFFFFFF
         return base64.b64encode(struct.pack(">I", crc)).decode()
+    if algo == "CRC64NVME":
+        return base64.b64encode(struct.pack(">Q", _crc64nvme(body))).decode()
     return None
 
 
@@ -753,12 +786,12 @@ def _resolve_object_checksums(body: bytes, headers: dict):
         server-computed value MUST match the supplied one or the request is
         rejected with `BadDigest` (HTTP 400).
 
-    Ministack-specific: CRC32C / CRC64NVME require optional native libraries
-    that the "no new dependencies" rule forbids us from adding. Rather than
-    silently accept an unverifiable checksum (which would round-trip on Get
-    without ever being validated against the body — a worse failure mode than
-    refusing the request), we reject the put with a clear error. SHA256 / SHA1
-    / CRC32 work end-to-end.
+    Ministack-specific: CRC32C requires an optional native library that the
+    "no new dependencies" rule forbids us from adding. Rather than silently
+    accept an unverifiable checksum (which would round-trip on Get without ever
+    being validated against the body — a worse failure mode than refusing the
+    request), we reject the put with a clear error. SHA256 / SHA1 / CRC32 /
+    CRC64NVME work end-to-end.
 
     Returns ``(checksums_dict, error_response_or_None)``.
     """
@@ -782,10 +815,10 @@ def _resolve_object_checksums(body: bytes, headers: dict):
             "InvalidRequest",
             (
                 f"Checksum algorithm not supported in this ministack build: "
-                f"{', '.join(sorted(unverifiable))}. Supported: SHA256, SHA1, CRC32. "
-                f"CRC32C and CRC64NVME require optional native dependencies that "
-                f"ministack does not bundle; use SHA256 instead, or omit the "
-                f"checksum header."
+                f"{', '.join(sorted(unverifiable))}. Supported: SHA256, SHA1, "
+                f"CRC32, CRC64NVME. CRC32C requires an optional native "
+                f"dependency that ministack does not bundle; use CRC64NVME "
+                f"instead, or omit the checksum header."
             ),
             400,
         )

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -3879,6 +3879,126 @@ def test_s3_put_object_with_crc32_checksum_roundtrips(s3):
     s3.delete_bucket(Bucket=bucket)
 
 
+# CRC-64/NVME's published check value: the checksum of b"123456789". The tests
+# below assert against it so the server is pinned to the specification rather
+# than to its own implementation.
+_CRC64NVME_CHECK = 0xAE8B14860A799888
+
+
+def _crc64nvme_bitwise(data: bytes) -> int:
+    """Bit-at-a-time CRC-64/NVME, independent of the server's table."""
+    crc = 0xFFFFFFFFFFFFFFFF
+    for byte in data:
+        crc ^= byte
+        for _ in range(8):
+            crc = (crc >> 1) ^ 0x9A6C9329AC4BC9B5 if crc & 1 else crc >> 1
+    return crc ^ 0xFFFFFFFFFFFFFFFF
+
+
+def _put_with_checksum(bucket: str, key: str, body: bytes, headers: dict):
+    """PUT over raw HTTP, the way the CLI sends a checksummed upload.
+
+    boto3 can only compute CRC-64/NVME when the optional `awscrt` package is
+    installed, so these tests build the headers themselves rather than making
+    the suite depend on it.
+    """
+    import urllib.request
+    req = urllib.request.Request(
+        f"{ENDPOINT}/{bucket}/{key}", data=body, method="PUT", headers=headers)
+    return urllib.request.urlopen(req)
+
+
+def _head_checksum(bucket: str, key: str, algorithm: str):
+    import urllib.request
+    req = urllib.request.Request(
+        f"{ENDPOINT}/{bucket}/{key}", method="HEAD",
+        headers={"x-amz-checksum-mode": "ENABLED"})
+    with urllib.request.urlopen(req) as r:
+        return r.headers.get(f"x-amz-checksum-{algorithm}"), r.headers.get("x-amz-checksum-type")
+
+
+def test_s3_put_object_with_crc64nvme_checksum_roundtrips(s3):
+    """CRC-64/NVME is the algorithm current SDKs and the CLI checksum uploads
+    with by default, so a stock `aws s3 cp` fails outright unless the server
+    computes it. It is plain arithmetic and needs no native library."""
+    import base64
+    import struct
+
+    bucket = "checksum-crc64nvme-bucket"
+    s3.create_bucket(Bucket=bucket)
+    body = b"123456789"
+    expected = base64.b64encode(struct.pack(">Q", _CRC64NVME_CHECK)).decode()
+
+    with _put_with_checksum(bucket, "k", body,
+                            {"x-amz-sdk-checksum-algorithm": "CRC64NVME"}) as r:
+        assert r.status == 200
+
+    value, csum_type = _head_checksum(bucket, "k", "crc64nvme")
+    assert value == expected
+    assert csum_type == "FULL_OBJECT"
+    assert s3.get_object(Bucket=bucket, Key="k")["Body"].read() == body
+
+    s3.delete_object(Bucket=bucket, Key="k")
+    s3.delete_bucket(Bucket=bucket)
+
+
+def test_s3_crc64nvme_matches_bitwise_reference_over_long_body(s3):
+    """The server's table-driven CRC must agree with a bit-at-a-time reference
+    over a body long enough to reach every table entry."""
+    import base64
+    import struct
+
+    # A wrong reference must not be able to rubber-stamp a wrong server.
+    assert _crc64nvme_bitwise(b"123456789") == _CRC64NVME_CHECK
+
+    bucket = "checksum-crc64nvme-long-bucket"
+    s3.create_bucket(Bucket=bucket)
+    body = bytes(range(256)) * 40 + b"tail"
+    expected = base64.b64encode(struct.pack(">Q", _crc64nvme_bitwise(body))).decode()
+
+    with _put_with_checksum(bucket, "k", body,
+                            {"x-amz-sdk-checksum-algorithm": "CRC64NVME"}) as r:
+        assert r.status == 200
+
+    value, _ = _head_checksum(bucket, "k", "crc64nvme")
+    assert value == expected
+
+    s3.delete_object(Bucket=bucket, Key="k")
+    s3.delete_bucket(Bucket=bucket)
+
+
+def test_s3_put_object_with_explicit_crc64nvme_value_validated(s3):
+    """A client-supplied CRC-64/NVME must match the server-computed one, so the
+    algorithm is verified rather than echoed back unchecked."""
+    import base64
+    import struct
+    import urllib.error
+
+    bucket = "checksum-crc64nvme-validate-bucket"
+    s3.create_bucket(Bucket=bucket)
+    body = b"123456789"
+    good = base64.b64encode(struct.pack(">Q", _CRC64NVME_CHECK)).decode()
+    bad = base64.b64encode(struct.pack(">Q", _CRC64NVME_CHECK ^ 0xFF)).decode()
+
+    with _put_with_checksum(bucket, "ok", body, {
+        "x-amz-sdk-checksum-algorithm": "CRC64NVME",
+        "x-amz-checksum-crc64nvme": good,
+    }) as r:
+        assert r.status == 200
+    assert _head_checksum(bucket, "ok", "crc64nvme")[0] == good
+
+    with pytest.raises(urllib.error.HTTPError) as exc:
+        _put_with_checksum(bucket, "bad", body, {
+            "x-amz-sdk-checksum-algorithm": "CRC64NVME",
+            "x-amz-checksum-crc64nvme": bad,
+        })
+    assert exc.value.code == 400
+    assert b"BadDigest" in exc.value.read()
+
+    s3.delete_object(Bucket=bucket, Key="ok")
+    s3.delete_bucket(Bucket=bucket)
+
+
 def test_s3_delete_object_by_version_id_purges_version(s3):
     """DeleteObject with an explicit VersionId must physically remove exactly
     that version (not add a delete marker). Repro for the versioned-delete bug:


### PR DESCRIPTION
CRC-64/NVME is the algorithm current AWS SDKs and the CLI checksum uploads with by default, and PutObject answered it with InvalidRequest on the grounds that it needs a native CRC library. A stock `aws s3 cp` or `aws s3api put-object` therefore failed before it began, unless the caller knew to set AWS_REQUEST_CHECKSUM_CALCULATION=when_required.

The algorithm is plain arithmetic -- the reflected form of polynomial 0xAD93D23594C93659 with all-ones init and xorout -- so compute it from a byte-at-a-time table in the stdlib, adding no dependency. PutObject and CopyObject now validate a client-supplied x-amz-checksum-crc64nvme (BadDigest on mismatch), and Get/HeadObject return it under x-amz-checksum-mode: ENABLED. The tests pin the result to the algorithm's published check value, b"123456789" -> 0xAE8B14860A799888, and to a bit-at-a-time reference rather than to the table itself.

CRC32C still requires the native google-crc32c and is still refused.