### PR TITLE
feat(stepfunctions): States.StringSplit and States.Hash intrinsics

### DIFF
--- a/ministack/services/stepfunctions.py
+++ b/ministack/services/stepfunctions.py
@@ -3777,8 +3777,13 @@ def _eval_intrinsic_arg(arg, data, ctx):
     return None
 
 
-# Real AWS caps both base64 intrinsics at 10,000 characters of input
+# Real AWS caps the base64 intrinsics and States.Hash at 10,000 characters of input
 _BASE64_INTRINSIC_MAX = 10_000
+
+# The five States.Hash publishes, mapped to what hashlib calls them.
+_HASH_INTRINSIC_ALGORITHMS = {
+    "MD5": "md5", "SHA-1": "sha1", "SHA-256": "sha256", "SHA-384": "sha384", "SHA-512": "sha512",
+}
 
 
 def _base64_intrinsic_arg(name, value):
@@ -3833,6 +3838,28 @@ def _exec_intrinsic(node, data, ctx):
                 out.append(ch)
                 i += 1
         return "".join(out)
+    elif name == "States.Hash":
+        import hashlib
+        text, algorithm = args[0], args[1]
+        digest = _HASH_INTRINSIC_ALGORITHMS.get(algorithm)
+        if digest is None or not isinstance(text, str) or len(text) > _BASE64_INTRINSIC_MAX:
+            raise ValueError(f"Invalid arguments in {name}")
+        return hashlib.new(digest, text.encode("utf-8")).hexdigest()
+    elif name == "States.StringSplit":
+        # Every character of the second argument is a delimiter in its own right, and a run of them
+        # yields no empty members, so splitting an ARN on ":" indexes the same either way.
+        text, delimiters = args[0], args[1]
+        parts, current = [], []
+        for ch in text:
+            if ch in delimiters:
+                if current:
+                    parts.append("".join(current))
+                    current = []
+            else:
+                current.append(ch)
+        if current:
+            parts.append("".join(current))
+        return parts
     elif name == "States.ArrayGetItem":
         return args[0][int(args[1])]
     elif name == "States.Array":

--- a/tests/test_stepfunctions.py
+++ b/tests/test_stepfunctions.py
@@ -1,4 +1,5 @@
 import base64
+import hashlib
 import io
 import json
 import os
@@ -562,6 +563,90 @@ def test_sfn_intrinsic_json_merge(sfn, sfn_sync):
     assert resp["status"] == "SUCCEEDED"
     output = json.loads(resp["output"])
     assert output["merged"] == {"a": 1, "b": 2, "c": 99}
+
+def test_sfn_intrinsic_hash(sfn, sfn_sync):
+    """States.Hash covers AWS's five algorithms and refuses anything else."""
+    definition = json.dumps({
+        "StartAt": "Hash",
+        "States": {
+            "Hash": {
+                "Type": "Pass",
+                "Parameters": {
+                    "md5.$": "States.Hash($.text, 'MD5')",
+                    "sha1.$": "States.Hash($.text, 'SHA-1')",
+                    "sha256.$": "States.Hash($.text, 'SHA-256')",
+                    "sha384.$": "States.Hash($.text, 'SHA-384')",
+                    "sha512.$": "States.Hash($.text, 'SHA-512')",
+                },
+                "End": True,
+            }
+        },
+    })
+    sm = sfn.create_state_machine(
+        name="sfn-intrinsic-hash",
+        definition=definition,
+        roleArn="arn:aws:iam::000000000000:role/R",
+    )
+    resp = sfn_sync.start_sync_execution(
+        stateMachineArn=sm["stateMachineArn"], input=json.dumps({"text": "input data"}))
+    assert resp["status"] == "SUCCEEDED"
+    output = json.loads(resp["output"])
+    # Lowercase hex of the UTF-8 bytes, so the digests are the ones any other tool produces.
+    assert output["md5"] == hashlib.md5(b"input data").hexdigest()
+    assert output["sha1"] == hashlib.sha1(b"input data").hexdigest()
+    assert output["sha256"] == hashlib.sha256(b"input data").hexdigest()
+    assert output["sha384"] == hashlib.sha384(b"input data").hexdigest()
+    assert output["sha512"] == hashlib.sha512(b"input data").hexdigest()
+
+    # An algorithm AWS does not publish is refused rather than passed to hashlib.
+    bad = sfn.create_state_machine(
+        name="sfn-intrinsic-hash-bad",
+        definition=json.dumps({"StartAt": "H", "States": {"H": {
+            "Type": "Pass", "Parameters": {"h.$": "States.Hash($.text, 'SHA-224')"}, "End": True}}}),
+        roleArn="arn:aws:iam::000000000000:role/R",
+    )
+    resp = sfn_sync.start_sync_execution(
+        stateMachineArn=bad["stateMachineArn"], input=json.dumps({"text": "input data"}))
+    assert resp["status"] == "FAILED"
+    assert resp.get("error") == "States.Runtime"
+
+def test_sfn_intrinsic_string_split(sfn, sfn_sync):
+    """States.StringSplit takes a set of delimiter characters and keeps no empty member."""
+    definition = json.dumps({
+        "StartAt": "Split",
+        "States": {
+            "Split": {
+                "Type": "Pass",
+                "Parameters": {
+                    "simple.$": "States.StringSplit($.csv, ',')",
+                    "charset.$": "States.StringSplit($.mixed, '.+,=')",
+                    "runs.$": "States.StringSplit($.runs, ',')",
+                    "absent.$": "States.StringSplit($.plain, ',')",
+                    # Recovering the region from the execution ARN, which is what needs this.
+                    "region.$": "States.ArrayGetItem(States.StringSplit($$.Execution.Id, ':'), 3)",
+                },
+                "End": True,
+            }
+        },
+    })
+    sm = sfn.create_state_machine(
+        name="sfn-intrinsic-split",
+        definition=definition,
+        roleArn="arn:aws:iam::000000000000:role/R",
+    )
+    resp = sfn_sync.start_sync_execution(
+        stateMachineArn=sm["stateMachineArn"],
+        input=json.dumps({"csv": "1,2,3", "mixed": "This.is+a,test=string",
+                          "runs": ",a,,b,", "plain": "abc"}),
+    )
+    assert resp["status"] == "SUCCEEDED"
+    output = json.loads(resp["output"])
+    assert output["simple"] == ["1", "2", "3"]
+    assert output["charset"] == ["This", "is", "a", "test", "string"]
+    # Runs of delimiters, and delimiters at either end, contribute nothing.
+    assert output["runs"] == ["a", "b"]
+    assert output["absent"] == ["abc"]
+    assert output["region"] == "us-east-1"
 
 def test_sfn_intrinsic_format(sfn, sfn_sync):
     """States.Format interpolates arguments into a template string."""


### PR DESCRIPTION
We need `StringSplit` and `Hash`. Splitting `$$.Execution.Id` on `:` is how ASL recovers the machine's own region and account id, so anything that names or tags a resource from the execution ARN fails

### Fix

- `States.StringSplit(text, delimiters)`: the second argument is a set of delimiter characters rather than one separator string, and a run of them, or one at either end, yields no empty member. So an ARN indexes the same whichever way it is written
- `States.Hash(text, algorithm)`:  the five algorithms AWS publishes, as lowercase hex of the UTF-8 bytes. Anything outside that set is refused rather than handed to `hashlib`, and the input shares the 10,000-character cap the base64 intrinsics already carry

Both are measured against real Step Functions.
Code written with Claude Code.

### Testing

Two tests in `tests/test_stepfunctions.py`, one per intrinsic

- `test_sfn_intrinsic_string_split`: the delimiter set, the empty-member rule, and `States.ArrayGetItem(States.StringSplit($$.Execution.Id, ':'), 3)` recovering the region, which is the case that motivated it
- `test_sfn_intrinsic_hash`: the five algorithms against the digests any other tool produces, and `SHA-224` refused

The script below runs against MiniStack or real AWS:

| target | result |
| --- | --- |
| MiniStack main | 0/5 |
| this branch | 5/5 |
| real AWS | 5/5 |

```
                                            before                          this branch
execution ARN splits into region/account    Unsupported intrinsic function  region=eu-central-1
every character of the delimiter splits     Unsupported intrinsic function  [This, is, a, test, string]
no empty member survives a run or an edge   Unsupported intrinsic function  [a, b]
States.Hash matches the five algorithms     Unsupported intrinsic function  sha256=b4a697a057313163…
an unpublished algorithm is refused         Unsupported intrinsic function  States.Runtime
```

Every check is a Pass state, so scoring it against AWS creates one role with no permissions and nothing else.

<details>
<summary>check_sfn_missing_intrinsics.py</summary>

```python
#!/usr/bin/env python3
"""Check the two intrinsics MiniStack does not implement: States.StringSplit and States.Hash.

Every other intrinsic AWS publishes is there, so a machine using either of these dies with
"States.Runtime: Unsupported intrinsic function". Splitting $$.Execution.Id on ":" is the
documented way for a machine to recover its own region and account id, so anything that names or
tags a resource from the execution ARN needs StringSplit.

Its delimiter argument is a set of characters rather than a separator string, and a run of them
yields no empty members; States.Hash publishes five algorithms and a 10,000-character cap. All of
it is checked here rather than assumed.

Against MiniStack:
  python check_sfn_missing_intrinsics.py --endpoint http://localhost:4566 --region eu-central-1

Against AWS, after `aws sso login --profile <profile>`:
  python check_sfn_missing_intrinsics.py --profile <profile> --region eu-central-1

Creates and deletes the state machines and, on AWS only, one role with no permissions: every check
is a Pass state, so nothing is called and nothing else is created. Pass --keep to leave them
behind. Exit status is 0 when every check passes.
"""

import argparse
import hashlib
import json
import sys
import time
import uuid
from contextlib import suppress

import boto3
from botocore.exceptions import ClientError

DUMMY_ROLE = "arn:aws:iam::000000000000:role/sfn-intrinsics-check"
TRUST_POLICY = {
    "Version": "2012-10-17",
    "Statement": [{
        "Effect": "Allow",
        "Principal": {"Service": "states.amazonaws.com"},
        "Action": "sts:AssumeRole",
    }],
}


def options():
    parser = argparse.ArgumentParser(description=__doc__)
    parser.add_argument("--endpoint", help="Emulator endpoint, e.g. http://localhost:4566")
    parser.add_argument("--profile", help="AWS CLI/SSO profile; defaults to AWS_PROFILE")
    parser.add_argument("--region", default=None, help="AWS region; defaults to AWS_REGION")
    parser.add_argument("--keep", action="store_true", help="Leave resources behind")
    return parser.parse_args()


def run_pass(sfn, name, role_arn, parameters, created, timeout=60):
    """Evaluate intrinsics in a Pass state and return (status, result, error, cause)."""
    definition = json.dumps({
        "StartAt": "Eval",
        "States": {"Eval": {"Type": "Pass", "Parameters": parameters, "End": True}},
    })
    arn = sfn.create_state_machine(name=name, definition=definition,
                                   roleArn=role_arn)["stateMachineArn"]
    created.append(("state_machine", arn))
    execution_arn = sfn.start_execution(stateMachineArn=arn, input="{}")["executionArn"]
    deadline = time.monotonic() + timeout
    execution = sfn.describe_execution(executionArn=execution_arn)
    while execution["status"] == "RUNNING" and time.monotonic() < deadline:
        time.sleep(0.25)
        execution = sfn.describe_execution(executionArn=execution_arn)
    output = json.loads(execution.get("output") or "{}") if execution["status"] == "SUCCEEDED" else {}
    return execution["status"], output, execution.get("error") or "", execution.get("cause") or ""


def main():
    args = options()
    if args.endpoint and not args.profile:
        session = boto3.Session(region_name=args.region, aws_access_key_id="test",
                                aws_secret_access_key="test")
    else:
        session = boto3.Session(profile_name=args.profile, region_name=args.region)
    client_args = {"endpoint_url": args.endpoint} if args.endpoint else {}
    sfn = session.client("stepfunctions", **client_args)
    iam = session.client("iam", **client_args)

    prefix = f"sfn-intrinsics-{uuid.uuid4().hex[:8]}"
    created = []
    results = []

    def check(label, ok, detail):
        results.append((label, ok, detail))
        print(f"{'PASS' if ok else 'FAIL'}  {label:44} {detail}")

    try:
        if args.endpoint:
            role_arn = DUMMY_ROLE
        else:
            role = iam.create_role(RoleName=f"{prefix}-role",
                                   AssumeRolePolicyDocument=json.dumps(TRUST_POLICY))["Role"]
            created.append(("role", role["RoleName"]))
            role_arn = role["Arn"]
            time.sleep(15)  # IAM propagation before Step Functions accepts the role

        def evaluate(name, parameters):
            return run_pass(sfn, f"{prefix}-{name}", role_arn, parameters, created)

        # 1. The caller's actual shape: recover the region and account id from the execution ARN.
        #    arn:aws:states:<region>:<account>:execution:<machine>:<id> -- indexes 3 and 4.
        status, out, error, cause = evaluate("arn", {
            "region.$": "States.ArrayGetItem(States.StringSplit($$.Execution.Id, ':'), 3)",
            "account.$": "States.ArrayGetItem(States.StringSplit($$.Execution.Id, ':'), 4)",
        })
        ok = status == "SUCCEEDED" and bool(out.get("region")) and bool(out.get("account"))
        check("execution ARN splits into region and account", ok,
              f"region={out.get('region')} account={out.get('account')}" if ok
              else f"status={status} error={error} cause={cause[:60]}")

        # 2. The second argument is a set of characters, not one separator string.
        status, out, error, cause = evaluate("charset", {
            "parts.$": "States.StringSplit('This.is+a,test=string', '.+,=')"})
        ok = out.get("parts") == ["This", "is", "a", "test", "string"]
        check("every character of the delimiter splits", ok,
              f"{out.get('parts')}" if ok else f"{error or out.get('parts')}")

        # 3. Runs of delimiters, and delimiters at either end: both decide whether empty
        #    members survive, so one string asks both at once.
        status, out, error, cause = evaluate("empties", {
            "parts.$": "States.StringSplit(',a,,b,', ',')"})
        ok = out.get("parts") == ["a", "b"]
        check("no empty member survives a run or an edge", ok,
              f"{out.get('parts')}" if ok else f"{error or out.get('parts')}")

        # 4. States.Hash over the five algorithms AWS publishes, against the digests any other
        #    tool produces, which pins the UTF-8 encoding and the lowercase hex with them.
        status, out, error, cause = evaluate("hash", {
            "md5.$": "States.Hash('input data', 'MD5')",
            "sha1.$": "States.Hash('input data', 'SHA-1')",
            "sha256.$": "States.Hash('input data', 'SHA-256')",
            "sha384.$": "States.Hash('input data', 'SHA-384')",
            "sha512.$": "States.Hash('input data', 'SHA-512')",
        })
        want = {algo: hashlib.new(algo, b"input data").hexdigest()
                for algo in ("md5", "sha1", "sha256", "sha384", "sha512")}
        got = {algo: out.get(algo) for algo in want}
        ok = got == want
        check("States.Hash matches the five published algorithms", ok,
              f"sha256={want['sha256'][:16]}..." if ok else f"{error or got}")

        # 5. An algorithm AWS does not publish is refused rather than quietly hashed. A build
        #    without States.Hash at all also fails here, so the cause has to be read: "unsupported
        #    intrinsic" is the function missing, not the argument being rejected.
        status, out, error, cause = evaluate("hash-bad", {
            "h.$": "States.Hash('input data', 'SHA-224')"})
        missing = "unsupported intrinsic" in cause.lower()
        ok = status == "FAILED" and not missing
        check("an unpublished algorithm is refused", ok,
              f"{error}" if ok
              else (f"States.Hash is not implemented: {cause[:48]}" if missing
                    else f"returned {out.get('h')}"))
    finally:
        if not args.keep:
            for kind, ident in reversed(created):
                with suppress(ClientError):
                    if kind == "state_machine":
                        sfn.delete_state_machine(stateMachineArn=ident)
                    elif kind == "role":
                        iam.delete_role(RoleName=ident)

    failed = [label for label, ok, _ in results if not ok]
    print(f"\n{len(results) - len(failed)}/{len(results)} checks passed"
          + (f"; failed: {', '.join(failed)}" if failed else ""))
    return 1 if failed else 0


if __name__ == "__main__":
    try:
        sys.exit(main())
    except ClientError as exc:
        print(f"ERROR: {exc}", file=sys.stderr)
        sys.exit(2)
```

</details>
