### PR TITLE
fix(readme): Fix BedRock proxy URL example

### DIFF
--- a/README.md
+++ b/README.md
@@ -726,7 +726,7 @@ Point `MINISTACK_BEDROCK_PROXY_URL` at any OpenAI-compatible `/chat/completions`
 ```bash
 # Ollama on the host
 docker run -p 4566:4566 \
-  -e MINISTACK_BEDROCK_PROXY_URL=http://host.docker.internal:11434/v1 \
+  -e MINISTACK_BEDROCK_PROXY_URL=http://host.docker.internal:11434/ \
   ministackorg/ministack
 ```
 


### PR DESCRIPTION
The documentation example for MINISTACK_BEDROCK_PROXY_URL uses a URL finishing in "/v1".
However, the service, appends "/v1/chat/completions" to the proxy URL, making the documented URL return 404.

Update the documentation to reflect the expected value.