### PR TITLE
fix(s3): honour the size and last-modified-time delete conditions

### DIFF
--- a/ministack/services/s3.py
+++ b/ministack/services/s3.py
@@ -790,6 +790,67 @@ def _check_read_preconditions(headers: dict, obj: dict, resp_headers: dict):
     return None
 
 
+def _delete_condition_target(bucket: dict, bucket_name: str, key: str,
+                             version_id: str) -> dict | None:
+    """The object record a delete's conditions are evaluated against.
+
+    Without a version id that is the current object; with one it is the
+    version addressed, since that is what the delete would remove.  A delete
+    marker, or a version that is not there, reads as nothing to condition on.
+    """
+    if not version_id:
+        return bucket["objects"].get(key)
+    for v in _object_versions.get((bucket_name, key), []):
+        if v["version_id"] == version_id:
+            if v.get("is_delete_marker"):
+                return None
+            return _object_record_from_version(v)
+    current = bucket["objects"].get(key)
+    if version_id == "null" and current is not None and not current.get(
+            "version_id"):
+        return current
+    return None
+
+
+def _delete_conditions_hold(obj: dict | None, size: str | None,
+                            last_modified: str | None) -> bool:
+    """Whether a delete's size and last-modified-time conditions hold.
+
+    These ride alongside If-Match on a conditional delete and narrow it the
+    same way: the object goes only if it is still the one the caller last
+    read.  A key that is not there holds every condition, since deleting one
+    that is already gone is a success whatever the request asked for.
+
+    A malformed value never holds -- treating an unparseable size as "no
+    condition" would delete the object the caller was trying to protect.
+    """
+    if obj is None:
+        return True
+
+    if size is not None and size != "":
+        try:
+            if int(size) != int(obj.get("size") or 0):
+                return False
+        except (TypeError, ValueError):
+            return False
+
+    if last_modified is not None and last_modified != "":
+        wanted = _parse_http_date(last_modified)
+        if wanted is None:
+            try:
+                wanted = _dt.datetime.fromisoformat(
+                    last_modified.replace("Z", "+00:00"))
+            except ValueError:
+                return False
+            if wanted.tzinfo is None:
+                wanted = wanted.replace(tzinfo=_dt.timezone.utc)
+        # Last-Modified is second-precise, so compare at that resolution.
+        if wanted.replace(microsecond=0) != _object_mtime_dt(obj):
+            return False
+
+    return True
+
+
 def _find_xml_tag(parent, tag_name, ns=S3_NS):
     el = parent.find("{%s}%s" % (ns, tag_name))
     if el is None:
@@ -3794,16 +3855,23 @@ def _delete_object(bucket_name: str, key: str, headers: dict | None = None,
     if bucket is None:
         return _no_such_bucket(bucket_name)
 
-    # Conditional delete: If-Match against the current object's ETag. An
-    # object whose ETag differs fails the precondition with 412 and stays —
+    # Conditional delete: If-Match against the ETag, and the size and
+    # last-modified-time conditions that ride alongside it.  An object that
+    # differs on any of them fails the precondition with 412 and stays —
     # S3's compare-and-swap delete.  A key that is not there at all is not a
     # failed precondition: deleting one is a success either way, and S3
     # answers the conditional delete of an absent key 204 like any other.
     if_match = (headers.get("if-match") or "").strip()
-    if if_match:
-        _cur = bucket["objects"].get(key)
-        if _cur is not None and if_match != "*" and (
-                if_match.strip('"') != _cur["etag"].strip('"')):
+    if_match_size = (headers.get("x-amz-if-match-size") or "").strip()
+    if_match_mtime = (
+        headers.get("x-amz-if-match-last-modified-time") or "").strip()
+    if if_match or if_match_size or if_match_mtime:
+        _cur = _delete_condition_target(
+            bucket, bucket_name, key, _qp(query_params, "versionId", ""))
+        etag_holds = (not if_match or if_match == "*" or _cur is None
+                      or if_match.strip('"') == _cur["etag"].strip('"'))
+        if not etag_holds or not _delete_conditions_hold(
+                _cur, if_match_size, if_match_mtime):
             return _error(
                 "PreconditionFailed",
                 "At least one of the preconditions you specified did not hold.",
@@ -5016,9 +5084,18 @@ def _delete_objects(bucket_name: str, body: bytes, headers: dict = None):
         # (PreconditionFailed), not Deleted, so the object survives.
         etag_el = _find_xml_tag(obj_el, "ETag")
         cond_etag = etag_el.text if (etag_el is not None and etag_el.text) else ""
-        if cond_etag:
-            _cur = bucket["objects"].get(k)
-            if _cur is None or cond_etag.strip('"') != _cur["etag"].strip('"'):
+        size_el = _find_xml_tag(obj_el, "Size")
+        cond_size = size_el.text if (size_el is not None and size_el.text) else ""
+        mtime_el = _find_xml_tag(obj_el, "LastModifiedTime")
+        cond_mtime = (
+            mtime_el.text if (mtime_el is not None and mtime_el.text) else "")
+        if cond_etag or cond_size or cond_mtime:
+            _cur = _delete_condition_target(bucket, bucket_name, k, version_id)
+            etag_holds = not cond_etag or (
+                _cur is not None
+                and cond_etag.strip('"') == _cur["etag"].strip('"'))
+            if not etag_holds or not _delete_conditions_hold(
+                    _cur, cond_size, cond_mtime):
                 errors.append({
                     "key": k,
                     "version_id": version_id,

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -5057,6 +5057,68 @@ def test_s3_conditional_delete_of_absent_key_succeeds(s3):
     s3.delete_bucket(Bucket=bucket)
 
 
+def test_s3_conditional_delete_size_and_last_modified(s3):
+    """Size and LastModifiedTime narrow a delete the way an ETag does: the
+    object goes only if it is still the one the caller last read.  They ride
+    as headers on DeleteObject and as ObjectIdentifier fields in a batch, and
+    a version id points them at that version rather than the current one."""
+    import datetime
+
+    bucket = "intg-s3-conditional-delete-size"
+    s3.create_bucket(Bucket=bucket)
+    stale = datetime.datetime(2015, 1, 1)
+
+    s3.put_object(Bucket=bucket, Key="single", Body=b"1234")
+    mtime = s3.head_object(Bucket=bucket, Key="single")["LastModified"]
+    for condition in ({"IfMatchSize": 9999}, {"IfMatchLastModifiedTime": stale}):
+        with pytest.raises(ClientError) as exc:
+            s3.delete_object(Bucket=bucket, Key="single", **condition)
+        assert exc.value.response["Error"]["Code"] == "PreconditionFailed"
+    assert s3.get_object(Bucket=bucket, Key="single")["Body"].read() == b"1234"
+    s3.delete_object(Bucket=bucket, Key="single", IfMatchSize=4,
+                     IfMatchLastModifiedTime=mtime)
+
+    s3.put_object(Bucket=bucket, Key="batch", Body=b"1234")
+    resp = s3.delete_objects(
+        Bucket=bucket, Delete={"Objects": [{"Key": "batch", "Size": 9999}]})
+    assert resp["Errors"][0]["Code"] == "PreconditionFailed"
+    resp = s3.delete_objects(
+        Bucket=bucket,
+        Delete={"Objects": [{"Key": "batch", "LastModifiedTime": stale}]})
+    assert resp["Errors"][0]["Code"] == "PreconditionFailed"
+    resp = s3.delete_objects(
+        Bucket=bucket, Delete={"Objects": [{"Key": "batch", "Size": 4}]})
+    assert resp["Deleted"][0]["Key"] == "batch"
+
+    # A key already gone holds every condition, as with If-Match.
+    resp = s3.delete_objects(
+        Bucket=bucket, Delete={"Objects": [{"Key": "batch", "Size": 9999}]})
+    assert not resp.get("Errors")
+
+    s3.delete_bucket(Bucket=bucket)
+
+
+def test_s3_conditional_delete_size_reads_the_named_version(s3):
+    """A batch delete naming a version conditions on that version's size, not
+    on whatever the current object happens to be."""
+    bucket = "intg-s3-conditional-delete-version-size"
+    s3.create_bucket(Bucket=bucket)
+    s3.put_bucket_versioning(Bucket=bucket,
+                             VersioningConfiguration={"Status": "Enabled"})
+    first = s3.put_object(Bucket=bucket, Key="k", Body=b"1234")["VersionId"]
+    s3.put_object(Bucket=bucket, Key="k", Body=b"1234567890")
+
+    # The current version is 10 bytes; the condition names the 4-byte one.
+    resp = s3.delete_objects(
+        Bucket=bucket,
+        Delete={"Objects": [{"Key": "k", "VersionId": first, "Size": 10}]})
+    assert resp["Errors"][0]["Code"] == "PreconditionFailed"
+    resp = s3.delete_objects(
+        Bucket=bucket,
+        Delete={"Objects": [{"Key": "k", "VersionId": first, "Size": 4}]})
+    assert resp["Deleted"][0]["Key"] == "k"
+
+
 def test_s3_copy_object_specific_version(s3):
     """CopyObject with a source ?versionId copies that exact version, not the
     current object. Regression for #1328."""


### PR DESCRIPTION
DeleteObject took x-amz-if-match-size and
x-amz-if-match-last-modified-time and DeleteObjects took the Size and LastModifiedTime fields, and all four were read off the wire and dropped -- so a caller guarding a delete against a concurrent write had the object removed anyway, which is the one outcome the condition exists to prevent.

They now narrow the delete the way an ETag does: a mismatch is 412 on the single delete and a PreconditionFailed entry under Errors in a batch, an unparseable value never holds, and a key that is not there holds every condition.  A request naming a version conditions on that version rather than on whatever is current.