### PR TITLE
fix(ec2): emit the public address under the real wire tags, and generate valid ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- **EC2 — instance public IP and DNS reach the SDKs, and generated addresses are addresses** — `DescribeInstances` and `RunInstances` emitted the public address under `publicIpAddress` / `publicDnsName`, which are not the tags the EC2 wire schema defines (`ipAddress` / `dnsName`, per botocore's `ec2-2016-11-15` model), so every SDK dropped both fields silently and `PublicIpAddress` came back absent on instances that had one. They now ride the real tags. Fixing that exposed a second one: `_random_ip` appended two octets whatever it was given, so a one-octet prefix produced `52.55.218` — `AllocateAddress` has been handing back that shape as `PublicIp` all along, and no address parser accepts it. The generator now completes any prefix to four octets. Contributed by @iot-rocket.
+
 ## [1.4.19] — 2026-08-16
 
 ### Added

--- a/ministack/services/ec2.py
+++ b/ministack/services/ec2.py
@@ -3064,8 +3064,10 @@ def _instance_xml(inst):
         </placement>
         <privateDnsName>{inst['PrivateDnsName']}</privateDnsName>
         <privateIpAddress>{inst['PrivateIpAddress']}</privateIpAddress>
-        <publicDnsName>{inst['PublicDnsName']}</publicDnsName>
-        <publicIpAddress>{inst['PublicIpAddress']}</publicIpAddress>
+        <!-- public address wire tags are dnsName/ipAddress (not publicDnsName/
+             publicIpAddress) - the SDKs map those to PublicDnsName/PublicIpAddress -->
+        <dnsName>{inst['PublicDnsName']}</dnsName>
+        <ipAddress>{inst['PublicIpAddress']}</ipAddress>
         <sourceDestCheck>{'true' if inst.get('SourceDestCheck', True) else 'false'}</sourceDestCheck>
         <subnetId>{inst['SubnetId']}</subnetId>
         <vpcId>{inst['VpcId']}</vpcId>
@@ -3600,8 +3602,17 @@ def _new_igw_id():
 
 
 def _random_ip(prefix):
-    sep = "" if prefix.endswith(".") else "."
-    return f"{prefix}{sep}{random.randint(1,254)}.{random.randint(1,254)}"
+    """Random address completing ``prefix`` to four octets.
+
+    Two octets were appended unconditionally, which is right for a two-octet
+    prefix like ``10.0.`` and wrong for a one-octet one: ``_random_ip("52.")``
+    produced ``52.55.218``, which is not an address. Callers hand this straight
+    to ``PublicIp`` on AllocateAddress, so anything parsing the response with
+    ``ipaddress`` or an SDK validator sees a malformed value.
+    """
+    head = [octet for octet in prefix.split(".") if octet]
+    octets = head + [str(random.randint(1, 254)) for _ in range(4 - len(head))]
+    return ".".join(octets)
 
 
 def _now_ts():

--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -1,4 +1,5 @@
 import io
+import ipaddress
 import json
 import os
 import time
@@ -3558,3 +3559,37 @@ def test_modify_security_group_rules_updates_description(ec2):
     ec2.delete_security_group(GroupId=sg)
     ec2.delete_vpc(VpcId=vpc)
 
+
+
+def test_ec2_public_ip_and_dns_surface_via_sdk(ec2):
+    """The public address must ride the real wire tags (ipAddress/dnsName) —
+    the previous publicIpAddress/publicDnsName tags are not in the EC2 schema,
+    so boto3 silently dropped both fields and PublicIpAddress was always None."""
+    iid = ec2.run_instances(ImageId="ami-0abcdef1234567890", MinCount=1,
+                            MaxCount=1)["Instances"][0]["InstanceId"]
+    try:
+        inst = ec2.describe_instances(InstanceIds=[iid])["Reservations"][0]["Instances"][0]
+        assert inst.get("PublicIpAddress"), "PublicIpAddress missing from the wire"
+        assert inst.get("PublicDnsName"), "PublicDnsName missing from the wire"
+        assert inst["PrivateIpAddress"]
+        # The value has to be an address, not just present. Fixing the tags is
+        # what made this reachable: while the field never left the server, a
+        # malformed one could not be noticed.
+        ipaddress.ip_address(inst["PublicIpAddress"])
+        ipaddress.ip_address(inst["PrivateIpAddress"])
+    finally:
+        ec2.terminate_instances(InstanceIds=[iid])
+
+
+def test_ec2_allocated_address_is_a_valid_ipv4(ec2):
+    """AllocateAddress hands back `PublicIp` verbatim, so a generator that
+    completes a one-octet prefix with only two octets produces `52.55.218`,
+    which no address parser accepts."""
+    alloc = ec2.allocate_address(Domain="vpc")
+    try:
+        ipaddress.ip_address(alloc["PublicIp"])
+        described = ec2.describe_addresses(
+            AllocationIds=[alloc["AllocationId"]])["Addresses"][0]
+        ipaddress.ip_address(described["PublicIp"])
+    finally:
+        ec2.release_address(AllocationId=alloc["AllocationId"])


### PR DESCRIPTION
## Summary

`DescribeInstances` and `RunInstances` write the public address under `publicDnsName` / `publicIpAddress`, but the EC2 query protocol names those members `dnsName` / `ipAddress`. SDKs drop members they cannot map, so both fields are missing from every response even though the server generated them.

## Issue

botocore's `ec2-2016-11-15` model is explicit:

```
PublicDnsName    locationName = dnsName
PublicIpAddress  locationName = ipAddress
```

Against a stock server, `run_instances` followed by `describe_instances`:

```
PublicIpAddress present: False
PublicDnsName   present: False
PrivateIpAddress: 10.0.212.225      <- correctly tagged, comes through
```

MiniStack already generates the address (`_random_ip("54.")` on `RunInstances`), so nothing is missing except the ability to read it. Code that waits for an instance address, or feeds one to SSH or a health check, has nothing to wait for.

Fixing the tags made a second defect reachable, so this PR fixes both rather than shipping one into view. `_random_ip` appends exactly two octets regardless of prefix:

```
_random_ip("10.0.") -> 10.0.104.37     four octets
_random_ip("52.")   -> 52.55.218       three
```

`AllocateAddress` returns that shape as `PublicIp` today, where it is already visible: `ipaddress.ip_address("52.55.218")` raises. The generator now completes any prefix to four octets.

## Fix

- the two tags become `dnsName` and `ipAddress`
- `_random_ip` fills to four octets instead of appending a fixed two

## Validation

`tests/test_ec2.py`, 155 passed. Two new cases: the SDK round-trip for both instance fields, parsed with `ipaddress` rather than merely asserted present, and an `AllocateAddress` / `DescribeAddresses` validity check. Both fail on current `main`, the first on the missing field and the second on the malformed one.

## References

- botocore `botocore/data/ec2/2016-11-15/service-2.json`, `Instance` shape