### PR TITLE
fix(rds): support PostgreSQL major engine selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- **RDS — Aurora PostgreSQL major-version selectors return the matching catalog** — `DescribeDBEngineVersions` treated `EngineVersion=16` as an exact version and returned nothing. Major-only selectors now return every advertised minor in that family, and `DefaultOnly=true` narrows the result to AWS's configured default minor for that major.
+
 ## [1.5.0] — 2026-08-23
 
 ### Added

--- a/ministack/services/rds.py
+++ b/ministack/services/rds.py
@@ -282,6 +282,14 @@ AURORA_POSTGRESQL_ENGINE_VERSIONS = [
 AURORA_POSTGRESQL_ENGINE_VERSION_SET = {
     version for version, _ in AURORA_POSTGRESQL_ENGINE_VERSIONS
 }
+# Defaults deliberately trail the newest advertised minor when AWS does. Keep
+# this explicit instead of deriving it from the catalog ordering. Refresh with:
+#   aws rds describe-db-engine-versions --engine aurora-postgresql \
+#     --engine-version <major> --default-only
+AURORA_POSTGRESQL_DEFAULT_ENGINE_VERSIONS = {
+    "16": "16.11",
+    "17": "17.7",
+}
 
 AURORA_MYSQL_IMAGE_MAP = {
     "5.6": "mysql:5.6",
@@ -6739,6 +6747,17 @@ def _global_cluster_xml(gc):
 def _describe_engine_versions(p):
     engine = _p(p, "Engine") or "postgres"
     version_filter = _p(p, "EngineVersion")
+    default_only = _p(p, "DefaultOnly") == "true"
+    major_version_filter = (
+        version_filter
+        if engine == "aurora-postgresql" and version_filter.isdigit()
+        else ""
+    )
+    default_version = (
+        AURORA_POSTGRESQL_DEFAULT_ENGINE_VERSIONS.get(major_version_filter)
+        if major_version_filter
+        else _default_engine_version(engine)
+    )
     versions_map = {
         "postgres": [
             ("18.3", "18"), ("17.5", "17"), ("16.4", "16"),
@@ -6757,7 +6776,12 @@ def _describe_engine_versions(p):
     members = ""
     supports_global = engine in ("aurora-mysql", "aurora-postgresql")
     for ver, family in versions:
-        if version_filter and ver != version_filter:
+        if major_version_filter:
+            if not ver.startswith(major_version_filter + "."):
+                continue
+        elif version_filter and ver != version_filter:
+            continue
+        if default_only and ver != default_version:
             continue
         members += f"""<DBEngineVersion>
             <Engine>{engine}</Engine>

--- a/tests/test_rds.py
+++ b/tests/test_rds.py
@@ -20,6 +20,7 @@ from conftest import ENDPOINT
 DEFAULT_AURORA_MYSQL_ENGINE_VERSION = "8.0.mysql_aurora.3.10.3"
 UNSUPPORTED_AURORA_MYSQL_ENGINE_VERSION = "9.0.mysql_aurora.9.0.1"
 DEFAULT_AURORA_POSTGRESQL_ENGINE_VERSION = "17.7"
+DEFAULT_AURORA_POSTGRESQL_16_ENGINE_VERSION = "16.11"
 UNSUPPORTED_AURORA_POSTGRESQL_ENGINE_VERSION = "16.99"
 EXPECTED_AURORA_POSTGRESQL_ENGINE_VERSIONS = {
     "11.9": "aurora-postgresql11",
@@ -1182,6 +1183,43 @@ def test_rds_describe_aurora_postgresql_engine_versions_by_family(rds):
         EngineVersion=UNSUPPORTED_AURORA_POSTGRESQL_ENGINE_VERSION,
     )["DBEngineVersions"]
     assert filtered == []
+
+
+def test_rds_describe_aurora_postgresql_engine_versions_by_major(rds):
+    family = "aurora-postgresql16"
+    expected_versions = {
+        version
+        for version, expected_family in EXPECTED_AURORA_POSTGRESQL_ENGINE_VERSIONS.items()
+        if expected_family == family
+    }
+
+    major_versions = rds.describe_db_engine_versions(
+        Engine="aurora-postgresql",
+        EngineVersion="16",
+    )["DBEngineVersions"]
+    assert len(major_versions) == 13
+    assert {version["EngineVersion"] for version in major_versions} == expected_versions
+    assert all(version["DBParameterGroupFamily"] == family for version in major_versions)
+    assert all(version["Status"] == "available" for version in major_versions)
+
+    default_versions = rds.describe_db_engine_versions(
+        Engine="aurora-postgresql",
+        EngineVersion="16",
+        DefaultOnly=True,
+    )["DBEngineVersions"]
+    assert [version["EngineVersion"] for version in default_versions] == [
+        DEFAULT_AURORA_POSTGRESQL_16_ENGINE_VERSION
+    ]
+    assert default_versions[0]["DBParameterGroupFamily"] == family
+    assert default_versions[0]["Status"] == "available"
+
+    exact_versions = rds.describe_db_engine_versions(
+        Engine="aurora-postgresql",
+        EngineVersion="16.14",
+    )["DBEngineVersions"]
+    assert [version["EngineVersion"] for version in exact_versions] == ["16.14"]
+    assert exact_versions[0]["DBParameterGroupFamily"] == family
+    assert exact_versions[0]["Status"] == "available"
 
 
 def test_rds_describe_aurora_postgresql_engine_version_status(rds):


### PR DESCRIPTION
## Summary

- treat a major-only Aurora PostgreSQL `EngineVersion` such as `16` as a dot-boundary selector for every advertised minor in that major
- honor `DefaultOnly` and keep major defaults explicit, matching AWS's current `16` default of `16.11` rather than deriving it from the newest catalog entry
- preserve exact-version selection

## Root cause

`DescribeDBEngineVersions` compared `EngineVersion` to each catalog version with exact string equality. The catalog contains concrete versions such as `16.8` and `16.14`, so `EngineVersion=16` returned zero records.

Against AWS in `us-east-1`, `Engine=aurora-postgresql, EngineVersion=16` currently returns 13 available `aurora-postgresql16` records. Adding `DefaultOnly=true` returns exactly `16.11`. MiniStack v1.5.0 returned zero for both calls, while exact `16.14` already worked.

## Validation

- regression reproduced against `ministackorg/ministack:1.5.0-full`
- `pytest -q tests/test_rds.py::test_rds_describe_engine_versions_family tests/test_rds.py::test_rds_describe_aurora_mysql_engine_versions_by_family tests/test_rds.py::test_rds_describe_aurora_postgresql_engine_versions_by_family tests/test_rds.py::test_rds_describe_aurora_postgresql_engine_versions_by_major tests/test_rds.py::test_rds_describe_aurora_postgresql_engine_version_status` — 5 passed
- regression covers 13-version major listing, unrelated-major exclusion, `16` + `DefaultOnly` → `16.11`, exact `16.14`, family metadata, and `Status=available`
- `ruff check ministack/ tests/test_rds.py` — passed
