### PR TITLE
feat(ssm): implement Run Command

### DIFF
--- a/ministack/services/ssm.py
+++ b/ministack/services/ssm.py
@@ -1,10 +1,12 @@
 """
-SSM Parameter Store Emulator.
+SSM Parameter Store and Run Command Emulator.
 JSON-based API via X-Amz-Target (AmazonSSM).
 Supports: PutParameter, GetParameter, GetParameters, GetParametersByPath,
           DeleteParameter, DeleteParameters, DescribeParameters,
           GetParameterHistory, LabelParameterVersion,
-          AddTagsToResource, RemoveTagsFromResource, ListTagsForResource.
+          AddTagsToResource, RemoveTagsFromResource, ListTagsForResource,
+          SendCommand, GetCommandInvocation, ListCommands,
+          DescribeInstanceInformation.
 """
 
 import base64
@@ -36,6 +38,7 @@ from ministack.core.persistence import PERSIST_STATE, load_state
 _parameters = AccountRegionScopedDict()
 _parameter_history = AccountRegionScopedDict()
 _tags = AccountRegionScopedDict()
+_commands = AccountRegionScopedDict()
 
 
 # ── Persistence ────────────────────────────────────────────
@@ -45,6 +48,7 @@ def get_state():
         "parameters": copy.deepcopy(_parameters),
         "parameter_history": copy.deepcopy(_parameter_history),
         "tags": copy.deepcopy(_tags),
+        "commands": copy.deepcopy(_commands),
     }
 
 
@@ -96,6 +100,7 @@ def restore_state(data):
         _parameters.update(data.get("parameters", {}))
         _restore_parameter_history(data.get("parameter_history", {}))
         _tags.update(data.get("tags", {}))
+        _commands.update(data.get("commands", {}))
 
 
 def _now_iso() -> str:
@@ -243,6 +248,10 @@ async def handle_request(method, path, headers, body, query_params):
         "AddTagsToResource": _add_tags_to_resource,
         "RemoveTagsFromResource": _remove_tags_from_resource,
         "ListTagsForResource": _list_tags_for_resource,
+        "SendCommand": _send_command,
+        "GetCommandInvocation": _get_command_invocation,
+        "ListCommands": _list_commands,
+        "DescribeInstanceInformation": _describe_instance_information,
     }
 
     handler = handlers.get(action)
@@ -689,7 +698,185 @@ def _param_out(param, with_decryption=False):
     return out
 
 
+# ── Run Command ────────────────────────────────────────────
+#
+# Nothing here runs a script, so an invocation completes as Success with empty output rather than
+# never converging. Only an unreachable instance fails, which is how a caller reaches its error path.
+
+_RUN_COMMAND_PLUGIN = "aws:runShellScript"
+
+
+def _managed_instance_ids() -> set:
+    """Instances Run Command can reach: the ones EC2 has running in this account and region.
+
+    Anything else has no agent answering, so real SSM neither lists it nor takes a command for it.
+    """
+    from ministack.services import ec2 as ec2_svc
+
+    return {
+        instance_id
+        for instance_id, inst in ec2_svc._instances.items()
+        if (inst.get("State") or {}).get("Name") == "running"
+    }
+
+
+def _command_target_ids(data) -> list:
+    """The instances a SendCommand addresses: InstanceIds, or a Targets entry naming them."""
+    instance_ids = list(data.get("InstanceIds") or [])
+    for target in data.get("Targets") or []:
+        if target.get("Key") in ("InstanceIds", "instanceids"):
+            instance_ids.extend(target.get("Values") or [])
+    return instance_ids
+
+
+def _public_command(record) -> dict:
+    """The Command shape, without the per-instance invocations kept alongside it."""
+    return {k: v for k, v in record.items() if k != "Invocations"}
+
+
+def _send_command(data):
+    document = data.get("DocumentName") or ""
+    if not document:
+        return error_response_json("ValidationException", "DocumentName is required", 400)
+
+    instance_ids = _command_target_ids(data)
+    if not instance_ids:
+        return error_response_json(
+            "ValidationException", "InstanceIds or a Targets entry is required", 400
+        )
+    live = _managed_instance_ids()
+    unknown = [i for i in instance_ids if i not in live]
+    if unknown:
+        return error_response_json(
+            "InvalidInstanceId",
+            f"Instances [[{', '.join(unknown)}]] not in a valid state for account "
+            f"{get_account_id()}",
+            400,
+        )
+
+    command_id = new_uuid()
+    now = _now_epoch()
+    started = _now_iso()
+    record = {
+        "CommandId": command_id,
+        "DocumentName": document,
+        "DocumentVersion": data.get("DocumentVersion", "$DEFAULT"),
+        "Comment": data.get("Comment", ""),
+        "ExpiresAfter": now + 3600,
+        "Parameters": data.get("Parameters", {}),
+        "InstanceIds": instance_ids,
+        "Targets": data.get("Targets", []),
+        "RequestedDateTime": now,
+        "Status": "Success",
+        "StatusDetails": "Success",
+        "OutputS3Region": get_region(),
+        "OutputS3BucketName": data.get("OutputS3BucketName", ""),
+        "OutputS3KeyPrefix": data.get("OutputS3KeyPrefix", ""),
+        "MaxConcurrency": data.get("MaxConcurrency", "50"),
+        "MaxErrors": data.get("MaxErrors", "0"),
+        "TargetCount": len(instance_ids),
+        "CompletedCount": len(instance_ids),
+        "ErrorCount": 0,
+        "DeliveryTimedOutCount": 0,
+        "ServiceRole": data.get("ServiceRoleArn", ""),
+        "TimeoutSeconds": data.get("TimeoutSeconds", 3600),
+        "Invocations": {
+            instance_id: {
+                "CommandId": command_id,
+                "InstanceId": instance_id,
+                "Comment": data.get("Comment", ""),
+                "DocumentName": document,
+                "DocumentVersion": data.get("DocumentVersion", "$DEFAULT"),
+                "PluginName": _RUN_COMMAND_PLUGIN,
+                "ResponseCode": 0,
+                # These three are strings in the SSM model, not timestamps.
+                "ExecutionStartDateTime": started,
+                "ExecutionElapsedTime": "PT0.001S",
+                "ExecutionEndDateTime": started,
+                "Status": "Success",
+                "StatusDetails": "Success",
+                "StandardOutputContent": "",
+                "StandardOutputUrl": "",
+                "StandardErrorContent": "",
+                "StandardErrorUrl": "",
+            }
+            for instance_id in instance_ids
+        },
+    }
+    _commands[command_id] = record
+    return json_response({"Command": _public_command(record)})
+
+
+def _get_command_invocation(data):
+    command_id = data.get("CommandId") or ""
+    instance_id = data.get("InstanceId") or ""
+    invocation = ((_commands.get(command_id) or {}).get("Invocations") or {}).get(instance_id)
+    if not invocation:
+        # AWS resolves the invocation before the command, so an unknown command id lands here too.
+        return error_response_json(
+            "InvocationDoesNotExist",
+            f"Invocation not found for {command_id}, {instance_id}",
+            400,
+        )
+    return json_response(dict(invocation))
+
+
+def _list_commands(data):
+    command_id = data.get("CommandId")
+    instance_id = data.get("InstanceId")
+    # An absent command id narrows to nothing rather than failing, which is what AWS answers.
+    commands = [
+        _public_command(record)
+        for record in _commands.values()
+        if (not command_id or record["CommandId"] == command_id)
+        and (not instance_id or instance_id in record.get("InstanceIds", []))
+    ]
+    commands.sort(key=lambda c: c["RequestedDateTime"], reverse=True)
+
+    start = _decode_next_token(data.get("NextToken", "")) if data.get("NextToken") else 0
+    limit = data.get("MaxResults") or DEFAULT_PAGE_SIZE
+    page = commands[start:start + limit]
+    out = {"Commands": page}
+    if start + limit < len(commands):
+        out["NextToken"] = _encode_next_token(start + limit)
+    return json_response(out)
+
+
+def _describe_instance_information(data):
+    from ministack.services import ec2 as ec2_svc
+
+    now = _now_epoch()
+    managed = _managed_instance_ids()
+    entries = []
+    for instance_id, inst in sorted(ec2_svc._instances.items()):
+        if instance_id not in managed:
+            continue
+        private_ip = inst.get("PrivateIpAddress", "")
+        entries.append({
+            "InstanceId": instance_id,
+            "PingStatus": "Online",
+            "LastPingDateTime": now,
+            "AgentVersion": "3.2.1377.0",
+            "IsLatestVersion": True,
+            "PlatformType": "Linux",
+            "PlatformName": "Amazon Linux",
+            "PlatformVersion": "2023",
+            "ResourceType": "EC2Instance",
+            "IPAddress": private_ip,
+            "ComputerName": inst.get("PrivateDnsName", ""),
+        })
+
+    start = _decode_next_token(data.get("NextToken", "")) if data.get("NextToken") else 0
+    limit = data.get("MaxResults") or DEFAULT_PAGE_SIZE
+    page = entries[start:start + limit]
+    out = {"InstanceInformationList": page}
+    if start + limit < len(entries):
+        out["NextToken"] = _encode_next_token(start + limit)
+    return json_response(out)
+
+
 def reset():
     _parameters.clear()
     _parameter_history.clear()
     _tags.clear()
+    _commands.clear()

--- a/tests/test_ssm.py
+++ b/tests/test_ssm.py
@@ -791,3 +791,111 @@ def test_cloudformation_ssm_parameter_is_region_scoped():
         ssm_service.reset()
         set_request_account_id(original_account)
         set_request_region(original_region)
+
+
+def test_ssm_run_command_health_probe(ssm, ec2):
+    """The Run Command shape a health probe needs: send, then poll to a terminal invocation."""
+    tag = _uuid_mod.uuid4().hex[:8]
+    instance_id = ec2.run_instances(ImageId="ami-12345678", MinCount=1, MaxCount=1,
+                                    TagSpecifications=[{"ResourceType": "instance",
+                                                        "Tags": [{"Key": f"ssm-{tag}",
+                                                                  "Value": tag}]}],
+                                    )["Instances"][0]["InstanceId"]
+    try:
+        command = ssm.send_command(InstanceIds=[instance_id], DocumentName="AWS-RunShellScript",
+                                   Comment=f"probe {tag}",
+                                   Parameters={"commands": ["echo ok"]})["Command"]
+        assert command["CommandId"]
+        assert command["DocumentName"] == "AWS-RunShellScript"
+        assert command["InstanceIds"] == [instance_id]
+        assert command["TargetCount"] == 1
+
+        # Nothing runs, so the output is empty; what a polling caller needs is a terminal Status.
+        inv = ssm.get_command_invocation(CommandId=command["CommandId"], InstanceId=instance_id)
+        assert inv["Status"] == "Success"
+        assert inv["StatusDetails"] == "Success"
+        assert inv["ResponseCode"] == 0
+        assert inv["StandardOutputContent"] == ""
+        assert inv["DocumentName"] == "AWS-RunShellScript"
+        # These are strings in the SSM model, not timestamps, so boto3 must not have parsed them.
+        assert isinstance(inv["ExecutionStartDateTime"], str)
+        assert isinstance(inv["ExecutionEndDateTime"], str)
+
+        # A caller that checks whether the instance is managed before sending must see it.
+        info = ssm.describe_instance_information()["InstanceInformationList"]
+        mine = [i for i in info if i["InstanceId"] == instance_id]
+        assert len(mine) == 1
+        assert mine[0]["PingStatus"] == "Online"
+        assert mine[0]["ResourceType"] == "EC2Instance"
+    finally:
+        ec2.terminate_instances(InstanceIds=[instance_id])
+
+
+def test_ssm_send_command_validates_the_instance(ssm, ec2):
+    """An instance that does not exist, is gone, or is stopped is rejected, a running one taken."""
+    with pytest.raises(ClientError) as exc:
+        ssm.send_command(InstanceIds=["i-00000000000000000"], DocumentName="AWS-RunShellScript")
+    assert exc.value.response["Error"]["Code"] == "InvalidInstanceId"
+
+    instance_id = ec2.run_instances(ImageId="ami-12345678", MinCount=1,
+                                    MaxCount=1)["Instances"][0]["InstanceId"]
+    ec2.terminate_instances(InstanceIds=[instance_id])
+    with pytest.raises(ClientError) as exc:
+        ssm.send_command(InstanceIds=[instance_id], DocumentName="AWS-RunShellScript")
+    assert exc.value.response["Error"]["Code"] == "InvalidInstanceId"
+
+    # A stopped box has no agent answering, so real SSM refuses it and stops listing it.
+    stopped = ec2.run_instances(ImageId="ami-12345678", MinCount=1,
+                                MaxCount=1)["Instances"][0]["InstanceId"]
+    try:
+        ec2.stop_instances(InstanceIds=[stopped])
+        with pytest.raises(ClientError) as exc:
+            ssm.send_command(InstanceIds=[stopped], DocumentName="AWS-RunShellScript")
+        assert exc.value.response["Error"]["Code"] == "InvalidInstanceId"
+        listed = [i["InstanceId"]
+                  for i in ssm.describe_instance_information()["InstanceInformationList"]]
+        assert stopped not in listed
+    finally:
+        ec2.terminate_instances(InstanceIds=[stopped])
+
+    # Rejecting everything would pass every assertion above, so prove a running one is taken.
+    live = ec2.run_instances(ImageId="ami-12345678", MinCount=1,
+                             MaxCount=1)["Instances"][0]["InstanceId"]
+    try:
+        assert ssm.send_command(InstanceIds=[live],
+                                DocumentName="AWS-RunShellScript")["Command"]["CommandId"]
+    finally:
+        ec2.terminate_instances(InstanceIds=[live])
+
+
+def test_ssm_command_lookup_filters_and_errors(ssm, ec2):
+    """listCommands narrows by command and instance; unknown ids get what AWS answers."""
+    instance_id = ec2.run_instances(ImageId="ami-12345678", MinCount=1,
+                                    MaxCount=1)["Instances"][0]["InstanceId"]
+    other_id = ec2.run_instances(ImageId="ami-12345678", MinCount=1,
+                                 MaxCount=1)["Instances"][0]["InstanceId"]
+    try:
+        mine = ssm.send_command(InstanceIds=[instance_id],
+                                DocumentName="AWS-RunShellScript")["Command"]["CommandId"]
+        theirs = ssm.send_command(InstanceIds=[other_id],
+                                  DocumentName="AWS-RunShellScript")["Command"]["CommandId"]
+
+        assert [c["CommandId"] for c in ssm.list_commands(CommandId=mine)["Commands"]] == [mine]
+        by_instance = [c["CommandId"] for c in ssm.list_commands(InstanceId=other_id)["Commands"]]
+        assert theirs in by_instance and mine not in by_instance
+
+        # A command id nobody knows narrows the list to nothing; AWS does not call it an error.
+        assert ssm.list_commands(CommandId="ffffffff-ffff-ffff-ffff-ffffffffffff")["Commands"] == []
+
+        # AWS resolves the invocation before the command, so this is not InvalidCommandId.
+        with pytest.raises(ClientError) as exc:
+            ssm.get_command_invocation(CommandId="ffffffff-ffff-ffff-ffff-ffffffffffff",
+                                       InstanceId=instance_id)
+        assert exc.value.response["Error"]["Code"] == "InvocationDoesNotExist"
+
+        # A real command, but not for that instance: the invocation does not exist.
+        with pytest.raises(ClientError) as exc:
+            ssm.get_command_invocation(CommandId=mine, InstanceId=other_id)
+        assert exc.value.response["Error"]["Code"] == "InvocationDoesNotExist"
+    finally:
+        ec2.terminate_instances(InstanceIds=[instance_id, other_id])

--- a/tests/test_stepfunctions.py
+++ b/tests/test_stepfunctions.py
@@ -4895,6 +4895,56 @@ def test_sfn_aws_sdk_query_pascal_case(sfn, sfn_sync, ssm):
     ssm.delete_parameter(Name="sfn-pascal-test-param")
 
 
+def test_sfn_aws_sdk_ssm_run_command_probe(sfn, sfn_sync, ec2):
+    """The health-probe shape: sendCommand, then getCommandInvocation on the id it returned."""
+    tag = _uuid_mod.uuid4().hex[:8]
+    instance_id = ec2.run_instances(ImageId="ami-12345678", MinCount=1,
+                                    MaxCount=1)["Instances"][0]["InstanceId"]
+    sm_arn = None
+    try:
+        sm_arn = sfn.create_state_machine(
+            name=f"sfn-ssm-run-{tag}",
+            definition=json.dumps({
+                "StartAt": "Send",
+                "States": {
+                    "Send": {
+                        "Type": "Task",
+                        "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
+                        "Parameters": {
+                            "InstanceIds": [instance_id],
+                            "DocumentName": "AWS-RunShellScript",
+                            "Parameters": {"commands": ["echo ok"]},
+                        },
+                        "ResultPath": "$.sent",
+                        "Next": "Poll",
+                    },
+                    "Poll": {
+                        "Type": "Task",
+                        "Resource": "arn:aws:states:::aws-sdk:ssm:getCommandInvocation",
+                        "Parameters": {
+                            "CommandId.$": "$.sent.Command.CommandId",
+                            "InstanceId": instance_id,
+                        },
+                        "End": True,
+                    },
+                },
+            }),
+            roleArn="arn:aws:iam::000000000000:role/R",
+        )["stateMachineArn"]
+
+        resp = sfn_sync.start_sync_execution(stateMachineArn=sm_arn, input="{}")
+        assert resp["status"] == "SUCCEEDED", f"{resp.get('error')} — {resp.get('cause')}"
+        # The poll addressed the CommandId the send returned, which is the part a probe needs.
+        output = json.loads(resp["output"])
+        assert output["Status"] == "Success"
+        assert output["InstanceId"] == instance_id
+        assert output["ResponseCode"] == 0
+    finally:
+        ec2.terminate_instances(InstanceIds=[instance_id])
+        if sm_arn:
+            sfn.delete_state_machine(stateMachineArn=sm_arn)
+
+
 def test_sfn_aws_sdk_json_pascal_case(sfn, sfn_sync, sm):
     """SFN aws-sdk integration converts camelCase action to PascalCase for JSON-protocol services."""
     definition = json.dumps({


### PR DESCRIPTION
`ssm` covers Parameter Store only, so `SendCommand`, `GetCommandInvocation`, `ListCommands` and `DescribeInstanceInformation` all return `InvalidAction: Unknown action: <X>`.

That takes out the standard way to health-check an instance: send `AWS-RunShellScript`, then poll `GetCommandInvocation` until the `Status` is terminal. The send fails, a `Retry` burns its attempts against an error that will never clear, and the caller drops into its error path, so an unhealthy instance surfaces as an internal failure instead.

We needed this in our step functions automation hence the extra test there.

### Fix

Implement the four verbs as mock:

- Each invocation completes as `Success` with empty output. Like ec2 Launch instance, there is no unhealthy path
- `SendCommand` validates its instance ids against EC2, taking a running instance and rejecting otherwise with `InvalidInstanceId`. 

Code written with Claude Code.

### Testing

Three tests in `tests/test_ssm.py` and one in `tests/test_stepfunctions.py`:

- `test_ssm_run_command_health_probe` — send, a terminal invocation with `ResponseCode 0`, the instance `Online`, and the date fields `str` (taken from boto model)
- `test_ssm_send_command_validates_the_instance` — an id that never existed, a terminated one and a stopped one are all `InvalidInstanceId`, the stopped one also gone from `describeInstanceInformation`; a running one then succeeds, since rejecting everything would satisfy the rest
- `test_ssm_command_lookup_filters_and_errors` — `listCommands` narrows by command and by instance, an unknown id narrows to nothing rather than failing, and a real command asked for the wrong instance is `InvocationDoesNotExist`
- `test_sfn_aws_sdk_ssm_run_command_probe` — the same probe from a state machine, the second state consuming `$.sent.Command.CommandId`

The script below runs against MiniStack or real AWS:

| target | result |
| --- | --- |
| MiniStack v1.4.21 | 0/6 |
| this branch | 6/6 |
| real AWS | 6/6 |

```
                                      before                          this branch
sendCommand returns a CommandId       InvalidAction: Unknown action   d12b3b64-0eb4-…
getCommandInvocation is terminal      no CommandId to poll            Status=Success ResponseCode=0
listCommands lists and filters        InvalidAction: Unknown action   1 listed, filter returns 1
describeInstanceInformation lists it  InvalidAction: Unknown action   PingStatus=Online
the probe runs from a state machine   Ssm.InvalidAction               Status=Success
an unknown instance is rejected       InvalidAction                   InvalidInstanceId
```

Real AWS was scored on a throwaway t3.micro carrying an SSM instance profile, passed in with --instance-id — the reproducer's own launch path makes an unmanaged instance, which AWS refuses every command for.

<details>
<summary>check_ssm_run_command.py</summary>

```python
#!/usr/bin/env python3
"""Check that SSM Run Command works, from boto3 and from a state machine.

MiniStack's ssm service implements Parameter Store only: SendCommand,
GetCommandInvocation, ListCommands and DescribeInstanceInformation all return
"InvalidAction: Unknown action: <X>" to plain boto3, no Step Functions involved. A machine that uses
Run Command as its health probe -- send AWS-RunShellScript, then poll getCommandInvocation until the
invocation reaches a terminal Status -- therefore cannot converge: the send fails, its Retry
exhausts, and the run routes to its error path.

MiniStack has nothing to execute a script on, so a successful invocation with empty output is the
answer here, the way ECS reports a faked exitCode 0. An instance id that does not exist still gets
InvalidInstanceId, which is the honest way for a caller to exercise its unhealthy path.

Against MiniStack:
  python check_ssm_run_command.py --endpoint http://localhost:4566 --region us-east-1

Against AWS, after `aws sso login --profile <profile>`, with an instance the SSM agent has
registered (an unmanaged instance is rejected by AWS itself, which is not what this checks):
  python check_ssm_run_command.py --profile <profile> --region us-east-1 --instance-id i-0123...

Without --instance-id an instance is launched and terminated again, which only makes sense against
an emulator. Exit status is 0 when every check passes.
"""

import argparse
import json
import sys
import time
import uuid

import boto3
from botocore.config import Config as BotoConfig
from botocore.exceptions import ClientError

TERMINAL = ("Success", "Cancelled", "TimedOut", "Failed", "Cancelling")


def options():
    parser = argparse.ArgumentParser(description=__doc__)
    parser.add_argument("--endpoint", help="Emulator endpoint, e.g. http://localhost:4566")
    parser.add_argument("--profile", help="AWS CLI/SSO profile; defaults to AWS_PROFILE")
    parser.add_argument("--region", default=None, help="AWS region; defaults to AWS_REGION")
    parser.add_argument("--instance-id", help="Use this instance instead of launching one")
    parser.add_argument("--role-arn", default="arn:aws:iam::000000000000:role/sfn-role",
                        help="Role the state machine assumes")
    parser.add_argument("--keep", action="store_true", help="Leave the instance running")
    return parser.parse_args()


def main():
    args = options()
    if args.endpoint and not args.profile:
        session = boto3.Session(region_name=args.region, aws_access_key_id="test",
                                aws_secret_access_key="test")
    else:
        session = boto3.Session(profile_name=args.profile, region_name=args.region)
    kwargs = {"endpoint_url": args.endpoint} if args.endpoint else {}
    ssm = session.client("ssm", **kwargs)
    ec2 = session.client("ec2", **kwargs)
    # StartSyncExecution normally goes to a sync- prefixed host, which an emulator does not serve.
    sfn = session.client("stepfunctions", config=BotoConfig(inject_host_prefix=not args.endpoint),
                         **kwargs)

    tag = uuid.uuid4().hex[:8]
    launched = None
    results = []

    def check(label, ok, detail):
        results.append((label, ok, detail))
        print(f"{'PASS' if ok else 'FAIL'}  {label:38} {detail}")

    def run_check(label, body):
        """Score one check. An API error is that check failing, not the end of the run --
        every call below is one of the actions that does not exist yet."""
        try:
            ok, detail = body()
        except ClientError as exc:
            err = exc.response["Error"]
            ok, detail = False, f"{err['Code']}: {err['Message'][:52]}"
        check(label, ok, detail)

    def send(instance_id):
        return ssm.send_command(InstanceIds=[instance_id], DocumentName="AWS-RunShellScript",
                                Comment=f"check {tag}",
                                Parameters={"commands": ["echo ok"]})["Command"]

    def poll(command_id, instance_id, tries=30):
        """Wait for a terminal invocation, the way the caller's polling loop does."""
        for _ in range(tries):
            try:
                inv = ssm.get_command_invocation(CommandId=command_id, InstanceId=instance_id)
            except ClientError as exc:
                if exc.response["Error"]["Code"] != "InvocationDoesNotExist":
                    raise
                time.sleep(1)
                continue
            if inv.get("Status") in TERMINAL:
                return inv
            time.sleep(1)
        return inv

    try:
        if args.instance_id:
            instance_id = args.instance_id
        else:
            instance_id = ec2.run_instances(ImageId="ami-12345678", MinCount=1, MaxCount=1,
                                            TagSpecifications=[
                                                {"ResourceType": "instance",
                                                 "Tags": [{"Key": f"check-{tag}",
                                                           "Value": tag}]}])["Instances"][0][
                "InstanceId"]
            launched = instance_id

        sent = {}

        # 1. The send half of the probe: a Command with an id to poll on.
        def check_send():
            sent.update(send(instance_id))
            ok = bool(sent.get("CommandId")) and sent.get("DocumentName") == "AWS-RunShellScript"
            return ok, f"{sent.get('CommandId')}" if ok else f"got {sorted(sent)}"

        run_check("sendCommand returns a CommandId", check_send)

        # 2. The poll half: a terminal Status, with the fields the Choice state reads. Without a
        #    terminal Status the caller's polling loop never exits.
        def check_poll():
            if not sent.get("CommandId"):
                return False, "no CommandId to poll"
            inv = poll(sent["CommandId"], instance_id)
            ok = inv.get("Status") in TERMINAL and "ResponseCode" in inv \
                and "StandardOutputContent" in inv
            return ok, (f"Status={inv.get('Status')} ResponseCode={inv.get('ResponseCode')}" if ok
                        else f"Status={inv.get('Status')} keys={sorted(inv)[:6]}")

        run_check("getCommandInvocation is terminal", check_poll)

        # 3. listCommands finds it, and filtering by id returns just that one. AWS can answer the
        #    first page empty and still carry a NextToken, so the listing has to be paginated.
        def check_list():
            if not sent.get("CommandId"):
                return False, "nothing was sent"
            by_id = ssm.list_commands(CommandId=sent["CommandId"])["Commands"]
            listed = [command for page in ssm.get_paginator("list_commands").paginate()
                      for command in page["Commands"]]
            ok = any(c["CommandId"] == sent["CommandId"] for c in listed) and \
                [c["CommandId"] for c in by_id] == [sent["CommandId"]]
            return ok, (f"{len(listed)} listed, filter returns 1" if ok
                        else f"listed={len(listed)} filtered={len(by_id)}")

        run_check("listCommands lists and filters", check_list)

        # 4. The instance has to look managed, or a caller that checks first never sends at all.
        def check_managed():
            info = ssm.describe_instance_information()["InstanceInformationList"]
            mine = [i for i in info if i["InstanceId"] == instance_id]
            ok = len(mine) == 1 and mine[0].get("PingStatus") == "Online"
            return ok, (f"PingStatus={mine[0].get('PingStatus')}" if ok
                        else f"{len(info)} managed, none matching {instance_id}")

        run_check("describeInstanceInformation lists it", check_managed)

        # 5. The caller's actual path: both calls from a state machine, the second consuming the
        #    first's CommandId. This is what fails today, one state after the dispatch error.
        sm_arn = sfn.create_state_machine(
            name=f"ssm-check-{tag}",
            definition=json.dumps({
                "StartAt": "Send",
                "States": {
                    "Send": {
                        "Type": "Task",
                        "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
                        "Parameters": {"InstanceIds": [instance_id],
                                       "DocumentName": "AWS-RunShellScript",
                                       "Parameters": {"commands": ["echo ok"]}},
                        "ResultPath": "$.sent",
                        "Next": "Get",
                    },
                    # AWS creates the invocation asynchronously, so the first poll can land
                    # before it exists and a real probe has to wait the status out.
                    "Get": {
                        "Type": "Task",
                        "Resource": "arn:aws:states:::aws-sdk:ssm:getCommandInvocation",
                        "Parameters": {"CommandId.$": "$.sent.Command.CommandId",
                                       "InstanceId": instance_id},
                        "Retry": [{"ErrorEquals": ["Ssm.InvocationDoesNotExistException"],
                                   "IntervalSeconds": 2, "MaxAttempts": 5, "BackoffRate": 1.5}],
                        "ResultPath": "$.invocation",
                        "Next": "Terminal?",
                    },
                    "Terminal?": {
                        "Type": "Choice",
                        "Choices": [{"Or": [{"Variable": "$.invocation.Status",
                                             "StringEquals": status} for status in TERMINAL],
                                     "Next": "Done"}],
                        "Default": "Wait",
                    },
                    "Wait": {"Type": "Wait", "Seconds": 2, "Next": "Get"},
                    "Done": {"Type": "Pass", "OutputPath": "$.invocation", "End": True},
                },
            }),
            roleArn=args.role_arn,
            # StartSyncExecution is EXPRESS-only on AWS; MiniStack serves either.
            type="EXPRESS",
        )["stateMachineArn"]
        try:
            resp = sfn.start_sync_execution(stateMachineArn=sm_arn, input=json.dumps({}))
            output = json.loads(resp["output"]) if resp.get("output") else {}
            ok = resp["status"] == "SUCCEEDED" and output.get("Status") in TERMINAL
            check("the probe runs from a state machine", ok,
                  f"Status={output.get('Status')}" if ok
                  else f"status={resp['status']} error={resp.get('error', '-')} "
                       f"cause={(resp.get('cause') or '-')[:60]}")
        finally:
            try:
                sfn.delete_state_machine(stateMachineArn=sm_arn)
            except ClientError:
                pass

        # 6. An instance that does not exist is rejected, which is how a caller exercises its
        #    unhealthy path deliberately rather than always breaking.
        def check_unknown_instance():
            try:
                send("i-00000000000000000")
            except ClientError as exc:
                code = exc.response["Error"]["Code"]
                return code == "InvalidInstanceId", code
            return False, "sendCommand accepted an instance that does not exist"

        run_check("an unknown instance is rejected", check_unknown_instance)
    finally:
        if launched and not args.keep:
            try:
                ec2.terminate_instances(InstanceIds=[launched])
            except ClientError:
                pass

    failed = [label for label, ok, _ in results if not ok]
    print(f"\n{len(results) - len(failed)}/{len(results)} checks passed"
          + (f"; failed: {', '.join(failed)}" if failed else ""))
    return 1 if failed else 0


if __name__ == "__main__":
    try:
        sys.exit(main())
    except ClientError as exc:
        print(f"ERROR: {exc}", file=sys.stderr)
        sys.exit(2)
```

</details>
