### PR TITLE
fix(s3): fail a named-ETag delete over a live version's delete marker

### DIFF
--- a/ministack/services/s3.py
+++ b/ministack/services/s3.py
@@ -3802,8 +3802,20 @@ def _delete_object(bucket_name: str, key: str, headers: dict | None = None,
     if_match = (headers.get("if-match") or "").strip()
     if if_match:
         _cur = bucket["objects"].get(key)
-        if _cur is not None and if_match != "*" and (
-                if_match.strip('"') != _cur["etag"].strip('"')):
+        if _cur is not None:
+            _holds = if_match == "*" or (
+                if_match.strip('"') == _cur["etag"].strip('"'))
+        else:
+            # No current object.  A key that holds nothing but delete markers
+            # -- including the marker a delete of an absent key leaves behind
+            # in a versioned bucket -- reads as gone, and any condition holds
+            # against it.  A key whose history still carries a real version
+            # is not gone, so a named ETag fails there; If-Match: * asks only
+            # that the key be addressable and holds either way.
+            _holds = if_match == "*" or not any(
+                not v.get("is_delete_marker")
+                for v in _object_versions.get((bucket_name, key)) or [])
+        if not _holds:
             return _error(
                 "PreconditionFailed",
                 "At least one of the preconditions you specified did not hold.",

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -5057,6 +5057,42 @@ def test_s3_conditional_delete_of_absent_key_succeeds(s3):
     s3.delete_bucket(Bucket=bucket)
 
 
+def test_s3_conditional_delete_over_a_delete_marker(s3):
+    """A key whose current version is a delete marker still has something to
+    compare against: S3 fails a named ETag with 412 there, where it lets the
+    same condition through on a key that was never written.  If-Match: * asks
+    only that the key be addressable, so it holds either way."""
+    bucket = "intg-s3-conditional-delete-marker"
+    s3.create_bucket(Bucket=bucket)
+    s3.put_bucket_versioning(
+        Bucket=bucket, VersioningConfiguration={"Status": "Enabled"})
+
+    # Nothing written yet: every condition is a success.
+    for condition in ("*", "badetag"):
+        resp = s3.delete_object(Bucket=bucket, Key="obj", IfMatch=condition)
+        assert resp["ResponseMetadata"]["HTTPStatusCode"] == 204
+
+    etag = s3.put_object(Bucket=bucket, Key="obj", Body=b"x")["ETag"]
+    with pytest.raises(ClientError) as exc:
+        s3.delete_object(Bucket=bucket, Key="obj", IfMatch="badetag")
+    assert exc.value.response["Error"]["Code"] == "PreconditionFailed"
+
+    resp = s3.delete_object(Bucket=bucket, Key="obj", IfMatch=etag)
+    assert resp["DeleteMarker"]
+
+    resp = s3.delete_object(Bucket=bucket, Key="obj", IfMatch="*")
+    assert resp["ResponseMetadata"]["HTTPStatusCode"] == 204
+    with pytest.raises(ClientError) as exc:
+        s3.delete_object(Bucket=bucket, Key="obj", IfMatch="badetag")
+    assert exc.value.response["Error"]["Code"] == "PreconditionFailed"
+
+    for version in s3.list_object_versions(Bucket=bucket).get("Versions", []):
+        s3.delete_object(Bucket=bucket, Key="obj", VersionId=version["VersionId"])
+    for marker in s3.list_object_versions(Bucket=bucket).get("DeleteMarkers", []):
+        s3.delete_object(Bucket=bucket, Key="obj", VersionId=marker["VersionId"])
+    s3.delete_bucket(Bucket=bucket)
+
+
 def test_s3_copy_object_specific_version(s3):
     """CopyObject with a source ?versionId copies that exact version, not the
     current object. Regression for #1328."""


### PR DESCRIPTION
The absent-key rule from #1451 read "no current object" as "nothing is there", but in a versioned bucket a delete marker sits over a version that still exists -- so a compare-and-swap delete carrying the wrong ETag was answered 204 and went through, the one outcome the condition is there to prevent.

Distinguish the two: a key holding nothing but delete markers, which is what a delete of an absent key leaves behind, still reads as gone and takes any condition, while one whose history carries a real version fails a named ETag with 412.  If-Match: * asks only that the key be addressable and holds either way.