### PR TITLE
Ship MySQL IAM plugins in slim image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -60,20 +60,6 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest
 
-      - name: Build and push (regular)
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            MINISTACK_VERSION=${{ steps.meta.outputs.version }}
-          cache-from: type=gha,scope=regular
-          cache-to: type=gha,mode=max,scope=regular
-
       # ── Full (Debian/glibc) image — :full, :{version}-full, :{major}.{minor}-full ──
       # Adds DuckDB (Athena engine), psycopg2-binary, pymysql. Larger
       # image (~360 MB vs ~110 MB) but all manylinux wheels install
@@ -95,6 +81,7 @@ jobs:
             type=raw,value=full
 
       - name: Build and push (full)
+        id: build_full
         uses: docker/build-push-action@v5
         with:
           context: .
@@ -107,3 +94,18 @@ jobs:
             MINISTACK_VERSION=${{ steps.meta.outputs.version }}
           cache-from: type=gha,scope=full
           cache-to: type=gha,mode=max,scope=full
+
+      - name: Build and push (regular)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            MINISTACK_VERSION=${{ steps.meta.outputs.version }}
+            PLUGIN_DONOR_IMAGE=ghcr.io/ministackorg/ministack@${{ steps.build_full.outputs.digest }}
+          cache-from: type=gha,scope=regular
+          cache-to: type=gha,mode=max,scope=regular

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,8 @@
+# Non-release builds intentionally use the maintainer-requested fallback of the latest
+# published full image. Release builds override this in docker-publish.yml with the
+# same-release full-image digest; plugin-source PRs use the full-preview label path.
+ARG PLUGIN_DONOR_IMAGE=ghcr.io/ministackorg/ministack:full
+
 FROM python:3.13-alpine AS builder
 
 RUN pip install --no-cache-dir --no-compile \
@@ -17,6 +22,9 @@ RUN rm -rf /usr/local/lib/python3.13/site-packages/awscli/examples \
     && find /usr/local/lib/python3.13/site-packages -type d -name '__pycache__' -exec rm -rf {} + 2>/dev/null \
     && rm -rf /usr/local/lib/python3.13/site-packages/pip*.dist-info \
     && rm -rf /usr/local/lib/python3.13/site-packages/pip*
+
+# Plugin artifacts are release-stable; release builds pin this donor by digest.
+FROM ${PLUGIN_DONOR_IMAGE} AS plugin-donor
 
 FROM python:3.13-alpine
 
@@ -40,6 +48,7 @@ COPY bin/awslocal /usr/local/bin/awslocal
 RUN chmod +x /usr/local/bin/awslocal
 
 COPY ministack/ ministack/
+COPY --from=plugin-donor /opt/ministack/mysql-plugins /opt/ministack/mysql-plugins
 
 RUN addgroup -S ministack && adduser -S ministack -G ministack
 RUN mkdir -p /tmp/ministack-data/s3 && chown -R ministack:ministack /tmp/ministack-data

--- a/contrib/mysql-iam-plugin/README.md
+++ b/contrib/mysql-iam-plugin/README.md
@@ -38,10 +38,11 @@ repository root:
 contrib/mysql-iam-plugin/build.sh
 ```
 
-This writes to `build/mysql-plugins` by default. The full Docker image places
-the same tree at `/opt/ministack/mysql-plugins`, the fixed runtime lookup path.
-Delivery and installation happen automatically when a matching bundled
-artifact exists and are silent when it is absent.
+This writes to `build/mysql-plugins` by default. `Dockerfile.full` compiles and
+places the tree at `/opt/ministack/mysql-plugins`; the slim image copies that
+tree from the same release's full image into the same fixed runtime lookup path.
+Delivery and installation happen automatically when a matching bundled artifact
+exists and are silent when it is absent.
 
 Artifact series selection uses the tag of the same resolved MySQL image that
 the RDS container launch uses. Accepted version prefixes such as Aurora MySQL
@@ -107,8 +108,8 @@ plugin is `ACTIVE` before reporting success. The maintenance session disables
 binary logging at entry so every current and future plugin-metadata statement
 remains compute-local and cannot alter a global-cluster secondary.
 
-Residuals: the full image carries the artifacts; the slim image remains
-artifact-free and therefore auto-off. The existing global-replication live
-fixture now asserts that an IAM user created on the primary reaches the
-secondary without breaking replication whenever artifacts are present. Each
-MySQL image-tag update must rebuild and reload-test its series artifact.
+Both image flavors carry the same artifacts; the slim image receives them from
+the same release's full image. The existing global-replication live fixture
+asserts that an IAM user created on the primary reaches the secondary without
+breaking replication whenever artifacts are present. Each MySQL image-tag
+update must rebuild and reload-test its series artifact.


### PR DESCRIPTION
## Why

The MySQL IAM auth plugin artifacts are compiled in `Dockerfile.full` and ship only in the `-full` image flavor; the slim image has no `/opt/ministack/mysql-plugins` tree, so IAM auth support silently disables itself there. An earlier revision of this PR compiled the plugins in the slim Dockerfile as well, which adds several minutes of compile time to every branch build. Per review feedback, this revision copies the artifact tree from the published full image instead — the plugins are release-stable, so recompiling them per branch buys nothing.

## What

- `Dockerfile` (slim): adds a global `PLUGIN_DONOR_IMAGE` build arg (default `ghcr.io/ministackorg/ministack:full`), a `plugin-donor` stage, and a final-stage `COPY --from=plugin-donor /opt/ministack/mysql-plugins /opt/ministack/mysql-plugins`. No compile stages are added.
- `.github/workflows/docker-publish.yml`: the full image now builds and pushes before the regular one, and the regular build pins `PLUGIN_DONOR_IMAGE` to the just-pushed full image digest. Release-tagged slim and full images therefore always carry the same release's plugin tree (the digest is a manifest list, so each architecture copies its own tree).
- `.github/workflows/docker-publish-on-pr.yml`: unchanged. PR previews use the build-arg default — the latest published full image — so ordinary branch builds skip plugin compilation entirely.
- `contrib/mysql-iam-plugin/README.md`: flavor claims updated to match.

## Behavior changes / risk

- Runtime behavior is unchanged: plugin delivery keys solely on artifact presence at the fixed lookup path, which the slim image now satisfies.
- Slim PR previews carry the latest release's plugin binaries rather than binaries built from the PR's source; PRs that change plugin source are validated via the `full-preview` label image, which compiles from source.
- The full-before-regular ordering and the digest handoff only run in the release workflow; the first tag push after merge exercises them for real.

## Validation

* `docker buildx build --check .` — clean
* `docker build --target plugin-donor .` — donor stage resolves and builds
* Copied plugin tree verified byte-identical (per-file sha256) to the tree carried by the published full image, for both artifact series
