### PR TITLE
fix(cloudformation): honor the ${!Literal} escape in Fn::Sub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- **CloudFormation — `Fn::Sub` honors the `${!Literal}` escape** — the leading `!` was not recognized, so the name fell through every lookup and rendered as `!Literal` with the braces consumed; `${!Literal}` now renders as the literal `${Literal}` and no longer registers a dependency on a resource of that name. An `AWS::IoT::Policy` pinned to `${!iot:Connection.Thing.ThingName}` deployed with a document matching nothing, so the policy denied every connect, publish and subscribe while the stack still reported `CREATE_COMPLETE`. Reported by @iot-rocket.
+
 ## [1.5.0] — 2026-08-23
 
 ### Added

--- a/ministack/services/cloudformation/engine.py
+++ b/ministack/services/cloudformation/engine.py
@@ -385,6 +385,9 @@ def _resolve_refs(value, resources, params, conditions, mappings,
 
         def _sub_replace(match):
             var = match.group(1)
+            # ${!Literal} escape: emit ${Literal} without substituting
+            if var.startswith("!"):
+                return "${" + var[1:] + "}"
             # Check explicit var map first
             if var in resolved_map:
                 return str(resolved_map[var])
@@ -574,6 +577,8 @@ def _extract_deps(resource_def: dict, all_resource_names: set) -> set:
                 template_str = sub_val[0] if isinstance(sub_val, list) else sub_val
                 for match in re.finditer(r"\$\{([^}]+)\}", str(template_str)):
                     var = match.group(1)
+                    if var.startswith("!"):
+                        continue
                     base = var.split(".")[0]
                     if base in all_resource_names:
                         deps.add(base)

--- a/tests/test_cfn.py
+++ b/tests/test_cfn.py
@@ -1267,6 +1267,40 @@ def test_cfn_fn_sub(cfn, ssm):
     val = ssm.get_parameter(Name="cfn-t06-param")["Parameter"]["Value"]
     assert val == "cfn-t06-src-replica"
 
+
+def test_cfn_fn_sub_literal_escape(cfn, ssm):
+    """`${!Literal}` is Fn::Sub's escape for emitting `${Literal}` verbatim —
+    the way an IoT policy carries `${iot:Connection.Thing.ThingName}` through a
+    template. The name must not be looked up, even when it matches a resource,
+    and the surrounding substitutions must still resolve."""
+    template = {
+        "AWSTemplateFormatVersion": "2010-09-09",
+        "Resources": {
+            "Plain": {
+                "Type": "AWS::S3::Bucket",
+                "Properties": {"BucketName": "cfn-sub-escape-src"},
+            },
+            "Param": {
+                "Type": "AWS::SSM::Parameter",
+                "Properties": {
+                    "Name": "/cfn-sub-escape/literal",
+                    "Type": "String",
+                    "Value": {
+                        "Fn::Sub": "client/${!iot:Connection.Thing.ThingName} "
+                                   "and ${!Plain} in ${AWS::Region}"
+                    },
+                },
+            },
+        },
+    }
+    cfn.create_stack(StackName="cfn-sub-escape", TemplateBody=json.dumps(template))
+    _wait_stack(cfn, "cfn-sub-escape")
+
+    val = ssm.get_parameter(Name="/cfn-sub-escape/literal")["Parameter"]["Value"]
+    assert val == ("client/${iot:Connection.Thing.ThingName} "
+                   "and ${Plain} in us-east-1")
+
+
 def test_cfn_multi_resource_dependencies(cfn, iam, lam):
     template = {
         "AWSTemplateFormatVersion": "2010-09-09",


### PR DESCRIPTION
### What

**CloudFormation — `Fn::Sub` honors the `${!Literal}` escape.** `Fn::Sub` treats an exclamation point after the opening brace as an escape: `${!Literal}` renders as the literal text `${Literal}`, with no substitution attempted. The replacer had no case for the leading `!`, so the name matched no var-map entry, pseudo-parameter, stack parameter or resource and fell through to returning itself — emitting `!Literal` with the braces already consumed. The escape is now handled before any lookup, and the dependency walker skips escaped names so a literal `${!Foo}` no longer orders the resource against a resource named `Foo`.

The escape exists mainly to emit the `${...}` syntax of *another* system, and IoT policy variables are the common case. An `AWS::IoT::Policy` pinned to `${!iot:Connection.Thing.ThingName}` deployed with every resource ARN reading `.../client/!iot:Connection.Thing.ThingName`, which matches nothing, so the policy denied every connect, publish and subscribe while the stack still reported `CREATE_COMPLETE`. `${!AWS::...}` literals in EC2 user data and shell `${VAR}` in inline scripts were corrupted the same way. Substitution is otherwise untouched.

### Testing Plan

- Test added to `tests/test_cfn.py` deploying a string that mixes two escapes with a pseudo-parameter, one of them naming a resource in the same stack. It fails on `dev` with `client/!iot:Connection.Thing.ThingName and !Plain in us-east-1`.
- `pytest tests/test_cfn.py` passes; the failures on this file are the same ten present on `dev` before the change.
- `ruff check ministack/` passes with no new findings on the changed files.