### PR TITLE
feat(bedrock-runtime): add named OrcaRouter proxy preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -739,6 +739,18 @@ resp = bedrock.converse(
 print(resp["output"]["message"]["content"][0]["text"])
 ```
 
+### Bedrock with OrcaRouter
+
+For a hosted, OpenAI-compatible backend, set `MINISTACK_ORCAROUTER_API_KEY` and MiniStack routes the Bedrock proxy through [OrcaRouter](https://www.orcarouter.ai) (`https://api.orcarouter.ai/v1`) with bearer auth — no `MINISTACK_BEDROCK_PROXY_URL` needed. Prompts are translated to OpenAI shape, forwarded, and translated back to Bedrock shape, exactly like the generic proxy. OrcaRouter also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.
+
+```bash
+docker run -p 4566:4566 \
+  -e MINISTACK_ORCAROUTER_API_KEY=sk-orca-... \
+  ministackorg/ministack
+```
+
+The model defaults to OrcaRouter's smart router `orcarouter/auto`; set `MINISTACK_ORCAROUTER_MODEL` to pin a specific model (full catalog: <https://www.orcarouter.ai/models>).
+
 Note: token counts are a chars/4 heuristic — shape-correct, but don't assert on exact counts against the mock.
 
 ---
@@ -836,6 +848,8 @@ end-to-end without any client config.
 | `MINISTACK_IMDS_V2_REQUIRED` | `0` | Reject token-less GETs on `/latest/meta-data/...`. When set, callers must first `PUT /latest/api/token` and pass the token as `X-aws-ec2-metadata-token`, matching real-AWS hop-limit-1 IMDSv2-only instances |
 | `MINISTACK_BEDROCK_PROXY_URL` | _(unset)_ | OpenAI-compatible `/chat/completions` endpoint (Ollama, llama.cpp, vLLM). When set, Bedrock `Converse`/`InvokeModel` prompts are translated to OpenAI shape, forwarded, and translated back to Bedrock shape — real completions through the Bedrock API. Falls back to the deterministic mock on connection error |
 | `MINISTACK_BEDROCK_PROXY_TIMEOUT_SECONDS` | `30` | Upstream request timeout for the Bedrock proxy |
+| `MINISTACK_ORCAROUTER_API_KEY` | _(unset)_ | Named OrcaRouter preset for the Bedrock proxy. When set, Bedrock `Converse`/`InvokeModel` are forwarded to `https://api.orcarouter.ai/v1/chat/completions` with bearer auth instead of `MINISTACK_BEDROCK_PROXY_URL`; falls back to the deterministic mock on connection error |
+| `MINISTACK_ORCAROUTER_MODEL` | `orcarouter/auto` | Model sent to OrcaRouter when `MINISTACK_ORCAROUTER_API_KEY` is set; defaults to OrcaRouter's smart router. Full catalog: https://www.orcarouter.ai/models |
 | `MINISTACK_MSK_BOOTSTRAP` | _(unset)_ | Plaintext bootstrap broker string returned by MSK `GetBootstrapBrokers` — point it at a real broker you bring (Redpanda, Kafka, KRaft). Unset → placeholder endpoint (control-plane only) |
 | `MINISTACK_MSK_BOOTSTRAP_TLS` | _(unset)_ | TLS bootstrap string (`BootstrapBrokerStringTls`) |
 | `MINISTACK_MSK_BOOTSTRAP_SASL_SCRAM` | _(unset)_ | SASL/SCRAM bootstrap string (`BootstrapBrokerStringSaslScram`) |

--- a/ministack/services/bedrock_runtime.py
+++ b/ministack/services/bedrock_runtime.py
@@ -25,6 +25,10 @@ Behavior:
     reachable, the prompt is translated to OpenAI shape, forwarded, and the
     response translated back to Converse shape. Falls back to mock silently
     on connection error.
+  Named OrcaRouter preset: set MINISTACK_ORCAROUTER_API_KEY to route the
+    Bedrock proxy through OrcaRouter (https://api.orcarouter.ai/v1) with
+    bearer auth and the orcarouter/auto model (override via
+    MINISTACK_ORCAROUTER_MODEL). See https://www.orcarouter.ai.
 
 Token counts are a heuristic (chars/4) — shape-correct, absolute counts are
 approximate. Documented in release notes; users asserting on exact counts
@@ -63,6 +67,15 @@ logger = logging.getLogger("bedrock-runtime")
 
 _PROXY_URL = os.environ.get("MINISTACK_BEDROCK_PROXY_URL", "").rstrip("/")
 _PROXY_TIMEOUT_S = float(os.environ.get("MINISTACK_BEDROCK_PROXY_TIMEOUT_SECONDS", "30"))
+# Named OrcaRouter preset: set MINISTACK_ORCAROUTER_API_KEY to route the
+# Bedrock proxy through OrcaRouter (https://api.orcarouter.ai/v1) with
+# bearer auth, instead of pointing MINISTACK_BEDROCK_PROXY_URL at a generic
+# OpenAI-compatible endpoint. The model defaults to orcarouter/auto and can
+# be overridden with MINISTACK_ORCAROUTER_MODEL.
+_ORCAROUTER_API_KEY = os.environ.get("MINISTACK_ORCAROUTER_API_KEY", "").strip()
+_ORCAROUTER_MODEL = os.environ.get("MINISTACK_ORCAROUTER_MODEL", "").strip()
+if _ORCAROUTER_API_KEY:
+    _PROXY_URL = "https://api.orcarouter.ai"
 
 # ---------------------------------------------------------------------------
 # Path regexes
@@ -254,8 +267,13 @@ def _proxy_to_openai_chat(model_id: str, messages, system, inference_config) -> 
                 parts.append(c["text"])
         if parts:
             openai_messages.append({"role": role, "content": "\n".join(parts)})
+    model = model_id
+    headers = {"Content-Type": "application/json"}
+    if _ORCAROUTER_API_KEY:
+        model = _ORCAROUTER_MODEL or "orcarouter/auto"
+        headers["Authorization"] = f"Bearer {_ORCAROUTER_API_KEY}"
     payload = {
-        "model": model_id,
+        "model": model,
         "messages": openai_messages,
         "stream": False,
     }
@@ -272,7 +290,7 @@ def _proxy_to_openai_chat(model_id: str, messages, system, inference_config) -> 
     req = urllib.request.Request(
         url,
         data=json.dumps(payload).encode("utf-8"),
-        headers={"Content-Type": "application/json"},
+        headers=headers,
         method="POST",
     )
     try:

--- a/tests/test_bedrock.py
+++ b/tests/test_bedrock.py
@@ -7,9 +7,11 @@ on presence and ordering, not absolute values.
 """
 
 import json
+import threading
 import urllib.error
 import urllib.parse
 import urllib.request
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 import botocore.exceptions
 from conftest import ENDPOINT, make_client
@@ -1687,3 +1689,125 @@ def test_bedrock_list_tags_rejects_unknown_resource_arn():
         assert exc.response["Error"]["Code"] == "ResourceNotFoundException"
     else:
         raise AssertionError("expected ResourceNotFoundException")
+
+
+# ===========================================================================
+# Bedrock proxy — named OrcaRouter preset (MINISTACK_ORCAROUTER_API_KEY)
+# Exercises the real _proxy_to_openai_chat path against a local mock upstream:
+# base URL, bearer auth header, and orcarouter/auto model default/override.
+# ===========================================================================
+
+
+class _MockUpstream:
+    """Minimal local OpenAI /chat/completions responder that records the request."""
+
+    def __init__(self):
+        captured = self.captured = {}
+
+        class _Handler(BaseHTTPRequestHandler):
+            def do_POST(self):
+                length = int(self.headers.get("Content-Length", 0))
+                body = json.loads(self.rfile.read(length) or b"{}")
+                captured["path"] = self.path
+                captured["auth"] = self.headers.get("Authorization")
+                captured["body"] = body
+                payload = {
+                    "id": "chatcmpl-orca",
+                    "object": "chat.completion",
+                    "created": 123,
+                    "model": body.get("model"),
+                    "choices": [{
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "hello from orca"},
+                        "finish_reason": "stop",
+                    }],
+                    "usage": {"prompt_tokens": 3, "completion_tokens": 4, "total_tokens": 7},
+                }
+                data = json.dumps(payload).encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(data)))
+                self.end_headers()
+                self.wfile.write(data)
+
+            def log_message(self, *args):
+                pass
+
+        self.server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+
+    @property
+    def url(self):
+        return f"http://127.0.0.1:{self.server.server_port}"
+
+    def close(self):
+        self.server.shutdown()
+        self.server.server_close()
+
+
+def test_bedrock_proxy_orcarouter_preset_default_model(monkeypatch):
+    """OrcaRouter preset sends bearer auth + orcarouter/auto and hits /v1/chat/completions."""
+    import ministack.services.bedrock_runtime as br
+
+    upstream = _MockUpstream()
+    try:
+        monkeypatch.setattr(br, "_PROXY_URL", upstream.url)
+        monkeypatch.setattr(br, "_ORCAROUTER_API_KEY", "sk-orca-test")
+        monkeypatch.setattr(br, "_ORCAROUTER_MODEL", "")
+        text = br._proxy_to_openai_chat(
+            "anthropic.claude-3-5-sonnet-20241022-v2:0",
+            [{"role": "user", "content": [{"text": "hi"}]}],
+            None,
+            None,
+        )
+    finally:
+        upstream.close()
+    assert text == "hello from orca"
+    assert upstream.captured["path"] == "/v1/chat/completions"
+    assert upstream.captured["auth"] == "Bearer sk-orca-test"
+    assert upstream.captured["body"]["model"] == "orcarouter/auto"
+
+
+def test_bedrock_proxy_orcarouter_model_override(monkeypatch):
+    """MINISTACK_ORCAROUTER_MODEL overrides the default orcarouter/auto model."""
+    import ministack.services.bedrock_runtime as br
+
+    upstream = _MockUpstream()
+    try:
+        monkeypatch.setattr(br, "_PROXY_URL", upstream.url)
+        monkeypatch.setattr(br, "_ORCAROUTER_API_KEY", "sk-orca-test")
+        monkeypatch.setattr(br, "_ORCAROUTER_MODEL", "orcarouter/openai/gpt-4o")
+        text = br._proxy_to_openai_chat(
+            "anthropic.claude-3-5-sonnet-20241022-v2:0",
+            [{"role": "user", "content": [{"text": "hi"}]}],
+            None,
+            None,
+        )
+    finally:
+        upstream.close()
+    assert text == "hello from orca"
+    assert upstream.captured["auth"] == "Bearer sk-orca-test"
+    assert upstream.captured["body"]["model"] == "orcarouter/openai/gpt-4o"
+
+
+def test_bedrock_proxy_generic_does_not_send_auth(monkeypatch):
+    """Without the OrcaRouter preset, no Authorization header is sent."""
+    import ministack.services.bedrock_runtime as br
+
+    upstream = _MockUpstream()
+    try:
+        monkeypatch.setattr(br, "_PROXY_URL", upstream.url)
+        monkeypatch.setattr(br, "_ORCAROUTER_API_KEY", "")
+        monkeypatch.setattr(br, "_ORCAROUTER_MODEL", "")
+        text = br._proxy_to_openai_chat(
+            "meta.llama3-1-70b-instruct-v1:0",
+            [{"role": "user", "content": [{"text": "hi"}]}],
+            None,
+            None,
+        )
+    finally:
+        upstream.close()
+    assert text == "hello from orca"
+    assert upstream.captured["auth"] is None
+    assert upstream.captured["body"]["model"] == "meta.llama3-1-70b-instruct-v1:0"


### PR DESCRIPTION
Adds a named [OrcaRouter](https://www.orcarouter.ai) preset to the Bedrock proxy, mirroring how the existing `MINISTACK_BEDROCK_PROXY_URL` OpenAI-compatible path is wired, so the docs and env-var table stay consistent.

Setting `MINISTACK_ORCAROUTER_API_KEY` routes Bedrock `Converse` / `InvokeModel` through OrcaRouter's `https://api.orcarouter.ai/v1/chat/completions` with bearer auth (keys start with `sk-orca-`), defaulting to OrcaRouter's smart router `orcarouter/auto` (`MINISTACK_ORCAROUTER_MODEL` to pin a specific model). Prompts are translated to OpenAI shape, forwarded, and translated back to Bedrock shape exactly like the generic proxy, and it falls back to the deterministic mock on connection error. OrcaRouter is an OpenAI-compatible gateway: one API key unlocks 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax and xAI behind a single endpoint. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

**Verification**

- `pytest tests/test_bedrock.py` — **111 passed** (108 existing + 3 new covering the preset: bearer auth header, `orcarouter/auto` default, `MINISTACK_ORCAROUTER_MODEL` override, and no-auth for the generic path).
- `ruff check` on the changed files — clean.
- L3 live test: with a real key, the Bedrock proxy returns text from `https://api.orcarouter.ai/v1/chat/completions`; an invalid key returns `None` and falls back to the mock silently.

I'm an engineer on the OrcaRouter team.
